### PR TITLE
Remove compiler warnings.

### DIFF
--- a/src/test/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp
+++ b/src/test/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp
@@ -71,7 +71,7 @@ TEST(McmcDiagEMetric, gradients) {
   
   Eigen::VectorXd g1 = metric.dtau_dq(z);
   
-  for (int i = 0; i < z.q.size(); ++i) {
+  for (size_t i = 0; i < z.q.size(); ++i) {
     
     double delta = 0;
     
@@ -94,7 +94,7 @@ TEST(McmcDiagEMetric, gradients) {
   
   Eigen::VectorXd g2 = metric.dtau_dp(z);
   
-  for (int i = 0; i < z.q.size(); ++i) {
+  for (size_t i = 0; i < z.q.size(); ++i) {
     
     double delta = 0;
     
@@ -114,7 +114,7 @@ TEST(McmcDiagEMetric, gradients) {
   
   Eigen::VectorXd g3 = metric.dphi_dq(z);
   
-  for (int i = 0; i < z.q.size(); ++i) {
+  for (size_t i = 0; i < z.q.size(); ++i) {
     
     double delta = 0;
     

--- a/src/test/mcmc/hmc/hamiltonians/unit_e_metric_test.cpp
+++ b/src/test/mcmc/hmc/hamiltonians/unit_e_metric_test.cpp
@@ -71,7 +71,7 @@ TEST(McmcUnitEMetric, gradients) {
   
   Eigen::VectorXd g1 = metric.dtau_dq(z);
   
-  for (int i = 0; i < z.q.size(); ++i) {
+  for (size_t i = 0; i < z.q.size(); ++i) {
     
     double delta = 0;
     
@@ -94,7 +94,7 @@ TEST(McmcUnitEMetric, gradients) {
   
   Eigen::VectorXd g2 = metric.dtau_dp(z);
   
-  for (int i = 0; i < z.q.size(); ++i) {
+  for (size_t i = 0; i < z.q.size(); ++i) {
     
     double delta = 0;
     
@@ -114,7 +114,7 @@ TEST(McmcUnitEMetric, gradients) {
   
   Eigen::VectorXd g3 = metric.dphi_dq(z);
   
-  for (int i = 0; i < z.q.size(); ++i) {
+  for (size_t i = 0; i < z.q.size(); ++i) {
     
     double delta = 0;
     

--- a/src/test/mcmc/hmc/integrators/expl_leapfrog_test.cpp
+++ b/src/test/mcmc/hmc/integrators/expl_leapfrog_test.cpp
@@ -389,7 +389,7 @@ TEST(McmcHmcIntegratorsExplLeapfrog, energy_conservation) {
   double tau = 6.28318530717959;
   size_t L = tau / epsilon;
   
-  for (int n = 0; n < L; ++n) {
+  for (size_t n = 0; n < L; ++n) {
     
     integrator.evolve(z, metric, epsilon);
     
@@ -445,7 +445,7 @@ TEST(McmcHmcIntegratorsExplLeapfrog, symplecticness) {
   for (int i = 0; i < n_points; ++i)
     metric.init(z.at(i));
   
-  for (int n = 0; n < L; ++n)
+  for (size_t n = 0; n < L; ++n)
     for (int i = 0; i < n_points; ++i)
       integrator.evolve(z.at(i), metric, epsilon);
   


### PR DESCRIPTION
- Summary: Removed compiler warnings in tests. This only touches new tests written in #341.
- Intended Effect: No change to code / test behavior. Only removes compiler warnings. This was accomplished by changing int to size_t in loops.
- How to Verify: Using g++, build and run these tests:
  - `make test/mcmc/hmc/hamiltonians/diag_e_metric`
  - `make test/mcmc/hmc/hamiltonians/unit_e_metric`
  - `make test/mcmc/hmc/integrators/expl_leapfrog`
- Side effects: none.
- Documentation: just tests. No doc needed.
- Reviewer Suggestions: @betanalpha. See the changes made and be aware of it for future pull requests.
