### PR TITLE
Updated makefile dependencies for auto-generated cpp files

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -64,6 +64,16 @@ test/%.d : src/test/%_test.cpp
 	sed -e 's,\($(notdir $*)\)\(_test\)\.o[ :]*,$(dir $@)\1\$(EXE) $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
 
+.PRECIOUS: test/test-models/stanc.d
+test/test-models/stanc.d : src/test/test-models/stanc.cpp
+	@mkdir -p $(dir $@)
+	@set -e; \
+	rm -f $@; \
+	$(CC) $(CFLAGS) -O$O $(CFLAGS_GTEST) $(TARGET_ARCH) -MM $< > $@.$$$$; \
+	sed -e 's,\($(basename $(@F))\)\.o[ :]*,$(dir $@)\1\$(EXE) $@ : ,g' < $@.$$$$ > $@; \
+	rm -f $@.$$$$
+
+
 ############################################################
 ##
 # Target to verify header files within Stan has
@@ -100,7 +110,7 @@ test/test-models/stanc$(EXE) : src/test/test-models/stanc.cpp bin/libstanc.a
 	$(LINK.c) -O$(O_STANC) $(OUTPUT_OPTION) $< $(LDLIBS_STANC)
 
 TEST_MODELS := $(shell find src/test/test-models -type f -name '*.stan')
-$(patsubst %.stan,%.cpp,$(TEST_MODELS)) : %.cpp : %.stan test/test-models/stanc$(EXE)
+$(patsubst %.stan,%.cpp,$(TEST_MODELS)) : %.cpp : %.stan test/test-models/stanc$(EXE) test/test-models/stanc
 	$(WINE) test/test-models/stanc$(EXE) --o=$@ $<
 
 ##
@@ -187,3 +197,7 @@ LIST_OF_GENERATED_TESTS := $(shell find src/test/unit-distribution -type f -name
 
 .PHONY: generate-tests
 generate-tests: $(LIST_OF_GENERATED_TESTS)
+
+ifeq (,$(filter-out test/% src/test/test-models/%.cpp,$(MAKECMDGOALS)))
+  -include test/test-models/stanc.d
+endif

--- a/makefile
+++ b/makefile
@@ -169,7 +169,7 @@ clean-deps:
 	$(shell find . -type f -name '*.d' -exec rm {} +)
 
 clean-all: clean clean-manual clean-deps
-	$(RM) -r test/* bin
+	$(RM) -r test bin
 	@echo '  removing .o files'
 	$(shell find src -type f -name '*.o' -exec rm {} +)
 	@echo '  removing generated test files'


### PR DESCRIPTION
#### Summary:

Make dependencies now work through the parser for automatically generated C++ from Stan programs.
#### Intended Effect:

Fixes broken _test_ behavior, not code behavior.
#### How to Verify:

`make src/test/test-models/good/io_example.cpp`
`make src/test/test-models/good/io_example.cpp`
(should do nothing the second time)
`touch src/stan/version.hpp`
`make src/test/test-models/good/io_example.cpp`
(should rebuild the parser and a new io_example.cpp)
#### Side Effects:

None.
#### Documentation:

None. Not user facing.
#### Reviewer Suggestions:

Anyone. Should take < 5 minutes to verify.
