### PR TITLE
updating .gitignore to ignore generated .cpp files and not ignore .stan within test-models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@ stan.kdev4
 !/src/models/**/makefile
 
 # tests: compiled models
-/src/test/test-models/**
-!/src/test/test-models/**.stan
+/src/test/test-models/**/*.cpp
+!/src/test/test-models/**/*.stan
 !/src/test/test-models/**/.gitignore
 
 # tests: generated agrad tests


### PR DESCRIPTION
#### Summary:

Fixes an issue with the .gitignore file.
#### Intended Effect:

New and changes to .stan files within src/test/test-models/\* should be recognized by git.
#### How to Verify:

Add a .stan file to src/test/test-models/ and it should show up in git status. Also if you change a file in src/test/test-models/. If you create a .cpp file in one of the subdirectories, this should not show up in git status.
#### Side Effects:

No.
#### Documentation:

N/A.
#### Reviewer Suggestions:

@bob-carpenter: can you verify that this does the right thing?
