### PR TITLE
as.array.stanfit, as.matrix.stanfit: added inc_warmup parameter

### DIFF
--- a/rstan/rstan/R/stanfit-class.R
+++ b/rstan/rstan/R/stanfit-class.R
@@ -600,15 +600,15 @@ sflist2stanfit <- function(sflist) {
 # sflist2stan(list(l1=ss1, l2=ss2))
 
 
-as.array.stanfit <- function(x, ...) {
+as.array.stanfit <- function(x, inc_warmup = FALSE, ...) {
   if (x@mode != 0) return(numeric(0)) 
-  out <- extract(x, permuted = FALSE, inc_warmup = FALSE, ...)
+  out <- extract(x, permuted = FALSE, inc_warmup = inc_warmup, ...)
   # dimnames(out) <- dimnames(x)
   return(out)
 } 
-as.matrix.stanfit <- function(x, ...) {
+as.matrix.stanfit <- function(x, inc_warmup = FALSE, ...) {
   if (x@mode != 0) return(numeric(0)) 
-  e <- extract(x, permuted = FALSE, inc_warmup = FALSE, ...) 
+  e <- extract(x, permuted = FALSE, inc_warmup = inc_warmup, ...)
   out <- apply(e, 3, FUN = function(y) y)
   dimnames(out) <- dimnames(e)[-2]
   return(out)

--- a/rstan/rstan/man/stanfit2array-method.Rd
+++ b/rstan/rstan/man/stanfit2array-method.Rd
@@ -25,16 +25,17 @@
 \arguments{
   \item{x}{An object of S4 class \code{stanfit}} 
   \item{\dots}{Additional parameters that can be passed to \code{extract} 
-    for extracting samples from \code{stanfit} object. For now, \code{pars}
-    is the only additional parameter.  
+    for extracting samples from \code{stanfit} object. For now,
+    \code{pars} and \code{inc_warmup} are the only valid additional parameters.
   } 
 } 
 
 \details{
-  \code{as.array} and \code{as.matrix} can be applied to a \code{stanfit}
-  object to coerce the samples without warmup to \code{array} or \code{matrix}.
-  The \code{as.data.frame} method first calls \code{as.matrix} and then coerces
-  this matrix to a \code{data.frame}.
+  \code{as.array} and \code{as.matrix} can be applied to a
+  \code{stanfit} object to coerce the samples to \code{array} or
+  \code{matrix}. Unlike \code{extract}, warmup samples are dropped by
+  default.  The \code{as.data.frame} method first calls \code{as.matrix}
+  and then coerces this matrix to a \code{data.frame}.
 
   The array has three named dimensions: iterations, chains, parameters. 
   For \code{as.matrix}, all chains are combined, leaving a matrix of iterations


### PR DESCRIPTION
Although the `as.array` and `as.matrix` methods for stanfit drop the warmup samples, I didn't see why that should be enforced, rather than a default setting.
