### PR TITLE
Bugfix/issue 624 json compare unsigned

### DIFF
--- a/src/stan/io/json/json_data_handler.hpp
+++ b/src/stan/io/json/json_data_handler.hpp
@@ -302,7 +302,6 @@ namespace stan {
         dim_last_ = dim_idx_;
       }
 
-
       // convert row-major offset to column-major offset
       size_t convert_offset_rtl_2_ltr(size_t rtl_offset, const std::vector<size_t>& dims) {
         size_t rtl_dsize = 1;
@@ -310,7 +309,7 @@ namespace stan {
           rtl_dsize *= dims[i];
 
         // array index should be valid, but check just in case
-        if (rtl_offset > rtl_dsize*dims[0]) {
+        if (rtl_offset >= rtl_dsize*dims[0]) {
           std::stringstream errorMsg;
           errorMsg << "variable: " << key_ << ", unexpected error";
           throw json_error(errorMsg.str());
@@ -326,7 +325,6 @@ namespace stan {
           size_t idx = rem / rtl_dsize;
           ltr_offset +=  idx * ltr_dsize;
           rem = rem - idx * rtl_dsize;
-          if (rem < 0) rem = 0;
           rtl_dsize = rtl_dsize / dims[i+1];
           ltr_dsize *= dims[i];
         }

--- a/src/test/unit/io/json/json_data_handler_test.cpp
+++ b/src/test/unit/io/json/json_data_handler_test.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+
+#include <stan/io/json.hpp>
+
+void test_rtl_2_ltr(size_t idx_rtl, 
+                    size_t idx_ltr,
+                    const std::vector<size_t>& dims) {
+  stan::json::vars_map_r vars_r;
+  stan::json::vars_map_i vars_i;
+  stan::json::json_data_handler handler(vars_r, vars_i);
+  size_t idx = handler.convert_offset_rtl_2_ltr(idx_rtl,dims);
+  EXPECT_EQ(idx, idx_ltr);
+}
+
+void test_exception(size_t idx_rtl, 
+                    const std::string& exception_text,
+                    const std::vector<size_t>& dims) {
+  stan::json::vars_map_r vars_r;
+  stan::json::vars_map_i vars_i;
+  stan::json::json_data_handler handler(vars_r, vars_i);
+  try {
+    handler.convert_offset_rtl_2_ltr(idx_rtl,dims);
+  } catch (const std::exception& e) {
+    EXPECT_EQ(e.what(), exception_text);
+    return;
+  }
+  FAIL();  // didn't throw an exception as expected.
+}
+
+
+TEST(ioJson,rtl_2_ltr_1) {
+  std::vector<size_t> dims(1);
+  dims[0] = 7;
+  test_rtl_2_ltr(0,0,dims);
+  test_rtl_2_ltr(1,1,dims);
+  test_rtl_2_ltr(2,2,dims);
+  test_rtl_2_ltr(3,3,dims);
+  test_rtl_2_ltr(4,4,dims);
+  test_rtl_2_ltr(5,5,dims);
+  test_rtl_2_ltr(6,6,dims);
+}
+
+//  row major:
+//  11 12 13 14 21 22 23 24
+//  column major:
+//  11 21 12 22 13 23 14 24
+
+TEST(ioJson,rtl_2_ltr_2) {
+  std::vector<size_t> dims(2);
+  dims[0] = 2;
+  dims[1] = 4;
+  test_rtl_2_ltr(0,0,dims);
+  test_rtl_2_ltr(1,2,dims);
+  test_rtl_2_ltr(2,4,dims);
+  test_rtl_2_ltr(3,6,dims);
+  test_rtl_2_ltr(4,1,dims);
+  test_rtl_2_ltr(5,3,dims);
+  test_rtl_2_ltr(6,5,dims);
+  test_rtl_2_ltr(7,7,dims);
+}
+
+TEST(ioJson,rtl_2_ltr_err_1) {
+  std::vector<size_t> dims(1);
+  dims[0] = 7;
+  test_exception(7,"variable: , unexpected error",dims);
+}
+
+TEST(ioJson,rtl_2_ltr_err_2) {
+  std::vector<size_t> dims(2);
+  dims[0] = 2;
+  dims[1] = 4;
+  test_exception(8,"variable: , unexpected error",dims);
+}
+
+TEST(ioJson,rtl_2_ltr_err_3n) {
+  std::vector<size_t> dims(2);
+  dims[0] = 2;
+  dims[1] = 4;
+  test_exception(11,"variable: , unexpected error",dims);
+}

--- a/src/test/unit/io/json/json_data_test.cpp
+++ b/src/test/unit/io/json/json_data_test.cpp
@@ -232,7 +232,7 @@ TEST(ioJson,jsonData_int_array_3D) {
   std::stringstream in(txt);
   stan::json::json_data jdata(in);
   std::vector<int> expected_vals;
-  expected_vals.push_back(111);
+  expected_vals.push_back(111);  
   expected_vals.push_back(211);
   expected_vals.push_back(121);
   expected_vals.push_back(221);


### PR DESCRIPTION
fixed boundary condition, changed comparison to >= instead of > and removed spurious error check which was causing a compiler warning or error.
