### PR TITLE
stan-reference: fix typo in "Problematic Posteriors"

### DIFF
--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -8392,7 +8392,7 @@ necessary because the $K$th is just one minus the sum of the first $K
 - 1$ parameters, so that if $\theta$ is a $K$-simplex,
 %
 \[
-\theta_K = 1 - \sum_{k=1}^K \theta_k.
+\theta_K = 1 - \sum_{k=1}^{K-1} \theta_k.
 \]
 %
 The softmax function (see \refsection{softmax}) maps a $K$-vector


### PR DESCRIPTION
Fix typo in stan-reference ("Softmax with K vs. K −1 Parameters" in section 19.1)

This equation came from "\sum_{k=1}^K \theta_k = 1".