### PR TITLE
Bugfix/issue 1171 fn signature tests log mix

### DIFF
--- a/src/test/test-models/good/function-signatures/math/functions/log_mix.stan
+++ b/src/test/test-models/good/function-signatures/math/functions/log_mix.stan
@@ -21,6 +21,24 @@ transformed parameters {
 
   transformed_param_real <- log_mix(p_real_theta,
                                     p_real_lam_1,
+                                    d_real_lam_1);
+  transformed_param_real <- log_mix(p_real_theta,
+                                    d_real_lam_1,
+                                    p_real_lam_1);
+  transformed_param_real <- log_mix(p_real_theta,
+                                    d_real_lam_1,
+                                    d_real_lam_1);
+  transformed_param_real <- log_mix(d_real_theta,
+                                    p_real_lam_1,
+                                    p_real_lam_1);
+  transformed_param_real <- log_mix(d_real_theta,
+                                    p_real_lam_1,
+                                    d_real_lam_1);
+  transformed_param_real <- log_mix(d_real_theta,
+                                    d_real_lam_1,
+                                    p_real_lam_1);
+  transformed_param_real <- log_mix(p_real_theta,
+                                    p_real_lam_1,
                                     p_real_lam_1);
 }
 model {  


### PR DESCRIPTION
#### Summary:

Addresses issue #1171 
#### Intended Effect:

Adds 6 function signatures for all permutations of var and double arguments to log_mix 
#### How to Verify:

src/test/unit/gm/parser/math_functions_test.cpp 
#### Side Effects:

None.
#### Documentation:

None
#### Reviewer Suggestions:

Anyone
