### PR TITLE
Fix bin/print and Extremely Small Numbers

### DIFF
--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -309,7 +309,6 @@ namespace stan {
             std::stringstream ls(line);
             for (int col = 0; col < cols; col++) {
               std::getline(ls, line, ',');
-              std::cout << row << "\t" << col << "\t" << line << std::endl;
               samples(row, col) = boost::lexical_cast<double>(line);
             }
           }


### PR DESCRIPTION
Parse CSV by hand and convert string values to doubles using boost::lexical cast instead of std::stringstream::operator>> which fails on numbers whose exponent has more than two digits.
