### PR TITLE
Removes make/local from repo

### DIFF
--- a/make/local
+++ b/make/local
@@ -1,4 +1,0 @@
-##
-# Can put stuff that is specific to your computer here, e.g.
-# CFLAGS += -march=native
-##

--- a/makefile
+++ b/makefile
@@ -131,7 +131,7 @@ include make/libstan  # bin/libstan.a bin/libstanc.a
 include make/tests    # tests
 include make/doxygen  # doxygen
 include make/manual   # manual: manual, doc/stan-reference.pdf
-include make/local    # for local stuff
+-include make/local    # for local stuff
 
 ##
 # Dependencies


### PR DESCRIPTION
#### Summary:

This is for developers. Removes make/local from the code repository.
#### Intended Effect:

Makes it easier for developers to not accidentally check in their make/local file.
#### How to Verify:

Merge. 
1) Try running `make help` without a make/local. This should work; it doesn't work under the current development branch.
2) Add a make/local file. git should ignore this file without having to mess with the git index.
#### Side Effects:

None.
#### Documentation:

None. This is a fix for developers.

The current v2.5.0 package includes a make/local file with comments to guide users. In the next version, this file won't be there, unless we do what we do with the built pdf files: include it for the release, remove it as the next commit to the repo.
#### Reviewer Suggestions:

Bob. This work for you?
