### PR TITLE
stan-reference: fix typo

### DIFF
--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -496,7 +496,7 @@ discrete distributions, require integer arguments.
 A two-dimensional array is just an array of arrays, both conceptually
 and in terms of current implementation.  When an index is supplied to
 an array, it returns the value at that index.  When more than one
-index is supplied, this idexing operation is chained.  For example, if
+index is supplied, this indexing operation is chained.  For example, if
 \code{a} is a two-dimensional array, then \code{a[m,n]} is just
 a convenient shorthand for \code{a[m][n]}.
 


### PR DESCRIPTION
`idexing` -> `indexing`