### PR TITLE
Feature/issue 384 arg shuffler

### DIFF
--- a/src/stan/command/shuffle_args.cpp
+++ b/src/stan/command/shuffle_args.cpp
@@ -1,0 +1,47 @@
+#include <algorithm>
+#include <ctime>
+#include <iostream>
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+
+
+/**
+ * Mersenne Twister RNG (global).
+ */
+boost::random::mt19937 gen_;
+
+/**
+ * Return non-negative random number strictly less than the upper
+ * bound value.
+ *
+ * @param upper_bound Upper bound (exclusive) for return value.
+ * @return Random non-negative value less than i.
+ */
+int range_rng(int upper_bound) {
+  boost::random::uniform_int_distribution<> dist(0, upper_bound - 1);
+  return dist(gen_);
+}
+
+/**
+ * Print a shuffled version of the arguments (excluding executable
+ * name) to <code>std::cout</code>.  
+ *
+ * <p>Uses <code>std::time(0)</code> to seed the
+ * global RNG <code>gen_</code>.
+ * 
+ * @param argc Number of arguments (including executable name)
+ * @param argv Arguments
+ * @return 0 if successful, -1 if not.
+ */
+int main(int argc, char* argv[]) {
+  gen_.seed(std::time(0));
+  std::random_shuffle(argv + 1, argv + argc, range_rng); 
+  for (int i = 1; i < argc; ++i) {
+    if (i > 0) 
+      std::cout << " ";
+    std::cout << argv[i];
+  }
+  std::cout << std::endl;
+  return 0;
+}


### PR DESCRIPTION
I added `src/stan/command/shuffle_args.cpp` which prints a shuffled version of its arguments to `std::cout`.

As is, it writes a `std::endl` when its done.

It's a simple function based on the builtin `std::random_shuffle` and the `boost::random::mt19937` RNG using `std::time(0)` for a seed.

I tested that I could build it and that it worked on the command-line.  I'm not sure what the best way is to test a main going forward.  Test cases include 0 arguments as input, 1 argument, 2 arguments, and then some random number like 17 arguments.  The only test is that all the values come out (that is, the shuffled args and original args have the same number of members when you put them in a set-like structure).
