### PR TITLE
Bugfix/issue 1200 optimizer segfault

### DIFF
--- a/src/stan/agrad/rev/var_stack.hpp
+++ b/src/stan/agrad/rev/var_stack.hpp
@@ -76,8 +76,9 @@ namespace stan {
                                " before calling recover_memory()");
       ChainableStack::var_stack_.clear();
       ChainableStack::var_nochain_stack_.clear();
-      for (size_t i = 0; i < ChainableStack::var_alloc_stack_.size(); i++)
+      for (size_t i = 0; i < ChainableStack::var_alloc_stack_.size(); ++i) {
         delete ChainableStack::var_alloc_stack_[i];
+      }
       ChainableStack::var_alloc_stack_.clear();
       ChainableStack::memalloc_.recover_all();
     }
@@ -103,8 +104,10 @@ namespace stan {
 
       for (size_t i = ChainableStack::nested_var_alloc_stack_starts_.back();
            i < ChainableStack::var_alloc_stack_.size(); 
-           ++i)
+           ++i) {
         delete ChainableStack::var_alloc_stack_[i];
+      }
+      ChainableStack::var_alloc_stack_.resize(ChainableStack::nested_var_alloc_stack_starts_.back());
       ChainableStack::nested_var_alloc_stack_starts_.pop_back();
 
       ChainableStack::memalloc_.recover_nested();

--- a/src/test/unit/agrad/rev/var_stack_test.cpp
+++ b/src/test/unit/agrad/rev/var_stack_test.cpp
@@ -3,6 +3,23 @@
 #include <test/unit/agrad/util.hpp>
 #include <gtest/gtest.h>
 
+struct foo : public stan::agrad::chainable_alloc {
+  std::vector<double> x_;
+  foo() : x_(3) { }
+  ~foo() { }
+  void chain() { }
+};
+
+TEST(AgradRev, varStackRecoverNestedSegFaultFix) {
+  // this test failed in 2.5, but passes in 2.6
+  stan::agrad::start_nested();
+  foo* x = new foo();
+  x->chain();
+  stan::agrad::recover_memory_nested();
+  // should be able to do this redundantly:
+  stan::agrad::recover_memory(); 
+}
+
 // just test basic autodiff;  no more free_memory operation
 TEST(AgradRev,varStack) { 
   AVAR a = 2.0;


### PR DESCRIPTION
#### Summary

Added a single line to resize `var_alloc_stack_` during nested memory recoverty so as to not double delete entries.

#### Intended Effect:

Make sure optimizer doesn't segfault deleting `chainable_alloc` entries (like LDLT class used by multi_normal) by resizing stacks keeping track of what needs to be deleted.  This will allow nested memory to be used and then a final `recover_memory()` to be called redundantly without errors.  (That's why it worked for sampling but not optimization---there was no redundant final call to recover memory anywhere in sampling.)

#### How to Verify:

There's a new unit test that fails in 2.5 with a segfault and succeeds in 2.6. 

You can also run the example model with data supplied by Jiqiang for the issue to see that there's no memory leak introduced for optimization or sampling and that sampling now converges.

#### Side Effects:

None --- everything should work as documented now.

#### Documentation:

Nothing user facing.

#### Reviewer Suggestions:

Anyone --- it's a very simple fix.