### PR TITLE
Updated dependencies for libstan

### DIFF
--- a/make/libstan
+++ b/make/libstan
@@ -1,15 +1,13 @@
-LIBSTAN_HEADERS := src/stan/agrad/rev/var_stack.hpp
 LIBSTAN_OFILES := bin/stan/agrad/rev/var_stack.o
-bin/libstan.a : $(LIBSTAN_OFILES) $(LIBSTAN_HEADERS)
+bin/libstan.a : $(LIBSTAN_OFILES)
 	@mkdir -p $(dir $@)
 	$(AR) -rs bin/libstan.a $(LIBSTAN_OFILES)
 
 
-LIBSTANC_HEADERS := $(shell find src/stan/gm/grammars -name '*.hpp') src/stan/gm/ast.hpp
 TEMPLATE_INSTANTIATION := $(shell find src/stan/gm -type f -name '*_inst.cpp') $(shell find src/stan/gm -type f -name '*_def.cpp')
 TEMPLATE_INSTANTIATION := $(TEMPLATE_INSTANTIATION:src/%.cpp=bin/%.o)
 
-bin/libstanc.a : $(TEMPLATE_INSTANTIATION) $(LIBSTANC_HEADERS)
+bin/libstanc.a : $(TEMPLATE_INSTANTIATION)
 	@mkdir -p $(dir $@)
 	$(AR) -rs bin/libstanc.a $(TEMPLATE_INSTANTIATION)
 

--- a/makefile
+++ b/makefile
@@ -70,7 +70,7 @@ bin/%.d : src/%.cpp
 	@set -e; \
 	rm -f $@; \
 	$(CC) $(CFLAGS) -O$O $(TARGET_ARCH) -MM $< > $@.$$$$; \
-	sed -e 's,\($(notdir $*)\)\.o[ :]*,$(dir $@)\1\$(EXE) $@ : ,g' < $@.$$$$ > $@; \
+	sed -e 's,\($(notdir $*)\)\.o[ :]*,$(dir $@)\1\.o $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
 
 .PHONY: help
@@ -136,7 +136,7 @@ include make/local    # for local stuff
 ##
 # Dependencies
 ##
-ifneq (,$(filter-out test-headers generate-tests %.d,$(filter-out clean%,$(MAKECMDGOALS))))
+ifneq (,$(filter-out test-headers generate-tests clean% %-test %.d,$(MAKECMDGOALS)))
   -include $(addsuffix .d,$(subst $(EXE),,$(MAKECMDGOALS)))
 endif
 
@@ -163,9 +163,8 @@ clean-manual:
 	cd src/docs/stan-reference; $(RM) *.brf *.aux *.bbl *.blg *.log *.toc *.pdf *.out *.idx *.ilg *.ind *.cb *.cb2 *.upa
 
 clean-deps:
-	$(RM) $(shell find test -type f -name '*.d')
+	$(RM) $(shell find . -type f -name '*.d')
 
 clean-all: clean clean-manual clean-deps
 	$(RM) -r test/* bin
-	$(RM) $(shell find src -type f -name '*.d') $(shell find src -type f -name '*.o') $(shell find src/test/unit-distribution -name '*_generated_test.cpp' -type f | sed 's#\(.*\)/.*#\1/*_generated_test.cpp#' | sort -u)
-
+	$(RM) $(shell find src -type f -name '*.o') $(shell find src/test/unit-distribution -name '*_generated_test.cpp' -type f | sed 's#\(.*\)/.*#\1/*_generated_test.cpp#' | sort -u)


### PR DESCRIPTION
#### Summary:

Fixes dependencies for libstan and libstanc.
#### Intended Effect:

Fixes make behavior.
#### How to Verify:

Build libstan.a; change any of its dependencies; build again.
Under this branch, it rebuilds the lib. Under the old branch, this wasn't guaranteed.
#### Side Effects:

None.
#### Documentation:

Not user facing. Fixes a problem with our make.
#### Reviewer Suggestions:

Anyone.
