### PR TITLE
Fixes Windows tests; squashes all warnings

### DIFF
--- a/make/os_mac
+++ b/make/os_mac
@@ -16,7 +16,7 @@ endif
 ifeq (clang++,$(CC_TYPE))
   CFLAGS_GTEST += -Wc++11-extensions
   CFLAGS_GTEST += -Wno-c++11-long-long
-  CFLAGS += -Wno-unused-funct
+  CFLAGS += -Wno-unused-function
   CFLAGS += -Wno-tautological-compare
   CFLAGS += -Wno-c++11-long-long
   CFLAGS += -Wsign-compare

--- a/make/os_mac
+++ b/make/os_mac
@@ -16,9 +16,10 @@ endif
 ifeq (clang++,$(CC_TYPE))
   CFLAGS_GTEST += -Wc++11-extensions
   CFLAGS_GTEST += -Wno-c++11-long-long
-  CFLAGS += -Wno-unused-function
+  CFLAGS += -Wno-unused-funct
   CFLAGS += -Wno-tautological-compare
   CFLAGS += -Wno-c++11-long-long
+  CFLAGS += -Wsign-compare
   ifeq (true,$(C++11))
     CFLAGS += -stdlib=libc++ -std=c++11
   endif

--- a/make/os_win
+++ b/make/os_win
@@ -22,6 +22,7 @@ ifeq (g++,$(CC_TYPE))
   CFLAGS += -m$(BIT)
   CFLAGS += -Wno-unused-function
   CFLAGS += -Wno-uninitialized
+  CFLAGS += -Wno-unused-but-set
   LDLIBS += -static-libgcc
   LDLIBS += -static-libstdc++
 endif

--- a/make/tests
+++ b/make/tests
@@ -13,14 +13,14 @@ $(LIBGTEST): $(LIBGTEST)(test/gtest.o)
 
 test/gtest.o: $(GTEST)/src/gtest-all.cc
 	@mkdir -p test
-	$(COMPILE.c) -O$O $(CFLAGS) $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
+	$(COMPILE.c) -O$O $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
 
 ##
 # Rule for building a test
 ##
 test/%.o : src/test/%_test.cpp $(LIBGTEST)
 	@mkdir -p $(dir $@)
-	$(COMPILE.c) -O$O $(CFLAGS) $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
+	$(COMPILE.c) -O$O $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
 
 ##
 # Rule for building a test executable
@@ -93,11 +93,11 @@ endif
 ##
 .PHONY: %.hpp-test
 src/test/test-models/good/%.hpp-test : src/test/test-models/good/%.hpp
-	$(COMPILE.c) $(CFLAGS) -fsyntax-only -O0 $< 
+	$(COMPILE.c) -fsyntax-only -O0 $< 
 
 .PHONY: HEADER_TESTS
 %.hpp-test : %.hpp test/dummy.cpp
-	$(COMPILE.c) $(CFLAGS) -O0 -include $< -o $(DEV_NULL) test/dummy.cpp
+	$(COMPILE.c) -O0 -include $< -o $(DEV_NULL) test/dummy.cpp
 
 test/dummy.cpp:
 	@mkdir -p test

--- a/make/tests
+++ b/make/tests
@@ -13,14 +13,14 @@ $(LIBGTEST): $(LIBGTEST)(test/gtest.o)
 
 test/gtest.o: $(GTEST)/src/gtest-all.cc
 	@mkdir -p test
-	$(COMPILE.c) -O$O $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
+	$(COMPILE.c) -O$O $(CFLAGS) $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
 
 ##
 # Rule for building a test
 ##
 test/%.o : src/test/%_test.cpp $(LIBGTEST)
 	@mkdir -p $(dir $@)
-	$(COMPILE.c) -O$O $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
+	$(COMPILE.c) -O$O $(CFLAGS) $(CFLAGS_GTEST) $< $(OUTPUT_OPTION)
 
 ##
 # Rule for building a test executable
@@ -93,11 +93,11 @@ endif
 ##
 .PHONY: %.hpp-test
 src/test/test-models/good/%.hpp-test : src/test/test-models/good/%.hpp
-	$(COMPILE.c) -fsyntax-only -O0 $< 
+	$(COMPILE.c) $(CFLAGS) -fsyntax-only -O0 $< 
 
 .PHONY: HEADER_TESTS
 %.hpp-test : %.hpp test/dummy.cpp
-	$(COMPILE.c) -O0 -include $< -o $(DEV_NULL) test/dummy.cpp
+	$(COMPILE.c) $(CFLAGS) -O0 -include $< -o $(DEV_NULL) test/dummy.cpp
 
 test/dummy.cpp:
 	@mkdir -p test

--- a/make/tests
+++ b/make/tests
@@ -4,7 +4,7 @@
 ##
 LIBGTEST = test/libgtest.a
 GTEST_MAIN = $(GTEST)/src/gtest_main.cc
-CFLAGS_GTEST += -I $(GTEST)/include -I $(GTEST)
+CFLAGS_GTEST += -isystem $(GTEST)/include -isystem $(GTEST)
 
 ##
 # Build the google test library.

--- a/makefile
+++ b/makefile
@@ -39,6 +39,7 @@ LDLIBS_STANC = -Lbin -lstanc
 EXE = 
 WINE =
 
+-include make/local    # for local stuff
 
 ##
 # Get information about the compiler used.
@@ -58,6 +59,19 @@ WINE =
 ##
 -include make/detect_os
 
+include make/libstan  # bin/libstan.a bin/libstanc.a
+include make/tests    # tests
+include make/doxygen  # doxygen
+include make/manual   # manual: manual, doc/stan-reference.pdf
+
+##
+# Dependencies
+##
+ifneq (,$(filter-out test-headers generate-tests clean% %-test %.d,$(MAKECMDGOALS)))
+  -include $(addsuffix .d,$(subst $(EXE),,$(MAKECMDGOALS)))
+endif
+
+
 bin/%.o : src/%.cpp
 	@mkdir -p $(dir $@)
 	$(COMPILE.c) -O$O $(OUTPUT_OPTION) $<
@@ -72,6 +86,8 @@ bin/%.d : src/%.cpp
 	$(CC) $(CFLAGS) -O$O $(TARGET_ARCH) -MM $< > $@.$$$$; \
 	sed -e 's,\($(notdir $*)\)\.o[ :]*,$(dir $@)\1\.o $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
+
+
 
 .PHONY: help
 help:
@@ -126,18 +142,6 @@ endif
 	@echo ''
 	@echo '--------------------------------------------------------------------------------'
 
-include make/libstan  # bin/libstan.a bin/libstanc.a
-include make/tests    # tests
-include make/doxygen  # doxygen
-include make/manual   # manual: manual, doc/stan-reference.pdf
--include make/local    # for local stuff
-
-##
-# Dependencies
-##
-ifneq (,$(filter-out test-headers generate-tests clean% %-test %.d,$(MAKECMDGOALS)))
-  -include $(addsuffix .d,$(subst $(EXE),,$(MAKECMDGOALS)))
-endif
 
 ##
 # Documentation

