### PR TITLE
ARM, Chapter 22: Fix anova_radon_nopred.stan, generate Figure 22.4

### DIFF
--- a/src/models/ARM/Ch.22/anova_radon_nopred.stan
+++ b/src/models/ARM/Ch.22/anova_radon_nopred.stan
@@ -27,7 +27,7 @@ generated quantities {
   real<lower=0> s_y;
   vector[N] e_y;
 
-  real<lower=0> s_a;
-  real<lower=0> s_y;
-  vector[N] e_y;
+  e_y <- y - y_hat;
+  s_a <- sd(a);
+  s_y <- sd(e_y);
 }


### PR DESCRIPTION
- `anova_radon_nopred.stan` didn't compile due to duplicate vars (`s_a`, `s_y`, and `e_y`) in the `generated quantities` block
- Generate something close to Figure 22.4 in 22.4_DoingANOVUsingMLM.R

Original Fig. 22.4
![image](https://cloud.githubusercontent.com/assets/637011/3068516/5d538afe-e28f-11e3-81cb-ffbd9bdf0467.png)

Generated figure
![image](https://cloud.githubusercontent.com/assets/637011/3068508/4ad7a824-e28f-11e3-81be-c55a787e0f67.png)
