### PR TITLE
Feature/issue 193 (reserve function names)

### DIFF
--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -1065,6 +1065,12 @@ a period character.
 
 \subsection{Reserved Names}
 
+Stan reserves many strings for internal use and these may not be used
+as the name of a variable.  An attempt to name a variable after an
+internal string results in the \code{stanc} translator halting with an
+error message indicating which reserved name was used and its location
+in the model code.
+
 \subsubsection{Model Name}
 
 The name of the model cannot be used as a variable within the model.
@@ -1113,7 +1119,7 @@ any of the following.
 \code{cov\_matrix}.
 \end{quote}
 %
-Variable names will not conflict with the following block identifiers,
+Variable names will {\it not}\ conflict with the following block identifiers,
 %
 \begin{quote}
 \code{model},
@@ -1124,9 +1130,6 @@ Variable names will not conflict with the following block identifiers,
 \code{generated},
 \end{quote}
 %
-nor will they conflict with the names of predefined functions or
-distributions.  Nevertheless, these names should be avoided for the
-sake of program clarity.
 
 \subsubsection{Reserved Names from Stan Implementation}
 
@@ -1138,8 +1141,21 @@ var
 fvar
 \end{quote}.
 %
-Most variables used in the implementation are suffixed with
-\code{\_\_}, so there is little chance of conflict.
+
+\subsubsection{Reserved Function and Distribution Names}
+
+Variable names will conflict with the names of predefined functions
+other than constants.  Thus a variable may not be named \code{logit}
+or \code{add}, but it may be named \code{pi} or \code{e}.
+
+Variable names will also conflict with the names of distributions
+suffixed with \code{\_log}, \code{\_cdf}, \code{\_cdf\_log},
+and \code{\_ccdf\_log}, such as \code{normal\_cdf\_log}.
+
+Using any of these variable names causes the \code{stanc} translator
+to halt and report the name and location of the variable causing the
+conflict.
+
 
 \subsubsection{Reserved Names from C++}
 

--- a/src/stan/gm/ast.hpp
+++ b/src/stan/gm/ast.hpp
@@ -4,6 +4,8 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <map>
+#include <set>
 
 #include <boost/variant/recursive_variant.hpp>
 
@@ -149,6 +151,7 @@ namespace stan {
       expr_type get_result_type(const std::string& name,
                                 const std::vector<expr_type>& args,
                                 std::ostream& error_msgs);
+      std::set<std::string> key_set() const;
     private:
       function_signatures(); 
       function_signatures(const function_signatures& fs);

--- a/src/stan/gm/ast_def.cpp
+++ b/src/stan/gm/ast_def.cpp
@@ -301,6 +301,21 @@ namespace stan {
     function_signatures::function_signatures() { 
 #include <stan/gm/function_signatures.h>
     }
+    std::set<std::string>
+    function_signatures::key_set() const {
+      using std::map;
+      using std::set;
+      using std::string;
+      using std::vector;
+      // inefficient:  if used intensively, should provide const iterator adaptor
+      set<string> result;
+      for (map<string,vector<function_signature_t> >::const_iterator it = sigs_map_.begin();
+           it != sigs_map_.end();
+           ++it)
+        result.insert(it->first);
+      return result;
+    }
+
     function_signatures* function_signatures::sigs_ = 0;
 
 

--- a/src/stan/gm/grammars/term_grammar_def.hpp
+++ b/src/stan/gm/grammars/term_grammar_def.hpp
@@ -210,7 +210,8 @@ namespace stan {
           sft(f,error_msgs);
           return expression(f);
         }
-        fun f("divide_left",args);
+        fun f("divide_left",args); // this doesn't exist, so will
+                                   // throw error on purpose
         sft(f,error_msgs);
         return expression(f);
       }

--- a/src/stan/gm/grammars/var_decls_grammar_def.hpp
+++ b/src/stan/gm/grammars/var_decls_grammar_def.hpp
@@ -15,6 +15,7 @@
 #include <boost/fusion/include/std_pair.hpp>
 #include <boost/config/warning_disable.hpp>
 #include <boost/spirit/include/qi_numeric.hpp>
+#include <stan/gm/ast.hpp>
 #include <stan/gm/grammars/var_decls_grammar.hpp>
 #include <stan/gm/grammars/common_adaptors_def.hpp>
 
@@ -411,7 +412,29 @@ namespace stan {
         reserve("while"); 
         reserve("xor"); 
         reserve("xor_eq");
-      }      
+
+        // function names declared in signatures
+        using stan::gm::function_signatures;
+        using std::set;
+        using std::string;
+        const function_signatures& sigs = function_signatures::instance();
+        set<string> fun_names = sigs.key_set();
+        fun_names.erase("pi");
+        fun_names.erase("e");
+        fun_names.erase("sqrt2");
+        fun_names.erase("log2");
+        fun_names.erase("log10");
+        fun_names.erase("not_a_number");
+        fun_names.erase("positive_infinity");
+        fun_names.erase("negative_infinity");
+        fun_names.erase("epsilon");
+        fun_names.erase("negative_epsilon");
+        for (set<string>::iterator it = fun_names.begin();  
+             it != fun_names.end();  
+             ++it)
+          reserve(*it);
+        
+      }
 
       bool operator()(const std::string& identifier,
                       std::stringstream& error_msgs) const {

--- a/src/test/gm/model_specs/bad_fun_name.stan
+++ b/src/test/gm/model_specs/bad_fun_name.stan
@@ -1,0 +1,9 @@
+data {
+  real logit; // causes error because logit is fun name
+}
+parameters {
+  real y;
+}
+model {
+  y ~ normal(0,1);
+}

--- a/src/test/gm/model_specs/good_fun_name.stan
+++ b/src/test/gm/model_specs/good_fun_name.stan
@@ -1,0 +1,15 @@
+parameters {
+  real e;
+  real pi;
+  real sqrt2;
+  real log2;
+  real log10;
+  real not_a_number;
+  real positive_infinity;
+  real negative_infinity;
+  real epsilon;
+  real negative_epsilon;
+}
+model {
+  e ~ normal(0,1);
+}

--- a/src/test/gm/parser_test.cpp
+++ b/src/test/gm/parser_test.cpp
@@ -182,6 +182,14 @@ TEST(gm_parser,parsable_test_bad11) {
   EXPECT_THROW(is_parsable("src/test/gm/model_specs/bad11.stan"),
                std::invalid_argument);
 }
+TEST(gm_parser,parsable_test_bad_fun_name) {
+  EXPECT_THROW(is_parsable("src/test/gm/model_specs/bad_fun_name.stan"),
+               std::invalid_argument);
+}
+TEST(gm_parser,parsable_test_good_fun_name) {
+  EXPECT_TRUE(is_parsable("src/test/gm/model_specs/good_fun_name.stan"));
+}
+
 TEST(gmParser,parsableBadPeriods) {
   EXPECT_THROW(is_parsable("src/test/gm/model_specs/bad_periods_data.stan"),
                std::invalid_argument);


### PR DESCRIPTION
I added function names to the list of reserved words which can't be used for variables.  
- constants are exempted --- they can't cause conflicts by being applied to themselves
- tests for parsability of constant functions (e.g., `e()`) as variables plus non-parsability using function name
- this catches all the "hidden" functions used to compile operators;  the compiler uses their declarations to check args and calculate return results
- updated doc to explain you can't use functions, with examples
