### PR TITLE
Fix to NUTS slice criterion

### DIFF
--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -198,13 +198,13 @@ namespace stan {
           double h = this->_hamiltonian.H(this->_z); 
           if (boost::math::isnan(h)) h = std::numeric_limits<double>::infinity();
           
-          util.criterion = util.log_u + (h - util.H0) < this->_max_delta;
+          util.criterion = ( util.log_u + (h - util.H0) ) < this->_max_delta;
           if (!util.criterion) ++(this->_n_divergent);
 
           util.sum_prob += stan::math::min(1, std::exp(util.H0 - h));
           util.n_tree += 1;
           
-          return (util.log_u + (h - util.H0) < 0);
+          return ( (util.log_u + (h - util.H0) ) < 0 );
           
         } 
         // General recursion

--- a/src/test/unit/mcmc/hmc/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/base_nuts_test.cpp
@@ -1,5 +1,6 @@
 #include <test/unit/mcmc/hmc/mock_hmc.hpp>
 #include <stan/mcmc/hmc/nuts/base_nuts.hpp>
+#include <stan/mcmc/hmc/integrators/expl_leapfrog.hpp>
 
 #include <boost/random/additive_combine.hpp>
 
@@ -28,6 +29,65 @@ namespace stan {
       bool compute_criterion(ps_point& start,
                              ps_point& finish,
                              Eigen::VectorXd& rho) { return true; }
+      
+    };
+    
+    // Mock Hamiltonian
+    template <typename M, typename BaseRNG>
+    class divergent_hamiltonian: public base_hamiltonian<M,
+                                                         ps_point,
+                                                         BaseRNG> {
+      
+    public:
+      
+      divergent_hamiltonian(M& m, std::ostream *e): base_hamiltonian<M,
+                                                                     ps_point,
+                                                                     BaseRNG> (m,e) {};
+      
+      double T(ps_point& z) { return 0; }
+      
+      double tau(ps_point& z) { return T(z); }
+      double phi(ps_point& z) { return this->V(z); }
+      
+      const Eigen::VectorXd dtau_dq(ps_point& z) {
+        return Eigen::VectorXd::Zero(this->_model.num_params_r());
+      }
+      
+      const Eigen::VectorXd dtau_dp(ps_point& z) {
+        return Eigen::VectorXd::Zero(this->_model.num_params_r());
+      }
+      
+      const Eigen::VectorXd dphi_dq(ps_point& z) {
+        return Eigen::VectorXd::Zero(this->_model.num_params_r());
+      }
+      
+      void init(ps_point& z) { z.V = 0; }
+      
+      void sample_p(ps_point& z, BaseRNG& rng) {};
+      
+      void update(ps_point& z) {
+        z.V += 500;
+      }
+      
+    };
+    
+    class divergent_nuts: public base_nuts<mock_model,
+                                           ps_point,
+                                           divergent_hamiltonian,
+                                           expl_leapfrog,
+                                           rng_t> {
+      
+    public:
+      
+      divergent_nuts(mock_model &m, rng_t& rng, std::ostream* o, std::ostream* e):
+        base_nuts<mock_model, ps_point, divergent_hamiltonian, expl_leapfrog,rng_t>(m, rng, o, e)
+      { this->_name = "Divergent NUTS"; }
+      
+    private:
+      
+      bool compute_criterion(ps_point& start,
+                             ps_point& finish,
+                             Eigen::VectorXd& rho) { return false; }
       
     };
     
@@ -119,5 +179,57 @@ TEST(McmcBaseNuts, build_tree) {
   
   EXPECT_EQ(8 * init_momentum, sampler.z().q(0));
   EXPECT_EQ(init_momentum, sampler.z().p(0));
+  
+}
+
+TEST(McmcBaseNuts, slice_criterion) {
+  
+  rng_t base_rng(0);
+  
+  int model_size = 1;
+  double init_momentum = 1.5;
+  
+  Eigen::VectorXd rho = Eigen::VectorXd::Zero(model_size);
+  
+  stan::mcmc::ps_point z_init(model_size);
+  z_init.q(0) = 0;
+  z_init.p(0) = init_momentum;
+  
+  stan::mcmc::ps_point z_propose(model_size);
+  
+  stan::mcmc::nuts_util util;
+  util.log_u = 0;
+  util.H0 = 0;
+  util.sign = 1;
+  util.n_tree = 0;
+  util.sum_prob = 0;
+  
+  stan::mcmc::mock_model model(model_size);
+  stan::mcmc::divergent_nuts sampler(model, base_rng, &std::cout, &std::cerr);
+  
+  sampler.set_nominal_stepsize(1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+  sampler.z() = z_init;
+  
+  int n_valid = 0;
+  
+  sampler.z().V = -750;
+  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util);
+  
+  EXPECT_EQ(1, n_valid);
+  EXPECT_EQ(0, sampler._n_divergent);
+  
+  sampler.z().V = -250;
+  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util);
+  
+  EXPECT_EQ(0, n_valid);
+  EXPECT_EQ(0, sampler._n_divergent);
+  
+  sampler.z().V = 750;
+  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util);
+  
+  EXPECT_EQ(0, n_valid);
+  EXPECT_EQ(1, sampler._n_divergent);
   
 }


### PR DESCRIPTION
## Summary

Bad parentheses and inadvertent casting.  NUTS was implementing the slice criterion as

util.log_u + (h - util.H0) < 0

which computes a check on (h - until.H0) and then adds until.log_u before casting to a bool.
This pull request fixes this to

(util.log_u + (h - util.H0) ) < 0

so that the slice is taken into account correctly.
## Intended Effect

Proper check of the slice criterion.
## How to Verify

The slicing behavior (both for an accepted slice and the max_delta condition) are checked in the accompanying unit test.  Run with mkfast test/unit/mcmc/hmc/base_nuts.
## Side Effects

No user-facing effects, will cause small differences in sampling behavior for some models.
## Documentation

None.
## Suggested Reviewers

Anyone, but @syclik should confirm if the unit test is sufficient.

@syclik, this is branched off v2.2.0.  I've made it a hot fix targeted as master here, but you can close this and push to develop or a proper hot fix branch as you'd like.
