### PR TITLE
Fix gamma parametrization

### DIFF
--- a/src/stan/prob/distributions/univariate/continuous/gamma.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/gamma.hpp
@@ -215,8 +215,13 @@ namespace stan {
               RNG& rng) {
       using boost::variate_generator;
       using boost::gamma_distribution;
+      /*
+        the boost gamma distribution is defined by
+	shape and scale, whereas the stan one is defined
+	by shape and rate
+      */
       variate_generator<RNG&, gamma_distribution<> >
-        gamma_rng(rng, gamma_distribution<>(alpha, beta));
+        gamma_rng(rng, gamma_distribution<>(alpha, 1/beta));
       return gamma_rng();
     }
 

--- a/src/test/prob/distributions/univariate/continuous/gamma_test.cpp
+++ b/src/test/prob/distributions/univariate/continuous/gamma_test.cpp
@@ -12,7 +12,7 @@ TEST(ProbDistributionGamma, chiSquareGoodnessFitTest) {
   boost::random::mt19937 rng;
   int N = 10000;
   int K = boost::math::round(2 * std::pow(N, 0.4));
-  boost::math::gamma_distribution<>dist (2.0,1.0);
+  boost::math::gamma_distribution<>dist (2.0,2.0);
   boost::math::chi_squared mydist(K-1);
 
   double loc[K - 1];
@@ -28,7 +28,11 @@ TEST(ProbDistributionGamma, chiSquareGoodnessFitTest) {
   }
 
   while (count < N) {
-    double a = stan::prob::gamma_rng(2.0,1.0,rng);
+    /*
+      the stan gamma distribution is defined by
+      shape and rate (hence 0.5 here and 2 above).
+    */
+    double a = stan::prob::gamma_rng(2.0,0.5,rng);
     int i = 0;
     while (i < K-1 && a > loc[i]) 
       ++i;


### PR DESCRIPTION
The gamma random number generator in stan claims to be parametrized by shape and rate.  However, something like

```
parameters {
   real<lower=0, upper=1> fake;
}

model {
}

generated quantities {
   real fred;
   fred <- gamma_rng(1, 3);
}
```

gives fred with a mean of 3 rather than the 1/3 it should be.  [In 

rstan (Version 1.3.0, packaged: 2013-04-12 21:12:02 UTC, GitRev: f57455593d14)

]

This is because the boost gamma is parametrized by shape and scale rather than shape and rate.  This should be the appropriate fix --- I haven't tested this code, so caveat emptor...
