### PR TITLE
Enhance documentation for censored data modeling

### DIFF
--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -2735,15 +2735,16 @@ does not report values above 300 pounds.
 
 One way to model censored data is to treat the censored data as
 missing data that is constrained to fall in the censored range of
-values.  Because \Stan does not allow unknown values in its arrays or
-matrices, the censored values must be represented explicitly.
+values.  Since \Stan does not allow unknown values in its arrays or
+matrices, the censored values must be represented explicitly, as in the
+following right-censored case.
 %
 \begin{quote}
 \begin{Verbatim}[fontsize=\small]
 data {
   int<lower=0> N_obs;
   int<lower=0> N_cens;
-  real<lower=0> y_obs[N_obs];
+  real y_obs[N_obs];
   real<lower=max(y_obs)> U;
 }
 parameters {
@@ -2752,10 +2753,8 @@ parameters {
   real<lower=0> sigma;
 }
 model {
-  for (n in 1:N_obs)
-    y_obs[n] ~ normal(mu,sigma);
-  for (n in 1:N_cens)
-    y_cens[n] ~ normal(mu,sigma);
+  y_obs ~ normal(mu,sigma);
+  y_cens ~ normal(mu,sigma);
 }
 \end{Verbatim}
 \end{quote}
@@ -2787,17 +2786,14 @@ is
 \[
 \log \prod_{m=1}^M \mbox{Pr}[y_m > U]
 = \log \left( 1 - \Phi\left(\frac{y - \mu}{\sigma}\right)\right)^{M}
-= M \, \log \left( 1 - \Phi\left(\frac{y - \mu}{\sigma}\right)\right)
-\]
-% 
-Although \Stan implements $\Phi$ with the function $\code{Phi}$, \Stan
-also provides the cumulative distribution function \code{normal\_cdf},
-defined by
-\[
-\code{normal\_cdf}(y,\mu,\sigma) = \Phi \left( \frac{y - \mu}{\sigma} \right).
+= M \, \code{normal\_ccdf\_log}(y,\mu,\sigma),
 \]
 %
-The following model assumes
+where \code{normal\_ccdf\_log} is the log of complementary CDF
+(\Stan provides \code{<distr>\_ccdf\_log} for each distribution
+implemented in \Stan).
+
+The following right-censored model assumes
 that the censoring point is known, so it is declared as data.
 %
 \begin{quote}
@@ -2805,7 +2801,7 @@ that the censoring point is known, so it is declared as data.
 data {
   int<lower=0> N_obs;
   int<lower=0> N_cens;
-  real<lower=0> y_obs[N_obs];
+  real y_obs[N_obs];
   real<lower=max(y_obs)> U;
 }
 parameters {
@@ -2813,9 +2809,8 @@ parameters {
   real<lower=0> sigma;
 }
 model {
-  for (n in 1:N_obs)
-    y_obs[n] ~ normal(mu,sigma); 
-  increment_log_prob(N_cens * log1m(normal_cdf(U,mu,sigma)));
+  y_obs ~ normal(mu,sigma); 
+  increment_log_prob(N_cens * normal_ccdf_log(U,mu,sigma));
 }
 \end{Verbatim}
 \end{quote}
@@ -2823,14 +2818,33 @@ model {
 For the observed values in \Verb|y_obs|, the normal sampling model is
 used without truncation.  The log probability is directly incremented
 using the calculated log cumulative normal probability of the censored
-data items.  The built-in function \code{log1m} is used, which maps
-$x$ to $\log (1 - x)$ in an arithmetically stable way.
+data items.
 
-To deal with situations where the censoring point variable \code{U} is
-unknown, the declaration of \code{U} should be moved from the data
-block to the parameters block.
-
-
+For the left-censored data the CDF
+(\code{normal\_cdf\_log}) has to be used instead of complementary CDF.
+If the censoring point variable (\code{L}) is unknown,
+its declaration should be moved from the data to the parameters block. 
+%
+\begin{quote}
+\begin{Verbatim}[fontsize=\small]
+data {
+  int<lower=0> N_obs;
+  int<lower=0> N_cens;
+  real y_obs[N_obs];
+}
+parameters {
+  real<upper=min(y_obs)> L;
+  real mu;
+  real<lower=0> sigma;
+}
+model {
+  L ~ normal(mu,sigma);
+  y_obs ~ normal(mu,sigma);
+  increment_log_prob(N_cens * normal_cdf_log(L,mu,sigma));
+}
+\end{Verbatim}
+\end{quote}
+%
 
 \chapter{Mixture Modeling}\label{mixture-modeling.chapter}
 


### PR DESCRIPTION
Stan has went a long way since this manual section was originally written, so now censoring could be implemented more efficiently than it's described there.

I've made a few changes:
- it's confusing that right-censored y_obs is declared to be positive, whereas it should be unconstrained
- it should be easier to read when it's explicitly specified that the examples deal with right-censored data; and left-censored case is also discussed
- now array sampling operator could be used instead of loops
- now there is normal_ccdf_log to be used instead of log1m( normal_cdf() )
