### PR TITLE
avoid integer division in tests

### DIFF
--- a/src/test/prob/distributions/univariate/continuous/scaled_inv_chi_square_test.cpp
+++ b/src/test/prob/distributions/univariate/continuous/scaled_inv_chi_square_test.cpp
@@ -11,7 +11,7 @@ TEST(ProbDistributionsScaledInvChiSquare, random) {
 TEST(ProbDistributionsScaledInvChiSquare, chiSquareGoodnessFitTest) {
   boost::random::mt19937 rng;
   int N = 10000;
-  int K = 5;
+  double K = 5;
   boost::math::inverse_chi_squared_distribution<>dist (2.0);
   boost::math::chi_squared mydist(K-1);
 

--- a/src/test/prob/distributions/univariate/continuous/student_t_test.cpp
+++ b/src/test/prob/distributions/univariate/continuous/student_t_test.cpp
@@ -12,7 +12,7 @@ TEST(ProbDistributionsStudentT, chiSquareGoodnessFitTest) {
   boost::random::mt19937 rng;
   boost::math::students_t_distribution<>dist (3.0);
   int N = 10000;
-  int K = 5;
+  double K = 5;
   boost::math::chi_squared mydist(K-1);
 
   double loc[4];


### PR DESCRIPTION
These two tests created an array of doubles where elements are
N / K where both N and K are integers, which is a "narrowing"
error under the C++11 standard. K is now changed to a double.
