### PR TITLE
Remove unused add method accepting vectors

### DIFF
--- a/src/stan/mcmc/chains.hpp
+++ b/src/stan/mcmc/chains.hpp
@@ -435,25 +435,6 @@ namespace stan {
         add(num_chains(), sample);
       }
 
-      void add(const std::vector<std::vector<double> >& sample) {
-        /**
-        * Convert a vector of vector<double> to Eigen::MatrixXd
-        *
-        * This method is added for the benefit of software wrapping
-        * Stan (e.g., PyStan) so that it need not additionally wrap Eigen.
-        *
-        */
-        int n_row = sample.size();
-        if (n_row == 0)
-            return;
-        int n_col = sample[0].size();
-        Eigen::MatrixXd sample_copy(n_row, n_col);
-        for (int i = 0; i < n_row; i++) {
-            sample_copy.row(i) = Eigen::VectorXd::Map(&sample[i][0], sample[0].size());
-        }
-        add(sample_copy);
-      }
-
       void add(const stan::io::stan_csv& stan_csv) {
         if (stan_csv.header.size() != num_params())
           throw std::invalid_argument("add(stan_csv): number of columns in"


### PR DESCRIPTION
This function is no longer used by PyStan and it is, moreover, designed
incorrectly. In RStan and PyStan chains are effectively stored in "row order" as
each parameter has its own vector<double> of size `num_iter`. This function
assumes this arrangement is transposed, that one has `num_iter` vectors.
#### Summary:

Removes one of the stan::mcmc::chains add methods that is no longer used by PyStan. It shouldn't be used in any event, as it assumes a different memory layout than is known to exist.
#### Intended Effect:
1. Clean up codebase
#### Side Effects:

None.
#### Documentation:

Not user-facing
#### Reviewer Suggestions:

Anyone.
