### PR TITLE
Use const_iterator to resolve Visual Studio 2008 compile error

### DIFF
--- a/src/stan/gm/grammars/functions_grammar_def.hpp
+++ b/src/stan/gm/grammars/functions_grammar_def.hpp
@@ -126,7 +126,7 @@ namespace stan {
       static bool fun_exists(const std::set<std::pair<std::string, 
                                                       function_signature_t> >& existing,
                              const std::pair<std::string,function_signature_t>& name_sig) {
-        for (std::set<std::pair<std::string, function_signature_t> >::iterator it 
+        for (std::set<std::pair<std::string, function_signature_t> >::const_iterator it 
                = existing.begin();
              it != existing.end();
              ++it)


### PR DESCRIPTION
Patch from @patricksnape.

This particular compile error didn't occur in Stan 2.2 so it seems there was a change that introduced the problem. I'm not sure why VS 2008 is raising an error, but perhaps the C++ savants can guess.
