### PR TITLE
Feature/issue 683 size 0 input

### DIFF
--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -434,7 +434,6 @@ namespace stan {
       std::vector<double> stack_r_;
       std::vector<size_t> dims_;
       std::istream& in_;
-      // stan::io::buffered_stream in_;
 
       bool scan_single_char(char c_expected) {
         int c = in_.peek();
@@ -818,7 +817,8 @@ namespace stan {
        * they are floating point.
        */
       bool is_int() {
-        return stack_i_.size() > 0;
+        // return stack_i_.size() > 0;
+        return stack_r_.size() == 0;
       }
 
       /**
@@ -868,8 +868,8 @@ namespace stan {
             BOOST_THROW_EXCEPTION (std::invalid_argument (msg));
           }
         }
-        catch ( const std::invalid_argument &exc ) {
-          std::string msg = "data " + name_ + " " + exc.what();
+        catch (const std::invalid_argument &e) {
+          std::string msg = "data " + name_ + " " + e.what();
           BOOST_THROW_EXCEPTION (std::invalid_argument (msg));
         }
         return true;
@@ -933,13 +933,13 @@ namespace stan {
             vars_i_[reader.name()] 
               = std::pair<std::vector<int>, 
                           std::vector<size_t> >(reader.int_values(), 
-                                                      reader.dims());
+                                                reader.dims());
             
           } else {
             vars_r_[reader.name()] 
               = std::pair<std::vector<double>, 
                           std::vector<size_t> >(reader.double_values(), 
-                                                      reader.dims());
+                                                reader.dims());
           }
         }
       }

--- a/src/test/unit/io/dump_test.cpp
+++ b/src/test/unit/io/dump_test.cpp
@@ -512,9 +512,29 @@ TEST(io_dump, reader_max_ints) {
   vs.push_back(imax);
   vs.push_back(imin);
   std::stringstream se;
-  se << "e <- c(" << imax<< "," << imin << "," << imax << "L," << imin << "L)";
+  se << "e <- c(" << imax << "," << imin << "," << imax << "L," << imin << "L)";
   test_list("e",vs,se.str());
 }
+
+TEST(ioDump, zeroLengthArray) {
+  std::vector<int> expected_vals;
+  std::vector<size_t> expected_dims;
+  expected_dims.push_back(0);
+  
+  std::string txt = "y <- c()\n";
+  std::stringstream in(txt);
+  stan::io::dump_reader reader(in);
+
+  test_list2(reader,"y",expected_vals,expected_dims);
+}
+TEST(ioDump, zeroLengthArrayDump) {
+  std::string txt = "M <- 0\ny <- c()\nN <- 0";
+  std::stringstream in(txt);
+  stan::io::dump d(in);
+  EXPECT_TRUE(d.contains_i("N"));
+  EXPECT_TRUE(d.contains_i("y"));
+}
+
 
 
 TEST(io_dump, reader_vec_data_max_dims) {


### PR DESCRIPTION
#### Summary:

Generalize R dump format parser to allow zero-size array and vector inputs, solving issue #683.
#### Intended Effect:

R dump format parser now accepts zero-size array and vector inputs. 
#### How to Verify:

Unit test in `unit/io/dump_test.hpp`.  Can also try to compile and run Bernoulli model to test zero-length integers in practice, or a simple normal with a prior on mu and no data.
#### Side Effects:

No.
#### Documentation:

The documentation for the dump format is in CmdStan's guide never ruled out zero-size inputs, which is why this is really a bug fix rather than a new feature.
#### Reviewer Suggestions:

Anyone.
