### PR TITLE
Bugfix/issue 432 pos inf ub

### DIFF
--- a/src/stan/gm/command.hpp
+++ b/src/stan/gm/command.hpp
@@ -371,18 +371,18 @@ namespace stan {
                                                        cont_params, disc_params, init_grad,
                                                        &std::cout);
           } catch (std::domain_error e) {
-            std::cout << "Rejecting inititialization at zero because of log_prob_grad failure." << std::endl;
+            std::cout << "Rejecting initialization at zero because of log_prob_grad failure." << std::endl;
             return error_codes::OK;
           }
           
           if (!boost::math::isfinite(init_log_prob)) {
-            std::cout << "Rejecting inititialization at zero because of vanishing density." << std::endl;
+            std::cout << "Rejecting initialization at zero because of vanishing density." << std::endl;
             return 0;
           }
           
           for (size_t i = 0; i < init_grad.size(); ++i) {
             if (!boost::math::isfinite(init_grad[i])) {
-              std::cout << "Rejecting inititialization at zero because of divergent gradient." << std::endl;
+              std::cout << "Rejecting initialization at zero because of divergent gradient." << std::endl;
               return 0;
             }
           }
@@ -477,18 +477,18 @@ namespace stan {
                                                      &std::cout);
 
         } catch (std::domain_error e) {
-          std::cout << "Rejecting user-specified inititialization because of log_prob_grad failure." << std::endl;
+          std::cout << "Rejecting user-specified initialization because of log_prob_grad failure." << std::endl;
           return 0;
         }
         
         if (!boost::math::isfinite(init_log_prob)) {
-          std::cout << "Rejecting user-specified inititialization because of vanishing density." << std::endl;
+          std::cout << "Rejecting user-specified initialization because of vanishing density." << std::endl;
           return 0;
         }
         
         for (size_t i = 0; i < init_grad.size(); ++i) {
           if (!boost::math::isfinite(init_grad[i])) {
-            std::cout << "Rejecting user-specified inititialization because of divergent gradient." << std::endl;
+            std::cout << "Rejecting user-specified initialization because of divergent gradient." << std::endl;
             return 0;
           }
         }

