### PR TITLE
removed tabs in stan and test files

### DIFF
--- a/src/stan/common/command.hpp
+++ b/src/stan/common/command.hpp
@@ -617,12 +617,12 @@ namespace stan {
                                       parser.arg("method")->arg("sample")->arg("adapt"));
         bool adapt_engaged = dynamic_cast<stan::gm::bool_argument*>(adapt->arg("engaged"))->value();
         
-	if (model.num_params_r() == 0 && algo->value() != "fixed_param") {
-	  std::cout
-	    << "Must use algorithm=fixed_param for model that has no parameters."
-	    << std::endl;
-	  return -1;
-	}      
+        if (model.num_params_r() == 0 && algo->value() != "fixed_param") {
+          std::cout
+            << "Must use algorithm=fixed_param for model that has no parameters."
+            << std::endl;
+          return -1;
+        }      
 
         if (algo->value() == "fixed_param") {
           

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -78,22 +78,22 @@ namespace stan {
       
       template <typename T>
       static inline void _fast_vector_copy(Eigen::Matrix<T, Eigen::Dynamic, 1>& v_to, const Eigen::Matrix<T, Eigen::Dynamic, 1>& v_from) {
-	int sz = v_from.size();
+        int sz = v_from.size();
         v_to.resize(sz);
-	if (sz > 0) {
-	  std::memcpy(&v_to(0), &v_from(0), v_from.size() * sizeof(double));
-	}
+        if (sz > 0) {
+          std::memcpy(&v_to(0), &v_from(0), v_from.size() * sizeof(double));
+        }
       }
 
       template <typename T>
       static inline void _fast_matrix_copy(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& v_to,
                                     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& v_from) {
-	int nr = v_from.rows();
-	int nc = v_from.cols();
+        int nr = v_from.rows();
+        int nc = v_from.cols();
         v_to.resize(nr, nc);
-	if (nr > 0 && nc > 0) {
-	  std::memcpy(&v_to(0), &v_from(0), v_from.size() * sizeof(double));
-	}
+        if (nr > 0 && nc > 0) {
+          std::memcpy(&v_to(0), &v_from(0), v_from.size() * sizeof(double));
+        }
       }
       
     };

--- a/src/stan/prob/distributions/multivariate/continuous/dirichlet.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/dirichlet.hpp
@@ -44,7 +44,7 @@ namespace stan {
               typename T_prob, typename T_prior_sample_size>
     typename boost::math::tools::promote_args<T_prob,T_prior_sample_size>::type
     dirichlet_log(const Eigen::Matrix<T_prob,Eigen::Dynamic,1>& theta,
-		  const Eigen::Matrix<T_prior_sample_size,Eigen::Dynamic,1>& alpha) {
+                  const Eigen::Matrix<T_prior_sample_size,Eigen::Dynamic,1>& alpha) {
       static const char* function = "stan::prob::dirichlet_log(%1%)";
       using boost::math::lgamma;
       using boost::math::tools::promote_args;

--- a/src/stan/prob/distributions/univariate/continuous/gamma.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/gamma.hpp
@@ -518,8 +518,8 @@ namespace stan {
 
       /*
         the boost gamma distribution is defined by
-	shape and scale, whereas the stan one is defined
-	by shape and rate
+        shape and scale, whereas the stan one is defined
+        by shape and rate
       */
       variate_generator<RNG&, gamma_distribution<> >
         gamma_rng(rng, gamma_distribution<>(alpha, 1.0 / beta));

--- a/src/test/unit/distribution/multivariate/continuous/dirichlet_test.cpp
+++ b/src/test/unit/distribution/multivariate/continuous/dirichlet_test.cpp
@@ -77,68 +77,68 @@ TEST_F(AgradDistributionsDirichlet,Bounds) {
 
   bad_theta << 0.25, 0.25;
   EXPECT_THROW(dirichlet_log(to_var(bad_theta),to_var(good_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "sum of theta is not 1";
   EXPECT_THROW(dirichlet_log(to_var(bad_theta),good_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "sum of theta is not 1";
   EXPECT_THROW(dirichlet_log(bad_theta,to_var(good_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "sum of theta is not 1";
 
   bad_theta << -0.25, 1.25;
   EXPECT_THROW(dirichlet_log(to_var(bad_theta),to_var(good_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "theta has element less than 0";
   EXPECT_THROW(dirichlet_log(to_var(bad_theta),good_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "theta has element less than 0";
   EXPECT_THROW(dirichlet_log(bad_theta,to_var(good_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "theta has element less than 0";
 
   bad_theta << -0.25, 1.25;
   EXPECT_THROW(dirichlet_log(to_var(bad_theta),to_var(good_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "theta has element less than 0";
   EXPECT_THROW(dirichlet_log(to_var(bad_theta),good_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "theta has element less than 0";
   EXPECT_THROW(dirichlet_log(bad_theta,to_var(good_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "theta has element less than 0";
 
   bad_alpha << 0.0, 1.0;
   EXPECT_THROW(dirichlet_log(to_var(good_theta),to_var(bad_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "alpha has element equal to 0";
   EXPECT_THROW(dirichlet_log(to_var(good_theta),bad_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "alpha has element equal to 0";
   EXPECT_THROW(dirichlet_log(good_theta,to_var(bad_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "alpha has element equal to 0";
 
   bad_alpha << -0.5, 1.0;
   EXPECT_THROW(dirichlet_log(to_var(good_theta),to_var(bad_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "alpha has element less than 0";
   EXPECT_THROW(dirichlet_log(to_var(good_theta),bad_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "alpha has element less than 0";
   EXPECT_THROW(dirichlet_log(good_theta,to_var(bad_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "alpha has element less than 0";
 
   bad_alpha = Matrix<double,Dynamic,1>(4,1);
   bad_alpha << 1, 2, 3, 4;
   EXPECT_THROW(dirichlet_log(to_var(good_theta),to_var(bad_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "size mismatch: theta is a 2-vector, alpha is a 4-vector";
   EXPECT_THROW(dirichlet_log(to_var(good_theta),bad_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "size mismatch: theta is a 2-vector, alpha is a 4-vector";
   EXPECT_THROW(dirichlet_log(good_theta,to_var(bad_alpha)),
-	       std::domain_error)
+               std::domain_error)
     << "size mismatch: theta is a 2-vector, alpha is a 4-vector";
 }

--- a/src/test/unit/mcmc/hmc/hamiltonians/ps_point_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/ps_point_test.cpp
@@ -13,42 +13,42 @@ namespace stan {
 
       static void fast_vector_copy()
       {
-	vector_t from3(3); from3 << 5.25, 3.125, -6.5;
-	vector_t to3(12);
-	ps_point::_fast_vector_copy(to3, from3);
+        vector_t from3(3); from3 << 5.25, 3.125, -6.5;
+        vector_t to3(12);
+        ps_point::_fast_vector_copy(to3, from3);
 
-	EXPECT_EQ(from3, to3);
+        EXPECT_EQ(from3, to3);
 
-	int zero = 0;
-	vector_t from0(zero);
-	vector_t to0(7);
-	ps_point::_fast_vector_copy(to0, from0);
+        int zero = 0;
+        vector_t from0(zero);
+        vector_t to0(7);
+        ps_point::_fast_vector_copy(to0, from0);
 
-	EXPECT_EQ(from0, to0);    
+        EXPECT_EQ(from0, to0);    
       }
 
       static void fast_matrix_copy()
       {
-	matrix_t from2_3(2, 3);
-	from2_3 << 5, 2, 7, -3, 4, -9;
-	matrix_t to2_3(1, 13);
-	ps_point::_fast_matrix_copy(to2_3, from2_3);
+        matrix_t from2_3(2, 3);
+        from2_3 << 5, 2, 7, -3, 4, -9;
+        matrix_t to2_3(1, 13);
+        ps_point::_fast_matrix_copy(to2_3, from2_3);
 
-	EXPECT_EQ(from2_3, to2_3);
+        EXPECT_EQ(from2_3, to2_3);
 
-	int zero = 0;
+        int zero = 0;
 
-	matrix_t from2_0(2, zero);
-	matrix_t to2_0(8, 3);
-	ps_point::_fast_matrix_copy(to2_0, from2_0);
+        matrix_t from2_0(2, zero);
+        matrix_t to2_0(8, 3);
+        ps_point::_fast_matrix_copy(to2_0, from2_0);
 
-	EXPECT_EQ(from2_0, to2_0);
+        EXPECT_EQ(from2_0, to2_0);
 
-	matrix_t from0_5(zero, 5);
-	matrix_t to0_5(7, 4);
-	ps_point::_fast_matrix_copy(to0_5, from0_5);
+        matrix_t from0_5(zero, 5);
+        matrix_t to0_5(7, 4);
+        ps_point::_fast_matrix_copy(to0_5, from0_5);
 
-	EXPECT_EQ(from0_5, to0_5);
+        EXPECT_EQ(from0_5, to0_5);
       }
   
     };

--- a/src/test/unit/prob/distributions/multivariate/continuous/dirichlet_test.cpp
+++ b/src/test/unit/prob/distributions/multivariate/continuous/dirichlet_test.cpp
@@ -50,33 +50,33 @@ TEST(ProbDistributions,DirichletBounds) {
 
   bad_theta << 0.25, 0.25;
   EXPECT_THROW(stan::prob::dirichlet_log(bad_theta,good_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "sum of theta is not 1";
 
   bad_theta << -0.25, 1.25;
   EXPECT_THROW(stan::prob::dirichlet_log(bad_theta,good_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "theta has element less than 0";
 
   bad_theta << -0.25, 1.25;
   EXPECT_THROW(stan::prob::dirichlet_log(bad_theta,good_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "theta has element less than 0";
 
   bad_alpha << 0.0, 1.0;
   EXPECT_THROW(stan::prob::dirichlet_log(good_theta,bad_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "alpha has element equal to 0";
 
   bad_alpha << -0.5, 1.0;
   EXPECT_THROW(stan::prob::dirichlet_log(good_theta,bad_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "alpha has element less than 0";
 
   bad_alpha = Matrix<double,Dynamic,1>(4,1);
   bad_alpha << 1, 2, 3, 4;
   EXPECT_THROW(stan::prob::dirichlet_log(good_theta,bad_alpha),
-	       std::domain_error)
+               std::domain_error)
     << "size mismatch: theta is a 2-vector, alpha is a 4-vector";
 }
 


### PR DESCRIPTION
#### Summary:

Removes tabs in all of src/stan and src/test files. (issue #696)
#### Intended Effect:

Removed tabs.
#### How to Verify:

See files changed and run 

```
grep -R "\t" src/stan 
```

```
grep -R "\t" src/test 
```
#### Side Effects:

None.
#### Documentation:

None.
#### Reviewer Suggestions:

Anyone.
