### PR TITLE
Fixes the speed regression from v2.5.0

### DIFF
--- a/src/docs/bibtex/all.bib
+++ b/src/docs/bibtex/all.bib
@@ -529,7 +529,7 @@
   Year = {2014},
   Volume = {15},
   Pages = {1593--1623},
-  Url  = \url{{http://jmlr.org/papers/v15/hoffman14a.html}}
+  url  = {\url{http://jmlr.org/papers/v15/hoffman14a.html}}
 }
 
 @inproceedings{Hoffman:2010,

--- a/src/stan/agrad/rev/error_handling/matrix/check_pos_definite.hpp
+++ b/src/stan/agrad/rev/error_handling/matrix/check_pos_definite.hpp
@@ -11,8 +11,8 @@ namespace stan {
 
   namespace agrad {
 
-    inline bool check_pos_definite(const std::string& function,
-                                   const std::string& name,
+    inline bool check_pos_definite(const char* function,
+                                   const char* name,
                                    const Eigen::Matrix<var,Eigen::Dynamic,Eigen::Dynamic>& y) {
       using Eigen::Matrix;
       using Eigen::Dynamic;

--- a/src/stan/error_handling/matrix/check_cholesky_factor.hpp
+++ b/src/stan/error_handling/matrix/check_cholesky_factor.hpp
@@ -25,8 +25,8 @@ namespace stan {
      * @tparam T_y Type of elements of Cholesky factor
      */
     template <typename T_y>
-    inline bool check_cholesky_factor(const std::string& function,
-                                      const std::string& name,
+    inline bool check_cholesky_factor(const char* function,
+                                      const char* name,
                                       const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y) {
       check_less_or_equal(function, "columns and rows of Cholesky factor",
                           y.cols(), y.rows());

--- a/src/stan/error_handling/matrix/check_cholesky_factor_corr.hpp
+++ b/src/stan/error_handling/matrix/check_cholesky_factor_corr.hpp
@@ -29,8 +29,8 @@ namespace stan {
      * @tparam T_y Type of elements of Cholesky factor
      */
     template <typename T_y>
-    bool check_cholesky_factor_corr(const std::string& function,
-                                    const std::string& name,
+    bool check_cholesky_factor_corr(const char* function,
+                                    const char* name,
                                     const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y) {
       if (!check_square(function, name, y))
         return false;
@@ -61,7 +61,7 @@ namespace stan {
      * @tparam T_result Type of result.
      */
     template <typename T_y>
-    inline bool check_cholesky_factor_corr(const std::string& function,
+    inline bool check_cholesky_factor_corr(const char* function,
                                            const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y) {
       return check_cholesky_factor_corr(function, "(internal variable)", y);
     }

--- a/src/stan/error_handling/matrix/check_column_index.hpp
+++ b/src/stan/error_handling/matrix/check_column_index.hpp
@@ -21,8 +21,8 @@ namespace stan {
      * @tparam T Type of scalar.
      */
     template <typename T_y, int R, int C>
-    inline bool check_column_index(const std::string& function,
-                                   const std::string& name,
+    inline bool check_column_index(const char* function,
+                                   const char* name,
                                    const Eigen::Matrix<T_y,R,C>& y,
                                    size_t i) {
       if ((i > 0) && (i <= static_cast<size_t>(y.cols())))
@@ -31,8 +31,9 @@ namespace stan {
       std::ostringstream msg;
       msg << ") must be greater than 0 and less than " 
           << y.cols();
+      std::string msg_str(msg.str());
       dom_err(function, name, i,
-              "(", msg.str());
+              "(", msg_str.c_str());
       return false;
     }
 

--- a/src/stan/error_handling/matrix/check_corr_matrix.hpp
+++ b/src/stan/error_handling/matrix/check_corr_matrix.hpp
@@ -34,8 +34,8 @@ namespace stan {
      */
     // FIXME: update warnings
     template <typename T_y>
-    inline bool check_corr_matrix(const std::string& function,
-                                  const std::string& name,
+    inline bool check_corr_matrix(const char* function,
+                                  const char* name,
                                   const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y) {
       using Eigen::Dynamic;
       using Eigen::Matrix;
@@ -58,8 +58,9 @@ namespace stan {
               << name << "(" << stan::error_index::value + k 
               << "," << stan::error_index::value + k 
               << ") is "; ;
+          std::string msg_str(msg.str());
           dom_err(function, name, y(k,k),
-                  msg.str(),
+                  msg_str.c_str(),
                   ", but should be near 1.0");
           return false;
         }

--- a/src/stan/error_handling/matrix/check_cov_matrix.hpp
+++ b/src/stan/error_handling/matrix/check_cov_matrix.hpp
@@ -25,8 +25,8 @@ namespace stan {
      */
     // FIXME: update warnings
     template <typename T_y>
-    inline bool check_cov_matrix(const std::string& function,
-                                 const std::string& name,
+    inline bool check_cov_matrix(const char* function,
+                                 const char* name,
                                  const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y) {
       check_size_match(function, 
                        "Rows of covariance matrix", y.rows(),

--- a/src/stan/error_handling/matrix/check_ldlt_factor.hpp
+++ b/src/stan/error_handling/matrix/check_ldlt_factor.hpp
@@ -20,16 +20,17 @@ namespace stan {
      * @tparam T Type of scalar.
      */
     template <typename T, int R, int C>
-    inline bool check_ldlt_factor(const std::string& function,
-                                  const std::string& name,
+    inline bool check_ldlt_factor(const char* function,
+                                  const char* name,
                                   stan::math::LDLT_factor<T,R,C> &A) {
       if (!A.success()) {
         std::ostringstream msg;
         msg << "is not positive definite. "
             << "last conditional variance is ";
+        std::string msg_str(msg.str());
         const T too_small = A.vectorD().tail(1)(0);
         dom_err(function, name, too_small,
-                msg.str(), ".");
+                msg_str.c_str(), ".");
         return false;
       }
       return true;

--- a/src/stan/error_handling/matrix/check_lower_triangular.hpp
+++ b/src/stan/error_handling/matrix/check_lower_triangular.hpp
@@ -23,8 +23,8 @@ namespace stan {
      * @tparam T Type of scalar.
      */
     template <typename T_y>
-    inline bool check_lower_triangular(const std::string& function,
-                const std::string& name,
+    inline bool check_lower_triangular(const char* function,
+                const char* name,
                 const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y) {
       for (int n = 1; n < y.cols(); ++n) {
         for (int m = 0; m < n && m < y.rows(); ++m) {
@@ -33,8 +33,9 @@ namespace stan {
             msg << "is not lower triangular;"
                 << " " << name << "[" << stan::error_index::value + m << "," 
                 << stan::error_index::value + n << "]=";
+            std::string msg_str(msg.str());
             dom_err(function, name, y(m,n),
-                    msg.str());
+                    msg_str.c_str());
             return false;
           }
         }

--- a/src/stan/error_handling/matrix/check_matching_dims.hpp
+++ b/src/stan/error_handling/matrix/check_matching_dims.hpp
@@ -11,10 +11,10 @@ namespace stan {
 
     // NOTE: this will not throw  if y1 or y2 contains nan values.
     template <typename T1, typename T2, int R1, int C1, int R2, int C2>
-    inline bool check_matching_dims(const std::string& function,
-                                    const std::string& name1,
+    inline bool check_matching_dims(const char* function,
+                                    const char* name1,
                                     const Eigen::Matrix<T1,R1,C1>& y1,
-                                    const std::string& name2,
+                                    const char* name2,
                                     const Eigen::Matrix<T2,R2,C2>& y2) {
       check_size_match(function, 
                        "Rows of matrix 1", y1.rows(),

--- a/src/stan/error_handling/matrix/check_matching_sizes.hpp
+++ b/src/stan/error_handling/matrix/check_matching_sizes.hpp
@@ -12,10 +12,10 @@ namespace stan {
 
     // NOTE: this will not throw if y1 or y2 contains nan values.
     template <typename T_y1, typename T_y2>
-    inline bool check_matching_sizes(const std::string& function,
-                                     const std::string& name1,
+    inline bool check_matching_sizes(const char* function,
+                                     const char* name1,
                                      const T_y1& y1,
-                                     const std::string& name2,
+                                     const char* name2,
                                      const T_y2& y2) {
       check_size_match(function,
                        "size of y1", y1.size(),

--- a/src/stan/error_handling/matrix/check_multiplicable.hpp
+++ b/src/stan/error_handling/matrix/check_multiplicable.hpp
@@ -12,10 +12,10 @@ namespace stan {
 
     // NOTE: this will not throw if y1 or y2 contains nan values.
     template <typename T1, typename T2>
-    inline bool check_multiplicable(const std::string& function,
-                                    const std::string& name1,
+    inline bool check_multiplicable(const char* function,
+                                    const char* name1,
                                     const T1& y1,
-                                    const std::string& name2,
+                                    const char* name2,
                                     const T2& y2) {
       check_size_match(function, 
                        "Columns of matrix 1", y1.cols(), 

--- a/src/stan/error_handling/matrix/check_nonzero_size.hpp
+++ b/src/stan/error_handling/matrix/check_nonzero_size.hpp
@@ -29,8 +29,8 @@ namespace stan {
      * @tparam T Type of scalar.
      */
     template <typename T_y>
-    inline bool check_nonzero_size(const std::string& function,
-                                   const std::string& name,
+    inline bool check_nonzero_size(const char* function,
+                                   const char* name,
                                    const T_y& y) {
       using stan::math::index_type;
 

--- a/src/stan/error_handling/matrix/check_ordered.hpp
+++ b/src/stan/error_handling/matrix/check_ordered.hpp
@@ -25,8 +25,8 @@ namespace stan {
      * @return throws if any element in y is nan
      */
     template <typename T_y>
-    bool check_ordered(const std::string& function,
-                       const std::string& name,
+    bool check_ordered(const char* function,
+                       const char* name,
                        const Eigen::Matrix<T_y,Eigen::Dynamic,1>& y) {
       using Eigen::Dynamic;
       using Eigen::Matrix;
@@ -43,11 +43,13 @@ namespace stan {
           msg1 << "is not a valid ordered vector."
                << " The element at " << stan::error_index::value + n 
                << " is ";
+          std::string msg1_str(msg1.str());
           std::ostringstream msg2;
           msg2 << ", but should be greater than the previous element, "
                << y[n-1];
+          std::string msg2_str(msg2.str());
           dom_err(function, name, y[n],
-                  msg1.str(), msg2.str());
+                  msg1_str.c_str(), msg2_str.c_str());
           return false;
         }
       }
@@ -55,8 +57,8 @@ namespace stan {
     }  
     
     template <typename T_y>
-    bool check_ordered(const std::string& function,
-                       const std::string& name,
+    bool check_ordered(const char* function,
+                       const char* name,
                        const std::vector<T_y>& y) {
       if (y.size() == 0) {
         return true;
@@ -67,11 +69,13 @@ namespace stan {
           msg1 << "is not a valid ordered vector."
                << " The element at " << stan::error_index::value + n 
                << " is ";
+          std::string msg1_str(msg1.str());
           std::ostringstream msg2;
           msg2 << ", but should be greater than the previous element, "
                << y[n-1];
+          std::string msg2_str(msg2.str());
           dom_err(function, name, y[n],
-                  msg1.str(), msg2.str());
+                  msg1_str.c_str(), msg2_str.c_str());
           return false;
         }
       }

--- a/src/stan/error_handling/matrix/check_pos_definite.hpp
+++ b/src/stan/error_handling/matrix/check_pos_definite.hpp
@@ -25,15 +25,16 @@ namespace stan {
      */
     // FIXME: update warnings (message has (0,0) item)
     template <typename T_y>
-    inline bool check_pos_definite(const std::string& function,
-                                   const std::string& name,
+    inline bool check_pos_definite(const char* function,
+                                   const char* name,
                                    const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y) {
       if (y.rows() == 1 && !(y(0,0) > CONSTRAINT_TOLERANCE)) {
         std::ostringstream msg;
         msg << "is not positive definite. " 
                 << name << "(0,0) is ";
+        std::string msg_str(msg.str());
         dom_err(function, name, y(0,0), 
-                msg.str());
+                msg_str.c_str());
       }
       for (int i = 0; i < y.size(); ++i)
         check_not_nan(function, name, y(i));
@@ -46,8 +47,9 @@ namespace stan {
         std::ostringstream msg;
         msg << "is not positive definite. " 
                 << name << "(0,0) is ";
+        std::string msg_str(msg.str());
         dom_err(function, name, y(0,0),
-                msg.str());
+                msg_str.c_str());
       }
       return true;
     }

--- a/src/stan/error_handling/matrix/check_pos_semidefinite.hpp
+++ b/src/stan/error_handling/matrix/check_pos_semidefinite.hpp
@@ -29,8 +29,8 @@ namespace stan {
     // FIXME: update warnings (message has (0,0) item)
     template <typename T_y>
     inline bool 
-    check_pos_semidefinite(const std::string& function,
-                           const std::string& name,
+    check_pos_semidefinite(const char* function,
+                           const char* name,
                            const Eigen::Matrix<T_y,
                                                Eigen::Dynamic,
                                                Eigen::Dynamic>& y) {
@@ -44,8 +44,9 @@ namespace stan {
         std::ostringstream msg;
         msg << "is not positive semi-definite. " 
             << name << "(0,0) is ";
+        std::string msg_str(msg.str());
         dom_err(function, name, y(0,0),
-                msg.str());
+                msg_str.c_str());
       }
       Eigen::LDLT< Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic> > cholesky 
         = y.ldlt();
@@ -53,16 +54,18 @@ namespace stan {
         std::ostringstream msg;
         msg << "is not positive semi-definite. " 
             << name << "(0,0) is ";
+        std::string msg_str(msg.str());
         dom_err(function, name, y(0,0),
-                msg.str());
+                msg_str.c_str());
       }
       for (int i = 0; i < y.size(); i++)
         if (boost::math::isnan(y(i))) {
           std::ostringstream msg;
           msg << "is not positive semi-definite. " 
                   << name << "(0,0) is ";
+          std::string msg_str(msg.str());
           dom_err(function, name, y(0,0), 
-                  msg.str(), "");
+                  msg_str.c_str(), "");
         }
       return true;
     }

--- a/src/stan/error_handling/matrix/check_positive_ordered.hpp
+++ b/src/stan/error_handling/matrix/check_positive_ordered.hpp
@@ -25,8 +25,8 @@ namespace stan {
      * values.
      */
     template <typename T_y>
-    bool check_positive_ordered(const std::string& function, 
-                                const std::string& name,
+    bool check_positive_ordered(const char* function, 
+                                const char* name,
                                 const Eigen::Matrix<T_y,Eigen::Dynamic,1>& y) {
       using Eigen::Dynamic;
       using Eigen::Matrix;
@@ -41,9 +41,9 @@ namespace stan {
         msg << "is not a valid positive_ordered vector."
             << " The element at " << stan::error_index::value 
             << " is ";
-
+        std::string msg_str(msg.str());
         dom_err(function, name, y[0],
-                msg.str(), ", but should be postive.");
+                msg_str.c_str(), ", but should be postive.");
       }
       for (size_type n = 1; n < y.size(); n++) {
         if (!(y[n] > y[n-1])) {
@@ -51,11 +51,13 @@ namespace stan {
           msg1 << "is not a valid ordered vector."
               << " The element at " << stan::error_index::value + n 
                << " is ";
+          std::string msg1_str(msg1.str());
           std::ostringstream msg2;
           msg2 << ", but should be greater than the previous element, "
                << y[n-1];
+          std::string msg2_str(msg2.str());
           dom_err(function, name, y[n],
-                  msg1.str(), msg2.str());
+                  msg1_str.c_str(), msg2_str.c_str());
           return false;
         }
       }

--- a/src/stan/error_handling/matrix/check_range.hpp
+++ b/src/stan/error_handling/matrix/check_range.hpp
@@ -11,7 +11,7 @@ namespace stan {
 
       void raise_range_error(size_t max,
                              size_t i, 
-                             const std::string& msg,
+                             const char* msg,
                              size_t idx) {
         std::stringstream s;
         s << "INDEX OPERATOR [] OUT OF BOUNDS"
@@ -21,7 +21,8 @@ namespace stan {
           << "; index position=" << idx
           << "; " << msg
           << std::endl;
-        throw std::out_of_range(s.str());
+        std::string s_str(s.str());
+        throw std::out_of_range(s_str.c_str());
       }
 
     }
@@ -29,7 +30,7 @@ namespace stan {
     inline
     void check_range(size_t max,
                      size_t i, 
-                     const std::string& msg,
+                     const char* msg,
                      size_t idx) {
       if (i < 1 || i > max) 
         raise_range_error(max,i,msg,idx);

--- a/src/stan/error_handling/matrix/check_row_index.hpp
+++ b/src/stan/error_handling/matrix/check_row_index.hpp
@@ -21,8 +21,8 @@ namespace stan {
      * @tparam T Type of scalar.
      */
     template <typename T_y, int R, int C>
-    inline bool check_row_index(const std::string& function,
-                                const std::string& name, 
+    inline bool check_row_index(const char* function,
+                                const char* name, 
                                 const Eigen::Matrix<T_y,R,C>& y, 
                                 size_t i) {
       if ((i > 0) && (i <= static_cast<size_t>(y.rows())))
@@ -31,8 +31,9 @@ namespace stan {
       std::ostringstream msg;
       msg << ") must be greater than 0 and less than " 
           << y.rows();
+      std::string msg_str(msg.str());
       dom_err(function, name, i,
-              "(", msg.str());
+              "(", msg_str.c_str());
       return false;
     }
 

--- a/src/stan/error_handling/matrix/check_simplex.hpp
+++ b/src/stan/error_handling/matrix/check_simplex.hpp
@@ -28,8 +28,8 @@ namespace stan {
      * @return throws if any element is nan.
      */
     template <typename T_prob>
-    bool check_simplex(const std::string& function,
-                       const std::string& name,
+    bool check_simplex(const char* function,
+                       const char* name,
                        const Eigen::Matrix<T_prob,Eigen::Dynamic,1>& theta) {
       using Eigen::Dynamic;
       using Eigen::Matrix;
@@ -41,8 +41,9 @@ namespace stan {
         std::stringstream msg;
         msg << "is not a valid simplex. " 
             << "length(" << name << ") = ";
+        std::string msg_str(msg.str());
         dom_err(function, name, 0,
-                msg.str());
+                msg_str.c_str());
         return false;
       }
       if (!(fabs(1.0 - theta.sum()) <= CONSTRAINT_TOLERANCE)) {
@@ -52,8 +53,9 @@ namespace stan {
         msg.precision(10);
         msg << " sum(" << name << ") = " << sum
             << ", but should be ";
+        std::string msg_str(msg.str());
         dom_err(function, name, 1.0,
-                msg.str());
+                msg_str.c_str());
          return false;
       }
       for (size_t n = 0; n < theta.size(); n++) {
@@ -62,8 +64,9 @@ namespace stan {
           msg << "is not a valid simplex. "
                  << name << "[" << n + stan::error_index::value << "]"
                  << " = ";
+          std::string msg_str(msg.str());
           dom_err(function, name, theta[n],
-                  msg.str(), 
+                  msg_str.c_str(), 
                   ", but should be greater than or equal to 0");
           return false;
         }

--- a/src/stan/error_handling/matrix/check_size_match.hpp
+++ b/src/stan/error_handling/matrix/check_size_match.hpp
@@ -10,10 +10,10 @@ namespace stan {
 
     // FIXME: update warnings
     template <typename T_size1, typename T_size2>
-    inline bool check_size_match(const std::string& function,
-                                 const std::string& name_i,
+    inline bool check_size_match(const char* function,
+                                 const char* name_i,
                                  T_size1 i,
-                                 const std::string& name_j, 
+                                 const char* name_j, 
                                  T_size2 j) {
       typedef typename boost::common_type<T_size1,T_size2>::type common_type;
       if (static_cast<common_type>(i) == static_cast<common_type>(j))
@@ -22,8 +22,9 @@ namespace stan {
       std::ostringstream msg;
       msg << ") and " 
           << name_j << " (" << j << ") must match in size";
+      std::string msg_str(msg.str());
       dom_err(function, name_i, i,
-              "(", msg.str());
+              "(", msg_str.c_str());
       return false;
     }
 

--- a/src/stan/error_handling/matrix/check_spsd_matrix.hpp
+++ b/src/stan/error_handling/matrix/check_spsd_matrix.hpp
@@ -25,8 +25,8 @@ namespace stan {
      */
     // FIXME: update warnings
     template <typename T_y>
-    inline bool check_spsd_matrix(const std::string& function, 
-                                  const std::string& name,
+    inline bool check_spsd_matrix(const char* function, 
+                                  const char* name,
                                   const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y) {
       check_square(function, name, y);
       check_positive(function, "rows", y.rows());

--- a/src/stan/error_handling/matrix/check_square.hpp
+++ b/src/stan/error_handling/matrix/check_square.hpp
@@ -20,8 +20,8 @@ namespace stan {
      * @tparam T Type of scalar.
      */
     template <typename T_y>
-    inline bool check_square(const std::string& function,
-                             const std::string& name,
+    inline bool check_square(const char* function,
+                             const char* name,
                              const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y) {
       check_size_match(function, 
                        "Rows of matrix", y.rows(), 

--- a/src/stan/error_handling/matrix/check_std_vector_index.hpp
+++ b/src/stan/error_handling/matrix/check_std_vector_index.hpp
@@ -21,8 +21,8 @@ namespace stan {
      * @tparam T Type of scalar.
      */
     template <typename T_y>
-    inline bool check_std_vector_index(const std::string& function,
-                                       const std::string& name,
+    inline bool check_std_vector_index(const char* function,
+                                       const char* name,
                                        const std::vector<T_y>& y,
                                        size_t i) {
       if ((i > 0) && (i <= static_cast<size_t>(y.size())))
@@ -31,8 +31,9 @@ namespace stan {
       std::ostringstream msg;
       msg << ") must be greater than 0 and less than " 
           << y.size();
+      std::string msg_str(msg.str());
       dom_err(function, name, i,
-              "(", msg.str());
+              "(", msg_str.c_str());
       return false;
     }
 

--- a/src/stan/error_handling/matrix/check_symmetric.hpp
+++ b/src/stan/error_handling/matrix/check_symmetric.hpp
@@ -27,8 +27,8 @@ namespace stan {
      */
     template <typename T_y>
     inline bool 
-    check_symmetric(const std::string& function,
-                    const std::string& name,
+    check_symmetric(const char* function,
+                    const char* name,
                     const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y) {
       using Eigen::Dynamic;
       using Eigen::Matrix;
@@ -46,13 +46,15 @@ namespace stan {
             msg1 << "is not symmetric. " 
                     << name << "[" << stan::error_index::value + m << "," 
                     << stan::error_index::value +n << "] is ";
+            std::string msg1_str(msg1.str());
             std::ostringstream msg2;
             msg2 << ", but "
                  << name << "[" << stan::error_index::value +n << "," 
                  << stan::error_index::value + m 
                  << "] element is " << y(n,m);
+            std::string msg2_str(msg2.str());
             dom_err(function, name, y(m,n), 
-                    msg1.str(), msg2.str());
+                    msg1_str.c_str(), msg2_str.c_str());
             return false;
           }
         }

--- a/src/stan/error_handling/matrix/check_unit_vector.hpp
+++ b/src/stan/error_handling/matrix/check_unit_vector.hpp
@@ -23,8 +23,8 @@ namespace stan {
      * @return throws if any element in theta is nan
      */
     template <typename T_prob>
-    bool check_unit_vector(const std::string& function,
-                           const std::string& name,
+    bool check_unit_vector(const char* function,
+                           const char* name,
                            const Eigen::Matrix<T_prob,Eigen::Dynamic,1>& theta) {
       if (theta.size() == 0) {
         dom_err(function, name, 0,
@@ -36,8 +36,9 @@ namespace stan {
         std::stringstream msg;
         msg << "is not a valid unit vector."
             << " The sum of the squares of the elements should be 1, but is ";
+        std::string msg_str(msg.str());
         dom_err(function, name, ssq,
-                msg.str());
+                msg_str.c_str());
       }
       return true;
     }

--- a/src/stan/error_handling/matrix/check_vector.hpp
+++ b/src/stan/error_handling/matrix/check_vector.hpp
@@ -11,8 +11,8 @@ namespace stan {
 
     // NOTE: this will not throw if x contains nan values.
     template <typename T, int R, int C>
-    inline bool check_vector(const std::string& function,
-                             const std::string& name,
+    inline bool check_vector(const char* function,
+                             const char* name,
                              const Eigen::Matrix<T,R,C>& x) {
       if (x.rows() == 1 || x.cols() == 1)
         return true;
@@ -21,10 +21,11 @@ namespace stan {
       msg << ") has " << x.rows() << " rows and " 
           << x.cols() << " columns but it should be a vector so it should "
           << "either have 1 row or 1 column";
+      std::string msg_str(msg.str());
       dom_err(function,
               name,
               typename scalar_type<T>::type(),
-              "(", msg.str());
+              "(", msg_str.c_str());
       return false;
     }
 

--- a/src/stan/error_handling/matrix/validate_non_negative_index.hpp
+++ b/src/stan/error_handling/matrix/validate_non_negative_index.hpp
@@ -18,7 +18,8 @@ namespace stan {
             << "; variable=" << var_name
             << "; dimension size expression=" << expr
             << "; expression value=" << val;
-        throw std::invalid_argument(msg.str());
+        std::string msg_str(msg.str());
+        throw std::invalid_argument(msg_str.c_str());
       }
     }
 

--- a/src/stan/error_handling/scalar/check_bounded.hpp
+++ b/src/stan/error_handling/scalar/check_bounded.hpp
@@ -20,8 +20,8 @@ namespace stan {
       template <typename T_y, typename T_low, typename T_high,
                 bool y_is_vec>
       struct bounded {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low,
                           const T_high& high) {
@@ -34,9 +34,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be between ";
               msg << "(" << low_vec[n] << ", " << high_vec[n] << ")";
-
+              std::string msg_str(msg.str());
               dom_err(function, name, y,
-                      "is ", msg.str());
+                      "is ", msg_str.c_str());
             }
           }
           return true;
@@ -45,8 +45,8 @@ namespace stan {
     
       template <typename T_y, typename T_low, typename T_high>
       struct bounded<T_y, T_low, T_high, true> {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low,
                           const T_high& high) {
@@ -60,8 +60,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be between ";
               msg << "(" << low_vec[n] << ", " << high_vec[n] << ")";
+              std::string msg_str(msg.str());
               dom_err_vec(function, name, y, n,
-                          "is ", msg.str());
+                          "is ", msg_str.c_str());
             }
           }
           return true;
@@ -71,8 +72,8 @@ namespace stan {
 
     // public check_bounded function
     template <typename T_y, typename T_low, typename T_high>
-    inline bool check_bounded(const std::string& function,
-                              const std::string& name,  
+    inline bool check_bounded(const char* function,
+                              const char* name,  
                               const T_y& y,
                               const T_low& low,
                               const T_high& high) {

--- a/src/stan/error_handling/scalar/check_consistent_size.hpp
+++ b/src/stan/error_handling/scalar/check_consistent_size.hpp
@@ -10,8 +10,8 @@ namespace stan {
 
     // NOTE: this will not throw if nan is passed in.
     template <typename T>
-    inline bool check_consistent_size(const std::string& function,
-                                      const std::string& name,
+    inline bool check_consistent_size(const char* function,
+                                      const char* name,
                                       const T& x,
                                       size_t max_size) {
       size_t x_size = stan::size_of(x);
@@ -27,10 +27,11 @@ namespace stan {
           << "scalar, array, vector, or matrix types, and they were not "
           << "consistently sized;  all arguments must be scalars or "
           << "multidimensional values of the same shape.";
+      std::string msg_str(msg.str());
 
       dom_err(function, name, x_size,
               "dimension=",
-              msg.str());
+              msg_str.c_str());
       
       return false;
     }

--- a/src/stan/error_handling/scalar/check_consistent_sizes.hpp
+++ b/src/stan/error_handling/scalar/check_consistent_sizes.hpp
@@ -10,10 +10,10 @@ namespace stan {
 
     // NOTE: this will not throw if nan is passed in.
     template <typename T1, typename T2>
-    inline bool check_consistent_sizes(const std::string& function,
-                                       const std::string& name1,
+    inline bool check_consistent_sizes(const char* function,
+                                       const char* name1,
                                        const T1& x1, 
-                                       const std::string& name2,
+                                       const char* name2,
                                        const T2& x2) {
       size_t max_size = std::max(size_of(x1),
                                  size_of(x2));
@@ -22,12 +22,12 @@ namespace stan {
     }
 
     template <typename T1, typename T2, typename T3>
-    inline bool check_consistent_sizes(const std::string& function,
-                                       const std::string& name1,
+    inline bool check_consistent_sizes(const char* function,
+                                       const char* name1,
                                        const T1& x1, 
-                                       const std::string& name2, 
+                                       const char* name2, 
                                        const T2& x2, 
-                                       const std::string& name3, 
+                                       const char* name3, 
                                        const T3& x3) {
       size_t max_size = std::max(size_of(x1),
                                  std::max(size_of(x2),size_of(x3)));
@@ -36,14 +36,14 @@ namespace stan {
         && check_consistent_size(function, name3, x3, max_size);
     }
     template <typename T1, typename T2, typename T3, typename T4>
-    inline bool check_consistent_sizes(const std::string& function,
-                                       const std::string& name1, 
+    inline bool check_consistent_sizes(const char* function,
+                                       const char* name1, 
                                        const T1& x1, 
-                                       const std::string& name2, 
+                                       const char* name2, 
                                        const T2& x2, 
-                                       const std::string& name3, 
+                                       const char* name3, 
                                        const T3& x3, 
-                                       const std::string& name4,
+                                       const char* name4,
                                        const T4& x4) {
       size_t max_size = std::max(size_of(x1),
                                  std::max(size_of(x2),

--- a/src/stan/error_handling/scalar/check_equal.hpp
+++ b/src/stan/error_handling/scalar/check_equal.hpp
@@ -12,8 +12,8 @@ namespace stan {
                 typename T_eq,
                 bool is_vec>
       struct equal {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_eq& eq) {
           using stan::length;
@@ -23,8 +23,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be equal to ";
               msg << eq_vec[n];
+              std::string msg_str(msg.str());
               dom_err(function, name, y,
-                      "is ", msg.str());
+                      "is ", msg_str.c_str());
             }
           }
           return true;
@@ -35,8 +36,8 @@ namespace stan {
       template <typename T_y,
                 typename T_eq>
       struct equal<T_y, T_eq, true> {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_eq& eq) {
           using stan::length;
@@ -47,8 +48,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be equal to ";
               msg << eq_vec[n];
+              std::string msg_str(msg.str());
               dom_err_vec(function, name, y, n,
-                          "is ", msg.str());
+                          "is ", msg_str.c_str());
             }
           }
           return true;
@@ -56,8 +58,8 @@ namespace stan {
       };
     }
     template <typename T_y, typename T_eq>
-    inline bool check_equal(const std::string& function,
-                            const std::string& name,
+    inline bool check_equal(const char* function,
+                            const char* name,
                             const T_y& y,
                             const T_eq& eq) {
       return equal<T_y, T_eq, is_vector_like<T_y>::value>

--- a/src/stan/error_handling/scalar/check_finite.hpp
+++ b/src/stan/error_handling/scalar/check_finite.hpp
@@ -12,8 +12,8 @@ namespace stan {
     namespace {
       template <typename T_y, bool is_vec>
       struct finite {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y) {
           if (!(boost::math::isfinite)(y))
             dom_err(function, name, y,
@@ -24,8 +24,8 @@ namespace stan {
     
       template <typename T_y>
       struct finite<T_y, true> {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y) {
           using stan::length;
           for (size_t n = 0; n < length(y); n++) {
@@ -43,8 +43,8 @@ namespace stan {
      * NOTE: throws if any element in y is nan.
      */
     template <typename T_y>
-    inline bool check_finite(const std::string& function,
-                             const std::string& name,
+    inline bool check_finite(const char* function,
+                             const char* name,
                              const T_y& y) {
       return finite<T_y, is_vector_like<T_y>::value>
         ::check(function, name, y);

--- a/src/stan/error_handling/scalar/check_greater.hpp
+++ b/src/stan/error_handling/scalar/check_greater.hpp
@@ -12,8 +12,8 @@ namespace stan {
                 typename T_low,
                 bool is_vec>
       struct greater {
-        static bool check(const std::string& function,
-                          const std::string& name,  
+        static bool check(const char* function,
+                          const char* name,  
                           const T_y& y,
                           const T_low& low) {
           using stan::length;
@@ -23,9 +23,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be greater than ";
               msg << low_vec[n];
-
+              std::string msg_str(msg.str());
               dom_err(function, name, y,
-                      "is ", msg.str());
+                      "is ", msg_str.c_str());
             }
           }
           return true;
@@ -35,8 +35,8 @@ namespace stan {
       template <typename T_y,
                 typename T_low>
       struct greater<T_y, T_low, true> {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low) {
           using stan::length;
@@ -46,8 +46,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be greater than ";
               msg << low_vec[n];
+              std::string msg_str(msg.str());
               dom_err_vec(function, name, y, n,
-                          "is ", msg.str());
+                          "is ", msg_str.c_str());
             }
           }
           return true;
@@ -57,8 +58,8 @@ namespace stan {
     
     // throws if any element in y or low is nan
     template <typename T_y, typename T_low>
-    inline bool check_greater(const std::string& function,
-                              const std::string& name,  
+    inline bool check_greater(const char* function,
+                              const char* name,  
                               const T_y& y,
                               const T_low& low) {
       return greater<T_y, T_low, is_vector_like<T_y>::value>

--- a/src/stan/error_handling/scalar/check_greater_or_equal.hpp
+++ b/src/stan/error_handling/scalar/check_greater_or_equal.hpp
@@ -12,8 +12,8 @@ namespace stan {
                 typename T_low,
                 bool is_vec>
       struct greater_or_equal {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low) {
           using stan::length;
@@ -23,8 +23,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be greater than or equal to ";
               msg << low_vec[n];
+              std::string msg_str(msg.str());
               dom_err(function, name, y,
-                      "is ", msg.str());
+                      "is ", msg_str.c_str());
             }
           }
           return true;
@@ -34,8 +35,8 @@ namespace stan {
       template <typename T_y,
                 typename T_low>
       struct greater_or_equal<T_y, T_low, true> {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low) {
           using stan::length;
@@ -46,8 +47,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be greater than or equal to ";
               msg << low_vec[n];
+              std::string msg_str(msg.str());
               dom_err_vec(function, name, y, n,
-                          "is ", msg.str());
+                          "is ", msg_str.c_str());
             }
           }
           return true;
@@ -57,8 +59,8 @@ namespace stan {
     
     // throws if any element in y or low is nan
     template <typename T_y, typename T_low>
-    inline bool check_greater_or_equal(const std::string& function,
-                                       const std::string& name,
+    inline bool check_greater_or_equal(const char* function,
+                                       const char* name,
                                        const T_y& y,
                                        const T_low& low) {
       return greater_or_equal<T_y, T_low, is_vector_like<T_y>::value>

--- a/src/stan/error_handling/scalar/check_less.hpp
+++ b/src/stan/error_handling/scalar/check_less.hpp
@@ -10,8 +10,8 @@ namespace stan {
     namespace {
       template <typename T_y, typename T_high, bool is_vec>
       struct less {
-        static bool check(const std::string& function,
-                          const std::string& name,  
+        static bool check(const char* function,
+                          const char* name,  
                           const T_y& y,
                           const T_high& high) {
           using stan::length;
@@ -21,8 +21,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be less than ";
               msg << high_vec[n];
+              std::string msg_str(msg.str());
               dom_err(function, name, y,
-                      "is ", msg.str());
+                      "is ", msg_str.c_str());
             }
           }
           return true;
@@ -31,8 +32,8 @@ namespace stan {
     
       template <typename T_y, typename T_high>
       struct less<T_y, T_high, true> {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_high& high) {
           using stan::length;
@@ -42,8 +43,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be less than ";
               msg << high_vec[n];
+              std::string msg_str(msg.str());
               dom_err_vec(function, name, y, n,
-                          "is ", msg.str());
+                          "is ", msg_str.c_str());
             }
           }
           return true;
@@ -53,8 +55,8 @@ namespace stan {
 
     // throws if any element of y or high is nan
     template <typename T_y, typename T_high>
-    inline bool check_less(const std::string& function,
-                           const std::string& name,  
+    inline bool check_less(const char* function,
+                           const char* name,  
                            const T_y& y,
                            const T_high& high) {
       return less<T_y, T_high, is_vector_like<T_y>::value>

--- a/src/stan/error_handling/scalar/check_less_or_equal.hpp
+++ b/src/stan/error_handling/scalar/check_less_or_equal.hpp
@@ -10,8 +10,8 @@ namespace stan {
     namespace {
       template <typename T_y, typename T_high, bool is_vec>
       struct less_or_equal {
-        static bool check(const std::string& function,
-                          const std::string& name,  
+        static bool check(const char* function,
+                          const char* name,  
                           const T_y& y,
                           const T_high& high) {
           using stan::length;
@@ -21,8 +21,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be less than or equal to ";
               msg << high_vec[n];
+              std::string msg_str(msg.str());
               dom_err(function, name, y,
-                      "is ", msg.str());
+                      "is ", msg_str.c_str());
             }
           }
           return true;
@@ -31,8 +32,8 @@ namespace stan {
     
       template <typename T_y, typename T_high>
       struct less_or_equal<T_y, T_high, true> {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_high& high) {
           using stan::length;
@@ -42,8 +43,9 @@ namespace stan {
               std::stringstream msg;
               msg << ", but must be less than or equal to ";
               msg << high_vec[n];
+              std::string msg_str(msg.str());
               dom_err_vec(function, name, y, n,
-                          "is ", msg.str());
+                          "is ", msg_str.c_str());
             }
           }
           return true;
@@ -53,8 +55,8 @@ namespace stan {
     
     // throws if any element of y or high is nan
     template <typename T_y, typename T_high>
-    inline bool check_less_or_equal(const std::string& function,
-                                    const std::string& name,  
+    inline bool check_less_or_equal(const char* function,
+                                    const char* name,  
                                     const T_y& y,
                                     const T_high& high) {
       return less_or_equal<T_y, T_high, is_vector_like<T_y>::value>

--- a/src/stan/error_handling/scalar/check_nonnegative.hpp
+++ b/src/stan/error_handling/scalar/check_nonnegative.hpp
@@ -14,8 +14,8 @@ namespace stan {
     namespace {
       template <typename T_y, bool is_vec>
       struct nonnegative {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y) {
           // have to use not is_unsigned. is_signed will be false
           // floating point types that have no unsigned versions.
@@ -28,8 +28,8 @@ namespace stan {
     
       template <typename T_y>
       struct nonnegative<T_y, true> {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y) {
           using stan::length;
           using stan::math::value_type;
@@ -47,8 +47,8 @@ namespace stan {
 
     // throws if any element in y is nan
     template <typename T_y>
-    inline bool check_nonnegative(const std::string& function,
-                                  const std::string& name,
+    inline bool check_nonnegative(const char* function,
+                                  const char* name,
                                   const T_y& y) {
       return nonnegative<T_y,is_vector_like<T_y>::value>
         ::check(function, name, y);

--- a/src/stan/error_handling/scalar/check_not_nan.hpp
+++ b/src/stan/error_handling/scalar/check_not_nan.hpp
@@ -12,8 +12,8 @@ namespace stan {
     namespace {
       template <typename T_y, bool is_vec>
       struct not_nan {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y) {
           if ((boost::math::isnan)(y)) 
             dom_err(function, name, y,
@@ -24,8 +24,8 @@ namespace stan {
     
       template <typename T_y>
       struct not_nan<T_y, true> {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y) {
           // using stan::length;
           for (size_t n = 0; n < stan::length(y); n++) {
@@ -47,8 +47,8 @@ namespace stan {
      * @tparam T_y Type of variable being tested.
      */
     template <typename T_y>
-    inline bool check_not_nan(const std::string& function,
-                              const std::string& name,
+    inline bool check_not_nan(const char* function,
+                              const char* name,
                               const T_y& y) {
       return not_nan<T_y, is_vector_like<T_y>::value>
         ::check(function, name, y);

--- a/src/stan/error_handling/scalar/check_positive.hpp
+++ b/src/stan/error_handling/scalar/check_positive.hpp
@@ -15,8 +15,8 @@ namespace stan {
 
       template <typename T_y, bool is_vec>
       struct positive {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y) {
           // have to use not is_unsigned. is_signed will be false
           // floating point types that have no unsigned versions.
@@ -29,8 +29,8 @@ namespace stan {
     
       template <typename T_y>
       struct positive<T_y, true> {
-        static bool check(const std::string& function,
-                          const std::string& name,
+        static bool check(const char* function,
+                          const char* name,
                           const T_y& y) {
           using stan::math::value_type;
           using stan::length;
@@ -48,8 +48,8 @@ namespace stan {
 
     // throws if any element in y is nan
     template <typename T_y>
-    inline bool check_positive(const std::string& function,
-                               const std::string& name,
+    inline bool check_positive(const char* function,
+                               const char* name,
                                const T_y& y) {
       return positive<T_y, is_vector_like<T_y>::value>
         ::check(function, name, y);

--- a/src/stan/error_handling/scalar/check_positive_finite.hpp
+++ b/src/stan/error_handling/scalar/check_positive_finite.hpp
@@ -9,8 +9,8 @@ namespace stan {
 
     // throws if any element in y is nan
     template <typename T_y>
-    inline bool check_positive_finite(const std::string& function,
-                                      const std::string& name,
+    inline bool check_positive_finite(const char* function,
+                                      const char* name,
                                       const T_y& y) {
       stan::error_handling::check_positive(function, name, y);
       stan::error_handling::check_finite(function, name, y);

--- a/src/stan/error_handling/scalar/dom_err.hpp
+++ b/src/stan/error_handling/scalar/dom_err.hpp
@@ -28,11 +28,11 @@ namespace stan {
      * @param msg2 Message to print after the variable
      */
     template <typename T>
-    inline void dom_err(const std::string& function,
-                        const std::string& name,
+    inline void dom_err(const char* function,
+                        const char* name,
                         const T& y,
-                        const std::string& msg1,
-                        const std::string& msg2) {
+                        const char* msg1,
+                        const char* msg2) {
       std::ostringstream message;
       
       message << function << "(" << typeid(T).name() << "): "
@@ -62,10 +62,10 @@ namespace stan {
      * @param msg1 Message to print before the variable
      */
     template <typename T>
-    inline void dom_err(const std::string& function,
-                        const std::string& name,
+    inline void dom_err(const char* function,
+                        const char* name,
                         const T& y,
-                        const std::string& msg1) {
+                        const char* msg1) {
       dom_err(function, name, y, msg1, "");
     }
 

--- a/src/stan/error_handling/scalar/dom_err_vec.hpp
+++ b/src/stan/error_handling/scalar/dom_err_vec.hpp
@@ -32,12 +32,12 @@ namespace stan {
      * @param msg2 Message to print after the variable
      */
     template <typename T>
-    inline void dom_err_vec(const std::string& function,
-                            const std::string& name,
+    inline void dom_err_vec(const char* function,
+                            const char* name,
                             const T& y,
                             const size_t i,
-                            const std::string& msg1,
-                            const std::string& msg2) {
+                            const char* msg1,
+                            const char* msg2) {
       std::ostringstream vec_name_stream;
       vec_name_stream << name
                       << "[" << stan::error_index::value + i << "]";
@@ -65,11 +65,11 @@ namespace stan {
      * @param msg Message to print before the variable
      */
     template <typename T>
-    inline void dom_err_vec(const std::string& function,
-                            const std::string& name,
+    inline void dom_err_vec(const char* function,
+                            const char* name,
                             const T& y,
                             const size_t i,
-                            const std::string& msg) {
+                            const char* msg) {
       dom_err_vec(function, name, y, i, msg, "");
     }
     

--- a/src/stan/gm/generator.hpp
+++ b/src/stan/gm/generator.hpp
@@ -1805,7 +1805,7 @@ namespace stan {
       
       generate_validate_transformed_params(p.derived_decl_.first,2,o);
       o << INDENT2
-        << "const std::string function__ = \"validate transformed params\";" 
+        << "const char* function__ = \"validate transformed params\";" 
         << EOL;
       o << INDENT2
         << "(void) function__; // dummy to suppress unused var warning" 
@@ -2526,8 +2526,8 @@ namespace stan {
         << EOL;
       o << INDENT2 << ": prob_grad(0) {"
         << EOL; // resize 0 with var_resizing
-      o << INDENT2 << "static const std::string function__(\"" 
-        << model_name << "_namespace::" << model_name << "\");" << EOL;
+      o << INDENT2 << "static const char* function__ = \"" 
+        << model_name << "_namespace::" << model_name << "\";" << EOL;
       suppress_warning(INDENT2, "function__", o);
       o << INDENT2 << "size_t pos__;" << EOL;
       suppress_warning(INDENT2, "pos__", o);
@@ -3791,8 +3791,8 @@ namespace stan {
       o << INDENT2 << "stan::io::reader<double> in__(params_r__,params_i__);" 
         << EOL;
       o << INDENT2 << "stan::io::csv_writer writer__(o__);" << EOL;
-      o << INDENT2 << "static const std::string function__(\""
-        << model_name << "_namespace::write_csv\");" << EOL;
+      o << INDENT2 << "static const char* function__ = \""
+        << model_name << "_namespace::write_csv\";" << EOL;
       suppress_warning(INDENT2, "function__", o);
 
       // declares, reads, and writes parameters
@@ -4152,8 +4152,8 @@ namespace stan {
       o << INDENT << "                 std::ostream* pstream__ = 0) const {" << EOL;
       o << INDENT2 << "vars__.resize(0);" << EOL;
       o << INDENT2 << "stan::io::reader<double> in__(params_r__,params_i__);" << EOL;
-      o << INDENT2 << "static const std::string function__(\""
-        << model_name << "_namespace::write_array\");" << EOL;
+      o << INDENT2 << "static const char* function__ = \""
+        << model_name << "_namespace::write_array\";" << EOL;
       suppress_warning(INDENT2, "function__", o);
 
       // declares, reads, and sets parameters

--- a/src/stan/math/matrix/get_base1.hpp
+++ b/src/stan/math/matrix/get_base1.hpp
@@ -26,7 +26,7 @@ namespace stan {
     inline const T& 
     get_base1(const std::vector<T>& x, 
               size_t i, 
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i,error_msg,idx);
@@ -53,7 +53,7 @@ namespace stan {
     get_base1(const std::vector<std::vector<T> >& x, 
               size_t i1, 
               size_t i2,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -82,7 +82,7 @@ namespace stan {
               size_t i1, 
               size_t i2,
               size_t i3,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -113,7 +113,7 @@ namespace stan {
               size_t i2,
               size_t i3,
               size_t i4,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -146,7 +146,7 @@ namespace stan {
               size_t i3,
               size_t i4,
               size_t i5,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -181,7 +181,7 @@ namespace stan {
               size_t i4,
               size_t i5,
               size_t i6,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -219,7 +219,7 @@ namespace stan {
               size_t i5,
               size_t i6,
               size_t i7,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -259,7 +259,7 @@ namespace stan {
                  size_t i6,
                  size_t i7,
                  size_t i8,
-                 const std::string& error_msg,
+                 const char* error_msg,
                  size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -291,7 +291,7 @@ namespace stan {
     inline Eigen::Matrix<T,1,Eigen::Dynamic>
     get_base1(const Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic>& x,
               size_t m,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.rows(),m,error_msg,idx);
@@ -319,7 +319,7 @@ namespace stan {
     get_base1(const Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic>& x,
               size_t m,
               size_t n,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.rows(),m,error_msg,idx);
@@ -345,7 +345,7 @@ namespace stan {
     inline
     const T& get_base1(const Eigen::Matrix<T,Eigen::Dynamic,1>& x,
                        size_t m,
-                       const std::string& error_msg,
+                       const char* error_msg,
                        size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),m,error_msg,idx);
@@ -370,7 +370,7 @@ namespace stan {
     inline const T& 
     get_base1(const Eigen::Matrix<T,1,Eigen::Dynamic>& x,
               size_t n,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),n,error_msg,idx);

--- a/src/stan/math/matrix/get_base1_lhs.hpp
+++ b/src/stan/math/matrix/get_base1_lhs.hpp
@@ -26,7 +26,7 @@ namespace stan {
     inline
     T& get_base1_lhs(std::vector<T>& x, 
                      size_t i, 
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i,error_msg,idx);
@@ -53,7 +53,7 @@ namespace stan {
     T& get_base1_lhs(std::vector<std::vector<T> >& x, 
                      size_t i1, 
                      size_t i2,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -82,7 +82,7 @@ namespace stan {
                      size_t i1, 
                      size_t i2,
                      size_t i3,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -113,7 +113,7 @@ namespace stan {
                      size_t i2,
                      size_t i3,
                      size_t i4,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -146,7 +146,7 @@ namespace stan {
                      size_t i3,
                      size_t i4,
                      size_t i5,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -181,7 +181,7 @@ namespace stan {
                      size_t i4,
                      size_t i5,
                      size_t i6,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -219,7 +219,7 @@ namespace stan {
                      size_t i5,
                      size_t i6,
                      size_t i7,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -259,7 +259,7 @@ namespace stan {
                      size_t i6,
                      size_t i7,
                      size_t i8,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),i1,error_msg,idx);
@@ -292,7 +292,7 @@ namespace stan {
     Eigen::Block<Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic> >
     get_base1_lhs(Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic>& x,
                   size_t m,
-                  const std::string& error_msg,
+                  const char* error_msg,
                   size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.rows(),m,error_msg,idx);
@@ -320,7 +320,7 @@ namespace stan {
     T& get_base1_lhs(Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic>& x,
                      size_t m,
                      size_t n,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.rows(),m,error_msg,idx);
@@ -346,7 +346,7 @@ namespace stan {
     inline
     T& get_base1_lhs(Eigen::Matrix<T,Eigen::Dynamic,1>& x,
                      size_t m,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),m,error_msg,idx);
@@ -371,7 +371,7 @@ namespace stan {
     inline
     T& get_base1_lhs(Eigen::Matrix<T,1,Eigen::Dynamic>& x,
                      size_t n,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       using stan::error_handling::check_range;
       check_range(x.size(),n,error_msg,idx);

--- a/src/stan/prob/distributions/multivariate/continuous/dirichlet.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/dirichlet.hpp
@@ -45,7 +45,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_prob,T_prior_sample_size>::type
     dirichlet_log(const Eigen::Matrix<T_prob,Eigen::Dynamic,1>& theta,
                   const Eigen::Matrix<T_prior_sample_size,Eigen::Dynamic,1>& alpha) {
-      static const std::string function("stan::prob::dirichlet_log");
+      static const char* function("stan::prob::dirichlet_log");
       using boost::math::lgamma;
       using boost::math::tools::promote_args;
       using stan::error_handling::check_consistent_sizes;

--- a/src/stan/prob/distributions/multivariate/continuous/gaussian_dlm_obs.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/gaussian_dlm_obs.hpp
@@ -82,7 +82,7 @@ namespace stan {
                      const Eigen::Matrix<T_W,Eigen::Dynamic,Eigen::Dynamic>& W,
                      const Eigen::Matrix<T_m0,Eigen::Dynamic,1>& m0,
                      const Eigen::Matrix<T_C0,Eigen::Dynamic,Eigen::Dynamic>& C0) {
-      static const std::string function("stan::prob::gaussian_dlm_obs_log");
+      static const char* function("stan::prob::gaussian_dlm_obs_log");
       typedef typename return_type<
         T_y,
         typename return_type<T_F,T_G,T_V,T_W,T_m0,T_C0>::type  >::type T_lp;
@@ -283,7 +283,7 @@ namespace stan {
                      const Eigen::Matrix<T_W,Eigen::Dynamic,Eigen::Dynamic>& W,
                      const Eigen::Matrix<T_m0,Eigen::Dynamic,1>& m0,
                      const Eigen::Matrix<T_C0,Eigen::Dynamic,Eigen::Dynamic>& C0) {
-      static const std::string function("stan::prob::gaussian_dlm_obs_log");
+      static const char* function("stan::prob::gaussian_dlm_obs_log");
       typedef typename return_type<
         T_y,
         typename return_type<T_F,T_G,T_V,T_W,T_m0,T_C0>::type  >::type T_lp;

--- a/src/stan/prob/distributions/multivariate/continuous/inv_wishart.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/inv_wishart.hpp
@@ -50,7 +50,7 @@ namespace stan {
     inv_wishart_log(const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& W,
                     const T_dof& nu,
                     const Eigen::Matrix<T_scale,Eigen::Dynamic,Eigen::Dynamic>& S) {
-      static const std::string function("stan::prob::inv_wishart_log");
+      static const char* function("stan::prob::inv_wishart_log");
       
       using boost::math::tools::promote_args;
       using Eigen::Dynamic;
@@ -128,7 +128,7 @@ namespace stan {
                     const Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>& S,
                     RNG& rng) {
 
-      static const std::string function("stan::prob::inv_wishart_rng");
+      static const char* function("stan::prob::inv_wishart_rng");
       
       using stan::error_handling::check_greater;
       using stan::error_handling::check_size_match;

--- a/src/stan/prob/distributions/multivariate/continuous/lkj_corr.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/lkj_corr.hpp
@@ -50,7 +50,7 @@ namespace stan {
              const Eigen::Matrix<T_covar,Eigen::Dynamic,Eigen::Dynamic>& L, 
              const T_shape& eta) {
 
-      static const std::string function("stan::prob::lkj_corr_cholesky_log");
+      static const char* function("stan::prob::lkj_corr_cholesky_log");
 
       using boost::math::tools::promote_args;
       using stan::error_handling::check_positive;
@@ -102,7 +102,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_y, T_shape>::type
     lkj_corr_log(const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y, 
                  const T_shape& eta) {
-      static const std::string function("stan::prob::lkj_corr_log");
+      static const char* function("stan::prob::lkj_corr_log");
 
       using stan::error_handling::check_size_match;
       using stan::error_handling::check_not_nan;
@@ -152,7 +152,7 @@ namespace stan {
     lkj_corr_cholesky_rng(const size_t K,
                           const double eta,
                           RNG& rng) {
-      static const std::string function("stan::prob::lkj_corr_cholesky_rng");
+      static const char* function("stan::prob::lkj_corr_cholesky_rng");
 
       using stan::error_handling::check_positive;
       
@@ -177,7 +177,7 @@ namespace stan {
                  const double eta,
                  RNG& rng) {
 
-      static const std::string function("stan::prob::lkj_corr_rng");
+      static const char* function("stan::prob::lkj_corr_rng");
 
       using stan::error_handling::check_positive;
       

--- a/src/stan/prob/distributions/multivariate/continuous/lkj_cov.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/lkj_cov.hpp
@@ -24,7 +24,7 @@ namespace stan {
                 const Eigen::Matrix<T_loc,Eigen::Dynamic,1>& mu,
                 const Eigen::Matrix<T_scale,Eigen::Dynamic,1>& sigma,
                 const T_shape& eta) {
-      static const std::string function("stan::prob::lkj_cov_log");
+      static const char* function("stan::prob::lkj_cov_log");
       
       using stan::error_handling::check_size_match;
       using stan::error_handling::check_finite;
@@ -86,7 +86,7 @@ namespace stan {
                 const T_loc& mu, 
                 const T_scale& sigma, 
                 const T_shape& eta) {
-      static const std::string function("stan::prob::lkj_cov_log");
+      static const char* function("stan::prob::lkj_cov_log");
 
       using stan::error_handling::check_finite;
       using stan::error_handling::check_positive;

--- a/src/stan/prob/distributions/multivariate/continuous/matrix_normal.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/matrix_normal.hpp
@@ -44,7 +44,7 @@ namespace stan {
                            const Eigen::Matrix<T_Mu,Eigen::Dynamic,Eigen::Dynamic>& Mu,
                            const Eigen::Matrix<T_Sigma,Eigen::Dynamic,Eigen::Dynamic>& Sigma,
                            const Eigen::Matrix<T_D,Eigen::Dynamic,Eigen::Dynamic>& D) {
-      static const std::string function("stan::prob::matrix_normal_prec_log");
+      static const char* function("stan::prob::matrix_normal_prec_log");
       typename boost::math::tools::promote_args<T_y,T_Mu,T_Sigma,T_D>::type lp(0.0);
       
       using stan::error_handling::check_not_nan;

--- a/src/stan/prob/distributions/multivariate/continuous/multi_gp.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/multi_gp.hpp
@@ -45,7 +45,7 @@ namespace stan {
     multi_gp_log(const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y,
                  const Eigen::Matrix<T_covar,Eigen::Dynamic,Eigen::Dynamic>& Sigma,
                  const Eigen::Matrix<T_w,Eigen::Dynamic,1>& w) {
-      static const std::string function("stan::prob::multi_gp_log");
+      static const char* function("stan::prob::multi_gp_log");
       typedef typename boost::math::tools::promote_args<T_y,T_covar,T_w>::type T_lp;
       T_lp lp(0.0);
       

--- a/src/stan/prob/distributions/multivariate/continuous/multi_gp_cholesky.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/multi_gp_cholesky.hpp
@@ -43,7 +43,7 @@ namespace stan {
     multi_gp_cholesky_log(const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& y,
                  const Eigen::Matrix<T_covar,Eigen::Dynamic,Eigen::Dynamic>& L,
                  const Eigen::Matrix<T_w,Eigen::Dynamic,1>& w) {
-      static const std::string function("stan::prob::multi_gp_cholesky_log");
+      static const char* function("stan::prob::multi_gp_cholesky_log");
       typedef typename boost::math::tools::promote_args<T_y,T_covar,T_w>::type T_lp;
       T_lp lp(0.0);
 

--- a/src/stan/prob/distributions/multivariate/continuous/multi_normal.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/multi_normal.hpp
@@ -25,7 +25,7 @@ namespace stan {
     multi_normal_log(const T_y& y,
                      const T_loc& mu,
                      const Eigen::Matrix<T_covar,Eigen::Dynamic,Eigen::Dynamic>& Sigma) {
-     static const std::string function("stan::prob::multi_normal_log");
+     static const char* function("stan::prob::multi_normal_log");
       typedef typename boost::math::tools::promote_args<typename scalar_type<T_y>::type, typename scalar_type<T_loc>::type, T_covar>::type lp_type;
       lp_type lp(0.0);
       
@@ -134,7 +134,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::normal_distribution;
 
-      static const std::string function("stan::prob::multi_normal_rng");
+      static const char* function("stan::prob::multi_normal_rng");
 
       using stan::error_handling::check_finite;
       using stan::error_handling::check_positive;

--- a/src/stan/prob/distributions/multivariate/continuous/multi_normal_cholesky.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/multi_normal_cholesky.hpp
@@ -48,7 +48,7 @@ namespace stan {
     multi_normal_cholesky_log(const T_y& y,
                               const T_loc& mu,
                               const Eigen::Matrix<T_covar,Eigen::Dynamic,Eigen::Dynamic>& L) {
-      static const std::string function("stan::prob::multi_normal_cholesky_log");
+      static const char* function("stan::prob::multi_normal_cholesky_log");
       typedef typename boost::math::tools::promote_args<typename scalar_type<T_y>::type, typename scalar_type<T_loc>::type, T_covar>::type lp_type;
       lp_type lp(0.0);
 
@@ -160,7 +160,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::normal_distribution;
 
-      static const std::string function("stan::prob::multi_normal_cholesky_rng");
+      static const char* function("stan::prob::multi_normal_cholesky_rng");
 
       using stan::error_handling::check_finite;
  

--- a/src/stan/prob/distributions/multivariate/continuous/multi_normal_prec.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/multi_normal_prec.hpp
@@ -34,7 +34,7 @@ namespace stan {
     multi_normal_prec_log(const T_y& y,
                           const T_loc& mu,
                           const Eigen::Matrix<T_covar,Eigen::Dynamic,Eigen::Dynamic>& Sigma) {
-      static const std::string function("stan::prob::multi_normal_prec_log");
+      static const char* function("stan::prob::multi_normal_prec_log");
       typedef typename boost::math::tools::promote_args<typename scalar_type<T_y>::type, typename scalar_type<T_loc>::type, T_covar>::type lp_type;
       lp_type lp(0.0);
       

--- a/src/stan/prob/distributions/multivariate/continuous/multi_student_t.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/multi_student_t.hpp
@@ -38,7 +38,7 @@ namespace stan {
                         const 
                         Eigen::Matrix<T_scale,
                                       Eigen::Dynamic,Eigen::Dynamic>& Sigma) {
-      static const std::string function("stan::prob::multi_student_t");
+      static const char* function("stan::prob::multi_student_t");
 
       using stan::error_handling::check_size_match;
       using stan::error_handling::check_finite;
@@ -178,7 +178,7 @@ namespace stan {
                         const Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>& s,
                      RNG& rng) {
 
-      static const std::string function("stan::prob::multi_student_t_rng");
+      static const char* function("stan::prob::multi_student_t_rng");
 
       using stan::error_handling::check_finite;
       using stan::error_handling::check_not_nan;

--- a/src/stan/prob/distributions/multivariate/continuous/wishart.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/wishart.hpp
@@ -59,7 +59,7 @@ namespace stan {
     wishart_log(const Eigen::Matrix<T_y,Eigen::Dynamic,Eigen::Dynamic>& W,
                 const T_dof& nu,
                 const Eigen::Matrix<T_scale,Eigen::Dynamic,Eigen::Dynamic>& S) {
-      static const std::string function("stan::prob::wishart_log");
+      static const char* function("stan::prob::wishart_log");
 
       using boost::math::tools::promote_args;
       using Eigen::Dynamic;
@@ -140,7 +140,7 @@ namespace stan {
       using stan::error_handling::check_size_match;
       using stan::error_handling::check_positive;
 
-      static const std::string function("stan::prob::wishart_rng");
+      static const char* function("stan::prob::wishart_rng");
 
       typename index_type<MatrixXd>::type k = S.rows();
 

--- a/src/stan/prob/distributions/multivariate/discrete/categorical.hpp
+++ b/src/stan/prob/distributions/multivariate/discrete/categorical.hpp
@@ -21,7 +21,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_log(int n, 
                     const Eigen::Matrix<T_prob,Eigen::Dynamic,1>& theta) {
-      static const std::string function("stan::prob::categorical_log");
+      static const char* function("stan::prob::categorical_log");
 
       using stan::error_handling::check_bounded;
       using stan::error_handling::check_simplex;
@@ -64,7 +64,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_log(const std::vector<int>& ns, 
                     const Eigen::Matrix<T_prob,Eigen::Dynamic,1>& theta) {
-      static const std::string function("stan::prob::categorical_log");
+      static const char* function("stan::prob::categorical_log");
 
       using boost::math::tools::promote_args;
       using stan::error_handling::check_bounded;
@@ -121,7 +121,7 @@ namespace stan {
       using boost::uniform_01;
       using stan::error_handling::check_simplex;
 
-      static const std::string function("stan::prob::categorical_rng");
+      static const char* function("stan::prob::categorical_rng");
 
       check_simplex(function, "Probabilities parameter", theta);
 

--- a/src/stan/prob/distributions/multivariate/discrete/categorical_logit.hpp
+++ b/src/stan/prob/distributions/multivariate/discrete/categorical_logit.hpp
@@ -21,7 +21,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_logit_log(int n, 
                           const Eigen::Matrix<T_prob,Eigen::Dynamic,1>& beta) {
-      static const std::string function("stan::prob::categorical_logit_log");
+      static const char* function("stan::prob::categorical_logit_log");
 
       using stan::error_handling::check_bounded;
       using stan::error_handling::check_finite;
@@ -50,7 +50,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_logit_log(const std::vector<int>& ns, 
                           const Eigen::Matrix<T_prob,Eigen::Dynamic,1>& beta) {
-      static const std::string function("stan::prob::categorical_logit_log");
+      static const char* function("stan::prob::categorical_logit_log");
 
       using stan::error_handling::check_bounded;
       using stan::error_handling::check_finite;

--- a/src/stan/prob/distributions/multivariate/discrete/multinomial.hpp
+++ b/src/stan/prob/distributions/multivariate/discrete/multinomial.hpp
@@ -24,7 +24,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_prob>::type
     multinomial_log(const std::vector<int>& ns,
                     const Eigen::Matrix<T_prob,Eigen::Dynamic,1>& theta) {
-      static const std::string function("stan::prob::multinomial_log");
+      static const char* function("stan::prob::multinomial_log");
 
       using stan::error_handling::check_nonnegative;
       using stan::error_handling::check_simplex;
@@ -66,7 +66,7 @@ namespace stan {
     multinomial_rng(const Eigen::Matrix<double,Eigen::Dynamic,1>& theta,
                     const int N,
                     RNG& rng) {
-      static const std::string function("stan::prob::multinomial_rng");
+      static const char* function("stan::prob::multinomial_rng");
       using stan::error_handling::check_simplex;
       using stan::error_handling::check_positive;
 

--- a/src/stan/prob/distributions/univariate/continuous/beta.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/beta.hpp
@@ -53,7 +53,7 @@ namespace stan {
     beta_log(const T_y& y, 
              const T_scale_succ& alpha, const T_scale_fail& beta) {
 
-      static const std::string function("stan::prob::beta_log");
+      static const char* function("stan::prob::beta_log");
 
       typedef typename stan::partials_return_type<T_y,
                                                   T_scale_succ,
@@ -239,7 +239,7 @@ namespace stan {
         return 1.0;
       
       // Error checks
-      static const std::string function("stan::prob::beta_cdf");
+      static const char* function("stan::prob::beta_cdf");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_not_nan;
@@ -382,7 +382,7 @@ namespace stan {
         return 0.0;
       
       // Error checks
-      static const std::string function("stan::prob::beta_cdf");
+      static const char* function("stan::prob::beta_cdf");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_not_nan;
@@ -498,7 +498,7 @@ namespace stan {
         return 0.0;
       
       // Error checks
-      static const std::string function("stan::prob::beta_cdf");
+      static const char* function("stan::prob::beta_cdf");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_not_nan;
@@ -608,7 +608,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::gamma_distribution;
       // Error checks
-      static const std::string function("stan::prob::beta_rng");
+      static const char* function("stan::prob::beta_rng");
 
       using stan::error_handling::check_positive_finite;
         

--- a/src/stan/prob/distributions/univariate/continuous/cauchy.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/cauchy.hpp
@@ -40,7 +40,7 @@ namespace stan {
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     cauchy_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::cauchy_log");
+      static const char* function("stan::prob::cauchy_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
 
@@ -168,7 +168,7 @@ namespace stan {
               && stan::length(sigma) ) ) 
         return 1.0;
         
-      static const std::string function("stan::prob::cauchy_cdf");
+      static const char* function("stan::prob::cauchy_cdf");
       
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_finite;
@@ -267,7 +267,7 @@ namespace stan {
               && stan::length(sigma) ) ) 
         return 0.0;
         
-      static const std::string function("stan::prob::cauchy_cdf");
+      static const char* function("stan::prob::cauchy_cdf");
       
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_finite;
@@ -337,7 +337,7 @@ namespace stan {
               && stan::length(sigma) ) ) 
         return 0.0;
         
-      static const std::string function("stan::prob::cauchy_cdf");
+      static const char* function("stan::prob::cauchy_cdf");
       
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_finite;
@@ -404,7 +404,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::cauchy_distribution;
 
-      static const std::string function("stan::prob::cauchy_rng");
+      static const char* function("stan::prob::cauchy_rng");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_finite;

--- a/src/stan/prob/distributions/univariate/continuous/chi_square.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/chi_square.hpp
@@ -45,7 +45,7 @@ namespace stan {
               typename T_y, typename T_dof>
     typename return_type<T_y,T_dof>::type
     chi_square_log(const T_y& y, const T_dof& nu) {
-      static const std::string function("stan::prob::chi_square_log");
+      static const char* function("stan::prob::chi_square_log");
       typedef typename stan::partials_return_type<T_y,T_dof>::type 
         T_partials_return;
 
@@ -156,7 +156,7 @@ namespace stan {
     template <typename T_y, typename T_dof>
     typename return_type<T_y,T_dof>::type
     chi_square_cdf(const T_y& y, const T_dof& nu) {
-      static const std::string function("stan::prob::chi_square_cdf");
+      static const char* function("stan::prob::chi_square_cdf");
       typedef typename stan::partials_return_type<T_y,T_dof>::type 
         T_partials_return;
 
@@ -255,7 +255,7 @@ namespace stan {
     template <typename T_y, typename T_dof>
     typename return_type<T_y,T_dof>::type
     chi_square_cdf_log(const T_y& y, const T_dof& nu) {
-      static const std::string function("stan::prob::chi_square_cdf_log");
+      static const char* function("stan::prob::chi_square_cdf_log");
       typedef typename stan::partials_return_type<T_y,T_dof>::type 
         T_partials_return;
 
@@ -348,7 +348,7 @@ namespace stan {
     template <typename T_y, typename T_dof>
     typename return_type<T_y,T_dof>::type
     chi_square_ccdf_log(const T_y& y, const T_dof& nu) {
-      static const std::string function("stan::prob::chi_square_ccdf_log");
+      static const char* function("stan::prob::chi_square_ccdf_log");
       typedef typename stan::partials_return_type<T_y,T_dof>::type 
         T_partials_return;
 
@@ -445,7 +445,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::chi_squared_distribution;
 
-      static const std::string function("stan::prob::chi_square_rng");
+      static const char* function("stan::prob::chi_square_rng");
 
       using stan::error_handling::check_positive_finite;
       

--- a/src/stan/prob/distributions/univariate/continuous/double_exponential.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/double_exponential.hpp
@@ -26,7 +26,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale>::type
     double_exponential_log(const T_y& y, 
                            const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::double_exponential_log");
+      static const char* function("stan::prob::double_exponential_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
       
@@ -145,7 +145,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale>::type
     double_exponential_cdf(const T_y& y, 
                            const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::double_exponential_cdf");
+      static const char* function("stan::prob::double_exponential_cdf");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
 
@@ -224,7 +224,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale>::type
     double_exponential_cdf_log(const T_y& y, const T_loc& mu, 
                                const T_scale& sigma) {
-      static const std::string function("stan::prob::double_exponential_cdf_log");
+      static const char* function("stan::prob::double_exponential_cdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
       
@@ -304,7 +304,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale>::type
     double_exponential_ccdf_log(const T_y& y, const T_loc& mu, 
                                const T_scale& sigma) {
-      static const std::string function("stan::prob::double_exponential_ccdf_log");
+      static const char* function("stan::prob::double_exponential_ccdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type
         T_partials_return;
       
@@ -385,7 +385,7 @@ namespace stan {
     double_exponential_rng(const double mu,
                            const double sigma,
                            RNG& rng) {
-      static const std::string function("stan::prob::double_exponential_rng");
+      static const char* function("stan::prob::double_exponential_rng");
 
       using boost::variate_generator;
       using boost::random::uniform_01;

--- a/src/stan/prob/distributions/univariate/continuous/exp_mod_normal.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/exp_mod_normal.hpp
@@ -27,7 +27,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale, T_inv_scale>::type
     exp_mod_normal_log(const T_y& y, const T_loc& mu, const T_scale& sigma, 
                        const T_inv_scale& lambda) {
-      static const std::string function("stan::prob::exp_mod_normal_log");
+      static const char* function("stan::prob::exp_mod_normal_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale,
                                                   T_inv_scale>::type 
         T_partials_return;
@@ -146,7 +146,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale,T_inv_scale>::type
     exp_mod_normal_cdf(const T_y& y, const T_loc& mu, const T_scale& sigma, 
                        const T_inv_scale& lambda) {
-      static const std::string function("stan::prob::exp_mod_normal_cdf");
+      static const char* function("stan::prob::exp_mod_normal_cdf");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale,
                                                   T_inv_scale>::type 
         T_partials_return;
@@ -266,7 +266,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale,T_inv_scale>::type
     exp_mod_normal_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma, 
                            const T_inv_scale& lambda) {
-      static const std::string function("stan::prob::exp_mod_normal_cdf_log");
+      static const char* function("stan::prob::exp_mod_normal_cdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale,
                                                   T_inv_scale>::type
         T_partials_return;
@@ -379,7 +379,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale,T_inv_scale>::type
     exp_mod_normal_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma, 
                             const T_inv_scale& lambda) {
-      static const std::string function("stan::prob::exp_mod_normal_ccdf_log");
+      static const char* function("stan::prob::exp_mod_normal_ccdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale,
                                                   T_inv_scale>::type
         T_partials_return;
@@ -494,7 +494,7 @@ namespace stan {
                        const double lambda,
                        RNG& rng) {
 
-      static const std::string function("stan::prob::exp_mod_normal_rng");
+      static const char* function("stan::prob::exp_mod_normal_rng");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_finite;

--- a/src/stan/prob/distributions/univariate/continuous/exponential.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/exponential.hpp
@@ -46,7 +46,7 @@ namespace stan {
     template <bool propto, typename T_y, typename T_inv_scale>
     typename return_type<T_y,T_inv_scale>::type
     exponential_log(const T_y& y, const T_inv_scale& beta) {
-      static const std::string function("stan::prob::exponential_log");
+      static const char* function("stan::prob::exponential_log");
       typedef typename stan::partials_return_type<T_y,T_inv_scale>::type 
         T_partials_return;
 
@@ -125,7 +125,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y,T_inv_scale>::type 
         T_partials_return;
 
-      static const std::string function("stan::prob::exponential_cdf");
+      static const char* function("stan::prob::exponential_cdf");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_nonnegative;
@@ -179,7 +179,7 @@ namespace stan {
     exponential_cdf_log(const T_y& y, const T_inv_scale& beta) {
       typedef typename stan::partials_return_type<T_y,T_inv_scale>::type T_partials_return;
 
-      static const std::string function("stan::prob::exponential_cdf_log");
+      static const char* function("stan::prob::exponential_cdf_log");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_nonnegative;
@@ -226,7 +226,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y,T_inv_scale>::type 
         T_partials_return;
 
-     static const std::string function("stan::prob::exponential_ccdf_log");
+     static const char* function("stan::prob::exponential_ccdf_log");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_nonnegative;
@@ -272,7 +272,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::exponential_distribution;
 
-      static const std::string function("stan::prob::exponential_rng");
+      static const char* function("stan::prob::exponential_rng");
 
       using stan::error_handling::check_positive_finite;
 

--- a/src/stan/prob/distributions/univariate/continuous/frechet.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/frechet.hpp
@@ -26,7 +26,7 @@ namespace stan {
               typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y,T_shape,T_scale>::type
     frechet_log(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      static const std::string function("stan::prob::frechet_log");
+      static const char* function("stan::prob::frechet_log");
       typedef typename stan::partials_return_type<T_y,T_shape,T_scale>::type
         T_partials_return;
 
@@ -137,7 +137,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y,T_shape,T_scale>::type
         T_partials_return;
 
-      static const std::string function("stan::prob::frechet_cdf");
+      static const char* function("stan::prob::frechet_cdf");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_positive;
@@ -201,7 +201,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y,T_shape,T_scale>::type
         T_partials_return;
 
-      static const std::string function("stan::prob::frechet_cdf_log");
+      static const char* function("stan::prob::frechet_cdf_log");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_positive;
@@ -254,7 +254,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y,T_shape,T_scale>::type
         T_partials_return;
 
-      static const std::string function("stan::prob::frechet_ccdf_log");
+      static const char* function("stan::prob::frechet_ccdf_log");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_positive;
@@ -313,7 +313,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::weibull_distribution;
 
-      static const std::string function("stan::prob::frechet_rng");
+      static const char* function("stan::prob::frechet_rng");
 
       using stan::error_handling::check_finite;
       using stan::error_handling::check_not_nan;

--- a/src/stan/prob/distributions/univariate/continuous/gamma.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/gamma.hpp
@@ -51,7 +51,7 @@ namespace stan {
               typename T_y, typename T_shape, typename T_inv_scale>
     typename return_type<T_y,T_shape,T_inv_scale>::type
     gamma_log(const T_y& y, const T_shape& alpha, const T_inv_scale& beta) {
-      static const std::string function("stan::prob::gamma_log");
+      static const char* function("stan::prob::gamma_log");
       typedef typename stan::partials_return_type<T_y,T_shape,
                                                   T_inv_scale>::type 
         T_partials_return;
@@ -189,7 +189,7 @@ namespace stan {
         T_partials_return;
           
       // Error checks
-      static const std::string function("stan::prob::gamma_cdf");
+      static const char* function("stan::prob::gamma_cdf");
           
       using stan::error_handling::check_positive_finite;      
       using stan::error_handling::check_not_nan;
@@ -304,7 +304,7 @@ namespace stan {
         T_partials_return;
 
       // Error checks
-      static const std::string function("stan::prob::gamma_cdf_log");
+      static const char* function("stan::prob::gamma_cdf_log");
           
       using stan::error_handling::check_positive_finite;      
       using stan::error_handling::check_not_nan;
@@ -412,7 +412,7 @@ namespace stan {
         T_partials_return;
  
       // Error checks
-      static const std::string function("stan::prob::gamma_ccdf_log");
+      static const char* function("stan::prob::gamma_ccdf_log");
           
       using stan::error_handling::check_positive_finite;      
       using stan::error_handling::check_not_nan;
@@ -515,7 +515,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::gamma_distribution;
 
-      static const std::string function("stan::prob::gamma_rng");
+      static const char* function("stan::prob::gamma_rng");
 
       using stan::error_handling::check_positive_finite;
       

--- a/src/stan/prob/distributions/univariate/continuous/gumbel.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/gumbel.hpp
@@ -20,7 +20,7 @@ namespace stan {
     template <bool propto, typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     gumbel_log(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const std::string function("stan::prob::gumbel_log");
+      static const char* function("stan::prob::gumbel_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type
         T_partials_return;
 
@@ -114,7 +114,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     gumbel_cdf(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const std::string function("stan::prob::gumbel_cdf");
+      static const char* function("stan::prob::gumbel_cdf");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
 
@@ -186,7 +186,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     gumbel_cdf_log(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const std::string function("stan::prob::gumbel_cdf_log");
+      static const char* function("stan::prob::gumbel_cdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type
         T_partials_return;
 
@@ -242,7 +242,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     gumbel_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const std::string function("stan::prob::gumbel_ccdf_log");
+      static const char* function("stan::prob::gumbel_ccdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
 
@@ -306,7 +306,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::uniform_01;
 
-      static const std::string function("stan::prob::gumbel_rng");
+      static const char* function("stan::prob::gumbel_rng");
 
       using stan::error_handling::check_positive;
       using stan::error_handling::check_finite;

--- a/src/stan/prob/distributions/univariate/continuous/inv_chi_square.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/inv_chi_square.hpp
@@ -45,7 +45,7 @@ namespace stan {
               typename T_y, typename T_dof>
     typename return_type<T_y,T_dof>::type
     inv_chi_square_log(const T_y& y, const T_dof& nu) {
-      static const std::string function("stan::prob::inv_chi_square_log");
+      static const char* function("stan::prob::inv_chi_square_log");
       typedef typename stan::partials_return_type<T_y,T_dof>::type 
         T_partials_return;
 
@@ -147,7 +147,7 @@ namespace stan {
       if ( !( stan::length(y) && stan::length(nu) ) ) return 1.0;
           
       // Error checks
-      static const std::string function("stan::prob::inv_chi_square_cdf");
+      static const char* function("stan::prob::inv_chi_square_cdf");
           
       using stan::error_handling::check_positive_finite;      
       using stan::error_handling::check_not_nan;
@@ -251,7 +251,7 @@ namespace stan {
       if ( !( stan::length(y) && stan::length(nu) ) ) return 0.0;
           
       // Error checks
-      static const std::string function("stan::prob::inv_chi_square_cdf_log");
+      static const char* function("stan::prob::inv_chi_square_cdf_log");
           
       using stan::error_handling::check_positive_finite;      
       using stan::error_handling::check_not_nan;
@@ -349,7 +349,7 @@ namespace stan {
       if ( !( stan::length(y) && stan::length(nu) ) ) return 0.0;
           
       // Error checks
-      static const std::string function("stan::prob::inv_chi_square_ccdf_log");
+      static const char* function("stan::prob::inv_chi_square_ccdf_log");
           
       using stan::error_handling::check_positive_finite;      
       using stan::error_handling::check_not_nan;
@@ -445,7 +445,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::chi_squared_distribution;
 
-      static const std::string function("stan::prob::inv_chi_square_rng");
+      static const char* function("stan::prob::inv_chi_square_rng");
 
       using stan::error_handling::check_positive_finite;      
 

--- a/src/stan/prob/distributions/univariate/continuous/inv_gamma.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/inv_gamma.hpp
@@ -44,7 +44,7 @@ namespace stan {
               typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y,T_shape,T_scale>::type
     inv_gamma_log(const T_y& y, const T_shape& alpha, const T_scale& beta) {
-      static const std::string function("stan::prob::inv_gamma_log");
+      static const char* function("stan::prob::inv_gamma_log");
       typedef typename stan::partials_return_type<T_y,T_shape,T_scale>::type 
         T_partials_return;
 
@@ -184,7 +184,7 @@ namespace stan {
         return 1.0;
           
       // Error checks
-      static const std::string function("stan::prob::inv_gamma_cdf");
+      static const char* function("stan::prob::inv_gamma_cdf");
           
       using stan::error_handling::check_positive_finite;      
       using stan::error_handling::check_not_nan;
@@ -303,7 +303,7 @@ namespace stan {
         return 0.0;
           
       // Error checks
-      static const std::string function("stan::prob::inv_gamma_cdf_log");
+      static const char* function("stan::prob::inv_gamma_cdf_log");
           
       using stan::error_handling::check_positive_finite;      
       using stan::error_handling::check_not_nan;
@@ -414,7 +414,7 @@ namespace stan {
         return 0.0;
           
       // Error checks
-      static const std::string function("stan::prob::inv_gamma_ccdf_log");
+      static const char* function("stan::prob::inv_gamma_ccdf_log");
           
       using stan::error_handling::check_positive_finite;      
       using stan::error_handling::check_not_nan;
@@ -522,7 +522,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::gamma_distribution;
 
-      static const std::string function("stan::prob::inv_gamma_rng");
+      static const char* function("stan::prob::inv_gamma_rng");
 
       using stan::error_handling::check_positive_finite;
  

--- a/src/stan/prob/distributions/univariate/continuous/logistic.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/logistic.hpp
@@ -24,7 +24,7 @@ namespace stan {
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     logistic_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::logistic_log");
+      static const char* function("stan::prob::logistic_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type
         T_partials_return;
       
@@ -148,7 +148,7 @@ namespace stan {
         return 1.0;
           
       // Error checks
-      static const std::string function("stan::prob::logistic_cdf");
+      static const char* function("stan::prob::logistic_cdf");
           
       using stan::error_handling::check_not_nan;
       using stan::error_handling::check_positive_finite;
@@ -244,7 +244,7 @@ namespace stan {
         return 0.0;
           
       // Error checks
-      static const std::string function("stan::prob::logistic_cdf_log");
+      static const char* function("stan::prob::logistic_cdf_log");
           
       using stan::error_handling::check_not_nan;
       using stan::error_handling::check_positive_finite;
@@ -325,7 +325,7 @@ namespace stan {
         return 0.0;
           
       // Error checks
-      static const std::string function("stan::prob::logistic_cdf_log");
+      static const char* function("stan::prob::logistic_cdf_log");
           
       using stan::error_handling::check_not_nan;
       using stan::error_handling::check_positive_finite;
@@ -404,7 +404,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::exponential_distribution;
 
-      static const std::string function("stan::prob::logistic_rng");
+      static const char* function("stan::prob::logistic_rng");
       
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_finite;

--- a/src/stan/prob/distributions/univariate/continuous/lognormal.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/lognormal.hpp
@@ -25,7 +25,7 @@ namespace stan {
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     lognormal_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::lognormal_log");
+      static const char* function("stan::prob::lognormal_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type
         T_partials_return;
 
@@ -151,7 +151,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     lognormal_cdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::lognormal_cdf");
+      static const char* function("stan::prob::lognormal_cdf");
 
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
@@ -230,7 +230,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     lognormal_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::lognormal_cdf_log");
+      static const char* function("stan::prob::lognormal_cdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
 
@@ -301,7 +301,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     lognormal_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::lognormal_ccdf_log");
+      static const char* function("stan::prob::lognormal_ccdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
 
@@ -377,7 +377,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::lognormal_distribution;
 
-      static const std::string function("stan::prob::lognormal_rng");
+      static const char* function("stan::prob::lognormal_rng");
 
       using stan::error_handling::check_finite;
       using stan::error_handling::check_positive_finite;

--- a/src/stan/prob/distributions/univariate/continuous/normal.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/normal.hpp
@@ -40,7 +40,7 @@ namespace stan {
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     normal_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::normal_log");
+      static const char* function("stan::prob::normal_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
 
@@ -153,7 +153,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     normal_cdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::normal_cdf");
+      static const char* function("stan::prob::normal_cdf");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type 
         T_partials_return;
 
@@ -237,7 +237,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     normal_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::normal_cdf_log");
+      static const char* function("stan::prob::normal_cdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type
         T_partials_return;
 
@@ -312,7 +312,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y,T_loc,T_scale>::type
     normal_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function("stan::prob::normal_ccdf_log");
+      static const char* function("stan::prob::normal_ccdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale>::type
         T_partials_return;
 
@@ -395,7 +395,7 @@ namespace stan {
       using stan::error_handling::check_finite;
       using stan::error_handling::check_not_nan;
 
-      static const std::string function("stan::prob::normal_rng");
+      static const char* function("stan::prob::normal_rng");
 
       check_finite(function, "Location parameter", mu);
       check_not_nan(function, "Location parameter", mu);

--- a/src/stan/prob/distributions/univariate/continuous/pareto.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/pareto.hpp
@@ -25,7 +25,7 @@ namespace stan {
               typename T_y, typename T_scale, typename T_shape>
     typename return_type<T_y,T_scale,T_shape>::type
     pareto_log(const T_y& y, const T_scale& y_min, const T_shape& alpha) {
-      static const std::string function("stan::prob::pareto_log");
+      static const char* function("stan::prob::pareto_log");
       typedef typename stan::partials_return_type<T_y,T_scale,T_shape>::type 
         T_partials_return;
 
@@ -138,7 +138,7 @@ namespace stan {
         return 1.0;
           
       // Check errors
-      static const std::string function("stan::prob::pareto_cdf");
+      static const char* function("stan::prob::pareto_cdf");
           
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_not_nan;
@@ -235,7 +235,7 @@ namespace stan {
         return 0.0;
           
       // Check errors
-      static const std::string function("stan::prob::pareto_cdf_log");
+      static const char* function("stan::prob::pareto_cdf_log");
           
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_not_nan;
@@ -320,7 +320,7 @@ namespace stan {
         return 0.0;
           
       // Check errors
-      static const std::string function("stan::prob::pareto_ccdf_log");
+      static const char* function("stan::prob::pareto_ccdf_log");
           
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_not_nan;
@@ -396,7 +396,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::exponential_distribution;
 
-      static const std::string function("stan::prob::pareto_rng");
+      static const char* function("stan::prob::pareto_rng");
       
       using stan::error_handling::check_positive_finite;
 

--- a/src/stan/prob/distributions/univariate/continuous/pareto_type_2.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/pareto_type_2.hpp
@@ -27,7 +27,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale,T_shape>::type
     pareto_type_2_log(const T_y& y, const T_loc& mu, const T_scale& lambda, 
                       const T_shape& alpha) {
-      static const std::string function("stan::prob::pareto_type_2_log");
+      static const char* function("stan::prob::pareto_type_2_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale,T_shape>::type 
         T_partials_return;      
 
@@ -157,7 +157,7 @@ namespace stan {
         return 1.0;
           
       // Check errors
-      static const std::string function("stan::prob::pareto_type_2_cdf");
+      static const char* function("stan::prob::pareto_type_2_cdf");
           
       using stan::error_handling::check_greater_or_equal;
       using stan::error_handling::check_finite;
@@ -278,7 +278,7 @@ namespace stan {
         return 0.0;
           
       // Check errors
-      static const std::string function("stan::prob::pareto_type_2_cdf_log");
+      static const char* function("stan::prob::pareto_type_2_cdf_log");
           
       using stan::error_handling::check_greater_or_equal;
       using stan::error_handling::check_finite;
@@ -383,7 +383,7 @@ namespace stan {
         return 0.0;
           
       // Check errors
-      static const std::string function("stan::prob::pareto_type_2_ccdf_log");
+      static const char* function("stan::prob::pareto_type_2_ccdf_log");
           
       using stan::error_handling::check_greater_or_equal;
       using stan::error_handling::check_positive_finite;
@@ -476,7 +476,7 @@ namespace stan {
                       const double lambda,
                       const double alpha,
                       RNG& rng) {
-      static const std::string function("stan::prob::pareto_type_2_rng");
+      static const char* function("stan::prob::pareto_type_2_rng");
       
       stan::error_handling::check_positive(function, "scale parameter", lambda);
 

--- a/src/stan/prob/distributions/univariate/continuous/rayleigh.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/rayleigh.hpp
@@ -23,7 +23,7 @@ namespace stan {
               typename T_y, typename T_scale>
     typename return_type<T_y,T_scale>::type
     rayleigh_log(const T_y& y, const T_scale& sigma) {
-      static const std::string function("stan::prob::rayleigh_log");
+      static const char* function("stan::prob::rayleigh_log");
       typedef typename stan::partials_return_type<T_y,T_scale>::type 
         T_partials_return;
 
@@ -108,7 +108,7 @@ namespace stan {
     template <typename T_y, typename T_scale>
     typename return_type<T_y,T_scale>::type
     rayleigh_cdf(const T_y& y, const T_scale& sigma) {
-      static const std::string function("stan::prob::rayleigh_cdf");
+      static const char* function("stan::prob::rayleigh_cdf");
       typedef typename stan::partials_return_type<T_y,T_scale>::type 
         T_partials_return;
 
@@ -180,7 +180,7 @@ namespace stan {
     template <typename T_y, typename T_scale>
     typename return_type<T_y,T_scale>::type
     rayleigh_cdf_log(const T_y& y, const T_scale& sigma) {
-      static const std::string function("stan::prob::rayleigh_cdf_log");
+      static const char* function("stan::prob::rayleigh_cdf_log");
       typedef typename stan::partials_return_type<T_y,T_scale>::type
         T_partials_return;
 
@@ -244,7 +244,7 @@ namespace stan {
     template <typename T_y, typename T_scale>
     typename return_type<T_y,T_scale>::type
     rayleigh_ccdf_log(const T_y& y, const T_scale& sigma) {
-      static const std::string function("stan::prob::rayleigh_ccdf_log");
+      static const char* function("stan::prob::rayleigh_ccdf_log");
       typedef typename stan::partials_return_type<T_y,T_scale>::type
         T_partials_return;
 
@@ -309,7 +309,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::uniform_real_distribution;
 
-      static const std::string function("stan::prob::rayleigh_rng");
+      static const char* function("stan::prob::rayleigh_rng");
 
       using stan::error_handling::check_positive;
 

--- a/src/stan/prob/distributions/univariate/continuous/scaled_inv_chi_square.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/scaled_inv_chi_square.hpp
@@ -48,7 +48,7 @@ namespace stan {
               typename T_y, typename T_dof, typename T_scale>
     typename return_type<T_y,T_dof,T_scale>::type
     scaled_inv_chi_square_log(const T_y& y, const T_dof& nu, const T_scale& s) {
-      static const std::string function("stan::prob::scaled_inv_chi_square_log");
+      static const char* function("stan::prob::scaled_inv_chi_square_log");
       typedef typename stan::partials_return_type<T_y,T_dof,T_scale>::type
         T_partials_return;
       
@@ -197,7 +197,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(nu) && stan::length(s)))
         return 1.0;
       
-      static const std::string function("stan::prob::scaled_inv_chi_square_cdf");
+      static const char* function("stan::prob::scaled_inv_chi_square_cdf");
           
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_not_nan;
@@ -326,7 +326,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(nu) && stan::length(s)))
         return 0.0;
       
-      static const std::string function("stan::prob::scaled_inv_chi_square_cdf_log");
+      static const char* function("stan::prob::scaled_inv_chi_square_cdf_log");
           
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_not_nan;
@@ -439,7 +439,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(nu) && stan::length(s)))
         return 0.0;
       
-      static const std::string function("stan::prob::scaled_inv_chi_square_ccdf_log");
+      static const char* function("stan::prob::scaled_inv_chi_square_ccdf_log");
           
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_not_nan;
@@ -550,7 +550,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::chi_squared_distribution;
 
-      static const std::string function("stan::prob::scaled_inv_chi_square_rng");
+      static const char* function("stan::prob::scaled_inv_chi_square_rng");
       
       using stan::error_handling::check_positive_finite;
 

--- a/src/stan/prob/distributions/univariate/continuous/skew_normal.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/skew_normal.hpp
@@ -24,7 +24,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale,T_shape>::type
     skew_normal_log(const T_y& y, const T_loc& mu, const T_scale& sigma, 
                     const T_shape& alpha) {
-      static const std::string function("stan::prob::skew_normal_log");
+      static const char* function("stan::prob::skew_normal_log");
       typedef typename stan::partials_return_type<T_y,T_loc,
                                                   T_scale,T_shape>::type 
         T_partials_return;
@@ -148,7 +148,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale,T_shape>::type
     skew_normal_cdf(const T_y& y, const T_loc& mu, const T_scale& sigma, 
                     const T_shape& alpha) {
-      static const std::string function("stan::prob::skew_normal_cdf");
+      static const char* function("stan::prob::skew_normal_cdf");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale,
                                                   T_shape>::type 
         T_partials_return;
@@ -251,7 +251,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale,T_shape>::type
     skew_normal_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma, 
                         const T_shape& alpha) {
-      static const std::string function("stan::prob::skew_normal_cdf_log");
+      static const char* function("stan::prob::skew_normal_cdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale,
                                                   T_shape>::type
         T_partials_return;
@@ -341,7 +341,7 @@ namespace stan {
     typename return_type<T_y,T_loc,T_scale,T_shape>::type
     skew_normal_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma, 
                          const T_shape& alpha) {
-      static const std::string function("stan::prob::skew_normal_ccdf_log");
+      static const char* function("stan::prob::skew_normal_ccdf_log");
       typedef typename stan::partials_return_type<T_y,T_loc,T_scale,
                                                   T_shape>::type 
         T_partials_return;
@@ -434,7 +434,7 @@ namespace stan {
                     RNG& rng) {
       boost::math::skew_normal_distribution<>dist (mu, sigma, alpha);
 
-      static const std::string function("stan::prob::skew_normal_rng");
+      static const char* function("stan::prob::skew_normal_rng");
 
       using stan::error_handling::check_positive;
       using stan::error_handling::check_finite;

--- a/src/stan/prob/distributions/univariate/continuous/student_t.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/student_t.hpp
@@ -56,7 +56,7 @@ namespace stan {
     typename return_type<T_y,T_dof,T_loc,T_scale>::type
     student_t_log(const T_y& y, const T_dof& nu, const T_loc& mu, 
                   const T_scale& sigma) {
-      static const std::string function("stan::prob::student_t_log");
+      static const char* function("stan::prob::student_t_log");
       typedef typename stan::partials_return_type<T_y,T_dof,T_loc,
                                                   T_scale>::type 
         T_partials_return;
@@ -233,7 +233,7 @@ namespace stan {
             && stan::length(sigma))) 
         return 1.0;
       
-      static const std::string function("stan::prob::student_t_cdf");
+      static const char* function("stan::prob::student_t_cdf");
           
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_finite;
@@ -419,7 +419,7 @@ namespace stan {
             && stan::length(sigma))) 
         return 0.0;
       
-      static const std::string function("stan::prob::student_t_cdf_log");
+      static const char* function("stan::prob::student_t_cdf_log");
           
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_finite;
@@ -592,7 +592,7 @@ namespace stan {
             && stan::length(sigma))) 
         return 0.0;
       
-      static const std::string function("stan::prob::student_t_ccdf_log");
+      static const char* function("stan::prob::student_t_ccdf_log");
           
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_finite;
@@ -763,7 +763,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::student_t_distribution;
 
-      static const std::string function("stan::prob::student_t_rng");
+      static const char* function("stan::prob::student_t_rng");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_finite;

--- a/src/stan/prob/distributions/univariate/continuous/uniform.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/uniform.hpp
@@ -44,7 +44,7 @@ namespace stan {
               typename T_y, typename T_low, typename T_high>
     typename return_type<T_y,T_low,T_high>::type
     uniform_log(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const std::string function("stan::prob::uniform_log");
+      static const char* function("stan::prob::uniform_log");
       typedef typename stan::partials_return_type<T_y,T_low,T_high>::type
         T_partials_return;
       
@@ -127,7 +127,7 @@ namespace stan {
     template <typename T_y, typename T_low, typename T_high>
     typename return_type<T_y,T_low,T_high>::type
     uniform_cdf(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const std::string function("stan::prob::uniform_cdf");
+      static const char* function("stan::prob::uniform_cdf");
       typedef typename stan::partials_return_type<T_y,T_low,T_high>::type
         T_partials_return;
       
@@ -204,7 +204,7 @@ namespace stan {
     template <typename T_y, typename T_low, typename T_high>
     typename return_type<T_y,T_low,T_high>::type
     uniform_cdf_log(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const std::string function("stan::prob::uniform_cdf_log");
+      static const char* function("stan::prob::uniform_cdf_log");
       typedef typename stan::partials_return_type<T_y,T_low,T_high>::type
         T_partials_return;
       
@@ -274,7 +274,7 @@ namespace stan {
     template <typename T_y, typename T_low, typename T_high>
     typename return_type<T_y,T_low,T_high>::type
     uniform_ccdf_log(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const std::string function("stan::prob::uniform_ccdf_log");
+      static const char* function("stan::prob::uniform_ccdf_log");
       typedef typename stan::partials_return_type<T_y,T_low,T_high>::type
         T_partials_return;
       
@@ -349,7 +349,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::uniform_real_distribution;
 
-      static const std::string function("stan::prob::uniform_rng");
+      static const char* function("stan::prob::uniform_rng");
       
       using stan::error_handling::check_finite;
       using stan::error_handling::check_greater;

--- a/src/stan/prob/distributions/univariate/continuous/von_mises.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/von_mises.hpp
@@ -145,7 +145,7 @@ namespace stan {
       using boost::variate_generator;
       using stan::prob::uniform_rng;
 
-      static const std::string function("stan::prob::von_mises_rng");
+      static const char* function("stan::prob::von_mises_rng");
 
       stan::error_handling::check_finite(function, "mean", mu);
       stan::error_handling::check_positive_finite(function, "inverse of variance", kappa);

--- a/src/stan/prob/distributions/univariate/continuous/weibull.hpp
+++ b/src/stan/prob/distributions/univariate/continuous/weibull.hpp
@@ -25,7 +25,7 @@ namespace stan {
               typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y,T_shape,T_scale>::type
     weibull_log(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      static const std::string function("stan::prob::weibull_log");
+      static const char* function("stan::prob::weibull_log");
       typedef typename stan::partials_return_type<T_y,T_shape,T_scale>::type
         T_partials_return;
 
@@ -144,7 +144,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y,T_shape,T_scale>::type
         T_partials_return;
 
-      static const std::string function("stan::prob::weibull_cdf");
+      static const char* function("stan::prob::weibull_cdf");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_nonnegative;
@@ -209,7 +209,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y,T_shape,T_scale>::type
         T_partials_return;
 
-      static const std::string function("stan::prob::weibull_cdf_log");
+      static const char* function("stan::prob::weibull_cdf_log");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_nonnegative;
@@ -264,7 +264,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y,T_shape,T_scale>::type 
         T_partials_return;
 
-      static const std::string function("stan::prob::weibull_ccdf_log");
+      static const char* function("stan::prob::weibull_ccdf_log");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_nonnegative;
@@ -318,7 +318,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::weibull_distribution;
 
-      static const std::string function("stan::prob::weibull_rng");
+      static const char* function("stan::prob::weibull_rng");
 
       using stan::error_handling::check_positive_finite;
   

--- a/src/stan/prob/distributions/univariate/discrete/bernoulli.hpp
+++ b/src/stan/prob/distributions/univariate/discrete/bernoulli.hpp
@@ -26,7 +26,7 @@ namespace stan {
     typename return_type<T_prob>::type
     bernoulli_log(const T_n& n,
                   const T_prob& theta) {
-      static const std::string function("stan::prob::bernoulli_log");
+      static const char* function("stan::prob::bernoulli_log");
       typedef typename stan::partials_return_type<T_n,T_prob>::type
         T_partials_return;
 
@@ -128,7 +128,7 @@ namespace stan {
     template <bool propto, typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_logit_log(const T_n& n, const T_prob& theta) {
-      static const std::string function("stan::prob::bernoulli_logit_log");
+      static const char* function("stan::prob::bernoulli_logit_log");
       typedef typename stan::partials_return_type<T_n,T_prob>::type
         T_partials_return;
 
@@ -213,7 +213,7 @@ namespace stan {
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_cdf(const T_n& n, const T_prob& theta) {
-      static const std::string function("stan::prob::bernoulli_cdf");
+      static const char* function("stan::prob::bernoulli_cdf");
       typedef typename stan::partials_return_type<T_n,T_prob>::type 
         T_partials_return;
       
@@ -276,7 +276,7 @@ namespace stan {
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_cdf_log(const T_n& n, const T_prob& theta) {
-      static const std::string function("stan::prob::bernoulli_cdf_log");
+      static const char* function("stan::prob::bernoulli_cdf_log");
       typedef typename stan::partials_return_type<T_n,T_prob>::type 
         T_partials_return;
        
@@ -336,7 +336,7 @@ namespace stan {
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_ccdf_log(const T_n& n, const T_prob& theta) {
-      static const std::string function("stan::prob::bernoulli_ccdf_log");
+      static const char* function("stan::prob::bernoulli_ccdf_log");
       typedef typename stan::partials_return_type<T_n,T_prob>::type 
         T_partials_return;
       
@@ -402,7 +402,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::bernoulli_distribution;
 
-      static const std::string function("stan::prob::bernoulli_rng");
+      static const char* function("stan::prob::bernoulli_rng");
 
       using stan::error_handling::check_finite;
       using stan::error_handling::check_bounded;

--- a/src/stan/prob/distributions/univariate/discrete/beta_binomial.hpp
+++ b/src/stan/prob/distributions/univariate/discrete/beta_binomial.hpp
@@ -34,7 +34,7 @@ namespace stan {
                       const T_N& N, 
                       const T_size1& alpha, 
                       const T_size2& beta) {
-      static const std::string function("stan::prob::beta_binomial_log");
+      static const char* function("stan::prob::beta_binomial_log");
       typedef typename stan::partials_return_type<T_size1,T_size2>::type
         T_partials_return;
 
@@ -184,7 +184,7 @@ namespace stan {
     typename return_type<T_size1,T_size2>::type
     beta_binomial_cdf(const T_n& n, const T_N& N, const T_size1& alpha, 
                       const T_size2& beta) {
-      static const std::string function("stan::prob::beta_binomial_cdf");
+      static const char* function("stan::prob::beta_binomial_cdf");
       typedef typename stan::partials_return_type<T_n,T_N,T_size1,
                                                   T_size2>::type
         T_partials_return;
@@ -309,7 +309,7 @@ namespace stan {
     typename return_type<T_size1,T_size2>::type
     beta_binomial_cdf_log(const T_n& n, const T_N& N, const T_size1& alpha, 
                           const T_size2& beta) {
-      static const std::string function("stan::prob::beta_binomial_cdf_log");
+      static const char* function("stan::prob::beta_binomial_cdf_log");
       typedef typename stan::partials_return_type<T_n,T_N,T_size1,
                                                   T_size2>::type 
         T_partials_return;
@@ -425,7 +425,7 @@ namespace stan {
     typename return_type<T_size1,T_size2>::type
     beta_binomial_ccdf_log(const T_n& n, const T_N& N, const T_size1& alpha, 
                            const T_size2& beta) {
-      static const std::string function("stan::prob::beta_binomial_ccdf_log");
+      static const char* function("stan::prob::beta_binomial_ccdf_log");
       typedef typename stan::partials_return_type<T_n,T_N,T_size1,
                                                   T_size2>::type 
         T_partials_return;
@@ -543,7 +543,7 @@ namespace stan {
                       const double beta,
                       RNG& rng) {
 
-      static const std::string function("stan::prob::beta_binomial_rng");
+      static const char* function("stan::prob::beta_binomial_rng");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_nonnegative;

--- a/src/stan/prob/distributions/univariate/discrete/binomial.hpp
+++ b/src/stan/prob/distributions/univariate/discrete/binomial.hpp
@@ -43,7 +43,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_n,T_N,T_prob>::type 
         T_partials_return;
 
-      static const std::string function("stan::prob::binomial_log");
+      static const char* function("stan::prob::binomial_log");
       
       using stan::error_handling::check_finite;
       using stan::error_handling::check_bounded;
@@ -146,7 +146,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_n,T_N,T_prob>::type 
         T_partials_return;
 
-      static const std::string function("stan::prob::binomial_logit_log");
+      static const char* function("stan::prob::binomial_logit_log");
       
       using stan::error_handling::check_finite;
       using stan::error_handling::check_bounded;
@@ -244,7 +244,7 @@ namespace stan {
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_cdf(const T_n& n, const T_N& N, const T_prob& theta) {
-      static const std::string function("stan::prob::binomial_cdf");
+      static const char* function("stan::prob::binomial_cdf");
       typedef typename stan::partials_return_type<T_n,T_N,T_prob>::type
         T_partials_return;
           
@@ -327,7 +327,7 @@ namespace stan {
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_cdf_log(const T_n& n, const T_N& N, const T_prob& theta) {
-      static const std::string function("stan::prob::binomial_cdf_log");
+      static const char* function("stan::prob::binomial_cdf_log");
       typedef typename stan::partials_return_type<T_n,T_N,T_prob>::type
         T_partials_return;
           
@@ -402,7 +402,7 @@ namespace stan {
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_ccdf_log(const T_n& n, const T_N& N, const T_prob& theta) {
-      static const std::string function("stan::prob::binomial_ccdf_log");
+      static const char* function("stan::prob::binomial_ccdf_log");
       typedef typename stan::partials_return_type<T_n,T_N,T_prob>::type 
         T_partials_return;
           
@@ -483,7 +483,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::binomial_distribution;
 
-      static const std::string function("stan::prob::binomial_rng");
+      static const char* function("stan::prob::binomial_rng");
       
       using stan::error_handling::check_finite;
       using stan::error_handling::check_less_or_equal;

--- a/src/stan/prob/distributions/univariate/discrete/hypergeometric.hpp
+++ b/src/stan/prob/distributions/univariate/discrete/hypergeometric.hpp
@@ -27,7 +27,7 @@ namespace stan {
     double
     hypergeometric_log(const T_n& n, const T_N& N, 
                        const T_a& a, const T_b& b) {
-      static const std::string function("stan::prob::hypergeometric_log");
+      static const char* function("stan::prob::hypergeometric_log");
 
       using stan::error_handling::check_finite;      
       using stan::error_handling::check_bounded;
@@ -95,7 +95,7 @@ namespace stan {
                        RNG& rng) {
       using boost::variate_generator;
       
-      static const std::string function("stan::prob::hypergeometric_rng");
+      static const char* function("stan::prob::hypergeometric_rng");
 
       using stan::error_handling::check_bounded;
       using stan::error_handling::check_positive;

--- a/src/stan/prob/distributions/univariate/discrete/neg_binomial.hpp
+++ b/src/stan/prob/distributions/univariate/discrete/neg_binomial.hpp
@@ -42,7 +42,7 @@ namespace stan {
                                                   T_inv_scale>::type 
         T_partials_return;
 
-      static const std::string function("stan::prob::neg_binomial_log");
+      static const char* function("stan::prob::neg_binomial_log");
 
       using stan::error_handling::check_positive_finite;      
       using stan::error_handling::check_nonnegative;
@@ -187,7 +187,7 @@ namespace stan {
     typename return_type<T_shape, T_inv_scale>::type
     neg_binomial_cdf(const T_n& n, const T_shape& alpha, 
                      const T_inv_scale& beta) {
-      static const std::string function("stan::prob::neg_binomial_cdf");
+      static const char* function("stan::prob::neg_binomial_cdf");
       typedef typename stan::partials_return_type<T_n,T_shape,
                                                   T_inv_scale>::type 
         T_partials_return;
@@ -319,7 +319,7 @@ namespace stan {
     typename return_type<T_shape, T_inv_scale>::type
     neg_binomial_cdf_log(const T_n& n, const T_shape& alpha, 
                      const T_inv_scale& beta) {
-      static const std::string function("stan::prob::neg_binomial_cdf_log");
+      static const char* function("stan::prob::neg_binomial_cdf_log");
       typedef typename stan::partials_return_type<T_n,T_shape,
                                                   T_inv_scale>::type 
         T_partials_return;
@@ -434,7 +434,7 @@ namespace stan {
     typename return_type<T_shape, T_inv_scale>::type
     neg_binomial_ccdf_log(const T_n& n, const T_shape& alpha, 
                      const T_inv_scale& beta) {
-      static const std::string function("stan::prob::neg_binomial_ccdf_log");
+      static const char* function("stan::prob::neg_binomial_ccdf_log");
       typedef typename stan::partials_return_type<T_n,T_shape,
                                                   T_inv_scale>::type
         T_partials_return;
@@ -551,7 +551,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::negative_binomial_distribution;
 
-      static const std::string function("stan::prob::neg_binomial_rng");
+      static const char* function("stan::prob::neg_binomial_rng");
 
       using stan::error_handling::check_positive_finite;      
 

--- a/src/stan/prob/distributions/univariate/discrete/neg_binomial_2.hpp
+++ b/src/stan/prob/distributions/univariate/discrete/neg_binomial_2.hpp
@@ -42,7 +42,7 @@ namespace stan {
                                                   T_precision>::type 
         T_partials_return;
 
-      static const std::string function("stan::prob::neg_binomial_2_log");
+      static const char* function("stan::prob::neg_binomial_2_log");
 
       using stan::error_handling::check_positive_finite;
       using stan::error_handling::check_nonnegative;
@@ -158,7 +158,7 @@ namespace stan {
                                                   T_precision>::type 
         T_partials_return;
 
-      static const std::string function("stan::prob::neg_binomial_log");
+      static const char* function("stan::prob::neg_binomial_log");
 
       using stan::error_handling::check_finite;
       using stan::error_handling::check_nonnegative;
@@ -281,7 +281,7 @@ namespace stan {
       using stan::error_handling::check_consistent_sizes;
       using stan::error_handling::check_less;
       
-      static const std::string function("stan::prob::neg_binomial_2_cdf");
+      static const char* function("stan::prob::neg_binomial_2_cdf");
       check_positive_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Precision parameter", phi);
       check_not_nan(function, "Random variable", n);
@@ -341,7 +341,7 @@ namespace stan {
       using stan::error_handling::check_consistent_sizes;
       using stan::error_handling::check_less;
       
-      static const std::string function("stan::prob::neg_binomial_2_cdf");
+      static const char* function("stan::prob::neg_binomial_2_cdf");
       check_positive_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Precision parameter", phi);
       check_not_nan(function, "Random variable", n);
@@ -504,7 +504,7 @@ namespace stan {
       using stan::error_handling::check_consistent_sizes;
       using stan::error_handling::check_less;
       
-      static const std::string function("stan::prob::neg_binomial_2_cdf");
+      static const char* function("stan::prob::neg_binomial_2_cdf");
       check_positive_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Precision parameter", phi);
       check_not_nan(function, "Random variable", n);
@@ -554,7 +554,7 @@ namespace stan {
       using stan::error_handling::check_consistent_sizes;
       using stan::error_handling::check_less;
       
-      static const std::string function("stan::prob::neg_binomial_2_cdf");
+      static const char* function("stan::prob::neg_binomial_2_cdf");
       check_positive_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Precision parameter", phi);
       check_not_nan(function, "Random variable", n);
@@ -607,7 +607,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::negative_binomial_distribution;
 
-      static const std::string function("stan::prob::neg_binomial_2_rng");
+      static const char* function("stan::prob::neg_binomial_2_rng");
 
       using stan::error_handling::check_positive_finite;
 
@@ -627,7 +627,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::negative_binomial_distribution;
 
-      static const std::string function("stan::prob::neg_binomial_2_log_rng");
+      static const char* function("stan::prob::neg_binomial_2_log_rng");
 
       using stan::error_handling::check_finite;
       using stan::error_handling::check_positive_finite;

--- a/src/stan/prob/distributions/univariate/discrete/ordered_logistic.hpp
+++ b/src/stan/prob/distributions/univariate/discrete/ordered_logistic.hpp
@@ -66,7 +66,7 @@ namespace stan {
       using stan::math::log1m;
       using stan::math::log1p_exp;
 
-      static const std::string function("stan::prob::ordered_logistic");
+      static const char* function("stan::prob::ordered_logistic");
       
       using stan::error_handling::check_finite;
       using stan::error_handling::check_positive;
@@ -118,7 +118,7 @@ namespace stan {
       using boost::variate_generator;
       using stan::math::inv_logit;
 
-      static const std::string function("stan::prob::ordered_logistic");
+      static const char* function("stan::prob::ordered_logistic");
       
       using stan::error_handling::check_finite;
       using stan::error_handling::check_positive;

--- a/src/stan/prob/distributions/univariate/discrete/poisson.hpp
+++ b/src/stan/prob/distributions/univariate/discrete/poisson.hpp
@@ -29,7 +29,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_n,T_rate>::type
         T_partials_return;
 
-      static const std::string function("stan::prob::poisson_log");
+      static const char* function("stan::prob::poisson_log");
       
       using boost::math::lgamma;
       using stan::error_handling::check_consistent_sizes;
@@ -110,7 +110,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_n,T_log_rate>::type
         T_partials_return;
 
-      static const std::string function("stan::prob::poisson_log_log");
+      static const char* function("stan::prob::poisson_log_log");
       
       using boost::math::lgamma;
       using stan::error_handling::check_not_nan;
@@ -193,7 +193,7 @@ namespace stan {
     template <typename T_n, typename T_rate>
     typename return_type<T_rate>::type
     poisson_cdf(const T_n& n, const T_rate& lambda) {
-      static const std::string function("stan::prob::poisson_cdf");
+      static const char* function("stan::prob::poisson_cdf");
       typedef typename stan::partials_return_type<T_n,T_rate>::type 
         T_partials_return;
           
@@ -263,7 +263,7 @@ namespace stan {
     template <typename T_n, typename T_rate>
     typename return_type<T_rate>::type
     poisson_cdf_log(const T_n& n, const T_rate& lambda) {
-      static const std::string function("stan::prob::poisson_cdf_log");
+      static const char* function("stan::prob::poisson_cdf_log");
       typedef typename stan::partials_return_type<T_n,T_rate>::type 
         T_partials_return;
           
@@ -331,7 +331,7 @@ namespace stan {
     template <typename T_n, typename T_rate>
     typename return_type<T_rate>::type
     poisson_ccdf_log(const T_n& n, const T_rate& lambda) {
-      static const std::string function("stan::prob::poisson_ccdf_log");
+      static const char* function("stan::prob::poisson_ccdf_log");
       typedef typename stan::partials_return_type<T_n,T_rate>::type 
         T_partials_return;
           
@@ -405,7 +405,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::poisson_distribution;
 
-      static const std::string function("stan::prob::poisson_rng");
+      static const char* function("stan::prob::poisson_rng");
       
       using stan::error_handling::check_not_nan;
       using stan::error_handling::check_nonnegative;
@@ -429,7 +429,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::poisson_distribution;
 
-      static const std::string function("stan::prob::poisson_log_rng");
+      static const char* function("stan::prob::poisson_log_rng");
       
       using stan::error_handling::check_not_nan;
       using stan::error_handling::check_nonnegative;

--- a/src/test/unit/agrad/rev/error_handling/matrix/check_cov_matrix_test.cpp
+++ b/src/test/unit/agrad/rev/error_handling/matrix/check_cov_matrix_test.cpp
@@ -9,7 +9,7 @@ TEST(AgradRevErrorHandlingMatrix,CheckCovMatrix) {
   
   using stan::error_handling::check_cov_matrix;
   
-  const std::string function = "check_cov_matrix";
+  const char* function = "check_cov_matrix";
   Matrix<var,Dynamic,Dynamic> Sigma;
   Sigma.resize(1,1);
   Sigma << 1;

--- a/src/test/unit/agrad/rev/error_handling/scalar/check_bounded_test.cpp
+++ b/src/test/unit/agrad/rev/error_handling/scalar/check_bounded_test.cpp
@@ -6,8 +6,8 @@ TEST(AgradRevErrorHandlingScalar,CheckBounded_X) {
   using stan::agrad::var;
   using stan::error_handling::check_bounded;
  
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   var x = 0;
   var low = -1;
   var high = 1;
@@ -50,8 +50,8 @@ TEST(AgradRevErrorHandlingScalar,CheckBounded_Low) {
   using stan::agrad::var;
   using stan::error_handling::check_bounded;
 
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   var x = 0;
   var low = -1;
   var high = 1;
@@ -75,8 +75,8 @@ TEST(AgradRevErrorHandlingScalar,CheckBounded_High) {
   using stan::agrad::var;
   using stan::error_handling::check_bounded;
 
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   var x = 0;
   var low = -1;
   var high = 1;

--- a/src/test/unit/agrad/rev/error_handling/scalar/check_not_nan_test.cpp
+++ b/src/test/unit/agrad/rev/error_handling/scalar/check_not_nan_test.cpp
@@ -5,7 +5,7 @@
 TEST(AgradRevErrorHandlingScalar,CheckNotNan) {
   using stan::agrad::var;
   using stan::error_handling::check_not_nan;
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   var x = 0;
   double x_d = 0;
  

--- a/src/test/unit/error_handling/scalar/check_bounded_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_bounded_test.cpp
@@ -4,8 +4,8 @@
 using stan::error_handling::check_bounded;
 
 TEST(ErrorHandlingScalar,CheckBounded_x) {
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   double x = 0;
   double low = -1;
   double high = 1;
@@ -43,8 +43,8 @@ TEST(ErrorHandlingScalar,CheckBounded_x) {
     << "check_bounded should throw with x: " << x << " and bounds: " << high << ", " << low;  
 }
 TEST(ErrorHandlingScalar,CheckBounded_Low) {
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   double x = 0;
   double low = -1;
   double high = 1;
@@ -66,8 +66,8 @@ TEST(ErrorHandlingScalar,CheckBounded_Low) {
     << "check_bounded should throw with x: " << x << " and bounds: " << low << ", " << high;
 }
 TEST(ErrorHandlingScalar,CheckBounded_High) {
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   double x = 0;
   double low = -1;
   double high = 1;
@@ -90,8 +90,8 @@ TEST(ErrorHandlingScalar,CheckBounded_High) {
 TEST(ErrorHandlingScalar,CheckBounded_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
 
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   double x = 0;
   double low = -1;
   double high = 1;

--- a/src/test/unit/error_handling/scalar/check_consistent_size_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_consistent_size_test.cpp
@@ -7,8 +7,8 @@ TEST(ErrorHandlingScalar, checkConsistentSize) {
   using stan::error_handling::check_consistent_size;
   using stan::size_of;
 
-  const std::string function = "checkConsistentSize";
-  const std::string name1 = "name1";
+  const char* function = "checkConsistentSize";
+  const char* name1 = "name1";
   
 
   Matrix<double,Dynamic,1> v1(4);
@@ -23,8 +23,8 @@ TEST(ErrorHandlingScalar, checkConsistentSize_nan) {
   using stan::error_handling::check_consistent_size;
   using stan::size_of;
 
-  const std::string function = "checkConsistentSize";
-  const std::string name1 = "name1";
+  const char* function = "checkConsistentSize";
+  const char* name1 = "name1";
   
   double nan = std::numeric_limits<double>::quiet_NaN();
 

--- a/src/test/unit/error_handling/scalar/check_consistent_sizes_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_consistent_sizes_test.cpp
@@ -7,11 +7,11 @@ TEST(ErrorHandlingScalar, checkConsistentSizes) {
   using stan::error_handling::check_consistent_sizes;
   using stan::size_of;
 
-  const std::string function = "testConsSizes";
-  const std::string name1 = "name1";
-  const std::string name2 = "name2";
-  const std::string name3 = "name3";
-  const std::string name4 = "name4";
+  const char* function = "testConsSizes";
+  const char* name1 = "name1";
+  const char* name2 = "name2";
+  const char* name3 = "name3";
+  const char* name4 = "name4";
   
 
   Matrix<double,Dynamic,1> v1(4);
@@ -29,7 +29,7 @@ TEST(ErrorHandlingScalar, checkConsistentSizes) {
   Matrix<double,Dynamic,1> v(3);
   
   ASSERT_EQ(3U, size_of(v));
-  const std::string name = "inconsistent";
+  const char* name = "inconsistent";
   EXPECT_THROW(check_consistent_sizes(function, name, v, name2, v2),
                std::domain_error);
   EXPECT_THROW(check_consistent_sizes(function, name1, v1, name, v),
@@ -57,11 +57,11 @@ TEST(ErrorHandlingScalar, checkConsistentSizes_nan) {
   using stan::error_handling::check_consistent_sizes;
   using stan::size_of;
 
-  const std::string function = "testConsSizes";
-  const std::string name1 = "name1";
-  const std::string name2 = "name2";
-  const std::string name3 = "name3";
-  const std::string name4 = "name4";
+  const char* function = "testConsSizes";
+  const char* name1 = "name1";
+  const char* name2 = "name2";
+  const char* name3 = "name3";
+  const char* name4 = "name4";
   
   double nan = std::numeric_limits<double>::quiet_NaN();
 
@@ -85,7 +85,7 @@ TEST(ErrorHandlingScalar, checkConsistentSizes_nan) {
   Matrix<double,Dynamic,1> v(3);
   v << nan,1,2;
   ASSERT_EQ(3U, size_of(v));
-  const std::string name = "inconsistent";
+  const char* name = "inconsistent";
   EXPECT_THROW(check_consistent_sizes(function, name, v, name2, v2),
                std::domain_error);
   EXPECT_THROW(check_consistent_sizes(function, name1, v1, name, v),

--- a/src/test/unit/error_handling/scalar/check_equal_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_equal_test.cpp
@@ -4,7 +4,7 @@
 using stan::error_handling::check_equal;
 
 TEST(ErrorHandlingScalar,CheckEqual) {
-  const std::string function = "check_equal";
+  const char* function = "check_equal";
   double x = 0.0;
   double eq = 0.0;
  
@@ -38,7 +38,7 @@ TEST(ErrorHandlingScalar,CheckEqual) {
 }
 
 TEST(ErrorHandlingScalar,CheckEqualMatrix) {
-  const std::string function = "check_equal";
+  const char* function = "check_equal";
   Eigen::Matrix<double,Eigen::Dynamic,1> x_vec;
   Eigen::Matrix<double,Eigen::Dynamic,1> eq_vec;
   x_vec.resize(3);
@@ -65,7 +65,7 @@ TEST(ErrorHandlingScalar,CheckEqualMatrix) {
 
 
 TEST(ErrorHandlingScalar,CheckEqual_Matrix_one_indexed_message) {
-  const std::string function = "check_equal";
+  const char* function = "check_equal";
   double x;
   double eq;
   Eigen::Matrix<double,Eigen::Dynamic,1> x_vec(3);
@@ -120,7 +120,7 @@ TEST(ErrorHandlingScalar,CheckEqual_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar,CheckEqual_nan) {
-  const std::string function = "check_equal";
+  const char* function = "check_equal";
   double x = 0.0;
   double eq = 0.0;
   double nan = std::numeric_limits<double>::quiet_NaN();

--- a/src/test/unit/error_handling/scalar/check_finite_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_finite_test.cpp
@@ -4,7 +4,7 @@
 using stan::error_handling::check_finite;
 
 TEST(ErrorHandlingScalar,CheckFinite) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   double x = 0;
  
   EXPECT_TRUE(check_finite(function, "x", x))
@@ -23,7 +23,7 @@ TEST(ErrorHandlingScalar,CheckFinite) {
 
 // ---------- check_finite: vector tests ----------
 TEST(ErrorHandlingScalar,CheckFinite_Vector) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   std::vector<double> x;
   
   x.clear();
@@ -57,7 +57,7 @@ TEST(ErrorHandlingScalar,CheckFinite_Vector) {
 
 // ---------- check_finite: matrix tests ----------
 TEST(ErrorHandlingScalar,CheckFinite_Matrix) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   Eigen::Matrix<double,Eigen::Dynamic,1> x;
   
   x.resize(3);
@@ -83,7 +83,7 @@ TEST(ErrorHandlingScalar,CheckFinite_Matrix) {
 
 
 TEST(ErrorHandlingScalar,CheckFinite_Matrix_one_indexed_message) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   Eigen::Matrix<double,Eigen::Dynamic,1> x;
   std::string message;
 
@@ -103,7 +103,7 @@ TEST(ErrorHandlingScalar,CheckFinite_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar,CheckFinite_nan) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(check_finite(function, "x", nan), std::domain_error);

--- a/src/test/unit/error_handling/scalar/check_greater_or_equal_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_greater_or_equal_test.cpp
@@ -4,7 +4,7 @@
 using stan::error_handling::check_greater_or_equal;
 
 TEST(ErrorHandlingScalar,CheckGreaterOrEqual) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   double x = 10.0;
   double lb = 0.0;
  
@@ -37,7 +37,7 @@ TEST(ErrorHandlingScalar,CheckGreaterOrEqual) {
 }
 
 TEST(ErrorHandlingScalar,CheckGreaterOrEqualMatrix) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   double x;
   double low;
   Eigen::Matrix<double,Eigen::Dynamic,1> x_vec;
@@ -147,7 +147,7 @@ TEST(ErrorHandlingScalar,CheckGreaterOrEqualMatrix) {
 
 
 TEST(ErrorHandlingScalar,CheckGreaterOrEqual_Matrix_one_indexed_message) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   double x;
   double low;
   Eigen::Matrix<double,Eigen::Dynamic,1> x_vec;
@@ -207,7 +207,7 @@ TEST(ErrorHandlingScalar,CheckGreaterOrEqual_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar,CheckGreaterOrEqual_nan) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   double x = 10.0;
   double lb = 0.0;
   double nan = std::numeric_limits<double>::quiet_NaN();

--- a/src/test/unit/error_handling/scalar/check_greater_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_greater_test.cpp
@@ -5,7 +5,7 @@
 using stan::error_handling::check_greater;
 
 TEST(ErrorHandlingScalar,CheckGreater) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   double x = 10.0;
   double lb = 0.0;
  
@@ -36,7 +36,7 @@ TEST(ErrorHandlingScalar,CheckGreater) {
 }
 
 TEST(ErrorHandlingScalar,CheckGreater_Matrix) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   double x;
   double low;
   Eigen::Matrix<double,Eigen::Dynamic,1> x_vec;
@@ -140,7 +140,7 @@ TEST(ErrorHandlingScalar,CheckGreater_Matrix) {
 }
 
 TEST(ErrorHandlingScalar,CheckGreater_Matrix_one_indexed_message) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   double x;
   double low;
   Eigen::Matrix<double,Eigen::Dynamic,1> x_vec;
@@ -200,7 +200,7 @@ TEST(ErrorHandlingScalar,CheckGreater_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar,CheckGreater_nan) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   double x = 10.0;
   double lb = 0.0;
   double nan = std::numeric_limits<double>::quiet_NaN();

--- a/src/test/unit/error_handling/scalar/check_less_or_equal_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_less_or_equal_test.cpp
@@ -4,7 +4,7 @@
 using stan::error_handling::check_less_or_equal;
 
 TEST(ErrorHandlingScalar,CheckLessOrEqual) {
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   double x = -10.0;
   double lb = 0.0;
  
@@ -37,7 +37,7 @@ TEST(ErrorHandlingScalar,CheckLessOrEqual) {
 }
 
 TEST(ErrorHandlingScalar,CheckLessOrEqual_Matrix) {
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   double x;
   double high;
   Eigen::Matrix<double,Eigen::Dynamic,1> x_vec;
@@ -117,7 +117,7 @@ TEST(ErrorHandlingScalar,CheckLessOrEqual_Matrix) {
 }
 
 TEST(ErrorHandlingScalar,CheckLessOrEqual_Matrix_one_indexed_message) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double x;
   double high;
   Eigen::Matrix<double,Eigen::Dynamic,1> x_vec;
@@ -178,7 +178,7 @@ TEST(ErrorHandlingScalar,CheckLessOrEqual_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar,CheckLessOrEqual_nan) {
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   double x = 10.0;
   double lb = 0.0;
   double nan = std::numeric_limits<double>::quiet_NaN();

--- a/src/test/unit/error_handling/scalar/check_less_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_less_test.cpp
@@ -4,7 +4,7 @@
 using stan::error_handling::check_less;
 
 TEST(ErrorHandlingScalar,CheckLess) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double x = -10.0;
   double lb = 0.0;
  
@@ -35,7 +35,7 @@ TEST(ErrorHandlingScalar,CheckLess) {
 }
 
 TEST(ErrorHandlingScalar,CheckLess_Matrix) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double x;
   double high;
   Eigen::Matrix<double,Eigen::Dynamic,1> x_vec;
@@ -122,7 +122,7 @@ TEST(ErrorHandlingScalar,CheckLess_Matrix) {
 
 
 TEST(ErrorHandlingScalar,CheckLess_Matrix_one_indexed_message) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double x;
   double high;
   Eigen::Matrix<double,Eigen::Dynamic,1> x_vec;
@@ -183,7 +183,7 @@ TEST(ErrorHandlingScalar,CheckLess_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar,CheckGreaterOrEqual_nan) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double x = 10.0;
   double lb = 0.0;
   double nan = std::numeric_limits<double>::quiet_NaN();

--- a/src/test/unit/error_handling/scalar/check_nonnegative_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_nonnegative_test.cpp
@@ -4,7 +4,7 @@
 using stan::error_handling::check_nonnegative;
 
 TEST(ErrorHandlingScalar,CheckNonnegative) {
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   double x = 0;
 
   EXPECT_TRUE(check_nonnegative(function, "x", x)) 
@@ -30,7 +30,7 @@ TEST(ErrorHandlingScalar,CheckNonnegative) {
 
 TEST(ErrorHandlingScalar,CheckNonnegativeVectorized) {
   int N = 5;
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   std::vector<double> x(N);
 
   x.assign(N, 0);
@@ -57,7 +57,7 @@ TEST(ErrorHandlingScalar,CheckNonnegativeVectorized) {
 
 TEST(ErrorHandlingScalar, CheckNonnegativeVectorized_one_indexed_message) {
   int N = 5;
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   std::vector<double> x(N);
   std::string message;
 
@@ -76,7 +76,7 @@ TEST(ErrorHandlingScalar, CheckNonnegativeVectorized_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar,CheckNonnegative_nan) {
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(check_nonnegative(function, "x", nan),

--- a/src/test/unit/error_handling/scalar/check_not_nan_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_not_nan_test.cpp
@@ -4,7 +4,7 @@
 using stan::error_handling::check_not_nan;
 
 TEST(ErrorHandlingScalar,CheckNotNan) {
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   double x = 0;
 
   EXPECT_TRUE(check_not_nan(function, "x", x))
@@ -26,7 +26,7 @@ TEST(ErrorHandlingScalar,CheckNotNan) {
 
 TEST(ErrorHandlingScalar,CheckNotNanVectorized) {
   int N = 5;
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   std::vector<double> x(N);
 
   x.assign(N, 0);
@@ -48,7 +48,7 @@ TEST(ErrorHandlingScalar,CheckNotNanVectorized) {
 
 TEST(ErrorHandlingScalar, CheckNotNanVectorized_one_indexed_message) {
   int N = 5;
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   std::vector<double> x(N);
   std::string message;
 

--- a/src/test/unit/error_handling/scalar/check_positive_finite_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_positive_finite_test.cpp
@@ -4,7 +4,7 @@
 using stan::error_handling::check_positive_finite;
 
 TEST(ErrorHandlingScalar,CheckPositiveFinite) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   double x = 1;
  
   EXPECT_TRUE(check_positive_finite(function, "x", x))
@@ -29,7 +29,7 @@ TEST(ErrorHandlingScalar,CheckPositiveFinite) {
 
 // ---------- check_positive_finite: vector tests ----------
 TEST(ErrorHandlingScalar,CheckPositiveFinite_Vector) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   std::vector<double> x;
   
   x.clear();
@@ -77,7 +77,7 @@ TEST(ErrorHandlingScalar,CheckPositiveFinite_Vector) {
 
 // ---------- check_positive_finite: matrix tests ----------
 TEST(ErrorHandlingScalar,CheckPositiveFinite_Matrix) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   Eigen::Matrix<double,Eigen::Dynamic,1> x;
   
   x.resize(3);
@@ -113,7 +113,7 @@ TEST(ErrorHandlingScalar,CheckPositiveFinite_Matrix) {
 
 
 TEST(ErrorHandlingScalar,CheckPositiveFinite_Matrix_one_indexed_message) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   Eigen::Matrix<double,Eigen::Dynamic,1> x;
   std::string message;
 
@@ -132,7 +132,7 @@ TEST(ErrorHandlingScalar,CheckPositiveFinite_Matrix_one_indexed_message) {
     << message;
 }
 TEST(ErrorHandlingScalar,CheckPositiveFinite_Matrix_one_indexed_message_2) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   Eigen::Matrix<double,Eigen::Dynamic,1> x;
   std::string message;
 
@@ -152,7 +152,7 @@ TEST(ErrorHandlingScalar,CheckPositiveFinite_Matrix_one_indexed_message_2) {
 }
 
 TEST(ErrorHandlingScalar,CheckPositiveFinite_Matrix_one_indexed_message_3) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   Eigen::Matrix<double,Eigen::Dynamic,1> x;
   std::string message;
 
@@ -172,7 +172,7 @@ TEST(ErrorHandlingScalar,CheckPositiveFinite_Matrix_one_indexed_message_3) {
 }
 
 TEST(ErrorHandlingScalar,CheckPositiveFinite_nan) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(check_positive_finite(function, "x", nan),

--- a/src/test/unit/error_handling/scalar/check_positive_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_positive_test.cpp
@@ -4,7 +4,7 @@
 
 TEST(ErrorHandlingScalar,CheckPositive_nan) {
   using stan::error_handling::check_positive;
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(check_positive(function, "x", nan),

--- a/src/test/unit/error_handling/scalar/dom_err_test.cpp
+++ b/src/test/unit/error_handling/scalar/dom_err_test.cpp
@@ -5,10 +5,6 @@
 class ErrorHandlingScalar_dom_err : public ::testing::Test {
 public:
   void SetUp() {
-    function_ = "function";
-    y_name_ = "y";
-    msg1_ = "error_message ";
-    msg2_ = " after y";
   }
 
 
@@ -66,10 +62,10 @@ public:
 
   }
 
-  std::string function_;
-  std::string y_name_;
-  std::string msg1_;
-  std::string msg2_;
+  const char* function_ = "function";
+  const char* y_name_ = "y";
+  const char* msg1_ = "error_message ";
+  const char* msg2_ = " after y";
 };
 
 TEST_F(ErrorHandlingScalar_dom_err, double) {

--- a/src/test/unit/error_handling/scalar/dom_err_vec_test.cpp
+++ b/src/test/unit/error_handling/scalar/dom_err_vec_test.cpp
@@ -9,10 +9,6 @@
 class ErrorHandlingScalar_dom_err_vec : public ::testing::Test {
 public:
   void SetUp() {
-    function_ = "function";
-    y_name_ = "y";
-    msg1_ = "error_message ";
-    msg2_ = " second message";
     index_ = 0;
   }
 
@@ -73,10 +69,10 @@ public:
     }
   }
 
-  std::string function_;
-  std::string y_name_;
-  std::string msg1_;
-  std::string msg2_;
+  const char* function_ = "function";
+  const char* y_name_ = "y";
+  const char* msg1_ = "error_message ";
+  const char* msg2_ = " second message";
   size_t index_;
 };
 


### PR DESCRIPTION
#### Summary:

Changes `const std::string&` back to `const char*`. This was causing Stan to be slow in the current develop branch.

#### Intended Effect:

Behavior is the same, but speed is much faster.

#### How to Verify:

Run any model. I ran the logistic model in the example models repository.

In v2.5.0, this model runs in ~2.3 seconds and ~4.1 in develop. With this fix, it runs in ~2.3.

#### Side Effects:

Gets back to the old speed.

#### Documentation:

None required.

#### Reviewer Suggestions: 

Anyone.