### PR TITLE
Bugfix/issue 1342 get base index except

### DIFF
--- a/src/stan/math/matrix/get_base1_lhs.hpp
+++ b/src/stan/math/matrix/get_base1_lhs.hpp
@@ -324,7 +324,7 @@ namespace stan {
                      size_t idx) {
       using stan::math::check_range;
       check_range("[]", "rows of x", x.rows(), m, idx, error_msg);
-      check_range("[]", "cols of x", x.rows(), n, idx + 1, error_msg);
+      check_range("[]", "cols of x", x.cols(), n, idx + 1, error_msg);
       return x(m - 1, n - 1);
     }
 

--- a/src/test/unit/math/matrix/get_base1_lhs_test.cpp
+++ b/src/test/unit/math/matrix/get_base1_lhs_test.cpp
@@ -1,6 +1,18 @@
 #include <stan/math/matrix/get_base1_lhs.hpp>
 #include <gtest/gtest.h>
 
+TEST(MathMatrix, failing_in_26) {
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+  using stan::math::get_base1_lhs;
+  Matrix<double,Dynamic,Dynamic> y(2,3);
+  EXPECT_THROW(get_base1_lhs(y,3,1,"y",2), std::exception);
+  EXPECT_THROW(get_base1_lhs(y,1,4,"y",2), std::exception);
+  for (int i = 1; i <= 2; ++i)
+    for (int j = 1; j <= 3; ++j)
+      EXPECT_FLOAT_EQ(y(i-1,j-1), get_base1_lhs(y,i,j,"y",2));
+}
+
 TEST(MathMatrix,failing_pre_20) {
   using Eigen::Matrix;
   using Eigen::Dynamic;


### PR DESCRIPTION
#### Summary:

Fix bug being thrown by matrix double-indexing by changing check_range to use cols instead of rows for second index.

#### Intended Effect:

Fix this bug!

#### How to Verify:

I added a unit test that failed in 2.6 but now passes for the entire range, including all in-range and out-of-range inputs.

#### Side Effects:

None.

#### Documentation:

Behavior now matches doc.

#### Reviewer Suggestions:

Daniel.