### PR TITLE
Bugfix/issue 499 multinomial rng size

### DIFF
--- a/src/stan/prob/distributions/multivariate/discrete/multinomial.hpp
+++ b/src/stan/prob/distributions/multivariate/discrete/multinomial.hpp
@@ -78,16 +78,16 @@ namespace stan {
       check_simplex(function, theta, "Probabilites parameter");
       check_positive(function,N,"number of trials variables");
 
-      std::vector<int> result(N,0);
+      std::vector<int> result(theta.size(),0);
       double mass_left = 1.0;
       int n_left = N;
       for (int k = 0; n_left > 0 && k < theta.size(); ++k) {
-        result[k] = binomial_rng(n_left,theta[k] / mass_left,rng);
+        double p = theta[k] / mass_left;
+        if (p > 1.0) p = 1.0;
+        result[k] = binomial_rng(n_left,p,rng);
         n_left -= result[k];
         mass_left -= theta[k];
       }
-      // for (int n = 0; n < N; ++n)
-      //   ++result[categorical_rng(theta,rng) - 1];
       return result;
     }
 

--- a/src/test/prob/distributions/multivariate/discrete/multinomial_test.cpp
+++ b/src/test/prob/distributions/multivariate/discrete/multinomial_test.cpp
@@ -6,6 +6,16 @@
 using Eigen::Matrix;
 using Eigen::Dynamic;
 
+TEST(ProbDistributions,MultinomialRNGSize) {
+  boost::random::mt19937 rng;
+  Matrix<double,Dynamic,1> theta(5);
+  // error in 2.1.0 due to overflow in binomial call due to division
+  theta << 0.3, 0.1, 0.2, 0.2, 0.2;  
+  std::vector<int> sample = stan::prob::multinomial_rng(theta,10,rng);
+  // bug in 2.1.0 returned 10 rather than 5 for returned size
+  EXPECT_EQ(5,sample.size());  
+}
+
 TEST(ProbDistributions,Multinomial) {
   std::vector<int> ns;
   ns.push_back(1);


### PR DESCRIPTION
#### Summary:

Fixes issue 499 with wrongly sized multinomial_rng return; bonus fix of arithmetic error overflowing binomial
#### Intended Effect:

See above.
#### How to Verify:

Run tests.
#### Side Effects:

None.
#### Documentation:

The doc's correct.
#### Reviewer Suggestions:

Anyone.
