### PR TITLE
Unify the format of the write_error_msg

### DIFF
--- a/src/stan/gm/command.hpp
+++ b/src/stan/gm/command.hpp
@@ -64,9 +64,10 @@ namespace stan {
                     << "rejected becuase of the following issue:"
                     << std::endl
                     << e.what() << std::endl
-                    << "If this warning occurs sporadically then the sampler is fine,"
+                    << "If this warning occurs sporadically, such as for highly constrained "
+                    << "variable types like covariance matrices, then the sampler is fine,"
                     << std::endl
-                    << "but if this warning occurs often then your model is either severely "
+                    << "but if this warning occurs often then your model may be either severely "
                     << "ill-conditioned or misspecified."
                     << std::endl;
       

--- a/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
@@ -70,16 +70,15 @@ namespace stan {
           if (!error_msgs) return;
           
           *error_msgs << std::endl
-                      << "Informational Message: The parameter state is about to be Metropolis"
-                      << " rejected due to the following underlying, non-fatal (really)"
-                      << " issue (and please ignore that what comes next might say 'error'): "
-                      << e.what()
+                      << "Informational Message: The current Metropolis proposal is about to be "
+                      << "rejected becuase of the following issue:"
                       << std::endl
-                      << "If the problem persists across multiple draws, you might have"
-                      << " a problem with an initial state or a gradient somewhere."
+                      << e.what() << std::endl
+                      << "If this warning occurs sporadically, such as for highly constrained "
+                      << "variable types like covariance matrices, then the sampler is fine,"
                       << std::endl
-                      << " If the problem does not persist, the resulting samples will still"
-                      << " be drawn from the posterior."
+                      << "but if this warning occurs often then your model may be either severely "
+                      << "ill-conditioned or misspecified."
                       << std::endl;
           
       }
@@ -89,6 +88,6 @@ namespace stan {
   } // mcmc
 
 } // stan
-          
+
 
 #endif


### PR DESCRIPTION
I had previously updated the text accompanying errors in command.hpp (which gets called for errors during initialization) but not the accompanying text in base_hamiltonian.hpp (which gets called during sampling).  Only constant text has been modified -- no implementation details are touched so no tests should be affected.

Not an immediate priority but would be nice to add before 2.0 and could easily be wrapped up into another request to avoid another round of testing.
