### PR TITLE
update pdflatex options

### DIFF
--- a/make/manual
+++ b/make/manual
@@ -12,5 +12,5 @@ manual: $(STANAPI_HOME)src/docs/stan-reference/stan-reference.pdf
 MANUAL_FLAGS=
 
 %.pdf: %.tex
-	cd $(dir $@); latexmk -pdf -pdflatex="pdflatex -interactive=nonstopmode" -use-make $(notdir $^)
+	cd $(dir $@); latexmk -pdf -pdflatex="pdflatex -interaction=nonstopmode -file-line-error" -use-make $(notdir $^)
 


### PR DESCRIPTION
# Summary
- Fixes a typo in the existing options so that nonstopmode works
- Adds an option to display filename and line number of error messages in LaTeX to help debugging.
# Verify

Run `make manual` when there is an error in the reference manual. pdflatex should not wait for user input, and the error messages should be in a format which display the file and line number of the error.
# Side Effects

None
# Reviewer

@syclik 
