### PR TITLE
Initialize HMC variables in mcmc_writer_test

### DIFF
--- a/src/test/io/mcmc_writer_test.cpp
+++ b/src/test/io/mcmc_writer_test.cpp
@@ -263,6 +263,10 @@ TEST(StanIoMcmcWriter, print_diagnostic_params) {
   
   stan::mcmc::adapt_diag_e_nuts<example_model_namespace::example_model, rng_t> sampler(model, base_rng, 0);
   sampler.seed(real, discrete);
+  sampler.z().p(0) = 0;
+  sampler.z().p(1) = 0;
+  sampler.z().g(0) = 0;
+  sampler.z().g(1) = 0;
   
   // Writer
   std::stringstream sample_stream;


### PR DESCRIPTION
@bgoodri noticed that the mcmc_writer_test was failing but not picked up by Jenkins.  The problem is that uninitialized variables were assumed to be zero, and with recent changes to ps_point explicit initialization was removed.  The default values are undefined and hence machine-dependent.  The test now explicitly initializes the variables before testing the mcmc_writer I/O.
