### PR TITLE
Windows build issues (#337 and #338)

### DIFF
--- a/make/models
+++ b/make/models
@@ -4,7 +4,7 @@
 MODEL_HEADER := src/stan/model/model_header.hpp
 
 .PRECIOUS: %.cpp %.o
-$(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : %$(EXE): %.o bin/libstan.a
+$(patsubst %.stan,%,$(wildcard $(addsuffix .stan,$(MAKECMDGOALS)))) : % : %.o bin/libstan.a %.stan
 	@echo ''
 	@echo '--- Linking C++ model ---'
 	$(LINK.c) -O$O $(OUTPUT_OPTION) $< $(LDLIBS)
@@ -15,7 +15,7 @@ src/%: src/%.o bin/libstan.a
 	$(LINK.c) -O$O $(OUTPUT_OPTION) $< $(LDLIBS)
 
 
-%.exe: %.o bin/libstan.a
+%.exe: %.o bin/libstan.a %.stan
 	@echo ''
 	@echo '--- Linking C++ model ---'
 	$(LINK.c) -O$O $(OUTPUT_OPTION) $< $(LDLIBS)
@@ -65,12 +65,6 @@ models/%.stan : src/models/%.stan
 		echo 'cp $(addsuffix .init.R,$(basename $<)) $(addsuffix .init.R,$(basename $@))';\
 	fi;
 
-
-#.PRECIOUS: %.cpp
-#models/%$(EXE): models/%.o bin/libstan.a
-#	@echo ''
-#	@echo '--- Linking C++ model ---'
-#	$(LINK.c) $(OUTPUT_OPTION) $< $(LDLIBS)
 
 $(MODEL_HEADER).d : $(MODEL_HEADER)
 	@if test -d $(dir $@); \

--- a/make/os_win
+++ b/make/os_win
@@ -35,5 +35,5 @@ endif
 
 ## adding target that maps targets without extensions
 ## to targets with .exe at the end.
-% : %.exe
+%: %.exe %.stan
 	@# this is an intentional blank line


### PR DESCRIPTION
Fixes both problems in this pull request. Even after the tests pass, should verify that:
- [x] Windows builds have `-m64` flag
- [x] a model (e.g. src/models/basic_estimators/normal_loc.stan) can be built without a file type in Windows.
- [x] a model can be built with `.exe` file type in Windows
- [x] a model can be built without a file type in non-Windows
