### PR TITLE
Print arg config after random seed generation

### DIFF
--- a/src/stan/common/command.hpp
+++ b/src/stan/common/command.hpp
@@ -83,9 +83,6 @@ namespace stan {
       
       if (parser.help_printed())
         return err_code;
-
-      parser.print(&std::cout);
-      std::cout << std::endl;
       
       // Identification
       unsigned int id = dynamic_cast<stan::gm::int_argument*>(parser.arg("id"))->value();
@@ -160,6 +157,9 @@ namespace stan {
 
       Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(model.num_params_r());
 
+      parser.print(&std::cout);
+      std::cout << std::endl;
+      
       if (output_stream) {
         write_stan(output_stream, "#");
         write_model(output_stream, model.model_name(), "#");


### PR DESCRIPTION
#### Summary:

Resolves #1049 by displaying the argument configuration to screen only after randomly generating a new seed.
#### Intended Effect:

Changes what is printed to screen in CmdStan (other interfaces do not use this code) -- has no effect on the actual configuration or running.
#### How to Verify:

In CmdStan run any model without specifying a random seed and see that the output printed to screen is the randomly generated seed consistent with that saved in output.csv.
#### Side Effects:

None.
#### Documentation:

None.
#### Reviewer Suggestions:

Anyone.
