### PR TITLE
shuffle the function_signature tests

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -100,7 +100,30 @@ endif
 ##
 # Builds a single test
 ##
-test/gm/compile_models$(EXE) : test/gm/compile_models.o bin/libstan.a $(patsubst %.stan,%$(EXE),$(wildcard src/test/gm/model_specs/compiled/*.stan))
+FILES := $(wildcard src/test/gm/model_specs/compiled/*.stan)
+ifeq ($(OS),win)
+  WH := where
+else
+  WH := which
+endif
+
+ifneq ($(shell $(WH) shuf),)
+  FILES := $(shell shuf -e $(FILES))
+else
+ifneq ($(shell $(WH) Rscript),)
+  FILES := $(shell Rscript -e "cat(sample(commandArgs(trailingOnly=TRUE)))" $(FILES))
+else
+ifneq ($(shell $(WH) python),)
+  FILES := $(shell python -c "import random; import os; import sys; sys.argv.remove('-'); s = sys.argv; random.shuffle(s); print ' '.join(s)" - $(FILES))
+else
+ifneq ($(shell $(WH) perl),)
+  FILES := $(shell perl -MList::Util=shuffle -le'print for shuffle @ARGV' $(FILES))
+endif
+endif
+endif
+endif
+
+test/gm/compile_models$(EXE) : test/gm/compile_models.o bin/libstan.a $(patsubst %.stan,%$(EXE),$(FILES))
 	@mkdir -p $(dir $@)
 	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS) $(LDLIBS_STANC)
 ifeq ($(findstring test-,$(MAKECMDGOALS))$(findstring runtest/,$(MAKECMDGOALS)),)


### PR DESCRIPTION
This is necessary to reduce the maximum RAM spike when executing
make test-unit. If the function_signature tests are done in
alphabetical order, then several tests with similar names and
high RAM requirements will be executed at once if done in
parallel, which may cause the machine to swap or if swap is
exhausted / unavailable, to cause the tests to fail. By shuffling
these tests, it is much less likely to be executing many tests
with high RAM requirements at the same time.
