### PR TITLE
give up on newton backtracking eventually

### DIFF
--- a/src/stan/optimization/newton.hpp
+++ b/src/stan/optimization/newton.hpp
@@ -54,9 +54,14 @@ namespace stan {
 
         std::vector<double> new_params_r(params_r.size());
         double step_size = 2;
+        double min_step_size = 1e-50;
         double f1 = -1e100;
-        while (!(f1 >= f0)) {
+
+        while (f1 < f0) {
           step_size *= 0.5;
+          if (step_size < min_step_size)
+            return f0;
+
           for (size_t i = 0; i < params_r.size(); i++)
             new_params_r[i] = params_r[i] - step_size * g[i];
           try {


### PR DESCRIPTION
Currently, if optimizing using Newton's method it can get stuck in an infinite loop in the line search if it so happened that a relatively large step brought us to within very close of the optimum. For example, try:

```
$ make -j4 models/misc/eight_schools/eight_schools
[...]
$ cd models/misc/eight_schools
$ ./eight_schools --data=eight_schools.data.R --point_estimate_newton --seed=1
[...]
Iteration 26. Log joint probability =    128.391. Improved by 5.14807.
```

where it'll stay forever, trying to take another step but the step size never gets small enough. Eventually, of course, `step_size` becomes `nan` and then it'll never work.

This patch has the search give up and not modify the state once the step size gets below 1e-50 (about 167 backtracks). In that case, the output ends with:

```
Iteration 26. Log joint probability =    128.391. Improved by 5.14807.
Iteration 27. Log joint probability =    128.391. Improved by 0.
```

I think 1e-50 is a fairly conservative choice, but maybe it should be smaller.
