### PR TITLE
updating model tests to skip another parameter in the output

### DIFF
--- a/src/test/models/model_test_fixture.hpp
+++ b/src/test/models/model_test_fixture.hpp
@@ -281,7 +281,7 @@ template<class Derived>
 std::vector<std::string> Model_Test_Fixture<Derived>::command_outputs;
 
 template<class Derived>
-const int Model_Test_Fixture<Derived>::skip = 3;
+const int Model_Test_Fixture<Derived>::skip = 4;
 
 template<class Derived>
 int Model_Test_Fixture<Derived>::iterations = 2000;


### PR DESCRIPTION
This fixes a lot of the model tests.
