### PR TITLE
Feature/issue90 periods in variable identifiers caught with warnings

### DIFF
--- a/src/stan/gm/grammars/var_decls_grammar_def.hpp
+++ b/src/stan/gm/grammars/var_decls_grammar_def.hpp
@@ -400,13 +400,26 @@ namespace stan {
         if (len >= 2
             && identifier[len-1] == '_'
             && identifier[len-2] == '_') {
-          error_msgs << "variable identifier (name) cannot end in double underscore (__)"
-                     << "; found identifer=" << identifier;
+          error_msgs << "variable identifier (name) may not end in double underscore (__)"
+                     << std::endl
+                     << "    found identifer=" << identifier << std::endl;
+          return false;
+        }
+        size_t period_position = identifier.find('.');
+        if (period_position != std::string::npos) {
+          error_msgs << "variable identifier may not contain a period (.)"
+                     << std::endl
+                     << "    found period at position (indexed from 0)=" << period_position
+                     << std::endl
+                     << "    found identifier=" << identifier 
+                     << std::endl;
           return false;
         }
         if (reserved_word_set_.find(identifier) != reserved_word_set_.end()) {
-          error_msgs << "variable identifier (name) cannot be reserved word"
-                     << "; found identifier=" << identifier;
+          error_msgs << "variable identifier (name) may not be reserved word"
+                     << std::endl
+                     << "    found identifier=" << identifier 
+                     << std::endl;
           return false;
         }
         return true;

--- a/src/test/gm/model_specs/bad_periods_data.stan
+++ b/src/test/gm/model_specs/bad_periods_data.stan
@@ -1,0 +1,9 @@
+data {
+  real x.y;
+}
+parameters {
+  real z;
+}
+model {
+  z ~ normal(x.y,1);
+}

--- a/src/test/gm/model_specs/bad_periods_gqs.stan
+++ b/src/test/gm/model_specs/bad_periods_gqs.stan
@@ -1,0 +1,10 @@
+parameters {
+  real z;
+}
+model {
+  z ~ normal(0,1);
+}
+generated quantities {
+  real x.y;
+  x.y <- z * 2;
+}

--- a/src/test/gm/model_specs/bad_periods_local.stan
+++ b/src/test/gm/model_specs/bad_periods_local.stan
@@ -1,0 +1,7 @@
+parameters {
+  real z;
+}
+model {
+  real x.y;
+  z ~ normal(x.y,1);
+}

--- a/src/test/gm/model_specs/bad_periods_params.stan
+++ b/src/test/gm/model_specs/bad_periods_params.stan
@@ -1,0 +1,6 @@
+parameters {
+  real x.y;
+}
+model {
+  x.y ~ normal(0,1);
+}

--- a/src/test/gm/model_specs/bad_periods_tdata.stan
+++ b/src/test/gm/model_specs/bad_periods_tdata.stan
@@ -1,0 +1,9 @@
+transformed data {
+  real x.y;
+}
+parameters {
+  real z;
+}
+model {
+  z ~ normal(x.y,1);
+}

--- a/src/test/gm/model_specs/bad_periods_tparams.stan
+++ b/src/test/gm/model_specs/bad_periods_tparams.stan
@@ -1,0 +1,7 @@
+transformed parameters {
+  real x.;
+  x. <- 1.0;
+}
+model {
+  2.0 ~ normal(x.,1);
+}

--- a/src/test/gm/parser_test.cpp
+++ b/src/test/gm/parser_test.cpp
@@ -172,6 +172,20 @@ TEST(gm_parser,parsable_test_bad_trunc) {
   EXPECT_THROW(is_parsable("src/test/gm/model_specs/bad_trunc3.stan"),
                std::invalid_argument);
 }
+TEST(gmParser,parsableBadPeriods) {
+  EXPECT_THROW(is_parsable("src/test/gm/model_specs/bad_periods_data.stan"),
+               std::invalid_argument);
+  EXPECT_THROW(is_parsable("src/test/gm/model_specs/bad_periods_tdata.stan"),
+               std::invalid_argument);
+  EXPECT_THROW(is_parsable("src/test/gm/model_specs/bad_periods_params.stan"),
+               std::invalid_argument);
+  EXPECT_THROW(is_parsable("src/test/gm/model_specs/bad_periods_tparams.stan"),
+               std::invalid_argument);
+  EXPECT_THROW(is_parsable("src/test/gm/model_specs/bad_periods_gqs.stan"),
+               std::invalid_argument);
+  EXPECT_THROW(is_parsable("src/test/gm/model_specs/bad_periods_local.stan"),
+               std::invalid_argument);
+}
 TEST(gm_parser,function_signatures) {
   EXPECT_TRUE(is_parsable("src/test/gm/model_specs/compiled/function_signatures1.stan"));
   EXPECT_TRUE(is_parsable("src/test/gm/model_specs/compiled/function_signatures6.stan"));


### PR DESCRIPTION
This should catch variable declarations containing variable identifiers with periods and supply a reasonable warning message. 

Of the 3 commits, two of them are merges of develop.  Should this be rebased somehow?
