### PR TITLE
stan-reference: fix typo in naive bayes

### DIFF
--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -5725,7 +5725,7 @@ The parameter $\phi_{z[m]}$ is a $V$-simplex representing the
 probability of each word in the vocabulary in documents of category
 $z_m$.
 
-The parameters $\theta$ and $\pi$ are typically given symmetric
+The parameters $\theta$ and $\phi$ are typically given symmetric
 Dirichlet priors.  The prevalence $\theta$ is sometimes fixed to
 produce equal probabilities for each category $k \in 1:K$.
 


### PR DESCRIPTION
The parameters of the categorical distributions were named $\theta$ and $\phi$ everywhere else in the naive bayes section, but here they appear as $\theta$ and $\pi$.