### PR TITLE
Add out-of-tree make/local.

### DIFF
--- a/makefile
+++ b/makefile
@@ -130,6 +130,7 @@ include make/libstan  # bin/libstan.a bin/libstanc.a
 include make/tests    # tests
 include make/doxygen  # doxygen
 include make/manual   # manual: manual, doc/stan-reference.pdf
+-include $(HOME)/.config/stan/make.local # for local stuff
 -include make/local    # for local stuff
 
 ##


### PR DESCRIPTION

#### Summary:

This one-line makefile change adds an out-of-tree makefile in addition to make/local, allowing users to place defines and build configuration (e.g. location of their compiler, additional CXXFLAGS, etc.) in a place outside of the git repository that will persist across otherwise destructive git commands.

#### Intended Effect:

Now, in addition to being able to use `make/local` to put any local build configuration or additional make rules, users can do so in `$HOME/.config/stan/make.local`.  If this file is present, it will be included by GNU make.  If it is not present, nothing should happen.

#### How to Verify:

Try putting a build configuration setting, e.g. setting CXXFLAGS or CXX or CC in ~/.config/stan/make.local and see if it sticks.

#### Side Effects:

If a user forgets that he/she has additional local build customizations in the aforementioned file location, his/her build may include said local build customizations unwittingly.  

#### Documentation:

This is documented in the same fashion as the `make/local` file is currently... :-)

#### Reviewer Suggestions:

Anyone with familiarity with the current (GNUmake-based) Stan build system would be a good reviewer for this.