### PR TITLE
set GTEST_USE_OWN_TR1_TUPLE globally

### DIFF
--- a/make/os_linux
+++ b/make/os_linux
@@ -27,7 +27,6 @@ ifeq (mingw32-g++,$(CC_TYPE))
 endif
 ifeq (clang++,$(CC_TYPE))
 #  CFLAGS += -stdlib=libc++
-#  CFLAGS_GTEST += -DGTEST_USE_OWN_TR1_TUPLE
   CFLAGS_GTEST += -DGTEST_HAS_PTHREAD=0
   CFLAGS += -Wno-unused-function
   CFLAGS += -Wno-uninitialized

--- a/makefile
+++ b/makefile
@@ -34,6 +34,7 @@ GTEST ?= lib/gtest_1.6.0
 # Set default compiler options.
 ## 
 CFLAGS = -I src -I $(EIGEN) -I $(BOOST) -Wall -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS
+CFLAGS_GTEST = -DGTEST_USE_OWN_TR1_TUPLE
 LDLIBS = -Lbin -lstan
 LDLIBS_STANC = -Lbin -lstanc
 EXE = 


### PR DESCRIPTION
GTEST_USE_OWN_TR1_TUPLE needs to be defined when compiling Stan
with the libc++ library. Setting it in the top-level makefile
is easier and more consistent than setting it in each of the
make/os_\* files.
