### PR TITLE
fixed correlation_matrix_test.cpp

### DIFF
--- a/src/test/CmdStan/models/transforms/correlation_matrix_test.cpp
+++ b/src/test/CmdStan/models/transforms/correlation_matrix_test.cpp
@@ -11,7 +11,7 @@ public:
     std::vector<std::string> model_path;
     model_path.push_back("models");
     model_path.push_back("transforms");
-    model_path.push_back("bounded_double");
+    model_path.push_back("correlation_matrix");
     return model_path;
   }
   static bool has_data() {


### PR DESCRIPTION
#### Summary:

Fixes the correlation_matrix test. Only touches the single test, no code.
#### Intended Effect:

Fixes the test.
#### How to Verify:

Run: `make test/CmdStan/models/transforms/correlation_matrix`. 

Before the fix, this individual test would fail from a clean build. This was masked when running all tests because the model that was called from the test was built with the bounded_model test.
#### Side Effects:

No.
#### Documentation:

Not user facing.
#### Reviewer Suggestions:

Anyone.
