### PR TITLE
Fixes CmdStan's printing elapsed time to file twice (and none to std::cout)

### DIFF
--- a/src/stan/common/command.hpp
+++ b/src/stan/common/command.hpp
@@ -516,7 +516,7 @@ namespace stan {
         
         stan::common::recorder::csv sample_recorder(output_stream, "# ");
         stan::common::recorder::csv diagnostic_recorder(diagnostic_stream, "# ");
-        stan::common::recorder::messages message_recorder(output_stream, "# ");
+        stan::common::recorder::messages message_recorder(&std::cout, "# ");
         
         stan::io::mcmc_writer<Model, 
                               stan::common::recorder::csv, stan::common::recorder::csv,


### PR DESCRIPTION
#### Summary:

CmdStan currently writes the elapsed time to the file twice. See stan-dev/cmdstan#21.
#### Intended Effect:

CmdStan will now write elapsed time to the output file once and to the output stream once.
#### How to Verify:

Run a CmdStan model after the merge. I am creating a pull request with automated tests checking for the correct behavior in CmdStan.
#### Side Effects:

None -- command.hpp is really a CmdStan thing now, but we're leaving it here for reference.
#### Documentation:

The behavior should now match documentation.
#### Reviewer Suggestions:

@betanalpha: you were spot on. 
