### PR TITLE
Bugfix/issue 568 epil

### DIFF
--- a/src/stan/gm/generator.hpp
+++ b/src/stan/gm/generator.hpp
@@ -1651,15 +1651,15 @@ namespace stan {
       o << INDENT2 << "return lp_accum__.sum();" << EOL2;
       o << INDENT << "} // log_prob()" << EOL2;
 
-      o << INDENT << "template <bool propto, bool jacobian, typename T>" << EOL;
-      o << INDENT << "T log_prob(Eigen::Matrix<T,Eigen::Dynamic,1>& params_r," << EOL;
+      o << INDENT << "template <bool propto, bool jacobian, typename T_>" << EOL;
+      o << INDENT << "T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r," << EOL;
       o << INDENT << "           std::ostream* pstream = 0) const {" << EOL;
-      o << INDENT << "  std::vector<T> vec_params_r;" << EOL;
+      o << INDENT << "  std::vector<T_> vec_params_r;" << EOL;
       o << INDENT << "  vec_params_r.reserve(params_r.size());" << EOL;
       o << INDENT << "  for (int i = 0; i < params_r.size(); ++i)" << EOL;
       o << INDENT << "    vec_params_r.push_back(params_r(i));" << EOL;
       o << INDENT << "  std::vector<int> vec_params_i;" << EOL;
-      o << INDENT << "  return log_prob<propto,jacobian,T>(vec_params_r, vec_params_i, pstream);" << EOL;
+      o << INDENT << "  return log_prob<propto,jacobian,T_>(vec_params_r, vec_params_i, pstream);" << EOL;
       o << INDENT << "}" << EOL2;
     }
 


### PR DESCRIPTION
## Summary

Fix #568 by changing the name of the template typename parameter T to T_ in the log_prob member function of a generated model class.
## Intended Effect

Avoid what appears to be a bug in gcc 4.2.1 on Mac OS X 10.7.5, in which a member variable T is confused with the template typename argument T, causing the epil model not to compile.
## Example

See issue 568.
## Side Effects

None.
## Documentation

None needed.
## Reviewer Suggestions