--- a/src/stan/agrad/fwd/matrix/log_sum_exp.hpp
+++ b/src/stan/agrad/fwd/matrix/log_sum_exp.hpp
@@ -29,7 +29,7 @@ namespace stan{
         vals[i] = v(i).val_;
       T deriv(0.0);
       T denominator(0.0);
-      for (size_t i = 0; i < v.size(); ++i) {
+      for (int i = 0; i < v.size(); ++i) {
         T exp_vi = exp(vals[i]);
         denominator += exp_vi;
         deriv += v(i).d_ * exp_vi;

--- a/src/stan/agrad/rev/ode/coupled_ode_system.hpp
+++ b/src/stan/agrad/rev/ode/coupled_ode_system.hpp
@@ -68,9 +68,9 @@ namespace stan {
       std::vector<double> theta_dbl_;
       const std::vector<double>& x_;
       const std::vector<int>& x_int_;
-      const int N_;
-      const int M_;
-      const int size_;
+      const size_t N_;
+      const size_t M_;
+      const size_t size_;
       std::ostream* msgs_;
 
       /**
@@ -102,7 +102,7 @@ namespace stan {
           size_(N_ + N_ * M_),
                 msgs_(msgs) {
 
-        for (int m = 0; m < M_; m++)
+        for (size_t m = 0; m < M_; m++)
           theta_dbl_[m] = stan::agrad::value_of(theta[m]);
       }
 
@@ -138,7 +138,7 @@ namespace stan {
         vector<double> grad;
         vector<var> vars;
 
-        for (int i = 0; i < N_; i++) {
+        for (size_t i = 0; i < N_; i++) {
           theta_temp.clear();
           y_temp.clear();
           dy_dt_temp.clear();
@@ -146,24 +146,24 @@ namespace stan {
           vars.clear();
           try {
             stan::agrad::start_nested();
-            for (int j = 0; j < N_; j++) {
+            for (size_t j = 0; j < N_; j++) {
               y_temp.push_back(y[j]);
               vars.push_back(y_temp[j]);
             }
 
-            for (int j = 0; j < M_; j++) {
+            for (size_t j = 0; j < M_; j++) {
               theta_temp.push_back(theta_dbl_[j]);
               vars.push_back(theta_temp[j]);
             }
             dy_dt_temp = f_(t,y_temp,theta_temp,x_,x_int_,msgs_);
             dy_dt_temp[i].grad(vars, grad);
           
-            for (int j = 0; j < M_; j++) { 
+            for (size_t j = 0; j < M_; j++) { 
               // orders derivatives by equation (i.e. if there are 2 eqns 
               // (y1, y2) and 2 parameters (a, b), dy_dt will be ordered as: 
               // dy1_dt, dy2_dt, dy1_da, dy2_da, dy1_db, dy2_db
               double temp_deriv = grad[y_temp.size() + j];
-              for (int k = 0; k < N_; k++)
+              for (size_t k = 0; k < N_; k++)
                 temp_deriv += y[N_ + N_ * j + k] * grad[k];
 
               coupled_sys[i + j * N_] = temp_deriv;
@@ -183,7 +183,7 @@ namespace stan {
        *
        * @return size of the coupled system.
        */
-      int size() const {
+      size_t size() const {
         return size_;
       }
 
@@ -202,7 +202,7 @@ namespace stan {
        */
       std::vector<double> initial_state() {
         std::vector<double> state(size_, 0.0);
-        for (int n = 0; n < N_; n++)
+        for (size_t n = 0; n < N_; n++)
           state[n] = y0_dbl_[n];
         return state;
       }
@@ -286,9 +286,9 @@ namespace stan {
       const std::vector<double>& x_;
       const std::vector<int>& x_int_;
       std::ostream* msgs_;
-      const int N_;
-      const int M_;
-      const int size_;
+      const size_t N_;
+      const size_t M_;
+      const size_t size_;
 
       /**
        * Construct a coupled ODE system for an unknown initial state
@@ -320,7 +320,7 @@ namespace stan {
         M_(theta.size()),
         size_(N_ + N_ * N_) {
 
-        for (int n = 0; n < N_; n++)
+        for (size_t n = 0; n < N_; n++)
           y0_dbl_[n] = stan::agrad::value_of(y0_[n]);
       }
 
@@ -341,7 +341,7 @@ namespace stan {
                       std::vector<double>& dy_dt,
                       double t) {
         std::vector<double> y_base(y.begin(), y.begin() + N_);
-        for (int n = 0; n < N_; n++)
+        for (size_t n = 0; n < N_; n++)
           y_base[n] += y0_dbl_[n];
 
         dy_dt = f_(t,y_base,theta_dbl_,x_,x_int_,msgs_);
@@ -355,14 +355,14 @@ namespace stan {
         std::vector<double> grad;
         std::vector<stan::agrad::var> vars;
 
-        for (int i = 0; i < N_; i++) {
+        for (size_t i = 0; i < N_; i++) {
           y_temp.clear();
           dy_dt_temp.clear();
           grad.clear();
           vars.clear();
           try {
             stan::agrad::start_nested();
-            for (int j = 0; j < N_; j++) {
+            for (size_t j = 0; j < N_; j++) {
               y_temp.push_back(y[j] + y0_dbl_[j]);
               vars.push_back(y_temp[j]);
             }
@@ -370,12 +370,12 @@ namespace stan {
             dy_dt_temp = f_(t,y_temp,theta_dbl_,x_,x_int_,msgs_);
             dy_dt_temp[i].grad(vars, grad);
 
-            for (int j = 0; j < N_; j++) { 
+            for (size_t j = 0; j < N_; j++) { 
               // orders derivatives by equation (i.e. if there are 2 eqns 
               // (y1, y2) and 2 parameters (a, b), dy_dt will be ordered as: 
               // dy1_dt, dy2_dt, dy1_da, dy2_da, dy1_db, dy2_db
               double temp_deriv = grad[j];
-              for (int k = 0; k < N_; k++)
+              for (size_t k = 0; k < N_; k++)
                 temp_deriv += y[N_ + N_ * j + k] * grad[k];
 
               coupled_sys[i+j*N_] = temp_deriv;
@@ -395,7 +395,7 @@ namespace stan {
        *
        * @return size of the coupled system.
        */
-      int size() const {
+      size_t size() const {
         return size_;
       }
 
@@ -509,9 +509,9 @@ namespace stan {
       std::vector<double> theta_dbl_;
       const std::vector<double>& x_;
       const std::vector<int>& x_int_;
-      const int N_;
-      const int M_;
-      const int size_;
+      const size_t N_;
+      const size_t M_;
+      const size_t size_;
       std::ostream* msgs_;
 
       /**
@@ -545,10 +545,10 @@ namespace stan {
           size_(N_ + N_ * (N_ + M_)),
           msgs_(msgs) {
 
-        for (int n = 0; n < N_; n++)
+        for (size_t n = 0; n < N_; n++)
           y0_dbl_[n] = stan::agrad::value_of(y0[n]);
 
-        for (int m = 0; m < M_; m++)
+        for (size_t m = 0; m < M_; m++)
           theta_dbl_[m] = stan::agrad::value_of(theta[m]);
       }
 
@@ -572,7 +572,7 @@ namespace stan {
         using stan::agrad::var;
           
         vector<double> y_base(y.begin(), y.begin()+N_);
-        for (int n = 0; n < N_; n++)
+        for (size_t n = 0; n < N_; n++)
           y_base[n] += y0_dbl_[n];
 
         dy_dt = f_(t,y_base,theta_dbl_,x_,x_int_,msgs_);
@@ -586,7 +586,7 @@ namespace stan {
         vector<double> grad;
         vector<var> vars;
 
-        for (int i = 0; i < N_; i++) {
+        for (size_t i = 0; i < N_; i++) {
           theta_temp.clear();
           y_temp.clear();
           dy_dt_temp.clear();
@@ -595,12 +595,12 @@ namespace stan {
           try {
             stan::agrad::start_nested();
 
-            for (int j = 0; j < N_; j++) {
+            for (size_t j = 0; j < N_; j++) {
               y_temp.push_back(y[j] + y0_dbl_[j]);
               vars.push_back(y_temp[j]);
             }
 
-            for (int j = 0; j < M_; j++) {
+            for (size_t j = 0; j < M_; j++) {
               theta_temp.push_back(theta_dbl_[j]);
               vars.push_back(theta_temp[j]);
             }
@@ -608,12 +608,12 @@ namespace stan {
             dy_dt_temp = f_(t,y_temp,theta_temp,x_,x_int_,msgs_);
             dy_dt_temp[i].grad(vars, grad);
 
-            for (int j = 0; j < N_+M_; j++) { 
+            for (size_t j = 0; j < N_+M_; j++) { 
               // orders derivatives by equation (i.e. if there are 2 eqns 
               // (y1, y2) and 2 parameters (a, b), dy_dt will be ordered as: 
               // dy1_dt, dy2_dt, dy1_da, dy2_da, dy1_db, dy2_db
               double temp_deriv = grad[j];
-              for (int k = 0; k < N_; k++)
+              for (size_t k = 0; k < N_; k++)
                 temp_deriv += y[N_ + N_ * j + k] * grad[k];
 
               coupled_sys[i + j * N_] = temp_deriv;
@@ -632,7 +632,7 @@ namespace stan {
        *
        * @return size of the coupled system.
        */
-      int size() const {
+      size_t size() const {
         return size_;
       }
 

--- a/src/stan/error_handling/matrix/check_ordered.hpp
+++ b/src/stan/error_handling/matrix/check_ordered.hpp
@@ -63,7 +63,7 @@ namespace stan {
       if (y.size() == 0) {
         return true;
       }
-      for (int n = 1; n < y.size(); n++) {
+      for (size_t n = 1; n < y.size(); n++) {
         if (!(y[n] > y[n-1])) {
           std::ostringstream msg1;
           msg1 << "is not a valid ordered vector."

--- a/src/stan/math/matrix/promote_scalar.hpp
+++ b/src/stan/math/matrix/promote_scalar.hpp
@@ -32,7 +32,7 @@ namespace stan {
       apply(const Eigen::Matrix<S, -1,-1>& x) {
         Eigen::Matrix<typename promote_scalar_type<T,S>::type, -1,-1>
           y(x.rows(), x.cols());
-        for (size_t i = 0; i < x.size(); ++i)
+        for (int i = 0; i < x.size(); ++i)
           y(i) = promote_scalar_struct<T,S>::apply(x(i));
         return y;
       }
@@ -63,7 +63,7 @@ namespace stan {
       apply(const Eigen::Matrix<S, 1,-1>& x) {
         Eigen::Matrix<typename promote_scalar_type<T,S>::type, 1,-1>
           y(x.rows(), x.cols());
-        for (size_t i = 0; i < x.size(); ++i)
+        for (int i = 0; i < x.size(); ++i)
           y(i) = promote_scalar_struct<T,S>::apply(x(i));
         return y;
       }
@@ -94,7 +94,7 @@ namespace stan {
       apply(const Eigen::Matrix<S, -1,1>& x) {
         Eigen::Matrix<typename promote_scalar_type<T,S>::type, -1,1>
           y(x.rows(), x.cols());
-        for (size_t i = 0; i < x.size(); ++i)
+        for (int i = 0; i < x.size(); ++i)
           y(i) = promote_scalar_struct<T,S>::apply(x(i));
         return y;
       }

--- a/src/stan/math/matrix/stan_print.hpp
+++ b/src/stan/math/matrix/stan_print.hpp
@@ -16,7 +16,7 @@ namespace stan {
     template <typename T>
     void stan_print(std::ostream* o, const std::vector<T>& x) {
       *o << '[';
-      for (int i = 0; i < x.size(); ++i) {
+      for (size_t i = 0; i < x.size(); ++i) {
         if (i > 0) *o << ',';
         stan_print(o,x[i]);
       }

--- a/src/stan/prob/distributions/multivariate/continuous/lkj_corr.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/lkj_corr.hpp
@@ -72,7 +72,7 @@ namespace stan {
         Eigen::Matrix<T_covar,Eigen::Dynamic,1> log_diagonals =
           L.diagonal().tail(Km1).array().log();
         Eigen::Matrix<T_covar,Eigen::Dynamic,1> values(Km1);
-        for (size_t k = 0; k < Km1; k++)
+        for (int k = 0; k < Km1; k++)
           values(k) = (Km1 - k - 1) * log_diagonals(k);
         if ( (eta == 1.0) &&
             stan::is_constant<typename stan::scalar_type<T_shape> >::value) {

--- a/src/stan/prob/distributions/multivariate/continuous/lkj_corr.hpp
+++ b/src/stan/prob/distributions/multivariate/continuous/lkj_corr.hpp
@@ -24,7 +24,7 @@ namespace stan {
       if (eta == 1.0) {
         // C++ integer division is appropriate in this block
         Eigen::VectorXd numerator( Km1 / 2 );
-        for(size_t k = 1; k <= numerator.rows(); k++)
+        for(int k = 1; k <= numerator.rows(); k++)
           numerator(k-1) = lgamma(2 * k);
         constant = sum(numerator);
         if ( (K % 2) == 1 ) constant += 0.25 * (K * K - 1) * LOG_PI -
@@ -35,7 +35,7 @@ namespace stan {
       }
       else {
         constant = -Km1 * lgamma(eta + 0.5 * Km1);
-        for (size_t k = 1; k <= Km1; k++)
+        for (int k = 1; k <= Km1; k++)
           constant += 0.5 * k * LOG_PI + lgamma(eta + 0.5 * (Km1 - k));
       }
       return constant;

--- a/src/test/unit-distribution/generate_tests.cpp
+++ b/src/test/unit-distribution/generate_tests.cpp
@@ -199,7 +199,7 @@ bool check_all_double(string base, string arg) {
         boost::is_any_of(delimiters), 
         boost::token_compress_on);
 
-  for (int i = 0; i < tokens.size(); i++) {
+  for (size_t i = 0; i < tokens.size(); i++) {
     if (tokens[i] == "1" || tokens[i] == "Eigen::Dynamic>" 
         || tokens[i] == "1>" || tokens[i] == "Eigen::Dynamic")
       result = result && true;
@@ -222,7 +222,7 @@ int num_doubles(string arguments) {
         boost::token_compress_on);
 
   int num = 0;
-  for (int i = 0; i < tokens.size(); i++) {
+  for (size_t i = 0; i < tokens.size(); i++) {
     if (tokens[i] == "Doubles")
       ++num;
   }
@@ -237,7 +237,7 @@ int num_ints(string arguments) {
         boost::token_compress_on);
 
   int num = 0;
-  for (int i = 0; i < tokens.size(); i++) {
+  for (size_t i = 0; i < tokens.size(); i++) {
     if (tokens[i] == "Ints")
       ++num;
   }

--- a/src/test/unit-distribution/generate_tests.cpp
+++ b/src/test/unit-distribution/generate_tests.cpp
@@ -404,11 +404,11 @@ int create_files(const int& argc, const char* argv[],const int& index,
  * @return 0 for success, negative number otherwise.
  */
 int main(int argc, const char* argv[]) {
-  int var_num = create_files(argc,argv,1,-1);
-  int fd_num = create_files(argc,argv,2,-1);
-  int fv_num = create_files(argc,argv,3,-1);
-  int ffd_num = create_files(argc,argv,4,-1);
-  int ffv_num = create_files(argc,argv,5,-1);
+  create_files(argc,argv,1,-1);  // create var tests
+  create_files(argc,argv,2,-1);   // create fd tests
+  create_files(argc,argv,3,-1);   // create fv tests
+  create_files(argc,argv,4,-1);  // create ffd tests
+  create_files(argc,argv,5,-1);  // create ffv tests
   
   return 0;
 }

--- a/src/test/unit-distribution/utility.hpp
+++ b/src/test/unit-distribution/utility.hpp
@@ -647,7 +647,7 @@ void add_var<fvar<var> >(vector<var>& x, fvar<var>& p) {
 
 template <>
 void add_var<vector<fvar<var> > >(vector<var>& x, vector<fvar<var> >& p) {
-  for (size_type n = 0; n < p.size(); n++)
+  for (size_t n = 0; n < p.size(); n++)
     x.push_back(p[n].val_);}
 
 template <>
@@ -669,7 +669,7 @@ void add_var<fvar<fvar<var> > >(vector<var>& x, fvar<fvar<var> >& p) {
 
 template <>
 void add_var<vector<fvar<fvar<var> > > >(vector<var>& x, vector<fvar<fvar<var> > >& p) {
-  for (size_type n = 0; n < p.size(); n++)
+  for (size_t n = 0; n < p.size(); n++)
     x.push_back(p[n].val_.val_);
 }
 

--- a/src/test/unit/agrad/rev/ode/coupled_ode_system_test.cpp
+++ b/src/test/unit/agrad/rev/ode/coupled_ode_system_test.cpp
@@ -56,7 +56,7 @@ TEST_F(StanAgradRevOde, decouple_states_dv) {
 
   mock_ode_functor mock_ode;
   
-  int T = 10;
+  size_t T = 10;
 
       
   std::vector<double> y0(2);
@@ -69,11 +69,11 @@ TEST_F(StanAgradRevOde, decouple_states_dv) {
   coupled_ode_system<mock_ode_functor, double, var> 
     coupled_system(mock_ode, y0, theta, x, x_int, &msgs);
 
-  int k = 0;
+  size_t k = 0;
   std::vector<std::vector<double> > ys_coupled(T);
-  for (int t = 0; t < T; t++) {
+  for (size_t t = 0; t < T; t++) {
     std::vector<double> coupled_state(coupled_system.size(), 0.0);
-    for (int n = 0; n < coupled_system.size(); n++)
+    for (size_t n = 0; n < coupled_system.size(); n++)
       coupled_state[n] = ++k;
     ys_coupled[t] = coupled_state;
   }
@@ -82,11 +82,11 @@ TEST_F(StanAgradRevOde, decouple_states_dv) {
   ys = coupled_system.decouple_states(ys_coupled);
 
   ASSERT_EQ(T, ys.size());
-  for (int t = 0; t < T; t++)
+  for (size_t t = 0; t < T; t++)
     ASSERT_EQ(2, ys[t].size());
   
-  for (int t = 0; t < T; t++)
-    for (int n = 0; n < 2; n++)
+  for (size_t t = 0; t < T; t++)
+    for (size_t n = 0; n < 2; n++)
       EXPECT_FLOAT_EQ(ys_coupled[t][n], ys[t][n].val());
 }
 TEST_F(StanAgradRevOde, initial_state_dv) {
@@ -94,25 +94,25 @@ TEST_F(StanAgradRevOde, initial_state_dv) {
   using stan::agrad::var;
   mock_ode_functor base_ode;
 
-  const int N = 3;
-  const int M = 4;
+  const size_t N = 3;
+  const size_t M = 4;
 
   std::vector<double> y0_d(N, 0.0);
   std::vector<var> theta_v(M, 0.0);
 
-  for (int n = 0; n < N; n++)
+  for (size_t n = 0; n < N; n++)
     y0_d[n] = n+1;
-  for (int m = 0; m < M; m++)
+  for (size_t m = 0; m < M; m++)
     theta_v[m] = 10 * (m+1);
      
   coupled_ode_system<mock_ode_functor, double, var>
     coupled_system_dv(base_ode, y0_d, theta_v, x, x_int, &msgs);
 
   std::vector<double> state = coupled_system_dv.initial_state();
-  for (int n = 0; n < N; n++) 
+  for (size_t n = 0; n < N; n++) 
     EXPECT_FLOAT_EQ(y0_d[n], state[n])
       << "we don't need derivatives of y0; initial state gets the initial values";
-  for (int n = N; n < state.size(); n++)
+  for (size_t n = N; n < state.size(); n++)
     EXPECT_FLOAT_EQ(0.0, state[n]);
 }
 TEST_F(StanAgradRevOde, size_dv) {
@@ -120,8 +120,8 @@ TEST_F(StanAgradRevOde, size_dv) {
   using stan::agrad::var;
   mock_ode_functor base_ode;
 
-  const int N = 3;
-  const int M = 4;
+  const size_t N = 3;
+  const size_t M = 4;
 
   std::vector<double> y0_d(N, 0.0);
   std::vector<var> theta_v(M, 0.0);
@@ -137,8 +137,8 @@ TEST_F(StanAgradRevOde, memory_recovery_dv) {
   using stan::agrad::var;
   mock_ode_functor base_ode;
 
-  const int N = 3;
-  const int M = 4;
+  const size_t N = 3;
+  const size_t M = 4;
 
   std::vector<double> y0_d(N, 0.0);
   std::vector<var> theta_v(M, 0.0);
@@ -160,9 +160,9 @@ TEST_F(StanAgradRevOde, memory_recovery_exception_dv) {
   using stan::agrad::var;
   std::string message = "ode throws";
 
-  const int N = 3;
-  const int M = 4;
-  for (int n = 0; n < N+1; n++) {
+  const size_t N = 3;
+  const size_t M = 4;
+  for (size_t n = 0; n < N+1; n++) {
     std::stringstream scoped_message;
     scoped_message << "iteration " << n;
     SCOPED_TRACE(scoped_message.str());
@@ -232,7 +232,7 @@ TEST_F(StanAgradRevOde, decouple_states_vd) {
   using stan::agrad::var;
 
   mock_ode_functor mock_ode;
-  int T = 10;
+  size_t T = 10;
 
   std::vector<var> y0(2);
   std::vector<double> theta(1);
@@ -244,11 +244,11 @@ TEST_F(StanAgradRevOde, decouple_states_vd) {
   coupled_ode_system<mock_ode_functor, var, double>
     coupled_system(mock_ode, y0, theta, x, x_int, &msgs);
       
-  int k = 0;
+  size_t k = 0;
   std::vector<std::vector<double> > ys_coupled(T);
-  for (int t = 0; t < T; t++) {
+  for (size_t t = 0; t < T; t++) {
     std::vector<double> coupled_state(coupled_system.size(), 0.0);
-    for (int n = 0; n < coupled_system.size(); n++)
+    for (size_t n = 0; n < coupled_system.size(); n++)
       coupled_state[n] = ++k;
     ys_coupled[t] = coupled_state;
   }
@@ -257,11 +257,11 @@ TEST_F(StanAgradRevOde, decouple_states_vd) {
   ys = coupled_system.decouple_states(ys_coupled);
       
   ASSERT_EQ(T, ys.size());
-  for (int t = 0; t < T; t++)
+  for (size_t t = 0; t < T; t++)
     ASSERT_EQ(2, ys[t].size());
   
-  for (int t = 0; t < T; t++)
-    for (int n = 0; n < 2; n++)
+  for (size_t t = 0; t < T; t++)
+    for (size_t n = 0; n < 2; n++)
       EXPECT_FLOAT_EQ(ys_coupled[t][n] + y0[n].val(), 
                       ys[t][n].val());
 }
@@ -270,15 +270,15 @@ TEST_F(StanAgradRevOde, initial_state_vd) {
   using stan::agrad::var;
   mock_ode_functor base_ode;
 
-  const int N = 3;
-  const int M = 4;
+  const size_t N = 3;
+  const size_t M = 4;
 
   std::vector<var> y0_v(N, 0.0);
   std::vector<double> theta_d(M, 0.0);
 
-  for (int n = 0; n < N; n++)
+  for (size_t n = 0; n < N; n++)
     y0_v[n] = n+1;
-  for (int m = 0; m < M; m++)
+  for (size_t m = 0; m < M; m++)
     theta_d[m] = 10 * (m+1);
      
   coupled_ode_system<mock_ode_functor, var, double>
@@ -287,10 +287,10 @@ TEST_F(StanAgradRevOde, initial_state_vd) {
   std::vector<double> state;
 
   state = coupled_system_vd.initial_state();
-  for (int n = 0; n < N; n++) 
+  for (size_t n = 0; n < N; n++) 
     EXPECT_FLOAT_EQ(0.0, state[n])
       << "we need derivatives of y0; initial state gets set to 0";
-  for (int n = N; n < state.size(); n++)
+  for (size_t n = N; n < state.size(); n++)
     EXPECT_FLOAT_EQ(0.0, state[n]);
 }
 TEST_F(StanAgradRevOde, size_vd) {
@@ -298,8 +298,8 @@ TEST_F(StanAgradRevOde, size_vd) {
   using stan::agrad::var;
   mock_ode_functor base_ode;
 
-  const int N = 3;
-  const int M = 4;
+  const size_t N = 3;
+  const size_t M = 4;
 
   std::vector<var> y0_v(N, 0.0);
   std::vector<double> theta_d(M, 0.0);
@@ -315,8 +315,8 @@ TEST_F(StanAgradRevOde, memory_recovery_vd) {
   using stan::agrad::var;
   mock_ode_functor base_ode;
 
-  const int N = 3;
-  const int M = 4;
+  const size_t N = 3;
+  const size_t M = 4;
 
   std::vector<var> y0_v(N, 0.0);
   std::vector<double> theta_d(M, 0.0);
@@ -338,9 +338,9 @@ TEST_F(StanAgradRevOde, memory_recovery_exception_vd) {
   using stan::agrad::var;
   std::string message = "ode throws";
 
-  const int N = 3;
-  const int M = 4;
-  for (int n = 0; n < N+1; n++) {
+  const size_t N = 3;
+  const size_t M = 4;
+  for (size_t n = 0; n < N+1; n++) {
     std::stringstream scoped_message;
     scoped_message << "iteration " << n;
     SCOPED_TRACE(scoped_message.str());
@@ -424,12 +424,12 @@ TEST_F(StanAgradRevOde, decouple_states_vv) {
   coupled_ode_system<harm_osc_ode_fun, var, var>
     coupled_system(harm_osc, y0, theta, x, x_int, &msgs);
 
-  int T = 10;
-  int k = 0;
+  size_t T = 10;
+  size_t k = 0;
   std::vector<std::vector<double> > ys_coupled(T);
-  for (int t = 0; t < T; t++) {
+  for (size_t t = 0; t < T; t++) {
     std::vector<double> coupled_state(coupled_system.size(), 0.0);
-    for (int n = 0; n < coupled_system.size(); n++)
+    for (size_t n = 0; n < coupled_system.size(); n++)
       coupled_state[n] = ++k;
     ys_coupled[t] = coupled_state;
   }
@@ -438,11 +438,11 @@ TEST_F(StanAgradRevOde, decouple_states_vv) {
   ys = coupled_system.decouple_states(ys_coupled);
 
   ASSERT_EQ(T, ys.size());
-  for (int t = 0; t < T; t++)
-    ASSERT_EQ(2, ys[t].size());
+  for (size_t t = 0; t < T; t++)
+    ASSERT_EQ(2U, ys[t].size());
   
-  for (int t = 0; t < T; t++)
-    for (int n = 0; n < 2; n++)
+  for (size_t t = 0; t < T; t++)
+    for (size_t n = 0; n < 2; n++)
       EXPECT_FLOAT_EQ(ys_coupled[t][n] + y0[n].val(), 
                       ys[t][n].val());
 }
@@ -451,25 +451,25 @@ TEST_F(StanAgradRevOde, initial_state_vv) {
   using stan::agrad::var;
   mock_ode_functor base_ode;
 
-  const int N = 3;
-  const int M = 4;
+  const size_t N = 3;
+  const size_t M = 4;
 
   std::vector<var> y0_v(N, 0.0);
   std::vector<var> theta_v(M, 0.0);
 
-  for (int n = 0; n < N; n++)
+  for (size_t n = 0; n < N; n++)
     y0_v[n] = n+1;
-  for (int m = 0; m < M; m++)
+  for (size_t m = 0; m < M; m++)
     theta_v[m] = 10 * (m+1);
      
   coupled_ode_system<mock_ode_functor, var, var>
     coupled_system_vv(base_ode, y0_v, theta_v, x, x_int, &msgs);
 
   std::vector<double>  state = coupled_system_vv.initial_state();
-  for (int n = 0; n < N; n++) 
+  for (size_t n = 0; n < N; n++) 
     EXPECT_FLOAT_EQ(0.0, state[n])
       << "we need derivatives of y0; initial state gets set to 0";
-  for (int n = N; n < state.size(); n++)
+  for (size_t n = N; n < state.size(); n++)
     EXPECT_FLOAT_EQ(0.0, state[n]);
 }
 TEST_F(StanAgradRevOde, size_vv) {
@@ -477,8 +477,8 @@ TEST_F(StanAgradRevOde, size_vv) {
   using stan::agrad::var;
   mock_ode_functor base_ode;
 
-  const int N = 3;
-  const int M = 4;
+  const size_t N = 3;
+  const size_t M = 4;
 
   std::vector<var> y0_v(N, 0.0);
   std::vector<var> theta_v(M, 0.0);
@@ -494,8 +494,8 @@ TEST_F(StanAgradRevOde, memory_recovery_vv) {
   using stan::agrad::var;
   mock_ode_functor base_ode;
 
-  const int N = 3;
-  const int M = 4;
+  const size_t N = 3;
+  const size_t M = 4;
 
   std::vector<var> y0_v(N, 0.0);
   std::vector<var> theta_v(M, 0.0);
@@ -517,9 +517,9 @@ TEST_F(StanAgradRevOde, memory_recovery_exception_vv) {
   using stan::agrad::var;
   std::string message = "ode throws";
 
-  const int N = 3;
-  const int M = 4;
-  for (int n = 0; n < N+1; n++) {
+  const size_t N = 3;
+  const size_t M = 4;
+  for (size_t n = 0; n < N+1; n++) {
     std::stringstream scoped_message;
     scoped_message << "iteration " << n;
     SCOPED_TRACE(scoped_message.str());

--- a/src/test/unit/agrad/rev/ode/coupled_ode_system_test.cpp
+++ b/src/test/unit/agrad/rev/ode/coupled_ode_system_test.cpp
@@ -83,7 +83,7 @@ TEST_F(StanAgradRevOde, decouple_states_dv) {
 
   ASSERT_EQ(T, ys.size());
   for (size_t t = 0; t < T; t++)
-    ASSERT_EQ(2, ys[t].size());
+    ASSERT_EQ(2U, ys[t].size());
   
   for (size_t t = 0; t < T; t++)
     for (size_t n = 0; n < 2; n++)
@@ -258,7 +258,7 @@ TEST_F(StanAgradRevOde, decouple_states_vd) {
       
   ASSERT_EQ(T, ys.size());
   for (size_t t = 0; t < T; t++)
-    ASSERT_EQ(2, ys[t].size());
+    ASSERT_EQ(2U, ys[t].size());
   
   for (size_t t = 0; t < T; t++)
     for (size_t n = 0; n < 2; n++)

--- a/src/test/unit/agrad/rev/ode/util.hpp
+++ b/src/test/unit/agrad/rev/ode/util.hpp
@@ -23,7 +23,7 @@ finite_diff_params(const F& f,
   std::stringstream msgs;
   std::vector<double> theta_ub(theta.size());
   std::vector<double> theta_lb(theta.size());
-  for (int i = 0; i < theta.size(); i++) {
+  for (size_t i = 0; i < theta.size(); i++) {
     if (i == param_index) {
       theta_ub[i] = theta[i] + diff;
       theta_lb[i] = theta[i] - diff;
@@ -43,8 +43,8 @@ finite_diff_params(const F& f,
 
   std::vector<std::vector<double> > results(ts.size());
 
-  for (int i = 0; i < ode_res_ub.size(); i++) 
-    for (int j = 0; j < ode_res_ub[j].size(); j++)
+  for (size_t i = 0; i < ode_res_ub.size(); i++) 
+    for (size_t j = 0; j < ode_res_ub[j].size(); j++)
       results[i].push_back((ode_res_ub[i][j] - ode_res_lb[i][j]) / (2*diff));
   return results;
 }
@@ -64,7 +64,7 @@ finite_diff_initial_position(const F& f,
   std::stringstream msgs;
   std::vector<double> y_in_ub(y_in.size());
   std::vector<double> y_in_lb(y_in.size());
-  for (int i = 0; i < y_in.size(); i++) {
+  for (size_t i = 0; i < y_in.size(); i++) {
     if (i == param_index) {
       y_in_ub[i] = y_in[i] + diff;
       y_in_lb[i] = y_in[i] - diff;
@@ -84,8 +84,8 @@ finite_diff_initial_position(const F& f,
 
   std::vector<std::vector<double> > results(ts.size());
 
-  for (int i = 0; i < ode_res_ub.size(); i++) 
-    for (int j = 0; j < ode_res_ub[j].size(); j++)
+  for (size_t i = 0; i < ode_res_ub.size(); i++) 
+    for (size_t j = 0; j < ode_res_ub[j].size(); j++)
       results[i].push_back((ode_res_ub[i][j] - ode_res_lb[i][j]) / (2*diff));
   return results;
 }
@@ -106,13 +106,13 @@ void test_ode_finite_diff_dv(const F& f,
   std::stringstream msgs;
 
   std::vector<std::vector<std::vector<double> > > finite_diff_res(theta.size());
-  for (int i = 0; i < theta.size(); i++)
+  for (size_t i = 0; i < theta.size(); i++)
     finite_diff_res[i] = finite_diff_params(f, t_in, ts, y_in, theta, x, x_int, i, diff);
 
   std::vector<double> grads_eff;
 
   std::vector<stan::agrad::var> theta_v;
-  for (int i = 0; i < theta.size(); i++)
+  for (size_t i = 0; i < theta.size(); i++)
     theta_v.push_back(theta[i]);
 
   std::vector<std::vector<stan::agrad::var> > ode_res;
@@ -120,12 +120,12 @@ void test_ode_finite_diff_dv(const F& f,
   ode_res = stan::math::integrate_ode(f, y_in, t_in,
                                       ts, theta_v, x, x_int, &msgs);
   
-  for (int i = 0; i < ts.size(); i++) {
-    for (int j = 0; j < y_in.size(); j++) {
+  for (size_t i = 0; i < ts.size(); i++) {
+    for (size_t j = 0; j < y_in.size(); j++) {
       grads_eff.clear();
       ode_res[i][j].grad(theta_v, grads_eff);
 
-      for (int k = 0; k < theta.size(); k++)
+      for (size_t k = 0; k < theta.size(); k++)
         EXPECT_NEAR(grads_eff[k], finite_diff_res[k][i][j], diff2)
           << "Gradient of integrate_ode failed with initial positions"
           << " known and parameters unknown at time index " << i
@@ -152,13 +152,13 @@ void test_ode_finite_diff_vd(const F& f,
   std::stringstream msgs;
 
   std::vector<std::vector<std::vector<double> > > finite_diff_res(y_in.size());
-  for (int i = 0; i < y_in.size(); i++)
+  for (size_t i = 0; i < y_in.size(); i++)
     finite_diff_res[i] = finite_diff_initial_position(f, t_in, ts, y_in, theta, x, x_int, i, diff);
 
   std::vector<double> grads_eff;
 
   std::vector<stan::agrad::var> y_in_v;
-  for (int k = 0; k < y_in.size(); k++)
+  for (size_t k = 0; k < y_in.size(); k++)
     y_in_v.push_back(y_in[k]);
 
   std::vector<std::vector<stan::agrad::var> > ode_res;
@@ -166,12 +166,12 @@ void test_ode_finite_diff_vd(const F& f,
   ode_res = stan::math::integrate_ode(f, y_in_v, t_in,
                                       ts, theta, x, x_int, &msgs);
 
-  for (int i = 0; i < ts.size(); i++) {
-    for (int j = 0; j < y_in.size(); j++) {
+  for (size_t i = 0; i < ts.size(); i++) {
+    for (size_t j = 0; j < y_in.size(); j++) {
       grads_eff.clear();
       ode_res[i][j].grad(y_in_v, grads_eff);
 
-      for (int k = 0; k < y_in.size(); k++)
+      for (size_t k = 0; k < y_in.size(); k++)
         EXPECT_NEAR(grads_eff[k], finite_diff_res[k][i][j], diff2)
           << "Gradient of integrate_ode failed with initial positions"
           << " unknown and parameters known at time index " << i
@@ -199,28 +199,28 @@ void test_ode_finite_diff_vv(const F& f,
   std::stringstream msgs;
 
   std::vector<std::vector<std::vector<double> > > finite_diff_res_y(y_in.size());
-  for (int i = 0; i < y_in.size(); i++)
+  for (size_t i = 0; i < y_in.size(); i++)
     finite_diff_res_y[i] = finite_diff_initial_position(f, t_in, ts, y_in,
                                                         theta, x, x_int, i, diff);
 
   std::vector<std::vector<std::vector<double> > > finite_diff_res_p(theta.size());
-  for (int i = 0; i < theta.size(); i++)
+  for (size_t i = 0; i < theta.size(); i++)
     finite_diff_res_p[i] = finite_diff_params(f, t_in, ts, y_in, theta, x,
                                               x_int, i, diff);
 
 
   std::vector<double> grads_eff;
   std::vector<stan::agrad::var> y_in_v;
-  for (int i = 0; i < y_in.size(); i++)
+  for (size_t i = 0; i < y_in.size(); i++)
     y_in_v.push_back(y_in[i]);
 
   std::vector<stan::agrad::var> vars = y_in_v;
 
   std::vector<stan::agrad::var> theta_v;
-  for (int i = 0; i < theta.size(); i++)
+  for (size_t i = 0; i < theta.size(); i++)
     theta_v.push_back(theta[i]);
 
-  for (int i = 0; i < theta_v.size(); i++)
+  for (size_t i = 0; i < theta_v.size(); i++)
     vars.push_back(theta_v[i]);
 
   std::vector<std::vector<stan::agrad::var> > ode_res;
@@ -228,18 +228,18 @@ void test_ode_finite_diff_vv(const F& f,
   ode_res = stan::math::integrate_ode(f, y_in_v, t_in,
                                       ts, theta_v, x, x_int, &msgs);
 
-  for (int i = 0; i < ts.size(); i++) {
-    for (int j = 0; j < y_in.size(); j++) {
+  for (size_t i = 0; i < ts.size(); i++) {
+    for (size_t j = 0; j < y_in.size(); j++) {
       grads_eff.clear();
       ode_res[i][j].grad(vars, grads_eff);
 
-      for (int k = 0; k < theta.size(); k++)
+      for (size_t k = 0; k < theta.size(); k++)
         EXPECT_NEAR(grads_eff[k+y_in.size()], finite_diff_res_p[k][i][j], diff2)
           << "Gradient of integrate_ode failed with initial positions"
           << " unknown and parameters unknown for param at time index " << i
           << ", equation index " << j 
           << ", and parameter index: " << k;
-      for (int k = 0; k < y_in.size(); k++)
+      for (size_t k = 0; k < y_in.size(); k++)
         EXPECT_NEAR(grads_eff[k], finite_diff_res_y[k][i][j], diff2)
           << "Gradient of integrate_ode failed with initial positions"
           << " unknown and parameters known for initial position at time index " << i
@@ -518,7 +518,7 @@ void test_ode_error_conditions_vd(const F& f,
                                   const std::vector<double>& x,
                                   const std::vector<int>& x_int) {
   std::vector<stan::agrad::var> y_var;
-  for (int i = 0; i < y_in.size(); i++) 
+  for (size_t i = 0; i < y_in.size(); i++) 
     y_var.push_back(y_in[i]);
   test_ode_error_conditions(f, t_in, ts, y_var, theta, x, x_int);
   test_ode_error_conditions_nan(f, t_in, ts, y_var, theta, x, x_int);
@@ -532,7 +532,7 @@ void test_ode_error_conditions_dv(const F& f,
                                   const std::vector<double>& x,
                                   const std::vector<int>& x_int) {
   std::vector<stan::agrad::var> theta_var;
-  for (int i = 0; i < theta.size(); i++) 
+  for (size_t i = 0; i < theta.size(); i++) 
     theta_var.push_back(theta[i]);
   test_ode_error_conditions(f, t_in, ts, y_in, theta_var, x, x_int);
   test_ode_error_conditions_nan(f, t_in, ts, y_in, theta_var, x, x_int);
@@ -546,10 +546,10 @@ void test_ode_error_conditions_vv(const F& f,
                                   const std::vector<double>& x,
                                   const std::vector<int>& x_int) {
   std::vector<stan::agrad::var> y_var;
-  for (int i = 0; i < y_in.size(); i++) 
+  for (size_t i = 0; i < y_in.size(); i++) 
     y_var.push_back(y_in[i]); 
   std::vector<stan::agrad::var> theta_var;
-  for (int i = 0; i < theta.size(); i++) 
+  for (size_t i = 0; i < theta.size(); i++) 
     theta_var.push_back(theta[i]);
   test_ode_error_conditions(f, t_in, ts, y_var, theta_var, x, x_int);
   test_ode_error_conditions_nan(f, t_in, ts, y_var, theta_var, x, x_int);

--- a/src/test/unit/agrad/rev/ode/util.hpp
+++ b/src/test/unit/agrad/rev/ode/util.hpp
@@ -18,7 +18,7 @@ finite_diff_params(const F& f,
                    const std::vector<double>& theta,
                    const std::vector<double>& x,
                    const std::vector<int>& x_int,
-                   const int& param_index,
+                   const size_t& param_index,
                    const double& diff) {
   std::stringstream msgs;
   std::vector<double> theta_ub(theta.size());
@@ -59,7 +59,7 @@ finite_diff_initial_position(const F& f,
                              const std::vector<double>& theta,
                              const std::vector<double>& x,
                              const std::vector<int>& x_int,
-                             const int& param_index,
+                             const size_t& param_index,
                              const double& diff) {
   std::stringstream msgs;
   std::vector<double> y_in_ub(y_in.size());

--- a/src/test/unit/agrad/rev/var_test.cpp
+++ b/src/test/unit/agrad/rev/var_test.cpp
@@ -135,7 +135,7 @@ struct gradable {
   void test() {
     std::vector<double> g;
     f_.grad(x_, g);
-    EXPECT_EQ(g_expected_.size(), g.size());
+    EXPECT_EQ(g_expected_.size(), static_cast<int>(g.size()));
     for (int i = 0; i < g_expected_.size(); ++i)
       EXPECT_FLOAT_EQ(g_expected_(i), g[i]);
   }

--- a/src/test/unit/common/initialize_state_test.cpp
+++ b/src/test/unit/common/initialize_state_test.cpp
@@ -464,7 +464,11 @@ TEST_F(StanCommon, initialize_state_source_inf) {
   EXPECT_EQ(0, inf_model.templated_log_prob_calls);
   EXPECT_EQ(1, inf_model.transform_inits_calls);
   EXPECT_EQ(0, rng.calls);
-  EXPECT_EQ("param_0 initialized to invalid value (inf)\n", output.str());
+  std::stringstream msg;
+  msg << "param_0 initialized to invalid value ("
+      << std::numeric_limits<double>::infinity()
+      << ")\n";
+  EXPECT_EQ(msg.str(), output.str());
   EXPECT_EQ(1, context_factory.calls);
   EXPECT_EQ("abcd", context_factory.last_call);
 }

--- a/src/test/unit/common/initialize_state_test.cpp
+++ b/src/test/unit/common/initialize_state_test.cpp
@@ -41,7 +41,7 @@ public:
                                  bool include_tparams__ = true,
                                  bool include_gqs__ = true) const {
     param_names__.clear();
-    for (int n = 0; n < num_params_r__; n++) {
+    for (size_t n = 0; n < num_params_r__; n++) {
       std::stringstream param_name;
       param_name << "param_" << n;
       param_names__.push_back(param_name.str());
@@ -92,7 +92,7 @@ public:
                                  bool include_tparams__ = true,
                                  bool include_gqs__ = true) const {
     param_names__.clear();
-    for (int n = 0; n < num_params_r__; n++) {
+    for (size_t n = 0; n < num_params_r__; n++) {
       std::stringstream param_name;
       param_name << "param_" << n;
       param_names__.push_back(param_name.str());

--- a/src/test/unit/error_handling/scalar/check_nonnegative_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_nonnegative_test.cpp
@@ -87,7 +87,7 @@ TEST(ErrorHandlingScalar,CheckNonnegative_nan) {
   x.push_back(2.0);
   x.push_back(3.0);
 
-  for (int i = 0; i < x.size(); i++) {
+  for (size_t i = 0; i < x.size(); i++) {
     x[i] = nan;
     EXPECT_THROW(check_nonnegative(function, "x", x),
                  std::domain_error);

--- a/src/test/unit/error_handling/scalar/check_positive_finite_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_positive_finite_test.cpp
@@ -183,7 +183,7 @@ TEST(ErrorHandlingScalar,CheckPositiveFinite_nan) {
   x.push_back(2.0);
   x.push_back(3.0);
 
-  for (int i = 0; i < x.size(); i++) {
+  for (size_t i = 0; i < x.size(); i++) {
     x[i] = nan;
     EXPECT_THROW(check_positive_finite(function, "x", x),
                  std::domain_error);

--- a/src/test/unit/error_handling/scalar/check_positive_test.cpp
+++ b/src/test/unit/error_handling/scalar/check_positive_test.cpp
@@ -15,7 +15,7 @@ TEST(ErrorHandlingScalar,CheckPositive_nan) {
   x.push_back(2.0);
   x.push_back(3.0);
 
-  for (int i = 0; i < x.size(); i++) {
+  for (size_t i = 0; i < x.size(); i++) {
     x[i] = nan;
     EXPECT_THROW(check_positive(function, "x", x),
                  std::domain_error);

--- a/src/test/unit/error_handling/scalar/dom_err_test.cpp
+++ b/src/test/unit/error_handling/scalar/dom_err_test.cpp
@@ -2,6 +2,12 @@
 #include <gtest/gtest.h>
 #include <stan/agrad/rev/var.hpp>
 
+
+const char* function_ = "function";
+const char* y_name_ = "y";
+const char* msg1_ = "error_message ";
+const char* msg2_ = " after y";
+
 class ErrorHandlingScalar_dom_err : public ::testing::Test {
 public:
   void SetUp() {
@@ -61,11 +67,6 @@ public:
     }
 
   }
-
-  const char* function_ = "function";
-  const char* y_name_ = "y";
-  const char* msg1_ = "error_message ";
-  const char* msg2_ = " after y";
 };
 
 TEST_F(ErrorHandlingScalar_dom_err, double) {

--- a/src/test/unit/error_handling/scalar/dom_err_vec_test.cpp
+++ b/src/test/unit/error_handling/scalar/dom_err_vec_test.cpp
@@ -6,6 +6,12 @@
 
 #include <gtest/gtest.h>
 
+
+const char* function_ = "function";
+const char* y_name_ = "y";
+const char* msg1_ = "error_message ";
+const char* msg2_ = " second message";
+
 class ErrorHandlingScalar_dom_err_vec : public ::testing::Test {
 public:
   void SetUp() {
@@ -69,10 +75,6 @@ public:
     }
   }
 
-  const char* function_ = "function";
-  const char* y_name_ = "y";
-  const char* msg1_ = "error_message ";
-  const char* msg2_ = " second message";
   size_t index_;
 };
 

--- a/src/test/unit/gm/arguments/arg_optimize_algo_test.cpp
+++ b/src/test/unit/gm/arguments/arg_optimize_algo_test.cpp
@@ -7,7 +7,7 @@ TEST(StanGmArguments, arg_optimize_algo) {
   EXPECT_EQ("algorithm", arg.name());
   EXPECT_EQ("Optimization algorithm", arg.description());
 
-  ASSERT_EQ(3, arg.values().size());
+  ASSERT_EQ(3U, arg.values().size());
   EXPECT_EQ("bfgs", arg.values()[0]->name());
   EXPECT_EQ("lbfgs", arg.values()[1]->name());
   EXPECT_EQ("newton", arg.values()[2]->name());

--- a/src/test/unit/gm/ast_test.cpp
+++ b/src/test/unit/gm/ast_test.cpp
@@ -293,7 +293,7 @@ TEST(gmAst, resetSigs) {
   stan::gm::function_signatures& fs1
     = stan::gm::function_signatures::instance();
   set<string> ks1 = fs1.key_set();
-  int keyset_size = ks1.size();
+  size_t keyset_size = ks1.size();
   EXPECT_TRUE(keyset_size > 0);
   
   stan::gm::function_signatures::reset_sigs();
@@ -302,8 +302,7 @@ TEST(gmAst, resetSigs) {
     = stan::gm::function_signatures::instance();
 
   set<string> ks2 = fs2.key_set();
-  EXPECT_EQ(keyset_size,ks2.size());
-
+  EXPECT_EQ(keyset_size, ks2.size());
 }
 
 TEST(gmAst, solveOde) {

--- a/src/test/unit/gm/parser_generator_test.cpp
+++ b/src/test/unit/gm/parser_generator_test.cpp
@@ -29,8 +29,8 @@ void test_pg(const std::string& program_name,
 
 int count_occurrences(const std::string target,
                       const std::string s) {
-  int count = 0;
-  int offset = 0;
+  size_t count = 0;
+  size_t offset = 0;
   while (true) {
     offset = s.find(target, offset);
     if (offset == std::string::npos) break;

--- a/src/test/unit/gm/reject/reject_func_call_generated_quantities_test.cpp
+++ b/src/test/unit/gm/reject/reject_func_call_generated_quantities_test.cpp
@@ -28,7 +28,7 @@ TEST(StanCommon, reject_func_call_generated_quantities) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp(0);
+  double lp;
 
   boost::ecuyer1988 base_rng;
   base_rng.seed(123456);

--- a/src/test/unit/gm/reject/reject_func_call_model_test.cpp
+++ b/src/test/unit/gm/reject/reject_func_call_model_test.cpp
@@ -26,11 +26,10 @@ TEST(StanCommon, reject_func_call_model) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp;
 
   // call model's log_prob function, check that exception is thrown
   try {
-    lp = model->log_prob<false, false>(cont_vector, disc_vector, &std::cout);
+    model->log_prob<false, false>(cont_vector, disc_vector, &std::cout);
   } catch (const std::domain_error& e) {
     if (std::string(e.what()).find(error_msg) == std::string::npos) {
       FAIL() << std::endl << "---------------------------------" << std::endl

--- a/src/test/unit/gm/reject/reject_func_call_model_test.cpp
+++ b/src/test/unit/gm/reject/reject_func_call_model_test.cpp
@@ -26,7 +26,7 @@ TEST(StanCommon, reject_func_call_model) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp(0);
+  double lp;
 
   // call model's log_prob function, check that exception is thrown
   try {

--- a/src/test/unit/gm/reject/reject_func_call_transformed_data_test.cpp
+++ b/src/test/unit/gm/reject/reject_func_call_transformed_data_test.cpp
@@ -19,8 +19,9 @@ TEST(StanCommon, reject_func_call_transformed_data) {
 
   // instantiate model
   try {
-     reject_func_call_transformed_data_model_namespace::reject_func_call_transformed_data_model* model 
-       = new reject_func_call_transformed_data_model_namespace::reject_func_call_transformed_data_model(empty_data_context, &model_output);
+    reject_func_call_transformed_data_model_namespace::reject_func_call_transformed_data_model* model 
+      = new reject_func_call_transformed_data_model_namespace::reject_func_call_transformed_data_model(empty_data_context, &model_output);
+    delete model;
   } catch (const std::domain_error& e) {
     if (std::string(e.what()).find(error_msg) == std::string::npos) {
       FAIL() << std::endl << "---------------------------------" << std::endl

--- a/src/test/unit/gm/reject/reject_func_call_transformed_parameters_test.cpp
+++ b/src/test/unit/gm/reject/reject_func_call_transformed_parameters_test.cpp
@@ -26,7 +26,7 @@ TEST(StanCommon, reject_func_call_transformed_parameters) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp(0);
+  double lp;
 
   // call model's log_prob function, check that exception is thrown
   try {

--- a/src/test/unit/gm/reject/reject_func_call_transformed_parameters_test.cpp
+++ b/src/test/unit/gm/reject/reject_func_call_transformed_parameters_test.cpp
@@ -26,11 +26,10 @@ TEST(StanCommon, reject_func_call_transformed_parameters) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp;
 
   // call model's log_prob function, check that exception is thrown
   try {
-    lp = model->log_prob<false, false>(cont_vector, disc_vector, &std::cout);
+    model->log_prob<false, false>(cont_vector, disc_vector, &std::cout);
   } catch (const std::domain_error& e) {
     if (std::string(e.what()).find(error_msg) == std::string::npos) {
       FAIL() << std::endl << "---------------------------------" << std::endl

--- a/src/test/unit/gm/reject/reject_generated_quantities_test.cpp
+++ b/src/test/unit/gm/reject/reject_generated_quantities_test.cpp
@@ -28,7 +28,7 @@ TEST(StanCommon, reject_generated_quantities) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp(0);
+  double lp;
 
   boost::ecuyer1988 base_rng;
   base_rng.seed(123456);

--- a/src/test/unit/gm/reject/reject_model_test.cpp
+++ b/src/test/unit/gm/reject/reject_model_test.cpp
@@ -26,11 +26,10 @@ TEST(StanCommon, reject_model) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp;
 
   // call model's log_prob function, check that exception is thrown
   try {
-    lp = model->log_prob<false, false>(cont_vector, disc_vector, &std::cout);
+    model->log_prob<false, false>(cont_vector, disc_vector, &std::cout);
   } catch (const std::domain_error& e) {
     if (std::string(e.what()).find(error_msg) == std::string::npos) {
       FAIL() << std::endl << "---------------------------------" << std::endl

--- a/src/test/unit/gm/reject/reject_model_test.cpp
+++ b/src/test/unit/gm/reject/reject_model_test.cpp
@@ -26,7 +26,7 @@ TEST(StanCommon, reject_model) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp(0);
+  double lp;
 
   // call model's log_prob function, check that exception is thrown
   try {

--- a/src/test/unit/gm/reject/reject_mult_args_test.cpp
+++ b/src/test/unit/gm/reject/reject_mult_args_test.cpp
@@ -26,11 +26,10 @@ TEST(StanCommon, reject_mult_args) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp;
 
   // call model's log_prob function, check that exception is thrown
   try {
-    lp = model->log_prob<false, false>(cont_vector, disc_vector, &std::cout);
+    model->log_prob<false, false>(cont_vector, disc_vector, &std::cout);
   } catch (const std::domain_error& e) {
     if (std::string(e.what()).find(error_msg) == std::string::npos) {
       FAIL() << std::endl << "---------------------------------" << std::endl

--- a/src/test/unit/gm/reject/reject_mult_args_test.cpp
+++ b/src/test/unit/gm/reject/reject_mult_args_test.cpp
@@ -26,7 +26,7 @@ TEST(StanCommon, reject_mult_args) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp(0);
+  double lp;
 
   // call model's log_prob function, check that exception is thrown
   try {

--- a/src/test/unit/gm/reject/reject_transformed_data_test.cpp
+++ b/src/test/unit/gm/reject/reject_transformed_data_test.cpp
@@ -19,8 +19,9 @@ TEST(StanCommon, reject_transformed_data) {
 
   // instantiate model
   try {
-     reject_transformed_data_model_namespace::reject_transformed_data_model* model 
-       = new reject_transformed_data_model_namespace::reject_transformed_data_model(empty_data_context, &model_output);
+    reject_transformed_data_model_namespace::reject_transformed_data_model* model 
+      = new reject_transformed_data_model_namespace::reject_transformed_data_model(empty_data_context, &model_output);
+    delete model;
   } catch (const std::domain_error& e) {
     if (std::string(e.what()).find(error_msg) == std::string::npos) {
       FAIL() << std::endl << "---------------------------------" << std::endl

--- a/src/test/unit/gm/reject/reject_transformed_parameters_test.cpp
+++ b/src/test/unit/gm/reject/reject_transformed_parameters_test.cpp
@@ -26,7 +26,7 @@ TEST(StanCommon, reject_transformed_parameters) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp(0);
+  double lp;
 
   // call model's log_prob function, check that exception is thrown
   try {

--- a/src/test/unit/gm/reject/reject_transformed_parameters_test.cpp
+++ b/src/test/unit/gm/reject/reject_transformed_parameters_test.cpp
@@ -26,11 +26,10 @@ TEST(StanCommon, reject_transformed_parameters) {
   for (int i = 0; i < cont_params.size(); ++i)
     cont_vector.at(i) = cont_params(i);
   std::vector<int> disc_vector;
-  double lp;
 
   // call model's log_prob function, check that exception is thrown
   try {
-    lp = model->log_prob<false, false>(cont_vector, disc_vector, &std::cout);
+    model->log_prob<false, false>(cont_vector, disc_vector, &std::cout);
   } catch (const std::domain_error& e) {
     if (std::string(e.what()).find(error_msg) == std::string::npos) {
       FAIL() << std::endl << "---------------------------------" << std::endl

--- a/src/test/unit/math/functions/as_bool_test.cpp
+++ b/src/test/unit/math/functions/as_bool_test.cpp
@@ -13,9 +13,9 @@ TEST(MathFunctions, as_bool) {
   EXPECT_FALSE(as_bool(0.0));
   EXPECT_FALSE(as_bool(0.0f));
 
-  EXPECT_EQ(true, as_bool(10));
-  EXPECT_EQ(true, as_bool(-1));
-  EXPECT_EQ(false, as_bool(0));
+  EXPECT_TRUE(as_bool(10));
+  EXPECT_TRUE(as_bool(-1));
+  EXPECT_FALSE(as_bool(0));
 }
 
 TEST(MathFunctions, as_bool_nan) {

--- a/src/test/unit/math/ode/coupled_ode_system_test.cpp
+++ b/src/test/unit/math/ode/coupled_ode_system_test.cpp
@@ -73,7 +73,7 @@ TEST_F(StanMathOde, initial_state_dd) {
   for (int n = 0; n < N; n++) 
     EXPECT_FLOAT_EQ(y0_d[n], state[n])
       << "we don't need derivatives of y0; initial state gets the initial values";
-  for (int n = N; n < state.size(); n++)
+  for (size_t n = N; n < state.size(); n++)
     EXPECT_FLOAT_EQ(0.0, state[n]);
 }
 

--- a/src/test/unit/memory/stack_alloc_test.cpp
+++ b/src/test/unit/memory/stack_alloc_test.cpp
@@ -24,11 +24,11 @@ TEST(MemoryStackAlloc, allocArrayBigger) {
   size_t K = 10;
   stan::memory::stack_alloc allocator;
   biggy* x = allocator.alloc_array<biggy>(N);
-  for (int i = 0; i < N; ++i)
-    for (int k = 1; k < K; ++k)
+  for (size_t i = 0; i < N; ++i)
+    for (size_t k = 1; k < K; ++k)
       x[i].r[k] = k * i;
-  for (int i = 0; i < N; ++i)
-    for (int k = 0; k < K; ++k)
+  for (size_t i = 0; i < N; ++i)
+    for (size_t k = 0; k < K; ++k)
       EXPECT_FLOAT_EQ(k * i, x[i].r[k]);
 }
 TEST(stack_alloc, bytes_allocated) {

--- a/src/test/unit/optimization/bfgs_update_test.cpp
+++ b/src/test/unit/optimization/bfgs_update_test.cpp
@@ -2,7 +2,7 @@
 #include <stan/optimization/bfgs_update.hpp>
 
 TEST(OptimizationBfgsUpdate, bfgs_update_secant) {
-  const unsigned int nDim = 10;
+  const int nDim = 10;
 
   typedef stan::optimization::BFGSUpdate_HInv<double,nDim> QNUpdateT;
   typedef QNUpdateT::VectorT VectorT;
@@ -12,7 +12,7 @@ TEST(OptimizationBfgsUpdate, bfgs_update_secant) {
 
   // Construct a set of BFGS update vectors and check that
   // the secant equation H*yk = sk is always satisfied.
-  for (unsigned int i = 0; i < nDim; i++) {
+  for (int i = 0; i < nDim; i++) {
     sk.setZero(nDim);
     yk.setZero(nDim);
     sk[i] = 1;
@@ -22,7 +22,7 @@ TEST(OptimizationBfgsUpdate, bfgs_update_secant) {
 
     // Because the constructed update vectors are all orthogonal the secant
     // equation should be exactlty satisfied for all nDim updates.
-    for (unsigned int j = 0; j <= i; j++) {
+    for (int j = 0; j <= i; j++) {
       sk.setZero(nDim);
       yk.setZero(nDim);
       sk[i - j] = 1;
@@ -36,7 +36,7 @@ TEST(OptimizationBfgsUpdate, bfgs_update_secant) {
 }
 
 TEST(OptimizationBfgsUpdate, BFGSUpdate_HInv_update) {
-  const unsigned int nDim = 10;
+  const int nDim = 10;
 
   typedef stan::optimization::BFGSUpdate_HInv<double,nDim> QNUpdateT;
   typedef QNUpdateT::VectorT VectorT;
@@ -44,7 +44,7 @@ TEST(OptimizationBfgsUpdate, BFGSUpdate_HInv_update) {
   QNUpdateT bfgsUp;
   VectorT yk(nDim), sk(nDim), sdir(nDim);
 
-  for (unsigned int i = 0; i < nDim; i++) {
+  for (int i = 0; i < nDim; i++) {
     sk.setZero(nDim);
     yk.setZero(nDim);
     sk[i] = 1;
@@ -55,7 +55,7 @@ TEST(OptimizationBfgsUpdate, BFGSUpdate_HInv_update) {
 }
 
 TEST(OptimizationBfgsUpdate, BFGSUpdate_HInv_search_direction) {
-  const unsigned int nDim = 10;
+  const int nDim = 10;
   typedef stan::optimization::BFGSUpdate_HInv<double,nDim> QNUpdateT;
   typedef QNUpdateT::VectorT VectorT;
 
@@ -67,9 +67,9 @@ TEST(OptimizationBfgsUpdate, BFGSUpdate_HInv_search_direction) {
   yk[0] = 1;
   bfgsUp.update(yk,sk,true);
 
-  for (unsigned int i = 0; i < nDim; i++) {
+  for (int i = 0; i < nDim; i++) {
 
-    for (unsigned int j = 0; j <= i; j++) {
+    for (int j = 0; j <= i; j++) {
       yk.setZero(nDim);
       yk[i - j] = 1;
       

--- a/src/test/unit/prob/distributions/multivariate/continuous/lkj_corr_test.cpp
+++ b/src/test/unit/prob/distributions/multivariate/continuous/lkj_corr_test.cpp
@@ -136,7 +136,7 @@ TEST(ProbDistributionsLkjCorrCholesky,testHalf) {
 TEST(ProbDistributionsLkjCorr,fvar_double) {
   using stan::agrad::fvar;
   boost::random::mt19937 rng;
-  unsigned int K = 4;
+  int K = 4;
   Eigen::Matrix<fvar<double>,Eigen::Dynamic,Eigen::Dynamic> Sigma(K,K);
   Sigma.setZero();
   Sigma.diagonal().setOnes();
@@ -155,7 +155,7 @@ TEST(ProbDistributionsLkjCorr,fvar_double) {
 TEST(ProbDistributionsLkjCorrCholesky,fvar_double) {
   using stan::agrad::fvar;
   boost::random::mt19937 rng;
-  unsigned int K = 4;
+  int K = 4;
   Eigen::Matrix<fvar<double>,Eigen::Dynamic,Eigen::Dynamic> Sigma(K,K);
   Sigma.setZero();
   Sigma.diagonal().setOnes();
@@ -175,7 +175,7 @@ TEST(ProbDistributionsLkjCorr,fvar_var) {
   using stan::agrad::fvar;
   using stan::agrad::var;
   boost::random::mt19937 rng;
-  unsigned int K = 4;
+  int K = 4;
   Eigen::Matrix<fvar<var>,Eigen::Dynamic,Eigen::Dynamic> Sigma(K,K);
   Sigma.setZero();
   Sigma.diagonal().setOnes();
@@ -195,7 +195,7 @@ TEST(ProbDistributionsLkjCorrCholesky,fvar_var) {
   using stan::agrad::fvar;
   using stan::agrad::var;
   boost::random::mt19937 rng;
-  unsigned int K = 4;
+  int K = 4;
   Eigen::Matrix<fvar<var>,Eigen::Dynamic,Eigen::Dynamic> Sigma(K,K);
   Sigma.setZero();
   Sigma.diagonal().setOnes();
@@ -214,7 +214,7 @@ TEST(ProbDistributionsLkjCorrCholesky,fvar_var) {
 TEST(ProbDistributionsLkjCorr,fvar_fvar_double) {
   using stan::agrad::fvar;
   boost::random::mt19937 rng;
-  unsigned int K = 4;
+  int K = 4;
   Eigen::Matrix<fvar<fvar<double> >,Eigen::Dynamic,Eigen::Dynamic> Sigma(K,K);
   Sigma.setZero();
   Sigma.diagonal().setOnes();
@@ -233,7 +233,7 @@ TEST(ProbDistributionsLkjCorr,fvar_fvar_double) {
 TEST(ProbDistributionsLkjCorrCholesky,fvar_fvar_double) {
   using stan::agrad::fvar;
   boost::random::mt19937 rng;
-  unsigned int K = 4;
+  int K = 4;
   Eigen::Matrix<fvar<fvar<double> >,Eigen::Dynamic,Eigen::Dynamic> Sigma(K,K);
   Sigma.setZero();
   Sigma.diagonal().setOnes();
@@ -253,7 +253,7 @@ TEST(ProbDistributionsLkjCorr,fvar_fvar_var) {
   using stan::agrad::fvar;
   using stan::agrad::var;
   boost::random::mt19937 rng;
-  unsigned int K = 4;
+  int K = 4;
   Eigen::Matrix<fvar<fvar<var> >,Eigen::Dynamic,Eigen::Dynamic> Sigma(K,K);
   Sigma.setZero();
   Sigma.diagonal().setOnes();
@@ -273,7 +273,7 @@ TEST(ProbDistributionsLkjCorrCholesky,fvar_fvar_var) {
   using stan::agrad::fvar;
   using stan::agrad::var;
   boost::random::mt19937 rng;
-  unsigned int K = 4;
+  int K = 4;
   Eigen::Matrix<fvar<fvar<var> >,Eigen::Dynamic,Eigen::Dynamic> Sigma(K,K);
   Sigma.setZero();
   Sigma.diagonal().setOnes();


### PR DESCRIPTION
#### Summary:

Fixes tests on Windows.
Squashes all warnings.

#### Intended Effect:

Get to 0 compiler warnings.

#### How to Verify:

Let Jenkins run all tests. There should be 0 compiler warnings.

#### Side Effects:

Added `-Wsign-compare` to clang++ build on mac, so we'll see the same warning messages.

#### Documentation:

None required.

#### Reviewer Suggestions: 

Anyone.