### PR TITLE
clarify model block variable locality

### DIFF
--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -3219,6 +3219,9 @@ may be used in the model block.  But a variable declared in the
 generated quantities block may not be used in any earlier block,
 including the model block.
 
+However, variables declared in the model block are always local to 
+the model block.
+
 \subsection{Automatic Variable Definitions}
 
 The variables declared in the \code{data} and \code{parameters} block


### PR DESCRIPTION
Something like this could be a helpful clarification -- I realize it's explained elsewhere, but "variable scope" in the "program blocks" chapter seems like a reasonable place to find this information.
