### PR TITLE
fixes #1187, refactor log det and type bug in array alloc

### DIFF
--- a/src/stan/agrad/rev/internal/precomputed_gradients.hpp
+++ b/src/stan/agrad/rev/internal/precomputed_gradients.hpp
@@ -32,13 +32,32 @@ namespace stan {
        * operands, and gradients.
        * 
        * @param[in] val The value of the variable.
+       * @param[in] size Size of operands and gradients
+       * @param[in] varis Operand implementations.
+       * @param[in] gradients Gradients with respect to operands.
+       */
+      precomputed_gradients_vari(double val,
+                                 size_t size, 
+                                 vari** varis,
+                                 double* gradients)
+        : vari(val),
+          size_(size),
+          varis_(varis),
+          gradients_(gradients) {
+      }
+
+      /**
+       * Construct a precomputed vari with the specified value,
+       * operands, and gradients.
+       * 
+       * @param[in] val The value of the variable.
        * @param[in] vars Vector of operands.
        * @param[in] gradients Vector of partial derivatives of value
        * with respect to operands.
        * @throws std::invalid_argument if the sizes of the vectors
        * don't match.
        */
-      precomputed_gradients_vari(const double val,
+      precomputed_gradients_vari(double val,
                                  const std::vector<var>& vars,
                                  const std::vector<double>& gradients)
         : vari(val),

--- a/src/stan/agrad/rev/matrix/log_determinant.hpp
+++ b/src/stan/agrad/rev/matrix/log_determinant.hpp
@@ -1,74 +1,41 @@
 #ifndef STAN__AGRAD__REV__MATRIX__LOG_DETERMINANT_HPP
 #define STAN__AGRAD__REV__MATRIX__LOG_DETERMINANT_HPP
 
-#include <vector>
+#include <stan/agrad/rev.hpp> 
 #include <stan/math/matrix/Eigen.hpp>
-#include <stan/math/matrix/typedefs.hpp>
-#include <stan/agrad/rev/var.hpp>
-#include <stan/agrad/rev/matrix/typedefs.hpp>
 #include <stan/error_handling/matrix/check_square.hpp>
 
-// FIXME: use explicit files
-#include <stan/agrad/rev.hpp> 
-
 namespace stan {
-  namespace agrad {
 
-    namespace {
-      template<int R,int C>
-      class log_determinant_vari : public vari {
-        int _rows;
-        int _cols;
-        double* A_;
-        vari** _adjARef;
-      public:
-        log_determinant_vari(const Eigen::Matrix<var,R,C> &A)
-          : vari(log_determinant_vari_calc(A)), 
-            _rows(A.rows()),
-            _cols(A.cols()),
-            A_((double*)stan::agrad::ChainableStack::memalloc_.alloc(sizeof(double) 
-                                                     * A.rows() * A.cols())),
-            _adjARef((vari**)stan::agrad::ChainableStack::memalloc_.alloc(sizeof(vari*) 
-                                                          * A.rows() * A.cols()))
-        {
-          size_t pos = 0;
-          for (size_type j = 0; j < _cols; j++) {
-            for (size_type i = 0; i < _rows; i++) {
-              A_[pos] = A(i,j).val();
-              _adjARef[pos++] = A(i,j).vi_;
-            }
-          }
-        }
-        static 
-        double log_determinant_vari_calc(const Eigen::Matrix<var,R,C> &A)
-        {
-          Eigen::Matrix<double,R,C> Ad(A.rows(),A.cols());
-          for (size_type j = 0; j < A.cols(); j++)
-            for (size_type i = 0; i < A.rows(); i++)
-              Ad(i,j) = A(i,j).val();
-          return Ad.fullPivHouseholderQr().logAbsDeterminant();
-        }
-        virtual void chain() {
-          using Eigen::Matrix;
-          using Eigen::Map;
-          Matrix<double,R,C> adjA(_rows,_cols);
-          adjA = adj_ 
-            * Map<Matrix<double,R,C> >(A_,_rows,_cols)
-            .inverse().transpose();
-          size_t pos = 0;
-          for (size_type j = 0; j < _cols; j++) {
-            for (size_type i = 0; i < _rows; i++) {
-              _adjARef[pos++]->adj_ += adjA(i,j);
-            }
-          }
-        }
-      };
-    }
+  namespace agrad {
 
     template <int R, int C>
     inline var log_determinant(const Eigen::Matrix<var,R,C>& m) {
-      stan::error_handling::check_square("log_determinant", "m", m);
-      return var(new log_determinant_vari<R,C>(m));
+      using Eigen::Matrix;
+
+      error_handling::check_square("log_determinant","m", m);
+
+      Matrix<double,R,C> m_d(m.rows(),m.cols());
+      for (int i = 0; i < m.size(); ++i)
+        m_d(i) = m(i).val();
+
+      Eigen::FullPivHouseholderQR<Matrix<double,R,C> > hh
+        = m_d.fullPivHouseholderQr();
+
+      double val = hh.logAbsDeterminant();
+
+      vari** varis 
+        = ChainableStack::memalloc_.alloc_array<vari*>(m.size());
+      for (int i = 0; i < m.size(); ++i)
+        varis[i] = m(i).vi_;
+
+      Matrix<double,R,C> m_inv_transpose = hh.inverse().transpose();
+      double* gradients 
+        = ChainableStack::memalloc_.alloc_array<double>(m.size());
+      for (int i = 0; i < m.size(); ++i)
+        gradients[i] = m_inv_transpose(i);
+
+      return var(new precomputed_gradients_vari(val,m.size(),varis,gradients));
     }
     
   }

--- a/src/stan/agrad/rev/matrix/log_determinant_spd.hpp
+++ b/src/stan/agrad/rev/matrix/log_determinant_spd.hpp
@@ -1,115 +1,69 @@
 #ifndef STAN__AGRAD__REV__MATRIX__LOG_DETERMINANT_SPD_HPP
 #define STAN__AGRAD__REV__MATRIX__LOG_DETERMINANT_SPD_HPP
 
-#include <vector>
-#include <stan/error_handling/scalar/dom_err.hpp>
-#include <stan/math/matrix/Eigen.hpp>
-#include <stan/math/matrix/typedefs.hpp>
-#include <stan/agrad/rev/var.hpp>
-#include <stan/agrad/rev/matrix/typedefs.hpp>
-#include <stan/error_handling/matrix/check_square.hpp>
-
-// FIXME: use explicit files
 #include <stan/agrad/rev.hpp> 
+#include <stan/error_handling/scalar/dom_err.hpp>
+#include <stan/error_handling/matrix/check_square.hpp>
+#include <stan/math/matrix/Eigen.hpp>
 
 namespace stan {
+
   namespace agrad {
-
-    namespace {
-      template <int R,int C>
-      class log_determinant_spd_alloc : public chainable_alloc {
-      public:
-        virtual ~log_determinant_spd_alloc() {}
-        
-        Eigen::Matrix<double,R,C> _invA;
-      };
-      
-
-      template<int R,int C>
-      class log_determinant_spd_vari : public vari {
-        log_determinant_spd_alloc<R,C> *_alloc;
-        int _rows;
-        int _cols;
-        vari** _adjARef;
-      public:
-        log_determinant_spd_vari(const Eigen::Matrix<var,R,C> &A)
-          : vari(log_determinant_spd_vari_calc(A,&_alloc)), 
-            _rows(A.rows()),
-            _cols(A.cols()),
-            _adjARef((vari**)stan::agrad::ChainableStack::memalloc_.alloc(sizeof(vari*) 
-                                                          * A.rows() * A.cols()))
-        {
-          size_t pos = 0;
-          for (size_type j = 0; j < _cols; j++) {
-            for (size_type i = 0; i < _rows; i++) {
-              _adjARef[pos++] = A(i,j).vi_;
-            }
-          }
-        }
-
-        static 
-        double log_determinant_spd_vari_calc(const Eigen::Matrix<var,R,C> &A,
-                                             log_determinant_spd_alloc<R,C> **alloc)
-        {
-          using stan::error_handling::dom_err;
-
-          // allocate space for information needed in chain
-          *alloc = new log_determinant_spd_alloc<R,C>();
-
-          // compute cholesky decomposition of A
-          (*alloc)->_invA.resize(A.rows(),A.cols());
-          for (size_type j = 0; j < A.cols(); j++)
-            for (size_type i = 0; i < A.rows(); i++)
-              (*alloc)->_invA(i,j) = A(i,j).val();
-          Eigen::LDLT< Eigen::Matrix<double,R,C> > ldlt((*alloc)->_invA);
-          if (ldlt.info() != Eigen::Success) {
-            // Handle this better.
-            (*alloc)->_invA.setZero(A.rows(),A.cols());
-            double y = 0;
-            dom_err("log_determinant_spd",
-                    "matrix argument", y,
-                    "failed LDLT factorization");
-          }
-
-          // compute the inverse of A (needed for the derivative)
-          (*alloc)->_invA.setIdentity(A.rows(),A.cols());
-          ldlt.solveInPlace((*alloc)->_invA);
-          
-          if (ldlt.isNegative() || (ldlt.vectorD().array() <= 1e-16).any()) {
-            double y = 0;
-            dom_err("log_determinant_spd",
-                    "matrix argument", y,
-                    "matrix is negative definite");
-          }
-
-          double ret = ldlt.vectorD().array().log().sum();
-          if (!boost::math::isfinite(ret)) {
-            double y = 0;
-            dom_err("log_determinant_spd",
-                    "matrix argument", y,
-                    "log determininant is infinite");
-          }
-          return ret;
-        }
-
-        virtual void chain() {
-          size_t pos = 0;
-          for (size_type j = 0; j < _cols; j++) {
-            for (size_type i = 0; i < _rows; i++) {
-              _adjARef[pos++]->adj_ += adj_*_alloc->_invA(i,j);
-            }
-          }
-        }
-      };
-    }
 
     template <int R, int C>
     inline var log_determinant_spd(const Eigen::Matrix<var,R,C>& m) {
-      stan::error_handling::check_square("log_determinant_spd", "m", m);
+      using stan::error_handling::dom_err;
+      using Eigen::Matrix;
 
-      return var(new log_determinant_spd_vari<R,C>(m));
+      error_handling::check_square("log_determinant_spd", "m", m);
+
+      Matrix<double,R,C> m_d(m.rows(),m.cols());
+      for (int i = 0; i < m.size(); ++i)
+        m_d(i) = m(i).val();
+
+      Eigen::LDLT<Matrix<double,R,C> > ldlt(m_d);
+      if (ldlt.info() != Eigen::Success) {
+        double y = 0;
+        dom_err("log_determinant_spd",
+                "matrix argument", y,
+                "failed LDLT factorization");
+      }
+
+       // compute the inverse of A (needed for the derivative)
+      m_d.setIdentity(m.rows(), m.cols());
+      ldlt.solveInPlace(m_d);
+          
+      if (ldlt.isNegative() || (ldlt.vectorD().array() <= 1e-16).any()) {
+        double y = 0;
+        dom_err("log_determinant_spd",
+                "matrix argument", y,
+                "matrix is negative definite");
+      }
+
+      double val = ldlt.vectorD().array().log().sum();
+
+      if (!boost::math::isfinite(val)) {
+        double y = 0;
+        dom_err("log_determinant_spd",
+                "matrix argument", y,
+                "log determininant is infinite");
+      }
+
+      vari** operands = ChainableStack::memalloc_
+        .alloc_array<vari*>(m.size());
+      for (int i = 0; i < m.size(); ++i)
+        operands[i] = m(i).vi_;
+
+      double* gradients = ChainableStack::memalloc_
+        .alloc_array<double>(m.size());
+      for (int i = 0; i < m.size(); ++i)
+        gradients[i] = m_d(i);
+
+      return var(new precomputed_gradients_vari(val,m.size(),operands,gradients));
     }
     
+
   }
+
 }
 #endif

--- a/src/stan/memory/stack_alloc.hpp
+++ b/src/stan/memory/stack_alloc.hpp
@@ -186,7 +186,7 @@ namespace stan {
       template <typename T>
       inline
       T* alloc_array(size_t n) {
-        return static_cast<T*>(alloc(n * sizeof(T*)));
+        return static_cast<T*>(alloc(n * sizeof(T)));
       }
 
 

--- a/src/test/unit/agrad/rev/matrix/log_determinant_ldlt_test.cpp
+++ b/src/test/unit/agrad/rev/matrix/log_determinant_ldlt_test.cpp
@@ -6,6 +6,8 @@
 #include <stan/math/matrix/log_determinant_spd.hpp>
 #include <stan/agrad/rev/functions/fabs.hpp>
 #include <stan/agrad/rev/functions/log.hpp>
+#include <stan/agrad/rev/matrix/typedefs.hpp>
+
 
 TEST(AgradRevMatrix,log_determinant_ldlt_diff) {
   using stan::agrad::matrix_v;

--- a/src/test/unit/agrad/rev/matrix/log_determinant_spd_test.cpp
+++ b/src/test/unit/agrad/rev/matrix/log_determinant_spd_test.cpp
@@ -5,6 +5,7 @@
 #include <stan/math/matrix/log_determinant_spd.hpp>
 #include <stan/agrad/rev/functions/fabs.hpp>
 #include <stan/agrad/rev/functions/log.hpp>
+#include <stan/agrad/rev/matrix/typedefs.hpp>
 
 TEST(AgradRevMatrix,log_determinant_spd_diff) {
   using stan::agrad::matrix_v;

--- a/src/test/unit/agrad/rev/matrix/log_determinant_test.cpp
+++ b/src/test/unit/agrad/rev/matrix/log_determinant_test.cpp
@@ -5,6 +5,7 @@
 #include <stan/math/matrix/log_determinant.hpp>
 #include <stan/agrad/rev/functions/fabs.hpp>
 #include <stan/agrad/rev/functions/log.hpp>
+#include <stan/agrad/rev/matrix/typedefs.hpp>
 
 TEST(AgradRevMatrix,log_determinant_diff) {
   using stan::agrad::matrix_v;

--- a/src/test/unit/memory/stack_alloc_test.cpp
+++ b/src/test/unit/memory/stack_alloc_test.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
+#include <cmath>
 #include <stdlib.h>
+#include <utility>
 #include <vector>
 #include <stan/memory/stack_alloc.hpp>
 
@@ -13,6 +15,22 @@ TEST(MemoryStackAlloc, allocArray) {
     EXPECT_EQ(3.0, x[i]);
 }
 
+struct biggy {
+  double r[10];
+};
+
+TEST(MemoryStackAlloc, allocArrayBigger) {
+  size_t N = 1000;
+  size_t K = 10;
+  stan::memory::stack_alloc allocator;
+  biggy* x = allocator.alloc_array<biggy>(N);
+  for (int i = 0; i < N; ++i)
+    for (int k = 1; k < K; ++k)
+      x[i].r[k] = k * i;
+  for (int i = 0; i < N; ++i)
+    for (int k = 0; k < K; ++k)
+      EXPECT_FLOAT_EQ(k * i, x[i].r[k]);
+}
 TEST(stack_alloc, bytes_allocated) {
   stan::memory::stack_alloc allocator;
   EXPECT_TRUE(0L <= allocator.bytes_allocated());


### PR DESCRIPTION
#### Summary:
1.  Refactors log determinant calcs to use standard array allocation in the arena and the precomputed gradient types.  
2.  Fix bug in array allocation with extra `*` in type so all allocations were of pointer sizes.
#### Intended Effect:

(1) Make log det easier to understand and (2) fix bug.
#### How to Verify:

There's a unit test that tickles (2) in Stan 2.5 and is fixed now.  (1) is a judgment call, but should be easy to see.
#### Side Effects:

None.
#### Documentation:

Nothing user facing.
#### Reviewer Suggestions:

Anyone.
