### PR TITLE
Bugfix/issue 1241 append row return

### DIFF
--- a/src/stan/math/matrix/append_col.hpp
+++ b/src/stan/math/matrix/append_col.hpp
@@ -41,24 +41,7 @@ namespace stan {
           result(i, j) = B(i, k);
       return result;
     }
-       
-    //row_vector append_col(row_vector, row_vector)
-    template <typename T1, typename T2, int C1, int C2>
-    inline Matrix<typename return_type<T1, T2>::type, 1, Dynamic>
-    append_col(const Matrix<T1, 1, C1> & A,
-          const Matrix<T2, 1, C2> & B) {
-      int Asize = A.size();
-      int Bsize = B.size();
-      Matrix<typename return_type<T1, T2>::type, 1, Dynamic>
-        result(Asize + Bsize);
-      for (int i = 0; i < Asize; i++)
-        result(i) = A(i);
-      for (int i = 0, j = Asize; i < Bsize; i++, j++)
-        result(j) = B(i);
-      return result;
-    }
     
-       
     //matrix append_col(matrix, matrix)
     //matrix append_col(matrix, vector)
     //matrix append_col(vector, matrix)
@@ -78,12 +61,11 @@ namespace stan {
     }
        
     //row_vector append_col(row_vector, row_vector)
-    template <typename T, int C1, int C2>
+    template <typename T>
     inline Matrix<T, 1, Dynamic>
-    append_col(const Matrix<T, 1, C1> & A,
-          const Matrix<T, 1, C2> & B) {          
-      Matrix<T, 1, Dynamic>
-        result(A.size()+B.size());
+    append_col(const Matrix<T, 1, Dynamic> & A,
+          const Matrix<T, 1, Dynamic> & B) {          
+      Matrix<T, 1, Dynamic> result(A.size()+B.size());
       result << A, B;
       return result;
     }

--- a/src/stan/math/matrix/append_row.hpp
+++ b/src/stan/math/matrix/append_row.hpp
@@ -42,22 +42,6 @@ namespace stan {
       return result;
     }
        
-    //vector append_row(vector, vector)
-    template <typename T1, typename T2, int R1, int R2>
-    inline Matrix<typename return_type<T1, T2>::type, Dynamic, 1>
-    append_row(const Matrix<T1, R1, 1> & A,
-               const Matrix<T2, R1, 1> & B) {          
-      int Asize = A.size();
-      int Bsize = B.size();
-      Matrix<typename return_type<T1, T2>::type, 1, Dynamic>
-        result(Asize + Bsize);
-      for (int i = 0; i < Asize; i++)
-        result(i) = A(i);
-      for (int i = 0, j = Asize; i < Bsize; i++, j++)
-        result(j) = B(i);
-      return result;
-    }
-    
     //matrix append_row(matrix, matrix)
     //matrix append_row(matrix, row_vector)
     //matrix append_row(row_vector, matrix)

--- a/src/stan/math/matrix/append_row.hpp
+++ b/src/stan/math/matrix/append_row.hpp
@@ -21,7 +21,7 @@ namespace stan {
     template <typename T1, typename T2, int R1, int C1, int R2, int C2>
     inline Matrix<typename return_type<T1, T2>::type, Dynamic, Dynamic>
     append_row(const Matrix<T1, R1, C1> & A,
-          const Matrix<T2, R2, C2> & B) {
+               const Matrix<T2, R2, C2> & B) {
       int Arows = A.rows();
       int Brows = B.rows();
       int Acols = A.cols();
@@ -46,7 +46,7 @@ namespace stan {
     template <typename T1, typename T2, int R1, int R2>
     inline Matrix<typename return_type<T1, T2>::type, Dynamic, 1>
     append_row(const Matrix<T1, R1, 1> & A,
-          const Matrix<T2, R1, 1> & B) {          
+               const Matrix<T2, R1, 1> & B) {          
       int Asize = A.size();
       int Bsize = B.size();
       Matrix<typename return_type<T1, T2>::type, 1, Dynamic>
@@ -65,7 +65,7 @@ namespace stan {
     template <typename T, int R1, int C1, int R2, int C2>
     inline Matrix<T, Dynamic, Dynamic>
     append_row(const Matrix<T, R1, C1> & A,
-          const Matrix<T, R2, C2> & B) {
+               const Matrix<T, R2, C2> & B) {
       check_size_match("append_row",
                        "columns of A", A.cols(), 
                        "columns of B", B.cols());
@@ -77,12 +77,11 @@ namespace stan {
     }
        
     //vector append_row(vector, vector)
-    template <typename T, int R1, int R2>
+    template <typename T>
     inline Matrix<T, Dynamic, 1>
-    append_row(const Matrix<T, R1, 1> & A,
-          const Matrix<T, R1, 1> & B) {          
-      Matrix<T, Dynamic, 1>
-        result(A.size()+B.size());
+    append_row(const Matrix<T, Dynamic, 1> & A,
+               const Matrix<T, Dynamic, 1> & B) {          
+      Matrix<T, Dynamic, 1> result(A.size() + B.size());
       result << A, B;
       return result;
     }

--- a/src/test/unit/math/matrix/append_col_test.cpp
+++ b/src/test/unit/math/matrix/append_col_test.cpp
@@ -10,6 +10,20 @@ using Eigen::VectorXd;
 using Eigen::RowVectorXd;
 using std::vector;
 
+template <int R, int C>
+void correct_type(const Eigen::Matrix<double,R,C>& x) {
+  EXPECT_EQ(Eigen::Dynamic, C);
+  EXPECT_EQ(1, R);
+}
+
+TEST(MathMatrix, append_col_types) {
+  RowVectorXd x(2);
+  x << 1, 2;
+  RowVectorXd y(3);
+  y << 3, 4, 5;
+  correct_type(append_col(x,y));
+}
+
 TEST(MathMatrix, append_col) {
   MatrixXd m33(3, 3);
   m33 << 1, 2, 3,

--- a/src/test/unit/math/matrix/append_row_test.cpp
+++ b/src/test/unit/math/matrix/append_row_test.cpp
@@ -10,6 +10,20 @@ using Eigen::VectorXd;
 using Eigen::RowVectorXd;
 using std::vector;
 
+template <int R, int C>
+void correct_type(const Eigen::Matrix<double,R,C>& x) {
+  EXPECT_EQ(Eigen::Dynamic, R);
+  EXPECT_EQ(1, C);
+}
+
+TEST(MathMatrix, append_row_types) {
+  VectorXd x(2);
+  x << 1, 2;
+  VectorXd y(3);
+  y << 3, 4, 5;
+  correct_type(append_row(x,y));
+}
+
 TEST(MathMatrix, append_row) {
   MatrixXd m33(3, 3);
   m33 << 1, 2, 3,


### PR DESCRIPTION
#### Summary:

Fixes return type of `append_row(vector,vector)` to be `vector`

#### Intended Effect:

See summary.

#### How to Verify:

Unit test added to check return type.  Failed in 2.5, passes in patch.

#### Side Effects:

Nothing user facing.

#### Documentation:

The behavior is being patched to match the doc.

#### Reviewer Suggestions:

Anyone.  This is a very tiny fix.