### PR TITLE
Bugfix/670 io check too large ints

### DIFF
--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -667,7 +667,6 @@ namespace stan {
           dims_.push_back(0U);
           return true;
         }
-        //        if (!scan_number()) return false;; // first entry
         scan_number(); // first entry
         while (scan_char(',')) {
           scan_number();
@@ -863,10 +862,14 @@ namespace stan {
         if (!scan_char('-')) 
           return false;
         try {
-          scan_value(); // set stack_r_, stack_i_, dims_
+          bool okSyntax = scan_value(); // set stack_r_, stack_i_, dims_
+          if (!okSyntax) {
+            std::string msg = "syntax error";
+            BOOST_THROW_EXCEPTION (std::invalid_argument (msg));
+          }
         }
         catch ( const std::invalid_argument &exc ) {
-          std::string msg = " variable " + name_ + " error: " + exc.what();
+          std::string msg = "data " + name_ + " " + exc.what();
           BOOST_THROW_EXCEPTION (std::invalid_argument (msg));
         }
         return true;


### PR DESCRIPTION
#### Summary:

Modified class dump_reader in stan/io/dump.hpp so that it throws exceptions when data values read in from a file in S-plus dump format exceed the min/max int and double values.
#### Intended Effect:

Provide more informative error diagnostics to Stan users.
Current behaviour is that the data_reader fails silently when it encounters a variable with bad data values and returns a var_context object that doesn't contain the variable.  Requests for the variable result in an exception with error message saying unknown variable.
Now data_reader throws an exception that gives the variable name and type of error.  
#### How to Verify:

a. Additional tests have been added to the unit tests src/test/io/dump_test.cpp 

b. Tested by running command stan from the command line using the example in src/model/basic_estimators/bernoulli.stan  and introducing errors into the variable definitions in the bernoulli.data.R file, e.g.,
changing N <- 10 to N <- 109999999999999999999999999999999999
Compiling the model and running it on the bad data file results in error message:
Exception:  variable N error: value 109999999999999999999999999999999999 beyond int range
Diagnostic information: 
src/stan/io/dump.hpp(869): Throw in function bool stan::io::dump_reader::next()
Dynamic exception type: boost::exception_detail::clone_implboost::exception_detail::error_info_injector<std::invalid_argument >
std::exception::what:  variable N error: value 109999999999999999999999999999999999 beyond int range
#### Side Effects:

Syntax checks for close parens on R sequence and structure statements may cause problems for existing data.R files which were ill-formed but allowed by the parser.
#### Documentation:

No documentation for users. 
#### Reviewer Suggestions:

Daniel Lee?
