### PR TITLE
updating arg_init. The test for this is in CmdStan.

### DIFF
--- a/src/stan/gm/arguments/arg_init.hpp
+++ b/src/stan/gm/arguments/arg_init.hpp
@@ -20,7 +20,7 @@ namespace stan {
         _default = "\"2\"";
         _default_value = "2";
         _constrained = false;
-        _good_value = "../src/test/test-models/compiled/CmdStan/test_model.init.R";
+        _good_value = "../src/test/test-models/test_model.init.R";
         _value = _default_value;
       };
       


### PR DESCRIPTION
Updates the good value for CmdStan. This should probably be pulled out of Stan, but it's part of it for now.

This doesn't affect Stan at all, just CmdStan.
