### PR TITLE
makefile build target broken

### DIFF
--- a/makefile
+++ b/makefile
@@ -187,6 +187,7 @@ endif
 
 .PHONY: all build docs
 build: bin/stanc$(EXE)
+	@echo '--- Stan tools built ---'
 docs: manual doxygen
 all: build docs
 


### PR DESCRIPTION
This fixes the broken `build` target.

I also updated the doc in the make `help` target.
