### PR TITLE
Actually return the return_code when optimizing.

### DIFF
--- a/src/stan/gm/command.hpp
+++ b/src/stan/gm/command.hpp
@@ -709,7 +709,8 @@ namespace stan {
           sample_stream->close();
           delete sample_stream;
         }
-        return 0;
+
+        return return_code;
       }
         
       //////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #396 
