### PR TITLE
stan-reference: fix typo in MCMC Sampling (54.2)

### DIFF
--- a/src/docs/stan-reference/advanced.tex
+++ b/src/docs/stan-reference/advanced.tex
@@ -849,7 +849,7 @@ described in \refchapter{hmc}.
 
 The Markov chains \Stan and other \MCMC samplers generate are ergodic
 in the sense required by the Markov chain central limit theorem,
-meaning roughly that there is there is a reasonable chance of reaching
+meaning roughly that there is a reasonable chance of reaching
 one value of $\theta$ from another.  The Markov chains are also
 stationary, meaning that the transition probabilities do not change at
 different positions in the chain, so that for $n, n' \geq 0$, the


### PR DESCRIPTION
"there is" was duplicated within the same sentence