### PR TITLE
moved underscores to end of capitalized variable names to avoid conflict...

### DIFF
--- a/src/stan/agrad/rev/matrix/determinant.hpp
+++ b/src/stan/agrad/rev/matrix/determinant.hpp
@@ -20,14 +20,14 @@ namespace stan {
       class determinant_vari : public vari {
         int _rows;
         int _cols;
-        double* _A;
+        double* A_;
         vari** _adjARef;
       public:
         determinant_vari(const Eigen::Matrix<var,R,C> &A)
           : vari(determinant_vari_calc(A)), 
             _rows(A.rows()),
             _cols(A.cols()),
-            _A((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            A_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * A.rows() * A.cols())),
             _adjARef((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                           * A.rows() * A.cols()))
@@ -35,7 +35,7 @@ namespace stan {
           size_t pos = 0;
           for (size_type j = 0; j < _cols; j++) {
             for (size_type i = 0; i < _rows; i++) {
-              _A[pos] = A(i,j).val();
+              A_[pos] = A(i,j).val();
               _adjARef[pos++] = A(i,j).vi_;
             }
           }
@@ -53,7 +53,7 @@ namespace stan {
           using Eigen::Map;
           Matrix<double,R,C> adjA(_rows,_cols);
           adjA = (adj_ * val_) * 
-            Map<Matrix<double,R,C> >(_A,_rows,_cols).inverse().transpose();
+            Map<Matrix<double,R,C> >(A_,_rows,_cols).inverse().transpose();
           size_t pos = 0;
           for (size_type j = 0; j < _cols; j++) {
             for (size_type i = 0; i < _rows; i++) {

--- a/src/stan/agrad/rev/matrix/ldlt.hpp
+++ b/src/stan/agrad/rev/matrix/ldlt.hpp
@@ -18,19 +18,19 @@ namespace stan {
       template<int R, int C>
       class LDLT_alloc : public chainable_alloc {
       public:
-        LDLT_alloc() : _N(0) {}
-        LDLT_alloc(const Eigen::Matrix<var,R,C> &A) : _N(0) {
+        LDLT_alloc() : N_(0) {}
+        LDLT_alloc(const Eigen::Matrix<var,R,C> &A) : N_(0) {
           compute(A);
         }
         
         inline void compute(const Eigen::Matrix<var,R,C> &A) {
           Eigen::Matrix<double,R,C> Ad(A.rows(),A.cols());
 
-          _N = A.rows();
+          N_ = A.rows();
           _variA.resize(A.rows(),A.cols());
 
-          for (size_t j = 0; j < _N; j++) {
-            for (size_t i = 0; i < _N; i++) {
+          for (size_t j = 0; j < N_; j++) {
+            for (size_t i = 0; i < N_; i++) {
               Ad(i,j) = A(i,j).val();
               _variA(i,j) = A(i,j).vi_;
             }
@@ -42,7 +42,7 @@ namespace stan {
           return _ldlt.vectorD().array().log().sum();
         }
         
-        size_t _N;
+        size_t N_;
         Eigen::LDLT< Eigen::Matrix<double,R,C> > _ldlt;
         Eigen::Matrix<vari*,R,C> _variA;
       };
@@ -78,8 +78,8 @@ namespace stan {
         return ret;
       }
       
-      inline size_t rows() const { return _alloc->_N; }
-      inline size_t cols() const { return _alloc->_N; }
+      inline size_t rows() const { return _alloc->N_; }
+      inline size_t cols() const { return _alloc->N_; }
       
       typedef size_t size_type;
 
@@ -102,11 +102,11 @@ namespace stan {
           Eigen::Matrix<double,R,C> invA;
           
           // If we start computing Jacobians, this may be a bit inefficient
-          invA.setIdentity(_alloc_ldlt->_N, _alloc_ldlt->_N);
+          invA.setIdentity(_alloc_ldlt->N_, _alloc_ldlt->N_);
           _alloc_ldlt->_ldlt.solveInPlace(invA);
 
-          for (size_t j = 0; j < _alloc_ldlt->_N; j++) {
-            for (size_t i = 0; i < _alloc_ldlt->_N; i++) {
+          for (size_t j = 0; j < _alloc_ldlt->N_; j++) {
+            for (size_t i = 0; i < _alloc_ldlt->N_; i++) {
               _alloc_ldlt->_variA(i,j)->adj_ += adj_ * invA(i,j);
             }
           }
@@ -121,14 +121,14 @@ namespace stan {
         virtual ~mdivide_left_ldlt_alloc() {}
         
         boost::shared_ptr< Eigen::LDLT< Eigen::Matrix<double,R1,C1> > > _ldltP;
-        Eigen::Matrix<double,R2,C2> _C;
+        Eigen::Matrix<double,R2,C2> C_;
       };
       
       template <int R1,int C1,int R2,int C2>
       class mdivide_left_ldlt_vv_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
         vari** _variRefB;
         vari** _variRefC;
         mdivide_left_ldlt_alloc<R1,C1,R2,C2> *_alloc;
@@ -137,8 +137,8 @@ namespace stan {
         mdivide_left_ldlt_vv_vari(const stan::math::LDLT_factor<var,R1,C1> &A,
                                   const Eigen::Matrix<var,R2,C2> &B)
         : vari(0.0),
-        _M(A.rows()),
-        _N(B.cols()),
+        M_(A.rows()),
+        N_(B.cols()),
         _variRefB((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                        * B.rows() * B.cols())),
         _variRefC((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
@@ -147,45 +147,45 @@ namespace stan {
         _alloc_ldlt(A._alloc)
         {
           size_t pos = 0;
-          _alloc->_C.resize(_M,_N);
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          _alloc->C_.resize(M_,N_);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefB[pos] = B(i,j).vi_;
-              _alloc->_C(i,j) = B(i,j).val();
+              _alloc->C_(i,j) = B(i,j).val();
               pos++;
             }
           }
           
-          _alloc_ldlt->_ldlt.solveInPlace(_alloc->_C);
+          _alloc_ldlt->_ldlt.solveInPlace(_alloc->C_);
           
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _variRefC[pos] = new vari(_alloc->_C(i,j),false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              _variRefC[pos] = new vari(_alloc->C_(i,j),false);
               pos++;
             }
           }
         }
         
         virtual void chain() {
-          Eigen::Matrix<double,R1,C1> adjA(_M,_M);
-          Eigen::Matrix<double,R2,C2> adjB(_M,_N);
+          Eigen::Matrix<double,R1,C1> adjA(M_,M_);
+          Eigen::Matrix<double,R2,C2> adjB(M_,N_);
           
           size_t pos = 0;
-          for (size_type j = 0; j < _N; j++)
-            for (size_type i = 0; i < _M; i++)
+          for (size_type j = 0; j < N_; j++)
+            for (size_type i = 0; i < M_; i++)
               adjB(i,j) = _variRefC[pos++]->adj_;
           
           _alloc_ldlt->_ldlt.solveInPlace(adjB);
-          adjA.noalias() = -adjB * _alloc->_C.transpose();
+          adjA.noalias() = -adjB * _alloc->C_.transpose();
 
-          for (size_type j = 0; j < _M; j++)
-            for (size_type i = 0; i < _M; i++)
+          for (size_type j = 0; j < M_; j++)
+            for (size_type i = 0; i < M_; i++)
               _alloc_ldlt->_variA(i,j)->adj_ += adjA(i,j);
           
           pos = 0;
-          for (size_type j = 0; j < _N; j++)
-            for (size_type i = 0; i < _M; i++)
+          for (size_type j = 0; j < N_; j++)
+            for (size_type i = 0; i < M_; i++)
               _variRefB[pos++]->adj_ += adjB(i,j);
         }
       };
@@ -193,8 +193,8 @@ namespace stan {
       template <int R1,int C1,int R2,int C2>
       class mdivide_left_ldlt_dv_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
         vari** _variRefB;
         vari** _variRefC;
         mdivide_left_ldlt_alloc<R1,C1,R2,C2> *_alloc;
@@ -202,8 +202,8 @@ namespace stan {
         mdivide_left_ldlt_dv_vari(const stan::math::LDLT_factor<double,R1,C1> &A,
                                   const Eigen::Matrix<var,R2,C2> &B)
         : vari(0.0),
-        _M(A.rows()),
-        _N(B.cols()),
+        M_(A.rows()),
+        N_(B.cols()),
         _variRefB((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                        * B.rows() * B.cols())),
         _variRefC((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
@@ -214,29 +214,29 @@ namespace stan {
           using Eigen::Map;
           
           size_t pos = 0;
-          _alloc->_C.resize(_M,_N);
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          _alloc->C_.resize(M_,N_);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefB[pos] = B(i,j).vi_;
-              _alloc->_C(i,j) = B(i,j).val();
+              _alloc->C_(i,j) = B(i,j).val();
               pos++;
             }
           }
           
           _alloc->_ldltP = A._ldltP;
-          _alloc->_ldltP->solveInPlace(_alloc->_C);
+          _alloc->_ldltP->solveInPlace(_alloc->C_);
           
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _variRefC[pos] = new vari(_alloc->_C(i,j),false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              _variRefC[pos] = new vari(_alloc->C_(i,j),false);
               pos++;
             }
           }
         }
         
         virtual void chain() {
-          Eigen::Matrix<double,R2,C2> adjB(_M,_N);
+          Eigen::Matrix<double,R2,C2> adjB(M_,N_);
           
           size_t pos = 0;
           for (size_type j = 0; j < adjB.cols(); j++)
@@ -255,8 +255,8 @@ namespace stan {
       template <int R1,int C1,int R2,int C2>
       class mdivide_left_ldlt_vd_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
         vari** _variRefC;
         mdivide_left_ldlt_alloc<R1,C1,R2,C2> *_alloc;
         const LDLT_alloc<R1,C1> *_alloc_ldlt;
@@ -264,35 +264,35 @@ namespace stan {
         mdivide_left_ldlt_vd_vari(const stan::math::LDLT_factor<var,R1,C1> &A,
                                   const Eigen::Matrix<double,R2,C2> &B)
           : vari(0.0),
-            _M(A.rows()),
-            _N(B.cols()),
+            M_(A.rows()),
+            N_(B.cols()),
             _variRefC((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                            * B.rows() * B.cols())),
             _alloc(new mdivide_left_ldlt_alloc<R1,C1,R2,C2>()),
             _alloc_ldlt(A._alloc)
         {
-          _alloc->_C = B;
-          _alloc_ldlt->_ldlt.solveInPlace(_alloc->_C);
+          _alloc->C_ = B;
+          _alloc_ldlt->_ldlt.solveInPlace(_alloc->C_);
           
           size_t pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _variRefC[pos] = new vari(_alloc->_C(i,j),false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              _variRefC[pos] = new vari(_alloc->C_(i,j),false);
               pos++;
             }
           }
         }
       
         virtual void chain() {
-          Eigen::Matrix<double,R1,C1> adjA(_M,_M);
-          Eigen::Matrix<double,R1,C2> adjC(_M,_N);
+          Eigen::Matrix<double,R1,C1> adjA(M_,M_);
+          Eigen::Matrix<double,R1,C2> adjC(M_,N_);
 
           size_t pos = 0;
           for (size_type j = 0; j < adjC.cols(); j++)
             for (size_type i = 0; i < adjC.rows(); i++)
               adjC(i,j) = _variRefC[pos++]->adj_;
         
-          adjA = -_alloc_ldlt->_ldlt.solve(adjC*_alloc->_C.transpose());
+          adjA = -_alloc_ldlt->_ldlt.solve(adjC*_alloc->C_.transpose());
 
           for (size_type j = 0; j < adjA.cols(); j++)
             for (size_type i = 0; i < adjA.rows(); i++)
@@ -373,34 +373,34 @@ namespace stan {
               Bd(i,j) = B(i,j).val();
             }
           }
-          _AinvB = _ldlt.solve(Bd);
+          AinvB_ = _ldlt.solve(Bd);
           if (haveD) 
-            _C.noalias() = Bd.transpose()*_AinvB;
+            C_.noalias() = Bd.transpose()*AinvB_;
           else
-            _value = (Bd.transpose()*_AinvB).trace();
+            _value = (Bd.transpose()*AinvB_).trace();
         }
         inline void initializeB(const Eigen::Matrix<double,R3,C3> &B,bool haveD) {
-          _AinvB = _ldlt.solve(B);
+          AinvB_ = _ldlt.solve(B);
           if (haveD) 
-            _C.noalias() = B.transpose()*_AinvB;
+            C_.noalias() = B.transpose()*AinvB_;
           else
-            _value = (B.transpose()*_AinvB).trace();
+            _value = (B.transpose()*AinvB_).trace();
         }
 
         template<int R1,int C1>
         inline void initializeD(const Eigen::Matrix<var,R1,C1> &D) {
-          _D.resize(D.rows(),D.cols());
+          D_.resize(D.rows(),D.cols());
           _variD.resize(D.rows(),D.cols());
           for (size_t j = 0; j < D.cols(); j++) {
             for (size_t i = 0; i < D.rows(); i++) {
               _variD(i,j) = D(i,j).vi_;
-              _D(i,j) = D(i,j).val();
+              D_(i,j) = D(i,j).val();
             }
           }
         }
         template<int R1,int C1>
         inline void initializeD(const Eigen::Matrix<double,R1,C1> &D) {
-          _D = D;
+          D_ = D;
         }
 
        public:
@@ -408,30 +408,30 @@ namespace stan {
         trace_inv_quad_form_ldlt_impl(const Eigen::Matrix<T1,R1,C1> &D,
                                       const stan::math::LDLT_factor<T2,R2,C2> &A,
                                       const Eigen::Matrix<T3,R3,C3> &B)
-        : _Dtype(boost::is_same<T1,var>::value?1:0),
+        : Dtype_(boost::is_same<T1,var>::value?1:0),
           _ldlt(A)
         {
           initializeB(B,true);
           initializeD(D);
           
-          _value = (_D*_C).trace();
+          _value = (D_*C_).trace();
         }
         
         trace_inv_quad_form_ldlt_impl(const stan::math::LDLT_factor<T2,R2,C2> &A,
                                       const Eigen::Matrix<T3,R3,C3> &B)
-        : _Dtype(2),
+        : Dtype_(2),
         _ldlt(A)
         {
           initializeB(B,false);
         }
         
-        const int _Dtype; // 0 = double, 1 = var, 2 = missing
+        const int Dtype_; // 0 = double, 1 = var, 2 = missing
         stan::math::LDLT_factor<T2,R2,C2> _ldlt;
-        Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> _D;
+        Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> D_;
         Eigen::Matrix<vari*,Eigen::Dynamic,Eigen::Dynamic> _variD;
         Eigen::Matrix<vari*,R3,C3> _variB;
-        Eigen::Matrix<double,R3,C3> _AinvB;
-        Eigen::Matrix<double,C3,C3> _C;
+        Eigen::Matrix<double,R3,C3> AinvB_;
+        Eigen::Matrix<double,C3,C3> C_;
         double _value;
       };
 
@@ -448,10 +448,10 @@ namespace stan {
         static inline void chainA(const double &adj,
                                   trace_inv_quad_form_ldlt_impl<var,R2,C2,T3,R3,C3> *impl) {
           Eigen::Matrix<double,R2,C2> aA;
-          if (impl->_Dtype != 2)
-            aA.noalias() = -adj*(impl->_AinvB*impl->_D.transpose()*impl->_AinvB.transpose());
+          if (impl->Dtype_ != 2)
+            aA.noalias() = -adj*(impl->AinvB_*impl->D_.transpose()*impl->AinvB_.transpose());
           else
-            aA.noalias() = -adj*(impl->_AinvB*impl->_AinvB.transpose());
+            aA.noalias() = -adj*(impl->AinvB_*impl->AinvB_.transpose());
           for (size_type j = 0; j < aA.cols(); j++)
             for (size_type i = 0; i < aA.rows(); i++)
               impl->_ldlt._alloc->_variA(i,j)->adj_ += aA(i,j);
@@ -459,10 +459,10 @@ namespace stan {
         static inline void chainB(const double &adj,
                                   trace_inv_quad_form_ldlt_impl<T2,R2,C2,var,R3,C3> *impl) {
           Eigen::Matrix<double,R3,C3> aB;
-          if (impl->_Dtype != 2)
-            aB.noalias() = adj*impl->_AinvB*(impl->_D + impl->_D.transpose());
+          if (impl->Dtype_ != 2)
+            aB.noalias() = adj*impl->AinvB_*(impl->D_ + impl->D_.transpose());
           else
-            aB.noalias() = adj*impl->_AinvB;
+            aB.noalias() = adj*impl->AinvB_;
           for (size_type j = 0; j < aB.cols(); j++)
             for (size_type i = 0; i < aB.rows(); i++)
               impl->_variB(i,j)->adj_ += aB(i,j);
@@ -482,10 +482,10 @@ namespace stan {
           
           chainB(adj_, _impl);
           
-          if (_impl->_Dtype == 1) {
+          if (_impl->Dtype_ == 1) {
             for (size_type j = 0; j < _impl->_variD.cols(); j++)
               for (size_type i = 0; i < _impl->_variD.rows(); i++)
-                _impl->_variD(i,j)->adj_ += adj_*_impl->_C(i,j);
+                _impl->_variD(i,j)->adj_ += adj_*_impl->C_(i,j);
           }
         }
 

--- a/src/stan/agrad/rev/matrix/log_determinant.hpp
+++ b/src/stan/agrad/rev/matrix/log_determinant.hpp
@@ -20,14 +20,14 @@ namespace stan {
       class log_determinant_vari : public vari {
         int _rows;
         int _cols;
-        double* _A;
+        double* A_;
         vari** _adjARef;
       public:
         log_determinant_vari(const Eigen::Matrix<var,R,C> &A)
           : vari(log_determinant_vari_calc(A)), 
             _rows(A.rows()),
             _cols(A.cols()),
-            _A((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            A_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * A.rows() * A.cols())),
             _adjARef((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                           * A.rows() * A.cols()))
@@ -35,7 +35,7 @@ namespace stan {
           size_t pos = 0;
           for (size_type j = 0; j < _cols; j++) {
             for (size_type i = 0; i < _rows; i++) {
-              _A[pos] = A(i,j).val();
+              A_[pos] = A(i,j).val();
               _adjARef[pos++] = A(i,j).vi_;
             }
           }
@@ -54,7 +54,7 @@ namespace stan {
           using Eigen::Map;
           Matrix<double,R,C> adjA(_rows,_cols);
           adjA = adj_ 
-            * Map<Matrix<double,R,C> >(_A,_rows,_cols)
+            * Map<Matrix<double,R,C> >(A_,_rows,_cols)
             .inverse().transpose();
           size_t pos = 0;
           for (size_type j = 0; j < _cols; j++) {

--- a/src/stan/agrad/rev/matrix/mdivide_left.hpp
+++ b/src/stan/agrad/rev/matrix/mdivide_left.hpp
@@ -16,10 +16,10 @@ namespace stan {
       template <int R1,int C1,int R2,int C2>
       class mdivide_left_vv_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
-        double* _A;
-        double* _C;
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
+        double* A_;
+        double* C_;
         vari** _variRefA;
         vari** _variRefB;
         vari** _variRefC;
@@ -27,11 +27,11 @@ namespace stan {
         mdivide_left_vv_vari(const Eigen::Matrix<var,R1,C1> &A,
                              const Eigen::Matrix<var,R2,C2> &B)
           : vari(0.0),
-            _M(A.rows()),
-            _N(B.cols()),
-            _A((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            M_(A.rows()),
+            N_(B.cols()),
+            A_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * A.rows() * A.cols())),
-            _C((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            C_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * B.rows() * B.cols())),
             _variRefA((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                            * A.rows() * A.cols())),
@@ -44,32 +44,32 @@ namespace stan {
           using Eigen::Map;
 
           size_t pos = 0;
-          for (size_type j = 0; j < _M; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          for (size_type j = 0; j < M_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefA[pos] = A(i,j).vi_;
-              _A[pos++] = A(i,j).val();
+              A_[pos++] = A(i,j).val();
             }
           }
   
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefB[pos] = B(i,j).vi_;
-              _C[pos++] = B(i,j).val();
+              C_[pos++] = B(i,j).val();
             }
           }
         
-          Matrix<double,R1,C2> C(_M,_N);
-          C = Map<Matrix<double,R1,C2> >(_C,_M,_N);
+          Matrix<double,R1,C2> C(M_,N_);
+          C = Map<Matrix<double,R1,C2> >(C_,M_,N_);
 
-          C = Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          C = Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .colPivHouseholderQr().solve(C);
 
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _C[pos] = C(i,j);
-              _variRefC[pos] = new vari(_C[pos],false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              C_[pos] = C(i,j);
+              _variRefC[pos] = new vari(C_[pos],false);
               pos++;
             }
           }
@@ -78,9 +78,9 @@ namespace stan {
         virtual void chain() {
           using Eigen::Matrix;
           using Eigen::Map;
-          Eigen::Matrix<double,R1,C1> adjA(_M,_M);
-          Eigen::Matrix<double,R2,C2> adjB(_M,_N);
-          Eigen::Matrix<double,R1,C2> adjC(_M,_N);
+          Eigen::Matrix<double,R1,C1> adjA(M_,M_);
+          Eigen::Matrix<double,R2,C2> adjB(M_,N_);
+          Eigen::Matrix<double,R1,C2> adjC(M_,N_);
 
           size_t pos = 0;
           for (size_type j = 0; j < adjC.cols(); j++)
@@ -88,10 +88,10 @@ namespace stan {
               adjC(i,j) = _variRefC[pos++]->adj_;
         
         
-          adjB = Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          adjB = Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .transpose().colPivHouseholderQr().solve(adjC);
           adjA.noalias() = -adjB
-            * Map<Matrix<double,R1,C2> >(_C,_M,_N).transpose();
+            * Map<Matrix<double,R1,C2> >(C_,M_,N_).transpose();
         
           pos = 0;
           for (size_type j = 0; j < adjA.cols(); j++)
@@ -108,21 +108,21 @@ namespace stan {
       template <int R1,int C1,int R2,int C2>
       class mdivide_left_dv_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
-        double* _A;
-        double* _C;
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
+        double* A_;
+        double* C_;
         vari** _variRefB;
         vari** _variRefC;
       
         mdivide_left_dv_vari(const Eigen::Matrix<double,R1,C1> &A,
                              const Eigen::Matrix<var,R2,C2> &B)
           : vari(0.0),
-            _M(A.rows()),
-            _N(B.cols()),
-            _A((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            M_(A.rows()),
+            N_(B.cols()),
+            A_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * A.rows() * A.cols())),
-            _C((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            C_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * B.rows() * B.cols())),
             _variRefB((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                            * B.rows() * B.cols())),
@@ -133,31 +133,31 @@ namespace stan {
           using Eigen::Map;
   
           size_t pos = 0;
-          for (size_type j = 0; j < _M; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _A[pos++] = A(i,j);
+          for (size_type j = 0; j < M_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              A_[pos++] = A(i,j);
             }
           }
   
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefB[pos] = B(i,j).vi_;
-              _C[pos++] = B(i,j).val();
+              C_[pos++] = B(i,j).val();
             }
           }
                 
-          Matrix<double,R1,C2> C(_M,_N);
-          C = Map<Matrix<double,R1,C2> >(_C,_M,_N);
+          Matrix<double,R1,C2> C(M_,N_);
+          C = Map<Matrix<double,R1,C2> >(C_,M_,N_);
 
-          C = Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          C = Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .colPivHouseholderQr().solve(C);
   
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _C[pos] = C(i,j);
-              _variRefC[pos] = new vari(_C[pos],false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              C_[pos] = C(i,j);
+              _variRefC[pos] = new vari(C_[pos],false);
               pos++;
             }
           }
@@ -166,15 +166,15 @@ namespace stan {
         virtual void chain() {
           using Eigen::Matrix;
           using Eigen::Map;
-          Eigen::Matrix<double,R2,C2> adjB(_M,_N);
-          Eigen::Matrix<double,R1,C2> adjC(_M,_N);
+          Eigen::Matrix<double,R2,C2> adjB(M_,N_);
+          Eigen::Matrix<double,R1,C2> adjC(M_,N_);
 
           size_t pos = 0;
           for (size_type j = 0; j < adjC.cols(); j++)
             for (size_type i = 0; i < adjC.rows(); i++)
               adjC(i,j) = _variRefC[pos++]->adj_;
 
-          adjB = Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          adjB = Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .transpose().colPivHouseholderQr().solve(adjC);
 
           pos = 0;
@@ -187,21 +187,21 @@ namespace stan {
       template <int R1,int C1,int R2,int C2>
       class mdivide_left_vd_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
-        double* _A;
-        double* _C;
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
+        double* A_;
+        double* C_;
         vari** _variRefA;
         vari** _variRefC;
       
         mdivide_left_vd_vari(const Eigen::Matrix<var,R1,C1> &A,
                              const Eigen::Matrix<double,R2,C2> &B)
           : vari(0.0),
-            _M(A.rows()),
-            _N(B.cols()),
-            _A((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            M_(A.rows()),
+            N_(B.cols()),
+            A_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * A.rows() * A.cols())),
-            _C((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            C_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * B.rows() * B.cols())),
             _variRefA((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                            * A.rows() * A.cols())),
@@ -212,22 +212,22 @@ namespace stan {
           using Eigen::Map;
 
           size_t pos = 0;
-          for (size_type j = 0; j < _M; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          for (size_type j = 0; j < M_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefA[pos] = A(i,j).vi_;
-              _A[pos++] = A(i,j).val();
+              A_[pos++] = A(i,j).val();
             }
           }
   
-          Matrix<double,R1,C2> C(_M,_N);
-          C = Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          Matrix<double,R1,C2> C(M_,N_);
+          C = Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .colPivHouseholderQr().solve(B);
 
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _C[pos] = C(i,j);
-              _variRefC[pos] = new vari(_C[pos],false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              C_[pos] = C(i,j);
+              _variRefC[pos] = new vari(C_[pos],false);
               pos++;
             }
           }
@@ -236,8 +236,8 @@ namespace stan {
         virtual void chain() {
           using Eigen::Matrix;
           using Eigen::Map;
-          Eigen::Matrix<double,R1,C1> adjA(_M,_M);
-          Eigen::Matrix<double,R1,C2> adjC(_M,_N);
+          Eigen::Matrix<double,R1,C1> adjA(M_,M_);
+          Eigen::Matrix<double,R1,C2> adjC(M_,N_);
 
           size_t pos = 0;
           for (size_type j = 0; j < adjC.cols(); j++)
@@ -245,10 +245,10 @@ namespace stan {
               adjC(i,j) = _variRefC[pos++]->adj_;
         
           // FIXME: add .noalias() to LHS
-          adjA = -Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          adjA = -Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .transpose()
             .colPivHouseholderQr()
-            .solve(adjC*Map<Matrix<double,R1,C2> >(_C,_M,_N).transpose());
+            .solve(adjC*Map<Matrix<double,R1,C2> >(C_,M_,N_).transpose());
 
           pos = 0;
           for (size_type j = 0; j < adjA.cols(); j++)

--- a/src/stan/agrad/rev/matrix/mdivide_left_spd.hpp
+++ b/src/stan/agrad/rev/matrix/mdivide_left_spd.hpp
@@ -19,14 +19,14 @@ namespace stan {
         virtual ~mdivide_left_spd_alloc() {}
 
         Eigen::LLT< Eigen::Matrix<double,R1,C1> > _llt;
-        Eigen::Matrix<double,R2,C2> _C;
+        Eigen::Matrix<double,R2,C2> C_;
       };
       
       template <int R1,int C1,int R2,int C2>
       class mdivide_left_spd_vv_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
         vari** _variRefA;
         vari** _variRefB;
         vari** _variRefC;
@@ -35,8 +35,8 @@ namespace stan {
         mdivide_left_spd_vv_vari(const Eigen::Matrix<var,R1,C1> &A,
                                  const Eigen::Matrix<var,R2,C2> &B)
           : vari(0.0),
-            _M(A.rows()),
-            _N(B.cols()),
+            M_(A.rows()),
+            N_(B.cols()),
             _variRefA((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                            * A.rows() * A.cols())),
             _variRefB((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
@@ -51,8 +51,8 @@ namespace stan {
           Matrix<double,R1,C1> Ad(A.rows(),A.cols());
           
           size_t pos = 0;
-          for (size_type j = 0; j < _M; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          for (size_type j = 0; j < M_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefA[pos] = A(i,j).vi_;
               Ad(i,j) = A(i,j).val();
               pos++;
@@ -60,22 +60,22 @@ namespace stan {
           }
   
           pos = 0;
-          _alloc->_C.resize(_M,_N);
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          _alloc->C_.resize(M_,N_);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefB[pos] = B(i,j).vi_;
-              _alloc->_C(i,j) = B(i,j).val();
+              _alloc->C_(i,j) = B(i,j).val();
               pos++;
             }
           }
         
           _alloc->_llt = Ad.llt();
-          _alloc->_llt.solveInPlace(_alloc->_C);
+          _alloc->_llt.solveInPlace(_alloc->C_);
 
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _variRefC[pos] = new vari(_alloc->_C(i,j),false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              _variRefC[pos] = new vari(_alloc->C_(i,j),false);
               pos++;
             }
           }
@@ -84,25 +84,25 @@ namespace stan {
         virtual void chain() {
           using Eigen::Matrix;
           using Eigen::Map;
-          Eigen::Matrix<double,R1,C1> adjA(_M,_M);
-          Eigen::Matrix<double,R2,C2> adjB(_M,_N);
+          Eigen::Matrix<double,R1,C1> adjA(M_,M_);
+          Eigen::Matrix<double,R2,C2> adjB(M_,N_);
 
           size_t pos = 0;
-          for (size_type j = 0; j < _N; j++)
-            for (size_type i = 0; i < _M; i++)
+          for (size_type j = 0; j < N_; j++)
+            for (size_type i = 0; i < M_; i++)
               adjB(i,j) = _variRefC[pos++]->adj_;
 
           _alloc->_llt.solveInPlace(adjB);
-          adjA.noalias() = -adjB * _alloc->_C.transpose();
+          adjA.noalias() = -adjB * _alloc->C_.transpose();
         
           pos = 0;
-          for (size_type j = 0; j < _M; j++)
-            for (size_type i = 0; i < _M; i++)
+          for (size_type j = 0; j < M_; j++)
+            for (size_type i = 0; i < M_; i++)
               _variRefA[pos++]->adj_ += adjA(i,j);
         
           pos = 0;
-          for (size_type j = 0; j < _N; j++)
-            for (size_type i = 0; i < _M; i++)
+          for (size_type j = 0; j < N_; j++)
+            for (size_type i = 0; i < M_; i++)
               _variRefB[pos++]->adj_ += adjB(i,j);
         }
       };
@@ -110,8 +110,8 @@ namespace stan {
       template <int R1,int C1,int R2,int C2>
       class mdivide_left_spd_dv_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
         vari** _variRefB;
         vari** _variRefC;
         mdivide_left_spd_alloc<R1,C1,R2,C2> *_alloc;
@@ -119,8 +119,8 @@ namespace stan {
         mdivide_left_spd_dv_vari(const Eigen::Matrix<double,R1,C1> &A,
                                  const Eigen::Matrix<var,R2,C2> &B)
           : vari(0.0),
-            _M(A.rows()),
-            _N(B.cols()),
+            M_(A.rows()),
+            N_(B.cols()),
             _variRefB((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                            * B.rows() * B.cols())),
             _variRefC((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
@@ -131,22 +131,22 @@ namespace stan {
           using Eigen::Map;
   
           size_t pos = 0;
-          _alloc->_C.resize(_M,_N);
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          _alloc->C_.resize(M_,N_);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefB[pos] = B(i,j).vi_;
-              _alloc->_C(i,j) = B(i,j).val();
+              _alloc->C_(i,j) = B(i,j).val();
               pos++;
             }
           }
 
           _alloc->_llt = A.llt();
-          _alloc->_llt.solveInPlace(_alloc->_C);
+          _alloc->_llt.solveInPlace(_alloc->C_);
           
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _variRefC[pos] = new vari(_alloc->_C(i,j),false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              _variRefC[pos] = new vari(_alloc->C_(i,j),false);
               pos++;
             }
           }
@@ -155,7 +155,7 @@ namespace stan {
         virtual void chain() {
           using Eigen::Matrix;
           using Eigen::Map;
-          Eigen::Matrix<double,R2,C2> adjB(_M,_N);
+          Eigen::Matrix<double,R2,C2> adjB(M_,N_);
 
           size_t pos = 0;
           for (size_type j = 0; j < adjB.cols(); j++)
@@ -174,8 +174,8 @@ namespace stan {
       template <int R1,int C1,int R2,int C2>
       class mdivide_left_spd_vd_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
         vari** _variRefA;
         vari** _variRefC;
         mdivide_left_spd_alloc<R1,C1,R2,C2> *_alloc;
@@ -183,8 +183,8 @@ namespace stan {
         mdivide_left_spd_vd_vari(const Eigen::Matrix<var,R1,C1> &A,
                                  const Eigen::Matrix<double,R2,C2> &B)
           : vari(0.0),
-            _M(A.rows()),
-            _N(B.cols()),
+            M_(A.rows()),
+            N_(B.cols()),
             _variRefA((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                            * A.rows() * A.cols())),
             _variRefC((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
@@ -197,8 +197,8 @@ namespace stan {
           Matrix<double,R1,C1> Ad(A.rows(),A.cols());
           
           size_t pos = 0;
-          for (size_type j = 0; j < _M; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          for (size_type j = 0; j < M_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefA[pos] = A(i,j).vi_;
               Ad(i,j) = A(i,j).val();
               pos++;
@@ -206,12 +206,12 @@ namespace stan {
           }
           
           _alloc->_llt = Ad.llt();
-          _alloc->_C = _alloc->_llt.solve(B);
+          _alloc->C_ = _alloc->_llt.solve(B);
           
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _variRefC[pos] = new vari(_alloc->_C(i,j),false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              _variRefC[pos] = new vari(_alloc->C_(i,j),false);
               pos++;
             }
           }
@@ -220,15 +220,15 @@ namespace stan {
         virtual void chain() {
           using Eigen::Matrix;
           using Eigen::Map;
-          Eigen::Matrix<double,R1,C1> adjA(_M,_M);
-          Eigen::Matrix<double,R1,C2> adjC(_M,_N);
+          Eigen::Matrix<double,R1,C1> adjA(M_,M_);
+          Eigen::Matrix<double,R1,C2> adjC(M_,N_);
 
           size_t pos = 0;
           for (size_type j = 0; j < adjC.cols(); j++)
             for (size_type i = 0; i < adjC.rows(); i++)
               adjC(i,j) = _variRefC[pos++]->adj_;
         
-          adjA = -_alloc->_llt.solve(adjC*_alloc->_C.transpose());
+          adjA = -_alloc->_llt.solve(adjC*_alloc->C_.transpose());
 
           pos = 0;
           for (size_type j = 0; j < adjA.cols(); j++)

--- a/src/stan/agrad/rev/matrix/mdivide_left_tri.hpp
+++ b/src/stan/agrad/rev/matrix/mdivide_left_tri.hpp
@@ -16,10 +16,10 @@ namespace stan {
       template <int TriView,int R1,int C1,int R2,int C2>
       class mdivide_left_tri_vv_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
-        double* _A;
-        double* _C;
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
+        double* A_;
+        double* C_;
         vari** _variRefA;
         vari** _variRefB;
         vari** _variRefC;
@@ -27,11 +27,11 @@ namespace stan {
         mdivide_left_tri_vv_vari(const Eigen::Matrix<var,R1,C1> &A,
                                  const Eigen::Matrix<var,R2,C2> &B)
           : vari(0.0),
-            _M(A.rows()),
-            _N(B.cols()),
-            _A((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            M_(A.rows()),
+            N_(B.cols()),
+            A_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * A.rows() * A.cols())),
-            _C((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            C_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * B.rows() * B.cols())),
             _variRefA((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                            * A.rows() 
@@ -46,41 +46,41 @@ namespace stan {
 
           size_t pos = 0;
           if (TriView == Eigen::Lower) {
-            for (size_type j = 0; j < _M; j++)
-              for (size_type i = j; i < _M; i++)
+            for (size_type j = 0; j < M_; j++)
+              for (size_type i = j; i < M_; i++)
                 _variRefA[pos++] = A(i,j).vi_;
           } else if (TriView == Eigen::Upper) {
-            for (size_type j = 0; j < _M; j++)
+            for (size_type j = 0; j < M_; j++)
               for (size_type i = 0; i < j+1; i++)
                 _variRefA[pos++] = A(i,j).vi_;
           }
 
           pos = 0;
-          for (size_type j = 0; j < _M; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _A[pos++] = A(i,j).val();
+          for (size_type j = 0; j < M_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              A_[pos++] = A(i,j).val();
             }
           }
   
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefB[pos] = B(i,j).vi_;
-              _C[pos++] = B(i,j).val();
+              C_[pos++] = B(i,j).val();
             }
           }
         
-          Matrix<double,R1,C2> C(_M,_N);
-          C = Map<Matrix<double,R1,C2> >(_C,_M,_N);
+          Matrix<double,R1,C2> C(M_,N_);
+          C = Map<Matrix<double,R1,C2> >(C_,M_,N_);
 
-          C = Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          C = Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .template triangularView<TriView>().solve(C);
 
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _C[pos] = C(i,j);
-              _variRefC[pos] = new vari(_C[pos],false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              C_[pos] = C(i,j);
+              _variRefC[pos] = new vari(C_[pos],false);
               pos++;
             }
           }
@@ -90,19 +90,19 @@ namespace stan {
         virtual void chain() {
           using Eigen::Matrix;
           using Eigen::Map;
-          Matrix<double,R1,C1> adjA(_M,_M);
-          Matrix<double,R2,C2> adjB(_M,_N);
-          Matrix<double,R1,C2> adjC(_M,_N);
+          Matrix<double,R1,C1> adjA(M_,M_);
+          Matrix<double,R2,C2> adjB(M_,N_);
+          Matrix<double,R1,C2> adjC(M_,N_);
 
           size_t pos = 0;
           for (size_type j = 0; j < adjC.cols(); j++)
             for (size_type i = 0; i < adjC.rows(); i++)
               adjC(i,j) = _variRefC[pos++]->adj_;
         
-          adjB = Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          adjB = Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .template triangularView<TriView>().transpose().solve(adjC);
           adjA.noalias() = -adjB
-            * Map<Matrix<double,R1,C2> >(_C,_M,_N).transpose();
+            * Map<Matrix<double,R1,C2> >(C_,M_,N_).transpose();
         
           pos = 0;
           if (TriView == Eigen::Lower) {
@@ -125,21 +125,21 @@ namespace stan {
       template <int TriView,int R1,int C1,int R2,int C2>
       class mdivide_left_tri_dv_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
-        double* _A;
-        double* _C;
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
+        double* A_;
+        double* C_;
         vari** _variRefB;
         vari** _variRefC;
       
         mdivide_left_tri_dv_vari(const Eigen::Matrix<double,R1,C1> &A,
                                  const Eigen::Matrix<var,R2,C2> &B)
           : vari(0.0),
-            _M(A.rows()),
-            _N(B.cols()),
-            _A((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            M_(A.rows()),
+            N_(B.cols()),
+            A_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * A.rows() * A.cols())),
-            _C((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            C_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * B.rows() * B.cols())),
             _variRefB((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                            * B.rows() * B.cols())),
@@ -150,31 +150,31 @@ namespace stan {
           using Eigen::Map;
 
           size_t pos = 0;
-          for (size_type j = 0; j < _M; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _A[pos++] = A(i,j);
+          for (size_type j = 0; j < M_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              A_[pos++] = A(i,j);
             }
           }
 
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
               _variRefB[pos] = B(i,j).vi_;
-              _C[pos++] = B(i,j).val();
+              C_[pos++] = B(i,j).val();
             }
           }
 
-          Matrix<double,R1,C2> C(_M,_N);
-          C = Map<Matrix<double,R1,C2> >(_C,_M,_N);
+          Matrix<double,R1,C2> C(M_,N_);
+          C = Map<Matrix<double,R1,C2> >(C_,M_,N_);
   
-          C = Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          C = Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .template triangularView<TriView>().solve(C);
 
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _C[pos] = C(i,j);
-              _variRefC[pos] = new vari(_C[pos],false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              C_[pos] = C(i,j);
+              _variRefC[pos] = new vari(C_[pos],false);
               pos++;
             }
           }
@@ -183,15 +183,15 @@ namespace stan {
         virtual void chain() {
           using Eigen::Matrix;
           using Eigen::Map;
-          Matrix<double,R2,C2> adjB(_M,_N);
-          Matrix<double,R1,C2> adjC(_M,_N);
+          Matrix<double,R2,C2> adjB(M_,N_);
+          Matrix<double,R1,C2> adjC(M_,N_);
 
           size_t pos = 0;
           for (size_type j = 0; j < adjC.cols(); j++)
             for (size_type i = 0; i < adjC.rows(); i++)
               adjC(i,j) = _variRefC[pos++]->adj_;
 
-          adjB = Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          adjB = Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .template triangularView<TriView>().transpose().solve(adjC);
   
           pos = 0;
@@ -204,21 +204,21 @@ namespace stan {
       template <int TriView,int R1,int C1,int R2,int C2>
       class mdivide_left_tri_vd_vari : public vari {
       public:
-        int _M; // A.rows() = A.cols() = B.rows()
-        int _N; // B.cols()
-        double* _A;
-        double* _C;
+        int M_; // A.rows() = A.cols() = B.rows()
+        int N_; // B.cols()
+        double* A_;
+        double* C_;
         vari** _variRefA;
         vari** _variRefC;
 
         mdivide_left_tri_vd_vari(const Eigen::Matrix<var,R1,C1> &A,
                                  const Eigen::Matrix<double,R2,C2> &B)
           : vari(0.0),
-            _M(A.rows()),
-            _N(B.cols()),
-            _A((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            M_(A.rows()),
+            N_(B.cols()),
+            A_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * A.rows() * A.cols())),
-            _C((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
+            C_((double*)stan::agrad::memalloc_.alloc(sizeof(double) 
                                                      * B.rows() * B.cols())),
             _variRefA((vari**)stan::agrad::memalloc_.alloc(sizeof(vari*) 
                                                            * A.rows() 
@@ -231,31 +231,31 @@ namespace stan {
 
           size_t pos = 0;
           if (TriView == Eigen::Lower) {
-            for (size_type j = 0; j < _M; j++)
-              for (size_type i = j; i < _M; i++)
+            for (size_type j = 0; j < M_; j++)
+              for (size_type i = j; i < M_; i++)
                 _variRefA[pos++] = A(i,j).vi_;
           } else if (TriView == Eigen::Upper) {
-            for (size_type j = 0; j < _M; j++)
+            for (size_type j = 0; j < M_; j++)
               for (size_type i = 0; i < j+1; i++)
                 _variRefA[pos++] = A(i,j).vi_;
           } 
 
           pos = 0;
-          for (size_type j = 0; j < _M; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _A[pos++] = A(i,j).val();
+          for (size_type j = 0; j < M_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              A_[pos++] = A(i,j).val();
             }
           }
 
-          Matrix<double,R1,C2> C(_M,_N);
-          C = Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          Matrix<double,R1,C2> C(M_,N_);
+          C = Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .template triangularView<TriView>().solve(B);
 
           pos = 0;
-          for (size_type j = 0; j < _N; j++) {
-            for (size_type i = 0; i < _M; i++) {
-              _C[pos] = C(i,j);
-              _variRefC[pos] = new vari(_C[pos],false);
+          for (size_type j = 0; j < N_; j++) {
+            for (size_type i = 0; i < M_; i++) {
+              C_[pos] = C(i,j);
+              _variRefC[pos] = new vari(C_[pos],false);
               pos++;
             }
           }
@@ -264,17 +264,17 @@ namespace stan {
         virtual void chain() {
           using Eigen::Matrix;
           using Eigen::Map;
-          Matrix<double,R1,C1> adjA(_M,_M);
-          Matrix<double,R1,C2> adjC(_M,_N);
+          Matrix<double,R1,C1> adjA(M_,M_);
+          Matrix<double,R1,C2> adjC(M_,N_);
         
           size_t pos = 0;
           for (size_type j = 0; j < adjC.cols(); j++)
             for (size_type i = 0; i < adjC.rows(); i++)
               adjC(i,j) = _variRefC[pos++]->adj_;
 
-          adjA.noalias() = -Map<Matrix<double,R1,C1> >(_A,_M,_M)
+          adjA.noalias() = -Map<Matrix<double,R1,C1> >(A_,M_,M_)
             .template triangularView<TriView>()
-            .transpose().solve(adjC*Map<Matrix<double,R1,C2> >(_C,_M,_N).transpose());
+            .transpose().solve(adjC*Map<Matrix<double,R1,C2> >(C_,M_,N_).transpose());
   
           pos = 0;
           if (TriView == Eigen::Lower) {

--- a/src/stan/agrad/rev/matrix/quad_form.hpp
+++ b/src/stan/agrad/rev/matrix/quad_form.hpp
@@ -24,13 +24,13 @@ namespace stan {
         {
           size_t i,j;
           Eigen::Matrix<double,CB,CB> Cd(B.transpose()*A*B);
-          for (j = 0; j < _C.cols(); j++) {
-            for (i = 0; i < _C.rows(); i++) {
+          for (j = 0; j < C_.cols(); j++) {
+            for (i = 0; i < C_.rows(); i++) {
               if (_sym) {
-                _C(i,j) = var(new vari(0.5*(Cd(i,j) + Cd(j,i)),false));
+                C_(i,j) = var(new vari(0.5*(Cd(i,j) + Cd(j,i)),false));
               }
               else {
-                _C(i,j) = var(new vari(Cd(i,j),false));
+                C_(i,j) = var(new vari(Cd(i,j),false));
               }
             }
           }
@@ -40,14 +40,14 @@ namespace stan {
         quad_form_vari_alloc(const Eigen::Matrix<TA,RA,CA> &A,
                              const Eigen::Matrix<TB,RB,CB> &B,
                              bool symmetric = false)
-        : _A(A), _B(B), _C(_B.cols(),_B.cols()), _sym(symmetric)
+        : A_(A), B_(B), C_(B_.cols(),B_.cols()), _sym(symmetric)
         {
           compute(value_of(A),value_of(B));
         }
         
-        Eigen::Matrix<TA,RA,CA>  _A;
-        Eigen::Matrix<TB,RB,CB>  _B;
-        Eigen::Matrix<var,CB,CB> _C;
+        Eigen::Matrix<TA,RA,CA>  A_;
+        Eigen::Matrix<TB,RB,CB>  B_;
+        Eigen::Matrix<var,CB,CB> C_;
         bool                     _sym;
       };
       
@@ -106,14 +106,14 @@ namespace stan {
         
         virtual void chain() {
           size_t i,j;
-          Eigen::Matrix<double,CB,CB> adjC(_impl->_C.rows(),_impl->_C.cols());
+          Eigen::Matrix<double,CB,CB> adjC(_impl->C_.rows(),_impl->C_.cols());
           
-          for (j = 0; j < _impl->_C.cols(); j++)
-            for (i = 0; i < _impl->_C.rows(); i++)
-              adjC(i,j) = _impl->_C(i,j).vi_->adj_;
+          for (j = 0; j < _impl->C_.cols(); j++)
+            for (i = 0; i < _impl->C_.rows(); i++)
+              adjC(i,j) = _impl->C_(i,j).vi_->adj_;
           
-          chainAB(_impl->_A, _impl->_B,
-                  value_of(_impl->_A), value_of(_impl->_B),
+          chainAB(_impl->A_, _impl->B_,
+                  value_of(_impl->A_), value_of(_impl->B_),
                   adjC);
         };
 
@@ -134,7 +134,7 @@ namespace stan {
       
       quad_form_vari<TA,RA,CA,TB,RB,CB> *baseVari = new quad_form_vari<TA,RA,CA,TB,RB,CB>(A,B);
       
-      return baseVari->_impl->_C;
+      return baseVari->_impl->C_;
     }
     template<typename TA,int RA,int CA,typename TB,int RB>
     inline typename
@@ -149,7 +149,7 @@ namespace stan {
       
       quad_form_vari<TA,RA,CA,TB,RB,1> *baseVari = new quad_form_vari<TA,RA,CA,TB,RB,1>(A,B);
       
-      return baseVari->_impl->_C(0,0);
+      return baseVari->_impl->C_(0,0);
     }
     
     template<typename TA,int RA,int CA,typename TB,int RB,int CB>
@@ -166,7 +166,7 @@ namespace stan {
       
       quad_form_vari<TA,RA,CA,TB,RB,CB> *baseVari = new quad_form_vari<TA,RA,CA,TB,RB,CB>(A,B,true);
       
-      return baseVari->_impl->_C;
+      return baseVari->_impl->C_;
     }
     template<typename TA,int RA,int CA,typename TB,int RB>
     inline typename
@@ -182,7 +182,7 @@ namespace stan {
       
       quad_form_vari<TA,RA,CA,TB,RB,1> *baseVari = new quad_form_vari<TA,RA,CA,TB,RB,1>(A,B,true);
       
-      return baseVari->_impl->_C(0,0);
+      return baseVari->_impl->C_(0,0);
     }
   }
 }

--- a/src/stan/agrad/rev/matrix/trace_gen_quad_form.hpp
+++ b/src/stan/agrad/rev/matrix/trace_gen_quad_form.hpp
@@ -24,18 +24,18 @@ namespace stan {
         trace_gen_quad_form_vari_alloc(const Eigen::Matrix<TD,RD,CD> &D,
                                        const Eigen::Matrix<TA,RA,CA> &A,
                                        const Eigen::Matrix<TB,RB,CB> &B)
-        : _D(D), _A(A), _B(B)
+        : D_(D), A_(A), B_(B)
         { }
         
         double compute() {
-          return stan::math::trace_gen_quad_form(value_of(_D),
-                                                 value_of(_A),
-                                                 value_of(_B));
+          return stan::math::trace_gen_quad_form(value_of(D_),
+                                                 value_of(A_),
+                                                 value_of(B_));
         }
         
-        Eigen::Matrix<TD,RD,CD>  _D;
-        Eigen::Matrix<TA,RA,CA>  _A;
-        Eigen::Matrix<TB,RB,CB>  _B;
+        Eigen::Matrix<TD,RD,CD>  D_;
+        Eigen::Matrix<TA,RA,CA>  A_;
+        Eigen::Matrix<TB,RB,CB>  B_;
       };
       
       template<typename TD,int RD,int CD,
@@ -88,12 +88,12 @@ namespace stan {
         
         virtual void chain() {
           computeAdjoints(adj_,
-                          value_of(_impl->_D),
-                          value_of(_impl->_A),
-                          value_of(_impl->_B),
-                          (Eigen::Matrix<var,RD,CD>*)(boost::is_same<TD,var>::value?(&_impl->_D):NULL),
-                          (Eigen::Matrix<var,RA,CA>*)(boost::is_same<TA,var>::value?(&_impl->_A):NULL),
-                          (Eigen::Matrix<var,RB,CB>*)(boost::is_same<TB,var>::value?(&_impl->_B):NULL));
+                          value_of(_impl->D_),
+                          value_of(_impl->A_),
+                          value_of(_impl->B_),
+                          (Eigen::Matrix<var,RD,CD>*)(boost::is_same<TD,var>::value?(&_impl->D_):NULL),
+                          (Eigen::Matrix<var,RA,CA>*)(boost::is_same<TA,var>::value?(&_impl->A_):NULL),
+                          (Eigen::Matrix<var,RB,CB>*)(boost::is_same<TB,var>::value?(&_impl->B_):NULL));
         }
         
         trace_gen_quad_form_vari_alloc<TD,RD,CD,TA,RA,CA,TB,RB,CB> *_impl;

--- a/src/stan/agrad/rev/matrix/trace_quad_form.hpp
+++ b/src/stan/agrad/rev/matrix/trace_quad_form.hpp
@@ -21,16 +21,16 @@ namespace stan {
       public:
         trace_quad_form_vari_alloc(const Eigen::Matrix<TA,RA,CA> &A,
                                    const Eigen::Matrix<TB,RB,CB> &B)
-        : _A(A), _B(B)
+        : A_(A), B_(B)
         { }
         
         double compute() {
-          return stan::math::trace_quad_form(value_of(_A),
-                                             value_of(_B));
+          return stan::math::trace_quad_form(value_of(A_),
+                                             value_of(B_));
         }
         
-        Eigen::Matrix<TA,RA,CA>  _A;
-        Eigen::Matrix<TB,RB,CB>  _B;
+        Eigen::Matrix<TA,RA,CA>  A_;
+        Eigen::Matrix<TB,RB,CB>  B_;
       };
       
       template<typename TA,int RA,int CA,typename TB,int RB,int CB>
@@ -82,8 +82,8 @@ namespace stan {
         : vari(impl->compute()), _impl(impl) { }
         
         virtual void chain() {
-          chainAB(_impl->_A, _impl->_B,
-                  value_of(_impl->_A), value_of(_impl->_B),
+          chainAB(_impl->A_, _impl->B_,
+                  value_of(_impl->A_), value_of(_impl->B_),
                   adj_);
         };
 

--- a/src/stan/math/matrix/ldlt.hpp
+++ b/src/stan/math/matrix/ldlt.hpp
@@ -18,16 +18,16 @@ namespace stan {
     template<int R, int C>
     class LDLT_factor<double,R,C> {
     public:
-      LDLT_factor() : _N(0) {}
+      LDLT_factor() : N_(0) {}
       LDLT_factor(const Eigen::Matrix<double,R,C> &A)
-      : _N(0), _ldltP(new Eigen::LDLT< Eigen::Matrix<double,R,C> >())
+      : N_(0), _ldltP(new Eigen::LDLT< Eigen::Matrix<double,R,C> >())
       {
         compute(A);
       }
       
       inline void compute(const Eigen::Matrix<double,R,C> &A) {
         stan::math::validate_square(A,"LDLT_factor<double>::compute");
-        _N = A.rows();
+        N_ = A.rows();
         _ldltP->compute(A);
       }
       
@@ -44,7 +44,7 @@ namespace stan {
       }
       
       inline void inverse(Eigen::Matrix<double,R,C> &invA) const {
-        invA.setIdentity(_N);
+        invA.setIdentity(N_);
         _ldltP->solveInPlace(invA);
       }
 
@@ -58,12 +58,12 @@ namespace stan {
         return _ldltP->solve(B.transpose()).transpose();
       }
       
-      inline size_t rows() const { return _N; }
-      inline size_t cols() const { return _N; }
+      inline size_t rows() const { return N_; }
+      inline size_t cols() const { return N_; }
       
       typedef size_t size_type;
 
-      size_t _N;
+      size_t N_;
       boost::shared_ptr< Eigen::LDLT< Eigen::Matrix<double,R,C> > > _ldltP;
     };
     

--- a/src/stan/mcmc/hmc/static/base_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/base_static_hmc.hpp
@@ -20,7 +20,7 @@ namespace stan {
     public:
       
       base_static_hmc(M &m, BaseRNG& rng, std::ostream* o, std::ostream* e):
-      base_hmc<M, P, H, I, BaseRNG>(m, rng, o, e), _T(1)
+      base_hmc<M, P, H, I, BaseRNG>(m, rng, o, e), T_(1)
       { _update_L(); }
       
       ~base_static_hmc() {};
@@ -38,7 +38,7 @@ namespace stan {
 
         double H0 = this->_hamiltonian.H(this->_z);
         
-        for (int i = 0; i < _L; ++i) {
+        for (int i = 0; i < L_; ++i) {
           this->_integrator.evolve(this->_z, this->_hamiltonian, this->_epsilon);
         }
         
@@ -62,7 +62,7 @@ namespace stan {
       }
       
       void write_sampler_params(std::ostream& o) {
-        o << this->_epsilon << "," << this->_T << ",";
+        o << this->_epsilon << "," << this->T_ << ",";
       }
       
       void get_sampler_param_names(std::vector<std::string>& names) {
@@ -72,24 +72,24 @@ namespace stan {
       
       void get_sampler_params(std::vector<double>& values) {
         values.push_back(this->_epsilon);
-        values.push_back(this->_T);
+        values.push_back(this->T_);
       }
       
       void set_nominal_stepsize_and_T(const double e, const double t) {
         if(e > 0 && t > 0) {
-          this->_nom_epsilon = e; _T = t; _update_L();
+          this->_nom_epsilon = e; T_ = t; _update_L();
         }
       }
       
       void set_nominal_stepsize_and_L(const double e, const int l) {
         if(e > 0 && l > 0) {
-          this->_nom_epsilon = e; _L = l; _T = this->_nom_epsilon * _L;
+          this->_nom_epsilon = e; L_ = l; T_ = this->_nom_epsilon * L_;
         }
       }
       
       void set_T(const double t) { 
         if(t > 0) {
-          _T = t; _update_L();
+          T_ = t; _update_L();
         }
         
       }
@@ -100,17 +100,17 @@ namespace stan {
         }
       }
       
-      double get_T() { return this->_T; }
-      int get_L() { return this->_L; }
+      double get_T() { return this->T_; }
+      int get_L() { return this->L_; }
       
     protected:
       
-      double _T;
-      int _L;
+      double T_;
+      int L_;
       
       void _update_L() { 
-        _L = static_cast<int>(_T / this->_nom_epsilon);
-        _L = _L < 1 ? 1 : _L;
+        L_ = static_cast<int>(T_ / this->_nom_epsilon);
+        L_ = L_ < 1 ? 1 : L_;
       }
       
     };


### PR DESCRIPTION
This should be good to go and fix the issue, at least insofar as it was caused by variables beginning with underscores followed by a capital letter.  The incantation from Betancourt

```
grep -R '[ ,>\.]__*[A-Z]' * | grep -v 'lib/boost' | grep -v 'lib/eigen' | grep -v 'lib/gtest' | grep -v '#' > fix-underscore.txt
```

worked well to find issues and is now coming up clean.

I would hold off on merging to see if we can get the original bug reporter (or someone else) to try a Cygwin build. 
