### PR TITLE
add minipage to fitem so that function args can have multiple lines

### DIFF
--- a/src/docs/stan-reference/stan-manuals.sty
+++ b/src/docs/stan-reference/stan-manuals.sty
@@ -108,7 +108,7 @@
 \newcommand{\reffigure}[1]{Figure~\ref{#1.figure}}
 \newcommand{\refnote}[1]{Footnote~\ref{#1.footnote}}
 
-\newcommand{\fitem}[4]{\item[{\tt #1 {\bfseries #2}(#3)}]\mbox{ }
+\newcommand{\fitem}[4]{\item[\begin{minipage}{\textwidth}{\tt #1 {\bfseries #2}(#3)}\end{minipage}]\mbox{ }
  \\[4pt] #4\index{{\tt\bfseries #2 }!{\tt (#3):\,#1}|hyperpage}}
 % need special command for items requiring escapes in index
 \newcommand{\fitemindex}[5]{\item[{\tt #1 {\bfseries #2}(#3)}]\mbox{ }


### PR DESCRIPTION
`\fitem`  wasn't wrapping functions with long argument lists (e.g. `skew_normal_log`) 
