### PR TITLE
adding cpplint target

### DIFF
--- a/make/cpplint
+++ b/make/cpplint
@@ -1,0 +1,5 @@
+CPPLINT ?= cpplint.py
+
+.PHONY: cpplint
+cpplint:
+	@$(CPPLINT) --output=vs7 --counting=detailed --root=src --extension=hpp,cpp --filter=-runtime/indentation_namespace,-readability/namespace,-legal/copyright,-whitespace/indent,-runtime/reference $(shell find src/stan -name '*.hpp' -o -name '*.cpp')

--- a/makefile
+++ b/makefile
@@ -64,6 +64,7 @@ include make/libstan  # bin/libstan.a bin/libstanc.a
 include make/tests    # tests
 include make/doxygen  # doxygen
 include make/manual   # manual: manual, doc/stan-reference.pdf
+include make/cpplint  # cpplint
 
 ##
 # Dependencies


### PR DESCRIPTION
#### Summary:

Adds a `cpplint` target in make. Requires cpplint.py to be installed locally.

#### Intended Effect:

Runs cpplint with consistent arguments.

#### How to Verify:

Run `make cpplint` from the command line.

#### Side Effects:

None. Doesn't touch code.

#### Documentation:

None.

#### Reviewer Suggestions:

Anyone.
