### PR TITLE
Making call to Rscript safe; reducing depedencies on tools

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -118,10 +118,14 @@ ifeq ($(findstring test-,$(MAKECMDGOALS))$(findstring runtest_no_fail/,$(MAKECMD
 	-$@ --gtest_output="xml:$(basename $@).xml"
 endif
 
+
 ##
-# Builds a single test
+# all files that should be compiled as tests
 ##
 FILES := $(wildcard src/test/gm/model_specs/compiled/*.stan)
+
+
+## These lines are to shuffle the files
 ifeq ($(OS),win)
   WH := where
 else
@@ -132,17 +136,10 @@ ifneq ($(shell $(WH) shuf),)
   FILES := $(shell shuf -e $(FILES))
 else
 ifneq ($(shell $(WH) Rscript),)
-  FILES := $(shell Rscript -e "cat(sample(commandArgs(trailingOnly=TRUE)))" $(FILES))
-else
-ifneq ($(shell $(WH) python),)
-  FILES := $(shell python -c "import random; import os; import sys; sys.argv.remove('-'); s = sys.argv; random.shuffle(s); print ' '.join(s)" - $(FILES))
-else
-ifneq ($(shell $(WH) perl),)
-  FILES := $(shell perl -MList::Util=shuffle -le'print for shuffle @ARGV' $(FILES))
+  FILES := $(shell Rscript --vanilla -e "cat(sample(commandArgs(trailingOnly=TRUE)))" $(FILES))
 endif
 endif
-endif
-endif
+## end shuffling
 
 test/gm/command$(EXE) : test/gm/command.o bin/libstan.a bin/libstanc.a src/test/gm/model_specs/compiled/domain_fail$(EXE) src/test/gm/model_specs/compiled/value_fail$(EXE) 
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
Test case (run from command line):

``` text
echo "print('This will fuck : everything up')" > /tmp/Rprofile
export R_PROFILE=/tmp/Rprofile
make
```

The presence of the ":" is important in that string. The call to `make` will terminate with:

``` text
> make
make/tests:169: *** multiple target patterns.  Stop.
```

After the fix, the call to `make` returns the normal `help` target.
