### PR TITLE
added S4 method as.mcmc.list

### DIFF
--- a/rstan/rstan/NAMESPACE
+++ b/rstan/rstan/NAMESPACE
@@ -39,7 +39,8 @@ exportMethods(
   get_sampler_params,
   get_logposterior, 
   get_posterior_mean,
-  get_stanmodel 
+  get_stanmodel,
+  as.mcmc.list
 )
 S3method(print, stanfit)
 S3method(as.array, stanfit)

--- a/rstan/rstan/R/stanfit-class.R
+++ b/rstan/rstan/R/stanfit-class.R
@@ -697,7 +697,31 @@ as.data.frame.stanfit <- function(x, ...) {
 dim.stanfit <- function(x) {
   if (x@mode != 0) return(numeric(0)) 
   c(x@sim$n_save[1] - x@sim$warmup2[1], x@sim$chains, x@sim$n_flatnames)
-} 
+}
+
+# function to create mcmc objects and avoid dependency on coda::mcmc
+to_mcmc <- function(x, thin, end) {
+    x <- as.matrix(x)
+    niter <- nrow(x)
+    start <- end - (niter - 1) * thin
+    attr(x, "mcpar") <- c(start, end, thin)
+    class(x) <- "mcmc"
+    x
+}
+
+setGeneric("as.mcmc.list", function(x, ...) standardGeneric("as.mcmc.list"))
+
+as.mcmc.list.stanfit <- function(x, inc_warmup = FALSE, ...) {
+    thin <- x@sim$thin
+    end <- x@sim$iter
+    e <- extract(x, permuted = FALSE, inc_warmup = inc_warmup, ...)
+    out <- mapply(function(x, thin, end) to_mcmc(do.call(cbind, x), thin, end),
+                  x@sim$samples, end=end, thin=thin, SIMPLIFY=FALSE)
+    class(out) <- "mcmc.list"
+    out
+}
+
+setMethod("as.mcmc.list", "stanfit", as.mcmc.list.stanfit)
 
 dimnames.stanfit <- function(x) {
   if (x@mode != 0) return(character(0)) 


### PR DESCRIPTION
a followup to issue #17 (my branch had gotten out of whack with stan-dev repo).  

I implemented it as a S4 method named `as.mcmc.list`, and I improved its efficiency by directly using the `stanfit` object and using `as.array`. 

It works fine, but there is a problem.  If `coda` is loaded **after** `rstan`, then the S3 method defined by coda, `as.mcmc.list` masks the method defined in `rstan`. It can still be called explicitly with `rstan::as.mcmc.list`.

There doesn't appear to be any way around it being awkward as an S3 or S4 method without depending on coda, which makes no sense.   Maybe its better to submit code to `coda`.

Also, while digging around in the code I noticed that `as.matrix`, `as.array`, `is.array`, `dim`, and `dimnames` are all defined as S3 methods, when there are S4 methods defined in `base`. Since `stanfit` is an S4 class, I think they should be defined as S4 methods. 
