### PR TITLE
removed references to choleksy_(cor|cov) types

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,6 @@ Thanks to everyone!
 New Features
 ------------
 * user-defined function definitions added to Stan language
-* cholesky_corr data type for Cholesky factors of correlation matrices
 * a^b syntax for pow(a,b)  (thanks to Mitzi Morris)
 * reshaping functions: to_matrix(), to_vector(), to_row_vector(), 
   to_array_1d(), to_array_2d()

--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -425,11 +425,9 @@ Symmetric, positive-definite matrices have the type
 positive-definite matrices with unit diagonals, have the type
 \code{corr\_matrix}.
 
-For both correlation and covariance matrices, there are corresponding
-Cholesky factor types, \code{cholesky\_corr} and
-\code{cholesky\_cov}.  Using these can be much more efficient than the
-full correlation and covariance matrices because they are easier to
-factor and scale.
+There is also a Cholesky factor type, \code{cholesky\_factor\_cov}.
+Using this type can be much more efficient than the full covariance
+matrices because it is easier to factor and scale.
 
 
 


### PR DESCRIPTION
Although referenced in the RELEASE-NOTES.txt and the manual, these types are in
2.3.0, which still uses choleksy_factor_cov
