### PR TITLE
reserve the size of values vector of the sampling recorder

### DIFF
--- a/src/stan/common/recorder/values.hpp
+++ b/src/stan/common/recorder/values.hpp
@@ -23,6 +23,7 @@ namespace stan {
         values(const size_t N,
                const size_t M) 
           : m_(0), N_(N), M_(M) {
+          x_.reserve(N_);
           for (size_t n = 0; n < N_; n++)
             x_.push_back(InternalVector(M_));
         }


### PR DESCRIPTION
#### Summary:

In the case of saving samples in a container (typically a vector of vectors) such as in RStan, this PR reserve the size of the vector that contains vectors of iterations for each quantity. 
#### Intended Effect:

In the case of RStan, this PR would make it fast to allocate the container for saving samples.
#### How to Verify:

This one needs to be verified in RStan by checking the time needed for the following simple model, so building rstan from source is needed.  The other way is to make the same change of the following file in R library rstan.

```
`Rscript -e 'cat(R.home())'`/library/rstan/include/stansrc/stan/common/recorder/values.hpp
```

The R code:

```
code1 <- '
    data {
      int N;
    }
    parameters {
      vector[N] p;
    }
    model {
      p ~ normal(0, 1);
    }
'

library(rstan)
sm <- stan_model(model_code = code1)

system.time(sampling(sm, data = list(N = 10000), iter = 10))
```

For example, without the change, the time might be

```
   user  system elapsed
  1.925   0.018   1.945
```

But after the change, the time is

```
   user  system elapsed
  0.611   0.014   0.626
```
#### Side Effects:

None
#### Documentation:

No doc needed
#### Reviewer Suggestions:

Anyone, @syclik is more familiar with the C++ code though.
