### PR TITLE
Add index of functions to the TOC of the reference manual

### DIFF
--- a/src/docs/stan-reference/stan-reference.tex
+++ b/src/docs/stan-reference/stan-reference.tex
@@ -27,6 +27,9 @@
 \include{references}
 \titlespacing{\chapter}{0pt}{-4pt}{24pt}{}
 {\footnotesize
+\cleardoublepage
+\phantomsection
+\addcontentsline{toc}{chapter}{Index}
 \printindex
 }
 


### PR DESCRIPTION
I was missing this shortcut whenever I needed to look for a function in the manual.
