### PR TITLE
Removing compiler warnings.

### DIFF
--- a/src/test/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
+++ b/src/test/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
@@ -71,7 +71,7 @@ TEST(McmcDenseEMetric, gradients) {
   
   Eigen::VectorXd g1 = metric.dtau_dq(z);
   
-  for (int i = 0; i < z.q.size(); ++i) {
+  for (size_t i = 0; i < z.q.size(); ++i) {
     
     double delta = 0;
     
@@ -94,7 +94,7 @@ TEST(McmcDenseEMetric, gradients) {
   
   Eigen::VectorXd g2 = metric.dtau_dp(z);
   
-  for (int i = 0; i < z.q.size(); ++i) {
+  for (size_t i = 0; i < z.q.size(); ++i) {
     
     double delta = 0;
     
@@ -114,7 +114,7 @@ TEST(McmcDenseEMetric, gradients) {
   
   Eigen::VectorXd g3 = metric.dphi_dq(z);
   
-  for (int i = 0; i < z.q.size(); ++i) {
+  for (size_t i = 0; i < z.q.size(); ++i) {
     
     double delta = 0;
     


### PR DESCRIPTION
- Summary: Removed additional warnings in tests. This only touches new tests written in #341.
- Intended Effect: No change to code / test behavior. Only removes compiler warnings. This was accomplished by changing int to size_t in loops within test code.
- How to Verify: Using g++, build and run these tests:
  - `make test/mcmc/hmc/hamiltonians/dense_e_metric`
- Side effects: none.
- Documentation: just tests. No doc needed.
- Reviewer Suggestions: Anyone. (I've verified that the test runs on my machine. I don't think it needs the full tests -- if the reviewer agrees, we can merge.)
