### PR TITLE
Feature/issue 257 abs deprecate

### DIFF
--- a/src/stan/gm/grammars/term_grammar_def.hpp
+++ b/src/stan/gm/grammars/term_grammar_def.hpp
@@ -104,6 +104,17 @@ namespace stan {
                                                                     error_msgs);
 
         pass = !has_rng_suffix(fun.name_) || var_origin == derived_origin;
+        if (fun.name_ == "abs"
+            && fun.args_[0].expression_type().is_primitive_double()) {
+          error_msgs << "Warning: Function abs(real) is deprecated."
+                     << std::endl
+                     << "         It will be removed in a future release."
+                     << std::endl
+                     << "         Use fabs(real) instead."
+                     << std::endl << std::endl;
+        }
+
+
         if (!pass) {
           error_msgs << "random number generators only allowed in generated quantities block"
                      << "; found function=" << fun.name_

--- a/src/stan/math.hpp
+++ b/src/stan/math.hpp
@@ -10,6 +10,7 @@
 #include "stan/math/constants.hpp"
 #include "stan/math/functions/Phi.hpp"
 #include "stan/math/functions/Phi_approx.hpp"
+#include "stan/math/functions/abs.hpp"
 #include "stan/math/functions/as_bool.hpp"
 #include "stan/math/functions/bessel_first_kind.hpp"
 #include "stan/math/functions/bessel_second_kind.hpp"

--- a/src/stan/math/functions/abs.hpp
+++ b/src/stan/math/functions/abs.hpp
@@ -1,0 +1,26 @@
+#ifndef __STAN__MATH__FUNCTIONS__ABS_HPP__
+#define __STAN__MATH__FUNCTIONS__ABS_HPP__
+
+#include <cmath>
+
+namespace stan {
+
+  namespace math {
+
+    /**
+     * Return floating-point absolute value.
+     *
+     * Delegates to <code>fabs(double)</code> rather than
+     * <code>std::abs(int)</code>.
+     *
+     * @param x scalar
+     * @return absolute value of scalar
+     */
+    double abs(double x) {
+      return std::fabs(x);
+    }
+
+  }
+}
+
+#endif

--- a/src/test/math/functions/abs_test.cpp
+++ b/src/test/math/functions/abs_test.cpp
@@ -1,0 +1,21 @@
+#include "stan/math/functions/abs.hpp"
+#include <gtest/gtest.h>
+
+TEST(MathsSpecialFunctions, square) {
+  using stan::math::abs;
+
+  double y = 2.0;
+  EXPECT_FLOAT_EQ(2.0, abs(y));
+
+  y = 128745.72;
+  EXPECT_FLOAT_EQ(128745.72, abs(y));
+
+  y = -y;
+  EXPECT_FLOAT_EQ(128745.72, abs(y));
+
+  y = -1.3;
+  EXPECT_FLOAT_EQ(1.3, abs(y));
+
+  int z = 10; // promoted to double by abs(double)
+  EXPECT_FLOAT_EQ(10.0, abs(z));
+}


### PR DESCRIPTION
I think this fixes the issues with absolute.  I deprecated the use of abs(real) in the modeling language, which really just means it prints a warning.  

I added a `stan::math::abs(double)` which just delegates to `std::fabs(double)`.  The behavior was broken in Stan 1.3 because it called `std::abs(int)` and did the downcast.  

I made sure by running some models that it did the right thing, but I didn't include model tests.  The model syntax is already being tested with the function.
