### PR TITLE
remove test dependency on compiling grammars

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -47,30 +47,6 @@ test/gtest.o: $(GTEST)/src/gtest-all.cc
 	@mkdir -p test
 	$(COMPILE.c) -O$O $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
 
-##
-# Generate autodependencies for test files.
-# Adapted from the gnu make manual.
-# http://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html#Automatic-Prerequisites
-##
-$(GRAMMAR_TESTS) : test/%$(EXE) : test/%.o bin/libstan.a bin/libstanc.a
-	@mkdir -p $(dir $@)
-	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS) $(LDLIBS_STANC)
-ifeq ($(findstring test-,$(MAKECMDGOALS))\
-      $(findstring runtest/,$(MAKECMDGOALS))\
-      $(findstring src/test/,$(MAKECMDGOALS)),)
-	$@ --gtest_output="xml:$(basename $@).xml"
-endif
-
-.PRECIOUS: test/%.o
-test/%$(EXE) : test/%.o bin/libstan.a
-	@mkdir -p $(dir $@)
-	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS)
-ifeq ($(findstring test-,$(MAKECMDGOALS))\
-      $(findstring runtest/,$(MAKECMDGOALS))\
-      $(findstring src/test/,$(MAKECMDGOALS)),)
-	$@ --gtest_output="xml:$(basename $@).xml"
-endif
-
 test/%.o : src/test/%_test.cpp $(LIBGTEST)
 	@mkdir -p $(dir $@)
 	$(COMPILE.c) -O$O $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
@@ -136,6 +112,31 @@ ALL_TEST_EXECUTABLES = $(patsubst src/%_test.cpp,%$(EXE),$(ALL_TESTS))
 GRAMMAR_TESTS = $(foreach dir,\
                           $(patsubst src/%,%,$(shell find src/test -type d -name 'gm')),\
                           $(filter $(dir)/%,$(ALL_TEST_EXECUTABLES)))
+
+##
+# Generate autodependencies for test files.
+# Adapted from the gnu make manual.
+# http://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html#Automatic-Prerequisites
+##
+$(GRAMMAR_TESTS) : test/%$(EXE) : test/%.o bin/libstan.a bin/libstanc.a
+	@mkdir -p $(dir $@)
+	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS) $(LDLIBS_STANC)
+ifeq ($(strip $(findstring test-,$(MAKECMDGOALS))\
+              $(findstring runtest/,$(MAKECMDGOALS))\
+              $(findstring src/test/,$(MAKECMDGOALS))),)
+	$@ --gtest_output="xml:$(basename $@).xml"
+endif
+
+.PRECIOUS: test/%.o
+test/%$(EXE) : test/%.o bin/libstan.a
+	@mkdir -p $(dir $@)
+	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS)
+ifeq ($(strip $(findstring test-,$(MAKECMDGOALS))\
+              $(findstring runtest/,$(MAKECMDGOALS))\
+              $(findstring src/test/,$(MAKECMDGOALS))),)
+	$@ --gtest_output="xml:$(basename $@).xml"
+endif
+
 
 ####
 ## These make rules apply if SECONDEXPANSION is available


### PR DESCRIPTION
#### Summary:

Speeds up unit testing by only requiring the bin/libstanc.a when compiling grammars. This fixes issue #493.
#### Intended Effect:

Tests like:

``` text
make test/unit/math/functions/step
make src/test/unit/meta
```

do not compile the grammars and are now very quick to compile and execute.

Tests like:

``` text
make src/test/unit/gm
```

compiles the grammars and will take a long time to compile.
#### How to Verify:

This should run quickly: try any unit test folder excluding src/test/unit/gm. For example:

```
make src/test/unit/math/functions
```

That shouldn't compile the grammars.

This should compile the grammars and execute the tests:

```
make src/test/unit/gm
```
#### Side Effects:

None. Only changes to `make/tests`.
#### Documentation:

No public facing changes.
#### Reviewer Suggestions:

Bob.
