### PR TITLE
updating tests to link to the correct libs

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -15,13 +15,42 @@ test/gtest.o: $(GTEST)/src/gtest-all.cc
 	@mkdir -p test
 	$(COMPILE.c) -O$O $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
 
-
 ##
 # Rule for building a test
 ##
-test/%.o : src/test/%_test.cpp $(LIBGTEST)
+test/%.o : src/test/%_test.cpp $(LIBGTEST) bin/libstan.a
 	@mkdir -p $(dir $@)
 	$(COMPILE.c) -O$O $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
+
+##
+# Rule for building a test executable
+##
+test/%$(EXE) : test/%.o bin/libstan.a
+	@mkdir -p $(dir $@)
+	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS)
+
+
+##
+# static rule to link in libstanc.
+# needed by subset of unit tests that test stan compiler
+# all these tests are under stan/test/unit/gm
+##
+STANC_TESTS_HEADERS := $(shell find src/test/unit/gm -type f -name '*_test.cpp')
+STANC_TESTS_O := $(patsubst src/%_test.cpp,%.o,$(STANC_TESTS_HEADERS))
+STANC_TESTS := $(patsubst src/%_test.cpp,%$(EXE),$(STANC_TESTS_HEADERS))
+
+# $(STANC_TESTS) : test/%$(EXE) : test/%.o bin/libstan.a bin/libstanc.a
+# 	@mkdir -p $(dir $@)
+# 	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS) $(LDLIBS_STANC)
+
+# add additional dependency to libstanc.a
+##$(patsubst src/%_test.cpp,%.o,$(STANC_TEST_HEADERS)) : test/%.o : bin/libstanc.a
+$(STANC_TESTS_O) : bin/libstanc.a
+$(STANC_TESTS) : LDLIBS += $(LDLIBS_STANC)
+
+
+
+
 
 ##
 # Rule for generating dependencies.
@@ -59,21 +88,6 @@ test/dummy.cpp:
 
 .PHONY: test-headers
 test-headers: $(HEADER_TESTS)
-
-############################################################
-##
-# static rule to link in libstan.a libstanc.
-# needed by subset of unit tests that test stan compiler
-# all these tests are under stan/test/unit/gm
-##
-STANC_TESTS := $(patsubst src/%_test.cpp,%$(EXE),$(shell find src/test/unit/gm -type f -name '*_test.cpp'))
-$(STANC_TESTS) : test/%$(EXE) : test/%.o bin/libstan.a bin/libstanc.a
-	@mkdir -p $(dir $@)
-	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS) $(LDLIBS_STANC)
-
-test/%$(EXE) : test/%.o bin/libstan.a
-	@mkdir -p $(dir $@)
-	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS)
 
 ############################################################
 ##


### PR DESCRIPTION
#### Summary:

The last fix for #1062 didn't link the tests to the lib dependencies. This takes care of it.
#### Intended Effect:

Fixes expected behavior.
#### How to Verify:

Change a lib dependency file. Tests should all rebuild.
#### Side Effects:

More of the tests will rebuild when libstan.a or libstanc.a needs to be rebuilt. This is the correct behavior.
#### Documentation:

Not user facing.
#### Reviewer Suggestions:

Anyone.
