### PR TITLE
stan_rdump: logical variables converted to numeric before dumping

### DIFF
--- a/rstan/rstan/R/misc.R
+++ b/rstan/rstan/R/misc.R
@@ -488,7 +488,11 @@ stan_rdump <- function(list, file = "", append = FALSE,
       vv <- data.matrix(vv) 
     } else if (is.list(vv)) {
       vv <- data_list2array(vv)
-    } 
+    }
+
+    if (is.logical(vv)) {
+      mode(vv) <- "integer"
+    }
     
     if (!is.numeric(vv))  next
 


### PR DESCRIPTION
stan_rdump was ignoring logical variables; the patch converts them to integer before dumping them.
