### PR TITLE
fix for error messages in parser

### DIFF
--- a/src/stan/gm/ast.hpp
+++ b/src/stan/gm/ast.hpp
@@ -573,6 +573,7 @@ namespace stan {
                            boost::recursive_wrapper<assignment>,
                            boost::recursive_wrapper<sample>,
                            boost::recursive_wrapper<increment_log_prob_statement>,
+                           boost::recursive_wrapper<expression>, // dummy now
                            boost::recursive_wrapper<statements>,
                            boost::recursive_wrapper<for_statement>,
                            boost::recursive_wrapper<conditional_statement>,
@@ -585,11 +586,11 @@ namespace stan {
 
     statement();
     statement(const statement_t& st);
-
     statement(const nil& st);
     statement(const assignment& st);
     statement(const sample& st);
     statement(const increment_log_prob_statement& st);
+    statement(const expression& st);
     statement(const statements& st);
     statement(const for_statement& st);
     statement(const conditional_statement& st);

--- a/src/stan/gm/ast_def.cpp
+++ b/src/stan/gm/ast_def.cpp
@@ -906,6 +906,7 @@ namespace stan {
     statement::statement(const sample& st) : statement_(st) { }
     statement::statement(const increment_log_prob_statement& st) : statement_(st) { }
     statement::statement(const statements& st) : statement_(st) { }
+    statement::statement(const expression& st) : statement_(st) { }
     statement::statement(const for_statement& st) : statement_(st) { }
     statement::statement(const while_statement& st) : statement_(st) { }
     statement::statement(const conditional_statement& st) : statement_(st) { }

--- a/src/stan/gm/generator.hpp
+++ b/src/stan/gm/generator.hpp
@@ -1399,6 +1399,9 @@ namespace stan {
         generate_expression(x.expr_,o_);
         o_ << ");" << EOL;
       }
+      void operator()(expression const& x) const {
+        throw std::invalid_argument("expression statements not yet supported");
+      }
       void operator()(sample const& x) const {
         if (!include_sampling_) return;
         generate_indent(indent_,o_);

--- a/src/stan/gm/grammars/statement_grammar.hpp
+++ b/src/stan/gm/grammars/statement_grammar.hpp
@@ -44,6 +44,11 @@ namespace stan {
                               whitespace_grammar<Iterator> > 
       assignment_r;
 
+      boost::spirit::qi::rule<Iterator, 
+                              expression(var_origin), 
+                              whitespace_grammar<Iterator> > 
+      non_lvalue_assign_r;
+
 
       boost::spirit::qi::rule<Iterator, 
                               std::vector<expression>(var_origin), 
@@ -122,7 +127,7 @@ namespace stan {
                               whitespace_grammar<Iterator> > 
       sample_r;
 
-      boost::spirit::qi::rule<Iterator, 
+      boost::spirit::qi::rule<Iterator,
                               statement(bool,var_origin), 
                               whitespace_grammar<Iterator> > 
       statement_r;

--- a/src/stan/gm/grammars/statement_grammar_def.hpp
+++ b/src/stan/gm/grammars/statement_grammar_def.hpp
@@ -242,6 +242,34 @@ namespace stan {
     };
     boost::phoenix::function<validate_sample> validate_sample_f;
 
+    struct expression_as_statement {
+      template <typename T1, typename T2, typename T3>
+      struct result { typedef void type; };
+      void operator()(bool& pass,
+                      const stan::gm::expression& expr,
+                      std::stringstream& error_msgs) const {
+        error_msgs << "Illegal statement beginning with expression parsed as"
+                   << std::endl << "  ";
+        generate_expression(expr.expr_,error_msgs);
+        error_msgs << std::endl
+           << "Not a legal assignment or sampling statement.  Note that"
+           << std::endl
+           << "  * Assignment statements only allow variables (with optional indexes) on the left;"
+           << std::endl
+           << "    if you see an outer function logical_lt (<) with negated (-) second argument,"
+           << std::endl
+           << "    it indicates an assignment statement A <- B with illegal left"
+           << std::endl
+           << "    side A parsed as expression (A < (-B))."
+           << std::endl
+           << "  * Sampling statements allow arbitrary value-denoting expressions on the left."
+           << std::endl
+           << std::endl << std::endl;
+        pass = false;
+      }
+    };
+    boost::phoenix::function<expression_as_statement> expression_as_statement_f;
+
     struct unscope_locals {
       template <typename T1, typename T2>
       struct result { typedef void type; };
@@ -373,20 +401,19 @@ namespace stan {
       // set to true if sample_r are allowed
       statement_r.name("statement");
       statement_r
-        %= statement_seq_r(_r1,_r2)
-        | increment_log_prob_statement_r(_r2)
-        | for_statement_r(_r1,_r2)
-        | while_statement_r(_r1,_r2)
-        | statement_2_g(_r1,_r2)
-        | print_statement_r(_r2)
-        | assignment_r(_r2)
-          [_pass 
-            = validate_assignment_f(_1,_r2,boost::phoenix::ref(var_map_),
-                                     boost::phoenix::ref(error_msgs_))]
-        | sample_r(_r1,_r2) [_pass = validate_sample_f(_1,
-                                               boost::phoenix::ref(var_map_),
-                                               boost::phoenix::ref(error_msgs_))]
-        | no_op_statement_r
+        %= no_op_statement_r                        // key ";"
+        | statement_seq_r(_r1,_r2)                  // key "{"
+        | increment_log_prob_statement_r(_r2)       // key "increment"
+        | for_statement_r(_r1,_r2)                  // key "for"
+        | while_statement_r(_r1,_r2)                // key "while"
+        | statement_2_g(_r1,_r2)                    // key "if"
+        | print_statement_r(_r2)                    // key "print"
+        | assignment_r(_r2)                         // lvalue "<-"
+        // [_pass = validate_assignment_f(_1,_r2,boost::phoenix::ref(var_map_),
+        // boost::phoenix::ref(error_msgs_))]
+        | sample_r(_r1,_r2)                         // expression "~"
+        | expression_g(_r2)                         // expression
+          [expression_as_statement_f(_pass,_1,boost::phoenix::ref(error_msgs_))]
         ;
 
       // _r1, _r2 same as statement_r
@@ -477,7 +504,9 @@ namespace stan {
         %= ( var_lhs_r(_r1)
              >> lit("<-") )
         > expression_g(_r1)
-        > lit(';') 
+        > lit(';')
+          [_pass = validate_assignment_f(_val,_r1,boost::phoenix::ref(var_map_),
+                                         boost::phoenix::ref(error_msgs_))]
         ;
 
       var_lhs_r.name("variable and array dimensions");
@@ -504,12 +533,16 @@ namespace stan {
         %= ( expression_g(_r2)
              >> lit('~') )
         > eps
-        [_pass 
-         = validate_allow_sample_f(_r1,boost::phoenix::ref(error_msgs_))] 
+          [_pass = validate_allow_sample_f(_r1,
+                                           boost::phoenix::ref(error_msgs_))]
         > distribution_r(_r2)
         > -truncation_range_r(_r2)
-        > lit(';');
-
+        > lit(';')
+        > eps
+          [_pass = validate_sample_f(_val,
+                                     boost::phoenix::ref(var_map_),
+                                     boost::phoenix::ref(error_msgs_))]
+        ;
       distribution_r.name("distribution and parameters");
       distribution_r
         %= ( identifier_r


### PR DESCRIPTION
These were due to two things:  (a) not throwing an exception after setting _pass=false and (b) not having a rule to match expressions.  Fix (b) required updating the ast and generator to deal with statements consisting of expressions.  They're illegal and only throw errors, so there's no change to the doc required.
