### PR TITLE
Update appendices.tex

### DIFF
--- a/src/docs/stan-reference/appendices.tex
+++ b/src/docs/stan-reference/appendices.tex
@@ -1,4 +1,3 @@
-
 \part*{Appendices}
 \addcontentsline{toc}{part}{Appendices}
 
@@ -333,10 +332,11 @@ install wizard, then proceed through its options.
    Authoring}, click \code{Next},
 \item \emph{Select Additional Tasks}: check \code{Edit Path} and \code{Save
  Version in Registry}, click \code{Next},
-\item \emph{System Path Report}: click \code{Next},
+\item \emph{System Path Report}: ensure that that the paths to \code{c:\textbackslash{}Rtools\textbackslash{}bin} and \code{c:\textbackslash{}Rtools\textbackslash{}gcc-4.6.3\textbackslash{}bin} are listed at the beginning of the path and click \code{Next},
 \item \emph{Ready to Install}: click \code{Next}, wait for the
   install to complete, then
 \item \emph{Finish}: click \code{Finish}.
+\item \emph{Confirm Path}: After the install has completed, open a command prompt and type \code{PATH} to ensure that the new path is activated and the Rtools folders are in the system path.
 \end{itemize}
 
 \subsection{Downloading and Unpacking Stan}


### PR DESCRIPTION
Empasize need for proper Rtools path (using \textbackslash{}) in Windows installation. "Activate" path through calling PATH command after successful installation.

stan-reference.tex compiled (without images) under MikTeX 2.9 and Windows

![New text in pdf](https://f.cloud.github.com/assets/5596401/2286133/a6d368a6-9fdd-11e3-9102-8b3c163e5656.png)
