### PR TITLE
Allows Stan models to be built using g++ 4.4

### DIFF
--- a/src/stan/gm/command.hpp
+++ b/src/stan/gm/command.hpp
@@ -937,10 +937,10 @@ namespace stan {
         // Sampling
         start = clock();
         
-        sample<Model, rng_t>(sampler_ptr, num_warmup, num_samples, num_thin,
-                             refresh, true,
-                             writer,
-                             s, model, base_rng);
+        stan::gm::sample<Model, rng_t>(sampler_ptr, num_warmup, num_samples, num_thin,
+                                       refresh, true,
+                                       writer,
+                                       s, model, base_rng);
         
         end = clock();
         sampleDeltaT = (double)(end - start) / CLOCKS_PER_SEC;


### PR DESCRIPTION
- Summary: Allows Stan models to be built using g++ 4.4. It currently does not.
- Intended Effect: After the fix, the models build. Before this fix, models would fail with an compiler novel looking like:

``` text
g++-mp-4.4 -I src -isystem lib/eigen_3.2.0 -isystem lib/boost_1.54.0 -Wall -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -Wno-unused-function   -c -O3 -o models/basic_distributions/normal.o models/basic_distributions/normal.cpp
In file included from src/stan/model/model_header.hpp:20,
                 from models/basic_distributions/normal.cpp:3:
src/stan/mcmc/sample.hpp: In function 'int stan::gm::command(int, const char**) [with Model = normal_model_namespace::normal_model]':
models/basic_distributions/normal.cpp:241:   instantiated from here
src/stan/mcmc/sample.hpp:11: error: 'class stan::mcmc::sample' is not a function,
src/stan/gm/command.hpp:158: error:   conflict with 'template<class Model, class RNG> void stan::gm::sample(stan::mcmc::base_mcmc*, int, int, int, int, bool, stan::io::mcmc_writer<Model>&, stan::mcmc::sample&, Model&, RNG&)'
src/stan/gm/command.hpp:940: error:   in call to 'sample'
src/stan/math/constants.hpp: At global scope:
src/stan/math/constants.hpp:63: warning: 'stan::math::NEGATIVE_EPSILON' defined but not used
make: *** [models/basic_distributions/normal.o] Error 1
```
- How to Verify: Compile any model using g++ 4.4. For example, run:
  `make models/basic_distributions/normal`
- Side Effects: No. Everything should be the same in other version of g++.
- Documentation: None necessary.
- Reviewer Suggestions: Anyone with time. It's a one line change. Sooner is better than later.
