### PR TITLE
Feature/issue 508 copyright

### DIFF
--- a/licenses/README.txt
+++ b/licenses/README.txt
@@ -1,0 +1,10 @@
+The copyright holder for the various Stan licenses are listed
+collectively as the Stan Development Team. The copyright for each code
+contribution to Stan is held by its developer. Each contribution has
+been licensed by its developer under the appropriate license:
+
+   Stan:     new BSD
+   CmdStan:  new BSD
+   RStan:    GPLv3
+   PyStan:   GPLv3
+


### PR DESCRIPTION
(This is a no-code, no-build request, so can just be merged when reviewed.)
#### Summary:

Clarify licensing terms that each developer (or their assignee) holds copyright for their own work.  This was also changed in the manual as part of the manual updates.
#### Intended Effect:

Just clarification to users.
#### How to Verify:

look at the added file
#### Side Effects:

n/a
#### Documentation:

n/a
#### Reviewer Suggestions:

Anyone
