### PR TITLE
Gracefully handle NaNs in Hamiltonian

### DIFF
--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <stdexcept>
 
+#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <boost/random/uniform_01.hpp>
 
@@ -64,7 +65,7 @@ namespace stan {
         this->_integrator.evolve(this->_z, this->_hamiltonian, this->_nom_epsilon);
         
         double h = this->_hamiltonian.H(this->_z);
-        if (h != h) h = std::numeric_limits<double>::infinity();
+        if (boost::math::isnan(h)) h = std::numeric_limits<double>::infinity();
         
         double delta_H = H0 - h;
         
@@ -82,7 +83,7 @@ namespace stan {
           this->_integrator.evolve(this->_z, this->_hamiltonian, this->_nom_epsilon);
           
           double h = this->_hamiltonian.H(this->_z);
-          if (h != h) h = std::numeric_limits<double>::infinity();
+          if (boost::math::isnan(h)) h = std::numeric_limits<double>::infinity();
           
           double delta_H = H0 - h;
           

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -2,6 +2,7 @@
 #define __STAN__MCMC__BASE__NUTS__BETA__
 
 #include <math.h>
+#include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/math/functions/min.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
@@ -196,7 +197,7 @@ namespace stan {
           z_propose = static_cast<ps_point>(this->_z);
           
           double h = this->_hamiltonian.H(this->_z); 
-          if (h != h) h = std::numeric_limits<double>::infinity();
+          if (boost::math::isnan(h)) h = std::numeric_limits<double>::infinity();
           
           util.criterion = util.log_u + (h - util.H0) < this->_max_delta;
 

--- a/src/stan/mcmc/hmc/static/base_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/base_static_hmc.hpp
@@ -2,6 +2,7 @@
 #define __STAN__MCMC__BASE__STATIC__HMC__BETA__
 
 #include <math.h>
+#include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 
@@ -42,7 +43,7 @@ namespace stan {
         }
         
         double h = this->_hamiltonian.H(this->_z);
-        if (h != h) h = std::numeric_limits<double>::infinity();
+        if (boost::math::isnan(h)) h = std::numeric_limits<double>::infinity();
         
         double acceptProb = std::exp(H0 - h);
         


### PR DESCRIPTION
Addresses Issue #121.  The static HMC code was missing a NaN check.
