### PR TITLE
Allow construction of stan::mcmc::chains using vectors (rather than Eigen)

### DIFF
--- a/src/stan/mcmc/chains.hpp
+++ b/src/stan/mcmc/chains.hpp
@@ -317,6 +317,11 @@ namespace stan {
     public:
       chains(const Eigen::Matrix<std::string, Eigen::Dynamic, 1>& param_names) 
         : param_names_(param_names) { }
+
+      chains(const std::vector<std::string>& param_names) : param_names_(param_names.size()) {
+          for (int i = 0; i < param_names.size(); i++)
+              param_names_(i) = param_names[i];
+      }
       
       chains(const stan::io::stan_csv& stan_csv) 
         : param_names_(stan_csv.header) {
@@ -428,6 +433,25 @@ namespace stan {
           throw std::invalid_argument("add(sample): number of columns in"
                                       " sample does not match chains");
         add(num_chains(), sample);
+      }
+
+      void add(const std::vector<std::vector<double> >& sample) {
+        /**
+        * Convert a vector of vector<double> to Eigen::MatrixXd
+        *
+        * This method is added for the benefit of software wrapping
+        * Stan (e.g., PyStan) so that it need not additionally wrap Eigen.
+        *
+        */
+        int n_row = sample.size();
+        if (n_row == 0)
+            return;
+        int n_col = sample[0].size();
+        Eigen::MatrixXd sample_copy(n_row, n_col);
+        for (int i = 0; i < n_row; i++) {
+            sample_copy.row(i) = Eigen::VectorXd::Map(&sample[i][0], sample[0].size());
+        }
+        add(sample_copy);
       }
 
       void add(const stan::io::stan_csv& stan_csv) {

--- a/src/test/unit/mcmc/chains_test.cpp
+++ b/src/test/unit/mcmc/chains_test.cpp
@@ -6,6 +6,8 @@
 #include <exception>
 #include <utility>
 #include <fstream>
+#include <vector>
+#include <string>
 
 
 
@@ -130,6 +132,40 @@ TEST_F(McmcChains, add) {
   EXPECT_EQ(3002, chains.num_samples())
     << "validate state is identical to before";
 }
+
+TEST_F(McmcChains, add_adapter) {
+  stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream);
+
+  // construct with std::string
+  std::vector<std::string> param_names(blocker1.header.size());
+  for (int i = 0; i < blocker1.header.size(); i++) {
+      param_names[i] = blocker1.header[i];
+  }
+
+  stan::mcmc::chains<> chains(param_names);
+  EXPECT_EQ(0, chains.num_chains());
+  EXPECT_EQ(0, chains.num_samples());
+
+  std::vector<std::vector<double> > samples(blocker1.samples.rows());
+  for (int i = 0; i < blocker1.samples.rows(); i++) {
+      samples[i] = std::vector<double>(blocker1.samples.cols());
+  }
+  for (int i = 0; i < blocker1.samples.rows(); i++) {
+    for (int j = 0; j < blocker1.samples.cols(); j++) {
+        samples[i][j] = blocker1.samples(i, j);
+    }
+  }
+
+  EXPECT_EQ(blocker1.samples.rows(), samples.size());
+  EXPECT_EQ(blocker1.samples.cols(), samples[0].size());
+
+  EXPECT_NO_THROW(chains.add(samples))
+    << "adding multiple samples, adds new chain";
+  EXPECT_EQ(1, chains.num_chains());
+  EXPECT_EQ(1000, chains.num_samples(0));
+
+}
+
 
 TEST_F(McmcChains, blocker1_num_chains) {
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream);


### PR DESCRIPTION
Added to make using Stan's estimated sample size and rhat functions easier for PyStan (and any wrapping software that does not want to wrap Eigen).
