### PR TITLE
Feature/issue 1458 missing poisson log rng

### DIFF
--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -672,6 +672,7 @@ for (size_t i = 0; i < int_vector_types.size(); ++i)
     add("poisson_log_log",DOUBLE_T, int_vector_types[i],vector_types[j]);
   }
 add("poisson_rng",INT_T,DOUBLE_T);
+add("poisson_log_rng",INT_T,DOUBLE_T);
 add_nullary("positive_infinity");
 add_binary("pow");
 add("prod",INT_T,expr_type(INT_T,1));

--- a/src/test/test-models/good/function-signatures/distributions/rngs.stan
+++ b/src/test/test-models/good/function-signatures/distributions/rngs.stan
@@ -26,7 +26,7 @@ generated quantities {
   n <- neg_binomial_2_log_rng(1.2,3.9);
   n <- ordered_logistic_rng(1.9,theta);
   n <- poisson_rng(2.7);
-  // n <- poisson_log_rng(2.7);
+  n <- poisson_log_rng(2.7);
 
   n <- categorical_rng(theta);
   ns <- multinomial_rng(theta,20);
@@ -52,9 +52,9 @@ generated quantities {
   z <- pareto_type_2_rng(3.0, 2.0, 1.5);
   z <- beta_rng(110.0, 250.1);
   z <- uniform_rng(-1.0, 1.0);
-  z <- rayleigh_rng(1.0);  
+  z <- rayleigh_rng(1.0);
   z <- frechet_rng(2.0, 3.2);
-  
+
   theta <- dirichlet_rng(alpha);
   v <- multi_normal_rng(mu,Sigma);
   // v <- multi_normal_prec_rng(mu,Sigma);
@@ -65,8 +65,8 @@ generated quantities {
   Sigma <- lkj_corr_rng(3,2.5);
   L <- lkj_corr_cholesky_rng(3,3.0);
   // DEPRECATE:  Sigma <- lkj_cov_rng(Sigma, mu, alpha, 2.0);
-  
- 
-  
-  
+
+
+
+
 }

--- a/src/test/unit/math/prim/scal/prob/poisson_test.cpp
+++ b/src/test/unit/math/prim/scal/prob/poisson_test.cpp
@@ -16,6 +16,10 @@ TEST(ProbDistributionsPoisson, error_check) {
 
   EXPECT_THROW(stan::math::poisson_rng(pow(2.0,31), rng),std::domain_error);
 
+  EXPECT_NO_THROW(stan::math::poisson_log_rng(6, rng));
+
+  EXPECT_NO_THROW(stan::math::poisson_log_rng(-6, rng));
+
   EXPECT_NO_THROW(stan::math::poisson_log_rng(log(1e9), rng));
 
   EXPECT_THROW(stan::math::poisson_log_rng(log(pow(2.0,31)), rng),std::domain_error);
@@ -44,7 +48,7 @@ TEST(ProbDistributionsPoisson, chiSquareGoodnessFitTest) {
   while (count < N) {
     int a = stan::math::poisson_rng(5,rng);
     int i = 0;
-    while (i < K-1 && a > loc[i]) 
+    while (i < K-1 && a > loc[i])
       ++i;
     ++bin[i];
     count++;
@@ -83,7 +87,7 @@ TEST(ProbDistributionsPoisson, chiSquareGoodnessFitTest2) {
   while (count < N) {
     int a = stan::math::poisson_log_rng(log(5),rng);
     int i = 0;
-    while (i < K-1 && a > loc[i]) 
+    while (i < K-1 && a > loc[i])
       ++i;
     ++bin[i];
     count++;


### PR DESCRIPTION
This one is simple, fix issue  #1458: expose poisson_log_rng() which already has the tests and documentation.