### PR TITLE
Separate math/ode from math [POC]

### DIFF
--- a/src/stan/math.hpp
+++ b/src/stan/math.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/rep_matrix.hpp>
 #include <stan/math/constants.hpp>
 #include <stan/math/functions.hpp>
-#include <stan/math/ode.hpp>
 #include <stan/math/meta.hpp>
 
 #endif


### PR DESCRIPTION
For models where ODE is not required, it would be nice to avoid including all the ODE support headers. This change is worth about 110k lines of headers (600 header files).

Obviously, this change cannot be merged because I don't know where to add back the include ode.hpp that I remove here. Perhaps a more experienced developer can point out where to add it back?
