### PR TITLE
Fixes an issue with g++ 4.4

### DIFF
--- a/src/stan/common/command.hpp
+++ b/src/stan/common/command.hpp
@@ -736,7 +736,7 @@ namespace stan {
         // Sampling
         start = clock();
         
-        sample<Model, rng_t>(sampler_ptr, num_warmup, num_samples, num_thin,
+        stan::common::sample<Model, rng_t>(sampler_ptr, num_warmup, num_samples, num_thin,
                              refresh, true,
                              writer,
                              s, model, base_rng,


### PR DESCRIPTION
(stan-dev/stan#375, previously fixed in stan-dev/stan@66c57cfa746aa85ac2ac86c10d61d684e86e0900) but reintroduced later.

Now:

`bin/stanc ./src/test/test-models/test_model.stan --o=src/test/test-models/test_model.cpp && g++-4.4 -Isrc -Istan/src -isystem stan/lib/eigen_3.2.0 -isystem stan/lib/boost_1.54.0 -Wall -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -c -O3 -o src/test/test-models/test_model -include src/test/test-models/test_model.cpp src/cmdstan/main.cpp`

succeeds, where it previously failed with

`In file included from stan/src/stan/model/model_header.hpp:39,
                 from ./src/test/test-models/test_model.cpp:3,
                 from <command-line>:0:
stan/src/stan/mcmc/sample.hpp: In function ‘int stan::common::command(int, const char**) [with Model = test_model_model_namespace::test_model_model]’:
src/cmdstan/main.cpp:7:   instantiated from here
stan/src/stan/mcmc/sample.hpp:13: error: ‘class stan::mcmc::sample’ is not a function,
stan/src/stan/common/sample.hpp:27: error:   conflict with ‘template<class Model, class RNG, class StartTransitionCallback, class SampleRecorder, class DiagnosticRecorder, class MessageRecorder> void stan::common::sample(stan::mcmc::base_mcmc*, int, int, int, int, bool, stan::io::mcmc_writer<Model, SampleRecorder, DiagnosticRecorder, MessageRecorder>&, stan::mcmc::sample&, Model&, RNG&, const std::string&, const std::string&, std::ostream&, StartTransitionCallback&)’
stan/src/stan/common/command.hpp:739: error:   in call to ‘sample’`
