### PR TITLE
When dimensions don't match, print out the variable name

### DIFF
--- a/src/stan/io/var_context.hpp
+++ b/src/stan/io/var_context.hpp
@@ -151,6 +151,7 @@ namespace stan {
           std::stringstream msg;
           msg << "mismatch in number dimensions declared and found in context"
               << "; processing stage=" << stage
+              << "; variable name=" << name
               << "; dims declared=";
           add_vec(msg,dims_declared);
           msg << "; dims found=";
@@ -162,6 +163,7 @@ namespace stan {
             std::stringstream msg;
             msg << "mismatch in dimension declared and found in context"
                 << "; processing stage=" << stage
+                << "; variable name=" << name
                 << "; position="
                 << i
                 << "; dims declared=";


### PR DESCRIPTION
Currently, the error messages were very hard to use because the actual variable wasn't being reported.  This fixes that.
