### PR TITLE
Print error messages in initialization

### DIFF
--- a/src/stan/services/init/initialize_state.hpp
+++ b/src/stan/services/init/initialize_state.hpp
@@ -161,11 +161,22 @@ namespace stan {
               << std::endl;
             init_log_prob = -std::numeric_limits<double>::infinity();
           }
-          if (!boost::math::isfinite(init_log_prob))
+          if (!boost::math::isfinite(init_log_prob)) {
+            if (output)
+              *output << "Rejecting initialization at zero "
+                      << "because of vanishing density."
+                      << std::endl;
             continue;
-          for (int i = 0; i < init_grad.size(); ++i)
-            if (!boost::math::isfinite(init_grad(i)))
+          }
+          for (int i = 0; i < init_grad.size(); ++i) {
+            if (!boost::math::isfinite(init_grad(i))) {
+              if (output)
+                *output << "Rejecting initialization at zero "
+                        << "because of divergent gradient."
+                        << std::endl;
               continue;
+            }
+          }
           break;
         }
         

--- a/src/test/unit/services/init/initialize_state_test.cpp
+++ b/src/test/unit/services/init/initialize_state_test.cpp
@@ -298,6 +298,9 @@ TEST_F(StanServices, initialize_state_random_reject_all) {
   EXPECT_EQ(0, model.transform_inits_calls);
   EXPECT_EQ(300, rng.calls);
   EXPECT_NE("", output.str()) << "expecting error message";
+  EXPECT_TRUE(output.str()
+              .find("Rejecting initialization at zero because of vanishing density.")
+              != std::string::npos);
 }
 
 


### PR DESCRIPTION
#### Summary:

Print errors in random initialization.

#### Intended Effect:

These were accidentally omitted. This should help make debugging models a little easier.

#### How to Verify:

Run the model in #1326. This should now print error messages.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

Bob.