### PR TITLE
added callback for do_bfgs_optimize at every iteration

### DIFF
--- a/src/stan/common/command.hpp
+++ b/src/stan/common/command.hpp
@@ -432,6 +432,7 @@ namespace stan {
           }
           return_code = stan::gm::error_codes::OK;
         } else if (algo->value() == "bfgs") {
+          NoOpFunctor callback;
           typedef stan::optimization::BFGSLineSearch<Model,stan::optimization::BFGSUpdate_HInv<> > Optimizer;
           Optimizer bfgs(model, cont_vector, disc_vector, &std::cout);
 
@@ -452,8 +453,10 @@ namespace stan {
           return_code = do_bfgs_optimize(model,bfgs, base_rng,
                                          lp, cont_vector, disc_vector,
                                          output_stream, &std::cout, 
-                                         save_iterations, refresh);
+                                         save_iterations, refresh,
+                                         callback);
         } else if (algo->value() == "lbfgs") {
+          NoOpFunctor callback;
           typedef stan::optimization::BFGSLineSearch<Model,stan::optimization::LBFGSUpdate<> > Optimizer;
           Optimizer bfgs(model, cont_vector, disc_vector, &std::cout);
 
@@ -476,7 +479,8 @@ namespace stan {
           return_code = do_bfgs_optimize(model,bfgs, base_rng,
                                          lp, cont_vector, disc_vector,
                                          output_stream, &std::cout, 
-                                         save_iterations, refresh);
+                                         save_iterations, refresh,
+                                         callback);
         } else {
           return_code = stan::gm::error_codes::CONFIG;
         }

--- a/src/stan/common/do_bfgs_optimize.hpp
+++ b/src/stan/common/do_bfgs_optimize.hpp
@@ -16,7 +16,8 @@ namespace stan {
 
   namespace common {
 
-    template<typename ModelT,typename BFGSOptimizerT,typename RNGT>
+    template<typename ModelT,typename BFGSOptimizerT,typename RNGT,
+             typename StartIterationCallback>
     int do_bfgs_optimize(ModelT &model, BFGSOptimizerT &bfgs,
                          RNGT &base_rng,
                          double &lp,
@@ -25,7 +26,8 @@ namespace stan {
                          std::fstream* output_stream,
                          std::ostream* notice_stream,
                          bool save_iterations,
-                         int refresh) {
+                         int refresh,
+                         StartIterationCallback& callback) {
       lp = bfgs.logp();
           
       if (notice_stream) 
@@ -38,6 +40,7 @@ namespace stan {
       int ret = 0;
           
       while (ret == 0) {  
+        callback();
         if (notice_stream && do_print(bfgs.iter_num(), 50*refresh)) {
           (*notice_stream) << "    Iter ";
           (*notice_stream) << "     log prob ";

--- a/src/test/unit/common/do_bfgs_optimize_test.cpp
+++ b/src/test/unit/common/do_bfgs_optimize_test.cpp
@@ -7,7 +7,16 @@
 typedef rosenbrock_model_namespace::rosenbrock_model Model;
 typedef boost::ecuyer1988 rng_t; // (2**50 = 1T samples, 1000 chains)
 
-TEST(Common, do_bfgs_optimize) {
+struct mock_callback {
+  int n;
+  mock_callback() : n(0) { }
+  
+  void operator()() {
+    n++;
+  }
+};
+
+TEST(Common, do_bfgs_optimize__bfgs) {
   typedef stan::optimization::BFGSLineSearch<Model,stan::optimization::BFGSUpdate_HInv<> > Optimizer_BFGS;
 
   std::vector<double> cont_vector(2);
@@ -29,19 +38,46 @@ TEST(Common, do_bfgs_optimize) {
   rng_t base_rng(random_seed);
 
   std::fstream* output_stream = 0;
+  mock_callback callback;
 
   return_code = stan::common::do_bfgs_optimize(model,bfgs, base_rng,
                                                lp, cont_vector, disc_vector,
                                                output_stream, &std::cout, 
-                                               save_iterations, refresh);
+                                               save_iterations, refresh, 
+                                               callback);
   EXPECT_FLOAT_EQ(return_code, 0);
+  EXPECT_EQ(33, callback.n);
+}
+  
+TEST(Common, do_bfgs_optimize__lbfgs) {
+  std::vector<double> cont_vector(2);
+  cont_vector[0] = -1; cont_vector[1] = 1;
+  std::vector<int> disc_vector;
+
+  static const std::string DATA = "";
+  std::stringstream data_stream(DATA);
+  stan::io::dump dummy_context(data_stream);
+  Model model(dummy_context);
 
   typedef stan::optimization::BFGSLineSearch<Model,stan::optimization::LBFGSUpdate<> > Optimizer_LBFGS;
   Optimizer_LBFGS lbfgs(model, cont_vector, disc_vector, &std::cout);
 
-  return_code = stan::common::do_bfgs_optimize(model,lbfgs, base_rng,
+
+  double lp = 0;
+  bool save_iterations = true;
+  int refresh = 0;
+  int return_code;
+  unsigned int random_seed = 0;
+  rng_t base_rng(random_seed);
+
+  std::fstream* output_stream = 0;
+  mock_callback callback;
+
+  return_code = stan::common::do_bfgs_optimize(model, lbfgs, base_rng,
                                                lp, cont_vector, disc_vector,
                                                output_stream, &std::cout, 
-                                               save_iterations, refresh);
+                                               save_iterations, refresh, 
+                                               callback);
   EXPECT_FLOAT_EQ(return_code, 0);
+  EXPECT_EQ(35, callback.n);
 }


### PR DESCRIPTION
#### Summary:

Adds a callback at every iteration of do_bfgs_optimize. The intention is to allow RStan and PyStan to interrupt the process using ctrl-c.
#### How to Verify:

The test in src/test/unit/common/do_bfgs_optimize_test.cpp shows how to call do_bfgs_optimize with the additional parameter.
#### Side Effects:

RStan and PyStan will need to call do_bfgs_optimize with an additional parameter.
#### Documentation:

Not user facing.
#### Reviewer Suggestions:

Bob, want to take a look? Is there a better way to do this?
Jiqiang, do you want to verify?
