### PR TITLE
fixes #743. Instead of PI, multiplied by 2 and called it TWO_PI

### DIFF
--- a/src/stan/prob/distributions/univariate/continuous/von_mises.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/von_mises.hpp
@@ -161,6 +161,7 @@ namespace stan {
       double U3 = uniform_rng(0.0, 1.0, rng) - 0.5;
       double sign = ((U3 >= 0) - (U3 <= 0));
 
+      //  it's really an fmod() with a positivity constraint
       return sign * std::acos(W) + fmod(fmod(mu,2*stan::math::pi())+2*stan::math::pi(),2*stan::math::pi());
     }
 


### PR DESCRIPTION
#### Summary:

`PI` is used as a macro somewhere in RStan's preprocessed chain (could be from anywhere). This conflicts with our definition of von_mises.

This fix just replaces PI with TWO_PI (by multiplying by two).
#### Intended Effect:

Allows RStan to build without affecting Stan.
#### How to Verify:

Tests should all be the same.
#### Side Effects:

None.
#### Documentation:

Internal change.
#### Reviewer Suggestions:

Anyone.
