### PR TITLE
Feature/fix header guards

### DIFF
--- a/src/stan/agrad/fwd/log_rising_factorial.hpp
+++ b/src/stan/agrad/fwd/log_rising_factorial.hpp
@@ -1,5 +1,5 @@
 #ifndef __STAN__AGRAD__FWD__LOG_RISING_FACTORIAL__HPP__
-#define __STAN__AGRAD__FWD__log_RISING_FACTORIAL__HPP__
+#define __STAN__AGRAD__FWD__LOG_RISING_FACTORIAL__HPP__
 
 #include <stan/agrad/fwd/fvar.hpp>
 #include <stan/meta/traits.hpp>

--- a/src/stan/gm/arguments/arg_adapt_delta.hpp
+++ b/src/stan/gm/arguments/arg_adapt_delta.hpp
@@ -1,4 +1,4 @@
-#ifndef __STAN__GM__ARGUMENTS__ADAPT__DELTA_HPP__
+#ifndef __STAN__GM__ARGUMENTS__ADAPT__DELTA__HPP__
 #define __STAN__GM__ARGUMENTS__ADAPT__DELTA__HPP__
 
 #include <stan/gm/arguments/singleton_argument.hpp>

--- a/src/stan/prob/distributions/multivariate/continuous.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous.hpp
@@ -1,4 +1,4 @@
-#ifndef __STAN__PROB__DISTRIBUTIONS__MULTIVARIATE__CONTINOUS_HPP__
+#ifndef __STAN__PROB__DISTRIBUTIONS__MULTIVARIATE__CONTINUOUS_HPP__
 #define __STAN__PROB__DISTRIBUTIONS__MULTIVARIATE__CONTINUOUS_HPP__
 
 #include <stan/prob/distributions/multivariate/continuous/gaussian_dlm_obs.hpp>


### PR DESCRIPTION
clang++-3.4 flagged us for illegal use of header guards

```
goodrich@CYBERPOWERPC:/opt/stan$ grep "is used as a header guard here" /tmp/warnings.txt | sort | uniq
src/stan/agrad/fwd/log_rising_factorial.hpp:1:9: warning: '__STAN__AGRAD__FWD__LOG_RISING_FACTORIAL__HPP__' is used as a header guard here, followed by #define of a
src/stan/gm/arguments/arg_adapt_delta.hpp:1:9: warning: '__STAN__GM__ARGUMENTS__ADAPT__DELTA_HPP__' is used as a header guard here, followed by #define of a different
src/stan/prob/distributions/multivariate/continuous.hpp:1:9: warning: '__STAN__PROB__DISTRIBUTIONS__MULTIVARIATE__CONTINOUS_HPP__' is used as a header guard here,
```

see http://lists.cs.uiuc.edu/pipermail/cfe-commits/Week-of-Mon-20130610/081568.html

This shouldn't change any functionality.
