### PR TITLE
Bugfix/issue 1121 multivariate error

### DIFF
--- a/src/stan/math/matrix/multiply_lower_tri_self_transpose.hpp
+++ b/src/stan/math/matrix/multiply_lower_tri_self_transpose.hpp
@@ -38,11 +38,6 @@ namespace stan {
         }
       }
       return LLt;
-      
-      // FIXME:  write custom following agrad/matrix because can't get L_tri into
-      // multiplication as no template support for tri * tri
-      //matrix_d L_tri = L.transpose().triangularView<Eigen::Upper>();
-      //return L.triangularView<Eigen::Lower>() * L_tri;
     }
 
   }

--- a/src/test/unit/agrad/rev/matrix/multiply_lower_tri_self_transpose_test.cpp
+++ b/src/test/unit/agrad/rev/matrix/multiply_lower_tri_self_transpose_test.cpp
@@ -4,6 +4,27 @@
 #include <stan/agrad/rev.hpp>
 #include <test/unit/agrad/rev/jacobian.hpp>
 
+stan::agrad::matrix_v generate_large_L_tri_mat(){
+  using stan::agrad::matrix_v;
+  using stan::math::matrix_d;
+
+  matrix_v ret_mat(100,100);
+  matrix_d x;
+  double vals[10000];
+
+  vals[0] = 0.1;
+  for (int i = 1; i < 10000; ++i)
+    vals[i] = vals[i- 1] + 0.1123456;
+  
+  x = Eigen::Map< Eigen::Matrix<double,100,100> >(vals);
+  x *= 1e10;
+
+  for (int i = 0; i < x.cols(); ++i)
+    for (int j = 0; j < x.cols(); ++j)
+      ret_mat(i,j) = x(i,j);
+
+  return ret_mat;
+}
 
 void test_mult_LLT(const stan::agrad::matrix_v& L) {
   using stan::agrad::matrix_v;
@@ -236,10 +257,13 @@ TEST(AgradRevMatrix, multiplyLowerTriSelfTranspose) {
     4, -3;
   test_mult_LLT(I);
 
-  // matrix_v J(1,1);
-  // J << 3.0;
-  // test_mult_LLT(J);
+  L = generate_large_L_tri_mat();
+  EXPECT_NO_THROW(multiply_lower_tri_self_transpose(L));
 
-  // matrix_v K(0,0);
-  // test_mult_LLT(K);
+  matrix_v J(1,1);
+  J << 3.0;
+  test_mult_LLT(J);
+
+  matrix_v K(0,0);
+  test_mult_LLT(K);
 }

--- a/src/test/unit/math/matrix/multiply_lower_tri_self_transpose_test.cpp
+++ b/src/test/unit/math/matrix/multiply_lower_tri_self_transpose_test.cpp
@@ -8,33 +8,16 @@ using stan::math::matrix_d;
 
 matrix_d generate_large_L_tri_mat(){
   matrix_d x;
-  srand(1);
+  double vals[10000];
 
-  x = Eigen::MatrixXd::Random(100,100);
+  vals[0] = 0.1;
+  for (int i = 1; i < 10000; ++i)
+    vals[i] = vals[i- 1] + 0.1123456;
+  
+  x = Eigen::Map< Eigen::Matrix<double,100,100> >(vals);
   x *= 1e10;
 
   return x;
-}
-
-matrix_d old_multiply_lower_tri_self_transpose(const matrix_d& x){
-  using stan::error_handling::check_symmetric;
-
-  int K = x.rows();
-  static const char* function = "old_multiply_lower_tri_self_transpose(%1%)";
-
-  if (K == 0)
-    return matrix_d(0,0);
-  if (K == 1) {
-    matrix_d result(1,1);
-    result(0,0) = x(0,0) * x(0,0);
-    return result;
-  }
-
-  matrix_d Lt = x.transpose().triangularView<Eigen::Upper>();
-  matrix_d LLt = x.triangularView<Eigen::Lower>() * Lt; 
-
-  check_symmetric(function, "LLt", LLt);
-  return LLt;
 }
 
 void test_multiply_lower_tri_self_transpose(const matrix_d& x) {
@@ -101,5 +84,4 @@ TEST(MathMatrix, multiply_lower_tri_self_transpose) {
   EXPECT_NO_THROW(check_symmetric(function, 
                                   "Symmetric matrix", 
                                   multiply_lower_tri_self_transpose(x)));
-  EXPECT_THROW(old_multiply_lower_tri_self_transpose(x),std::domain_error);
 }


### PR DESCRIPTION
#### Summary:

Fix #1121 by ensuring that stan::math::multiply_lower_tri_self_transpose returns a symmetric matrix. 
#### Intended Effect:
- Double version of multiply_lower_tri_self_transpose matches the output of the var version of multiply_lower_tri_self_transpose 
#### How to Verify:
- Running `./runTests.py src/test/unit/math/matrix/multiply_lower_tri_self_transpose_test.cpp`. 
- Running the model outlined in #1121 should no longer fail before 100 warmup iterations
#### Side Effects:

None.
#### Documentation:

No changes.
#### Reviewer Suggestions:

Anyone
