### PR TITLE
Bugfix/issue 543 log prob grad exception spew

### DIFF
--- a/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
@@ -44,12 +44,12 @@ namespace stan {
         
         try {
           stan::model::gradient(_model, z.q, z.V, z.g, _err_stream);
+          z.V *= -1;
         } catch (const std::exception& e) {
           this->_write_error_msg(_err_stream, e);
           z.V = std::numeric_limits<double>::infinity();
         }
         
-        z.V *= -1;
         z.g *= -1;
         
       }


### PR DESCRIPTION
#### Summary:

Fixes issue #543, which was that models spewing error messages due to log prob grad failures
#### Intended Effect:

See summary.  

Updates position of negation inside `base_hamiltonian.hpp` to be inside the try block instead of outside of it.
#### How to Verify:

Issue #543 has a model, data, and command that were broken and now work.

see:  https://github.com/stan-dev/stan/issues/543 
#### Side Effects:

None.
#### Documentation:

It's user facing, but current doc is correct.
#### Reviewer Suggestions:

Michael.
