### PR TITLE
Feature/issue 1099 init transform data

### DIFF
--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -45,7 +45,11 @@ that was read, and the constraint that was declared.
 After data is read into the model, the transformed data variable
 statements are executed in order to define the transformed data
 variables.  As the statements execute, declared constraints on
-variables are not enforced.
+variables are not enforced.  
+
+Transformed data variables are initialized with real values set to
+\code{NaN} and integer values set to the smallest integer (large
+absolute value negative number).
 
 After the statements are executed, all declared constraints on
 transformed data variables are validated.  If the validation fails,
@@ -1229,6 +1233,11 @@ For parameters, constraints are enforced by the transform applied and
 do not need to be checked.  For transformed parameters, the check is
 done after the statements in the transformed parameter block have
 executed.  
+
+For all blocks defining variables (transformed data, transformed
+parameters, generated quantities), real values are initialized to
+\code{NaN} and integer values are initialized to the smallest legal
+integer (i.e., a large absolute value negative number).
 
 For generated quantities, constraints are enforced after the
 statements in the generated quantities block have executed.

--- a/src/stan/gm/generator.hpp
+++ b/src/stan/gm/generator.hpp
@@ -4197,6 +4197,12 @@ namespace stan {
       generate_comment("declare and define generated quantities",2,o);
       generate_local_var_decls(prog.generated_decl_.first,2,o,
                                is_var,is_fun_return); 
+
+      o << EOL;
+      o << INDENT2 << "double DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());" << EOL;
+      o << INDENT2 << "(void) DUMMY_VAR__;  // suppress unused var warning" << EOL2;
+      generate_init_vars(prog.generated_decl_.first, 2, o);
+
       o << EOL;
       generate_statements(prog.generated_decl_.second,2,o,include_sampling,
                           is_var,is_fun_return); 


### PR DESCRIPTION
#### Summary:
- Initialize transformed data in the same way as transformed params (-max for integers, NaN for reals)
- Initialize generated quantities in the same way as transformed params (ditto)
#### Intended Effect:

See above.  Makes behavior more consistent and makes it more likely that errors due to non-definition will be diagnosed.
#### How to Verify:

Run a model and see that it initializes properly at the start and in the generated quantities block.  This one works for that purpose:

```
transformed data {
  int n;
  real x;
  print("n=",n);
  print("x=",x);
}
parameters {
  real y;
}
model {
  y ~ normal(0,1);
}
generated quantities {
  int m;
  real z;
  print("m=", m, " z=", z);
}
```

I don't know how to make a real test out of this.  Here's what the above now prints out, first for transformed data (printed before config is dumped for some reason):

```
~/temp2$ ./td sample
n=-2147483648
x=nan
```

and then later during sampling for the generated quantities:

```
Iteration: 2000 / 2000 [100%]  (Sampling)
m=-2147483648 z=nan
```
#### Side Effects:

There will be different initializations, which could possibly change results for broken models.  But previous behavior wasn't documented, so this isn't a backward compatibility issue.

Transformed data init will be a bit slower.  Definitely won't be measurable as it'll only happen once.

Generated quantities will be a bit slower.  Probably not enough to be measurable, but more of an impact than for transformed data.
#### Documentation:

Added documentation to the language section of the manual on validating constraints. The new behavior will probably more closely match user expectations because behavior will be consistent across transformed data, transformed parameters, and generated quantities.
#### Reviewer Suggestions:

Anyone.
