### PR TITLE
adding a CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Submitting an Issue
+
+If you've clicked on the "guidelines for contributing" link from the GitHub issue tracker, you're in the right place. These guidelines will help the development team fix the issue.
+
+These links will pre-populate an issue with a template:
+
+| Libraries | Interfaces | Other |
+|-----------|------------|-------|
+| [Stan (bug report)](https://github.com/stan-dev/stan/issues/new?body=%23%23%20Bug%20Report%0A%0A__Version__%0A%0A__Description__%0A%0A__Steps__%0A%0A__Output__%0A%0A__Expected%20Output__%0A%0A__Additional%20Information__%0A%0A) <br /> [Stan (feature request)](https://github.com/stan-dev/stan/issues/new?body=%23%23%20Feature%20Request%0A%0A__Version__%0A%0A__Category__%0A%0A__Description__%0A%0A__Example__%0A%0A__Additional%20Information__%0A%0A)| [CmdStan](https://github.com/stan-dev/cmdstan/issues/new?body=__CmdStan%20Version__%0A%0A__Operating%20System__%0A%0A__Compiler__%0A%0A__Description__%0A%0A__Steps__%0A%0A__Output__%0A%0A__Expected%20Output__%0A%0A__Additional%20Information__) <br /> [RStan](https://github.com/stan-dev/rstan/issues/new?body=__RStan%20Version__%0A%0A__R%20version__%0A%0A__Operating%20System__%0A%0A__Compiler__%0A%0A__Description__%0A%0A__Steps__%0A%0A__Output__%0A%0A__Expected%20Output__%0A%0A__Additional%20Information__%0A) <br /> [PyStan](https://github.com/stan-dev/pystan/issues/new?body=__PyStan%20Version__%0A%0A__Python%20version__%0A%0A__Operating%20System__%0A%0A__Compiler__%0A%0A__Description__%0A%0A__Steps__%0A%0A__Output__%0A%0A__Expected%20Output__%0A%0A__Additional%20Information__%0A) 	| [shinyStan](https://github.com/stan-dev/shinystan/issues/new?body=__shinyStan%20Version__%0A%0A__R%20version__%0A%0A__Operating%20System__%0A%0A__Description__%0A%0A__Steps__%0A%0A__Output__%0A%0A__Expected%20Output__%0A%0A__Additional%20Information__%0A) |
+
+
+# Detailed information
+
+
+## Stan (bug report)
+
+Use this template for describing problems with the Stan library. Please be as specific as possible. If you're able to provide a simple reproducible example, this will go a long way to helping the developers fix the bug.
+
+__Title__
+
+Please give a descriptive summary of the bug.
+
+__Version__
+
+For tagged versions, please report the version number in `src/stan/version.hpp`.
+
+For git cloned versions, report the result of typing `git rev-parse HEAD` from the command line.
+
+__Description__
+
+Describe the problem as clearly as possible.
+
+__Steps__
+
+Steps to reproduce the bug, if possible. If not, a description of how you discovered the bug.
+
+If you have a reproducible example, put it here.
+
+__Output__
+
+Output you get from triggering the bug. Knowing what Stan currently does is useful.
+
+__Expected Output__
+
+Describe what you expected to happen. Knowing what the correct behavior should be is also very useful.
+
+__Additional Information__
+
+Provide any additional information here.
+
+
+## Stan (feature request)
+
+Use this template for requesting new features in Stan.
+
+__Title__
+
+Please give a descriptive summary of the feature.
+
+__Version__
+
+For tagged versions, please report the version number in `src/stan/version.hpp`.
+
+For git cloned versions, report the result of typing `git rev-parse HEAD` from the command line.
+
+__Category__
+
+Use one of the following or make up something reasonable:
+
+- language
+- new function
+- algorithm
+
+__Description__
+
+Describe the feature you'd like in Stan. Be descriptive.
+
+__Example__
+
+Provide at least one example. Also mock up the expected result from that example.
+
+__Additional Information__
+
+Provide any additional information here.
+
+


### PR DESCRIPTION
#### Summary:

Added a `CONTRIBUTING.md` file that:

1. Includes links for each issue tracker with pre-populated templates.
2. Describes what we expect in a bug report and a feature request in Stan.

#### Intended Effect:

Makes it easier for users to generate issues that are descriptive.

#### How to Verify:

Click on all the links.

#### Side Effects:

None.

#### Documentation:

This is all doc. No change to code.

#### Reviewer Suggestions: 

@bob-carpenter. Mind taking a look and updating the file? Or describing what changes you want.