### PR TITLE
Fix brittle command tests

### DIFF
--- a/src/test/CmdStan/command_test.cpp
+++ b/src/test/CmdStan/command_test.cpp
@@ -21,8 +21,6 @@ TEST(StanGmCommand, countMatches) {
   EXPECT_EQ(2, count_matches("aa","aaaa"));
 }
 
-
-
 void test_sample_prints(const std::string& base_cmd) {
   std::string cmd(base_cmd);
   cmd += " num_samples=100 num_warmup=100";
@@ -126,6 +124,9 @@ TEST(StanGmCommand, refresh_nonzero_ok) {
 }
 
 TEST(StanGmCommand, zero_init_value_fail) {
+  std::string expected_message
+    = "Rejecting initialization at zero because of vanishing density.\n";
+
   std::vector<std::string> model_path;
   model_path.push_back("src");
   model_path.push_back("test");
@@ -137,15 +138,18 @@ TEST(StanGmCommand, zero_init_value_fail) {
   std::string command = convert_model_path(model_path) + " sample init=0 output file=test/CmdStan/samples.csv";
   run_command_output out = run_command(command);
   EXPECT_EQ(int(stan::gm::error_codes::OK), out.err_code);
+
+  EXPECT_TRUE(out.header.length() > 0U);
+  EXPECT_TRUE(out.body.length() > 0U);
   
-  EXPECT_EQ(970U, out.output.length());
-  
-  EXPECT_EQ("Rejecting initialization at zero because of vanishing density.\n",
-            out.output.substr(907, 64))
+  EXPECT_EQ(1, count_matches(expected_message, out.body))
     << "Failed running: " << out.command;
 }
 
 TEST(StanGmCommand, zero_init_domain_fail) {
+  std::string expected_message
+    = "Rejecting initialization at zero because of gradient failure.\n";
+
   std::vector<std::string> model_path;
   model_path.push_back("src");
   model_path.push_back("test");
@@ -159,14 +163,17 @@ TEST(StanGmCommand, zero_init_domain_fail) {
   run_command_output out = run_command(command);
   EXPECT_EQ(int(stan::gm::error_codes::OK), out.err_code);
 
-  EXPECT_EQ(1054U, out.output.length());
-
-  EXPECT_EQ("Rejecting initialization at zero because of gradient failure.\n",
-            out.output.substr(907, 62))
+  EXPECT_TRUE(out.header.length() > 0U);
+  EXPECT_TRUE(out.body.length() > 0U);
+  
+  EXPECT_EQ(1, count_matches(expected_message, out.body))
     << "Failed running: " << out.command;
 }
 
 TEST(StanGmCommand, user_init_value_fail) {
+  std::string expected_message
+    = "Rejecting user-specified initialization because of vanishing density.\n";
+
   std::vector<std::string> model_path;
   model_path.push_back("src");
   model_path.push_back("test");
@@ -190,14 +197,17 @@ TEST(StanGmCommand, user_init_value_fail) {
   run_command_output out = run_command(command);
   EXPECT_EQ(int(stan::gm::error_codes::OK), out.err_code);
   
-  EXPECT_EQ(1031U, out.output.length());
+  EXPECT_TRUE(out.header.length() > 0U);
+  EXPECT_TRUE(out.body.length() > 0U);
   
-  EXPECT_EQ("Rejecting user-specified initialization because of vanishing density.\n",
-            out.output.substr(961, 70))
+  EXPECT_EQ(1, count_matches(expected_message, out.body))
     << "Failed running: " << out.command;
 }
 
 TEST(StanGmCommand, user_init_domain_fail) {
+  std::string expected_message
+    = "Rejecting user-specified initialization because of gradient failure.\n";
+
   std::vector<std::string> model_path;
   model_path.push_back("src");
   model_path.push_back("test");
@@ -221,10 +231,10 @@ TEST(StanGmCommand, user_init_domain_fail) {
   run_command_output out = run_command(command);
   EXPECT_EQ(int(stan::gm::error_codes::OK), out.err_code);
   
-  EXPECT_EQ(1116U, out.output.length());
+  EXPECT_TRUE(out.header.length() > 0U);
+  EXPECT_TRUE(out.body.length() > 0U);
   
-  EXPECT_EQ("Rejecting user-specified initialization because of gradient failure.\n",
-            out.output.substr(962, 69))
+  EXPECT_EQ(1, count_matches(expected_message, out.body))
     << "Failed running: " << out.command;
 }
 
@@ -333,5 +343,4 @@ typedef ::testing::Types<std::domain_error,
 
 INSTANTIATE_TYPED_TEST_CASE_P(, StanGmCommandException, 
                               BoostExceptionTypes);
-
 

--- a/src/test/CmdStan/models/utility.hpp
+++ b/src/test/CmdStan/models/utility.hpp
@@ -73,6 +73,8 @@ struct run_command_output {
   long time;
   int err_code;
   bool hasError;
+  std::string header;
+  std::string body;
 
   run_command_output(const std::string command,
                      const std::string output,
@@ -82,25 +84,39 @@ struct run_command_output {
       output(output),
       time(time),
       err_code(err_code),
-      hasError(err_code != 0)
-  { }
+      hasError(err_code != 0),
+      header(),
+      body()
+  { 
+    size_t end_of_header = output.find("\n\n");
+    if (end_of_header == std::string::npos)
+      end_of_header = 0;
+    else
+      end_of_header += 2;
+    header = output.substr(0, end_of_header);
+    body = output.substr(end_of_header);
+  }
   
   run_command_output() 
     : command(),
       output(),
       time(0),
       err_code(0),
-      hasError(false)
+      hasError(false),
+      header(),
+      body()
       { }
 };
 
 std::ostream& operator<<(std::ostream& os, const run_command_output& out) {
-  os << "run_command output:" << std::endl
-     << "  command:   " << out.command << std::endl
-     << "  output:    " << out.output << std::endl
-     << "  time (ms): " << out.time << std::endl
-     << "  err_code:  " << out.err_code << std::endl
-     << "  hasError:  " << (out.hasError ? "true" : "false") << std::endl;
+  os << "run_command output:" << "\n"
+     << "  command:   " << out.command << "\n"
+     << "  output:    " << out.output << "\n"
+     << "  time (ms): " << out.time << "\n"
+     << "  err_code:  " << out.err_code << "\n"
+     << "  hasError:  " << (out.hasError ? "true" : "false") << "\n"
+     << "  header:    " << out.header << "\n"
+     << "  body:      " << out.body << std::endl;
   return os;
 }
 


### PR DESCRIPTION
#### Summary:

Makes command tests more robust to minor changes in output.
#### Intended Effect:

Reduces the developer's need to change the command tests each time the output changes a little bit.
#### How to Verify:

Run: `make test/CmdStan/command`
#### Side Effects:

None.
#### Documentation:

None.
#### Reviewer Suggestions:

Anyone. This is a change to the tests only.