--- a/src/stan/io/writer.hpp
+++ b/src/stan/io/writer.hpp
@@ -130,9 +130,7 @@ namespace stan {
        * @throw std::runtime_error if y is lower than the lower bound provided.
        */
       void scalar_lb_unconstrain(double lb, T& y) {
-        if (y < lb)
-          BOOST_THROW_EXCEPTION(std::runtime_error ("y is lower than the lower bound"));
-        data_r_.push_back(log(y - lb));
+        data_r_.push_back(stan::prob::lb_free(y,lb));
       }
 
       /**
@@ -146,9 +144,7 @@ namespace stan {
        * @throw std::runtime_error if y is higher than the upper bound provided.
        */
       void scalar_ub_unconstrain(double ub, T& y) {
-        if (y > ub)
-          BOOST_THROW_EXCEPTION(std::runtime_error ("y is higher than the lower bound"));
-        data_r_.push_back(log(ub - y));
+        data_r_.push_back(stan::prob::ub_free(y,ub));
       }
 
       /**
@@ -164,9 +160,7 @@ namespace stan {
        * @throw std::runtime_error if y is not between the lower and upper bounds
        */
       void scalar_lub_unconstrain(double lb, double ub, T& y) {
-        if (y < lb || y > ub)
-          BOOST_THROW_EXCEPTION(std::runtime_error ("y is not between the lower and upper bounds"));
-        data_r_.push_back(stan::math::logit((y - lb) / (ub - lb)));
+        data_r_.push_back(stan::prob::lub_free(y,lb,ub));
       }
 
       /**
@@ -180,9 +174,7 @@ namespace stan {
        * @throw std::runtime_error if y is not between -1.0 and 1.0
        */
       void corr_unconstrain(T& y) {
-        if (y > 1.0 || y < -1.0)
-          BOOST_THROW_EXCEPTION(std::runtime_error ("y is not between -1.0 and 1.0"));
-        data_r_.push_back(atanh(y));
+        data_r_.push_back(stan::prob::corr_free(y));
       }
 
       /**
@@ -197,9 +189,7 @@ namespace stan {
        * @throw std::runtime_error if y is not between 0.0 and 1.0
         */
       void prob_unconstrain(T& y) {
-        if (y > 1.0 || y < 0.0)
-          BOOST_THROW_EXCEPTION(std::runtime_error ("y is not between 0.0 and 1.0"));
-        data_r_.push_back(stan::math::logit(y));
+        data_r_.push_back(stan::prob::prob_free(y));
       }
 
       /**
@@ -242,6 +232,7 @@ namespace stan {
        * @throw std::runtime_error if vector is not in ascending order.
        */
       void positive_ordered_unconstrain(vector_t& y) {
+        // reimplements pos_ordered_free in prob to avoid malloc
         if (y.size() == 0) return;
         stan::math::check_positive_ordered("stan::io::positive_ordered_unconstrain(%1%)", y, "Vector");
         data_r_.push_back(log(y[0]));

--- a/src/test/gm/command_test.cpp
+++ b/src/test/gm/command_test.cpp
@@ -104,7 +104,7 @@ TEST(StanGmCommand, zero_init_value_fail) {
   std::string command = convert_model_path(model_path) + " sample init=0 output file=test/gm/samples.csv";
   run_command_output out = run_command(command);
   EXPECT_EQ(int(stan::gm::error_codes::OK), out.err_code);
-  EXPECT_EQ("Rejecting inititialization at zero because of vanishing density.\n", 
+  EXPECT_EQ("Rejecting initialization at zero because of vanishing density.\n", 
             out.output)
     << "Failed running: " << out.command;
 }
@@ -122,7 +122,7 @@ TEST(StanGmCommand, zero_init_domain_fail) {
   
   run_command_output out = run_command(command);
   EXPECT_EQ(int(stan::gm::error_codes::OK), out.err_code);
-  EXPECT_EQ("Rejecting inititialization at zero because of log_prob_grad failure.\n",
+  EXPECT_EQ("Rejecting initialization at zero because of log_prob_grad failure.\n",
             out.output)
     << "Failed running: " << out.command;
 }
@@ -150,7 +150,7 @@ TEST(StanGmCommand, user_init_value_fail) {
 
   run_command_output out = run_command(command);
   EXPECT_EQ(int(stan::gm::error_codes::OK), out.err_code);
-  EXPECT_EQ("Rejecting user-specified inititialization because of vanishing density.\n",
+  EXPECT_EQ("Rejecting user-specified initialization because of vanishing density.\n",
             out.output)
     << "Failed running: " << out.command;
 }
@@ -178,7 +178,7 @@ TEST(StanGmCommand, user_init_domain_fail) {
   
   run_command_output out = run_command(command);
   EXPECT_EQ(int(stan::gm::error_codes::OK), out.err_code);
-  EXPECT_EQ("Rejecting user-specified inititialization because of log_prob_grad failure.\n",
+  EXPECT_EQ("Rejecting user-specified initialization because of log_prob_grad failure.\n",
             out.output)
     << "Failed running: " << out.command;
 }

--- a/src/test/io/writer_test.cpp
+++ b/src/test/io/writer_test.cpp
@@ -1,9 +1,49 @@
+#include <limits>
 #include <stdexcept>
+
 #include <stan/io/writer.hpp>
 #include <stan/io/reader.hpp>
 #include <gtest/gtest.h>
 
 #include <stan/math/matrix/typedefs.hpp>
+
+TEST(ioWriter, infBounds) {
+  std::vector<int> theta_i;
+  std::vector<double> theta;
+  stan::io::writer<double> writer(theta,theta_i);
+  
+  // lub
+
+  // lb finite; ub = +inf
+  double y = 12;
+  writer.scalar_lub_unconstrain(0,std::numeric_limits<double>::infinity(),y);
+  writer.scalar_lb_unconstrain(0,y);
+  EXPECT_FLOAT_EQ(writer.data_r()[0], writer.data_r()[1]);
+
+  // lb = -inf; ub finite
+  double z = -7.7;
+  writer.scalar_lub_unconstrain(-std::numeric_limits<double>::infinity(), -1.9, z);
+  writer.scalar_ub_unconstrain(-1.9, z);
+  EXPECT_FLOAT_EQ(writer.data_r()[2], writer.data_r()[3]);
+
+  // lb = -inf;  ub = +inf
+  double w = 197.345;
+  writer.scalar_lub_unconstrain(-std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(), w);
+  writer.scalar_unconstrain(w);
+  EXPECT_FLOAT_EQ(writer.data_r()[4], writer.data_r()[5]);
+
+  // ub = inf
+  double u = 9283475;
+  writer.scalar_ub_unconstrain(std::numeric_limits<double>::infinity(),u);
+  writer.scalar_unconstrain(u);
+  EXPECT_FLOAT_EQ(writer.data_r()[6], writer.data_r()[7]);
+
+  // lb = -inf
+  double v = -7464.737474;
+  writer.scalar_lb_unconstrain(-std::numeric_limits<double>::infinity(),v);
+  writer.scalar_unconstrain(v);
+  EXPECT_FLOAT_EQ(writer.data_r()[8], writer.data_r()[9]);
+}
 
 TEST(io_writer, integer) {
   std::vector<int> theta_i;
@@ -228,7 +268,7 @@ TEST(io_writer, scalar_lb_unconstrain_exception) {
   EXPECT_NO_THROW(writer.scalar_lb_unconstrain(lb, y));
 
   y = -1.0;
-  EXPECT_THROW(writer.scalar_lb_unconstrain(lb, y), std::runtime_error);
+  EXPECT_THROW(writer.scalar_lb_unconstrain(lb, y), std::domain_error);
 }
 TEST(io_writer, scalar_ub_unconstrain_exception) {
   std::vector<int> theta_i;
@@ -240,7 +280,7 @@ TEST(io_writer, scalar_ub_unconstrain_exception) {
   EXPECT_NO_THROW(writer.scalar_ub_unconstrain(ub, y));
 
   y = 1.0;
-  EXPECT_THROW(writer.scalar_ub_unconstrain(ub, y), std::runtime_error);
+  EXPECT_THROW(writer.scalar_ub_unconstrain(ub, y), std::domain_error);
 }
 TEST(io_writer, scalar_lub_unconstrain_exception) {
   std::vector<int> theta_i;
@@ -253,10 +293,10 @@ TEST(io_writer, scalar_lub_unconstrain_exception) {
   EXPECT_NO_THROW(writer.scalar_lub_unconstrain(lb, ub, y));
 
   y = 2.0;
-  EXPECT_THROW(writer.scalar_lub_unconstrain(lb, ub, y), std::runtime_error);
+  EXPECT_THROW(writer.scalar_lub_unconstrain(lb, ub, y), std::domain_error);
 
   y = -2.0;
-  EXPECT_THROW(writer.scalar_lub_unconstrain(lb, ub, y), std::runtime_error);
+  EXPECT_THROW(writer.scalar_lub_unconstrain(lb, ub, y), std::domain_error);
 }
 TEST(io_writer, corr_unconstrain_exception) {
   std::vector<int> theta_i;
@@ -267,10 +307,10 @@ TEST(io_writer, corr_unconstrain_exception) {
   EXPECT_NO_THROW(writer.corr_unconstrain(y));
 
   y = 2.0;
-  EXPECT_THROW(writer.corr_unconstrain(y), std::runtime_error);
+  EXPECT_THROW(writer.corr_unconstrain(y), std::domain_error);
 
   y = -2.0;
-  EXPECT_THROW(writer.corr_unconstrain(y), std::runtime_error);
+  EXPECT_THROW(writer.corr_unconstrain(y), std::domain_error);
 }
 TEST(io_writer, prob_unconstrain_exception) {
   std::vector<int> theta_i;
@@ -281,10 +321,10 @@ TEST(io_writer, prob_unconstrain_exception) {
   EXPECT_NO_THROW(writer.prob_unconstrain(y));
 
   y = 2.0;
-  EXPECT_THROW(writer.prob_unconstrain(y), std::runtime_error);
+  EXPECT_THROW(writer.prob_unconstrain(y), std::domain_error);
 
   y = -0.5;
-  EXPECT_THROW(writer.prob_unconstrain(y), std::runtime_error);
+  EXPECT_THROW(writer.prob_unconstrain(y), std::domain_error);
 }
 TEST(io_writer, ordered_unconstrain_exception) {
   std::vector<int> theta_i;


### PR DESCRIPTION
#### summary

fixes problems with user inits for infinite bounds by having `io::writer` call `prob::transform` to free + error in spelling for initialization error
#### intended effect

allow users to initialize params with infinite bounds
#### how to verify

user model in issue #432 now runs; unit tests in place to test that and other conditions;  grep for `initit` in code and tests and doc
#### side effects

throws from writer are now `std::domain_error` instead of `std::runtime_error`
#### documentation

no change --- doc was correct before
#### suggested reviewers

simple change --- anyone
