### PR TITLE
removed confusing 'Error in function' from exceptions

### DIFF
--- a/src/stan/math/error_handling/dom_err.hpp
+++ b/src/stan/math/error_handling/dom_err.hpp
@@ -43,8 +43,6 @@ namespace stan {
       msg_o << name << error_msg << error_msg2;
       
       std::string msg;
-      // FIXME: this is the line to remove in the future.
-      msg += "Error in function ";
       msg += (boost::format(function) % typeid(T).name()).str();
       msg += ": ";
       msg += msg_o.str();

--- a/src/stan/math/error_handling/dom_err_vec.hpp
+++ b/src/stan/math/error_handling/dom_err_vec.hpp
@@ -37,8 +37,6 @@ namespace stan {
       msg_o << name << "[" << stan::error_index::value + i << "] " << error_msg << error_msg2;
 
       std::string msg;
-      // FIXME: this is the line to remove in the future.
-      msg += "Error in function ";
       msg += (boost::format(function) % typeid(typename T::value_type).name()).str();
       msg += ": ";
       msg += msg_o.str();

--- a/src/test/unit/math/error_handling/dom_err_test.cpp
+++ b/src/test/unit/math/error_handling/dom_err_test.cpp
@@ -14,9 +14,6 @@ public:
   template <class T, class T_msg>
   std::string expected_message(T y, T_msg msg) {
     std::stringstream expected_message;
-    // FIXME: remove this piece of the message
-    expected_message << "Error in function ";
-  
     expected_message << "function("
                      << typeid(T).name()
                      << "): "

--- a/src/test/unit/math/error_handling/dom_err_vec_test.cpp
+++ b/src/test/unit/math/error_handling/dom_err_vec_test.cpp
@@ -15,9 +15,6 @@ public:
   template <class T, class T_msg>
   std::string expected_message(T y, T_msg msg) {
     std::stringstream expected_message;
-    // FIXME: remove this piece of the message
-    expected_message << "Error in function ";
-  
     expected_message << "function("
                      << typeid(typename T::value_type).name()
                      << "): "


### PR DESCRIPTION
Fixes #640. 
#### Summary:

Removes "Error in function" from exception messages.
#### Intended Effect:

The hope is to confuse users less. Warning messages wrap the exception error messages. The exception messages used to have "Error in function" and now do not.
#### How to Verify:

There are two unit tests that actually test for the error message:
- src/test/unit/math/error_handling/dom_err_test.cpp
- src/test/unit/math/error_handling/dom_err_vec_test.cpp

You can also verify by running a model with an error message.
#### Side Effects:

This will change all error messages.
#### Documentation:

This string is not in Stan documentation (I searched in the latex files). This will need to be updated in CmdStan's documentation.
#### Reviewer Suggestions:

Anyone.
