### PR TITLE
stan-reference: fix typo in HMC (56.1)

### DIFF
--- a/src/docs/stan-reference/algorithms.tex
+++ b/src/docs/stan-reference/algorithms.tex
@@ -59,7 +59,7 @@ matrix, and will be a unit, diagonal, or dense if $\Sigma$ is.
 
 \subsection{The Hamiltonian}
 
-The joint desnity $p(\rho,\theta)$ defines a Hamiltonian
+The joint density $p(\rho,\theta)$ defines a Hamiltonian
 %
 \begin{eqnarray*}
 H(\rho,\theta) & = & - \log p(\rho,\theta)


### PR DESCRIPTION
"desnity" should be "density"