### PR TITLE
Bugfix/issue 1152 ccdf sigs

### DIFF
--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -248,6 +248,26 @@ namespace stan {
         std::string function_name(s.dist_.family_);
         std::string internal_function_name = function_name + "_log";
 
+        if ((internal_function_name.find("multiply_log") 
+             != std::string::npos)
+            || (internal_function_name.find("binomial_coefficient_log")
+                != std::string::npos)) {
+          error_msgs << "Only distribution names can be used with"
+                     << " sampling (~) notation; found non-distribution"
+                     << " function: " << function_name
+                     << std::endl;
+          return false;
+        }
+
+        if (internal_function_name.find("cdf_log") != std::string::npos) {
+          error_msgs << "CDF and CCDF functions may not be used with"
+                     << " sampling notation."
+                     << " Use increment_log_prob("
+                     << internal_function_name << "(...)) instead."
+                     << std::endl;
+          return false;
+        }
+
         if (!is_double_return(internal_function_name, arg_types, error_msgs))
           return false;
 
@@ -265,10 +285,10 @@ namespace stan {
         if (has_non_param_var(s.expr_, var_map)) {
           // FIXME:  really want to get line numbers in here too
           error_msgs << "Warning (non-fatal):"
-             << " Left-hand side of sampling statement (~) contains a"
+             << " Left-hand side of sampling statement (~) may contain a"
              << " non-linear transform of a parameter or local variable."
              << std::endl
-             << " You must call increment_log_prob() with the log"
+             << " You may need to call increment_log_prob() with the log"
              << " absolute determinant of the Jacobian of the transform."
              << std::endl
              << "  Sampling Statement left-hand-side expression:"

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -248,7 +248,7 @@ namespace stan {
         std::string function_name(s.dist_.family_);
         std::string internal_function_name = function_name + "_log";
 
-        if ((internal_function_name.find("multiply_log") 
+        if ((internal_function_name.find("multiply_log")
              != std::string::npos)
             || (internal_function_name.find("binomial_coefficient_log")
                 != std::string::npos)) {
@@ -285,13 +285,14 @@ namespace stan {
         if (has_non_param_var(s.expr_, var_map)) {
           // FIXME:  really want to get line numbers in here too
           error_msgs << "Warning (non-fatal):"
+             << std::endl
              << " Left-hand side of sampling statement (~) may contain a"
              << " non-linear transform of a parameter or local variable."
              << std::endl
-             << " You may need to call increment_log_prob() with the log"
+             << "If so, you need to call increment_log_prob() with the log"
              << " absolute determinant of the Jacobian of the transform."
              << std::endl
-             << "  Sampling Statement left-hand-side expression:"
+             << "Left-hand-side of sampling statement:"
              << std::endl
              << "    ";
           generate_expression(s.expr_, error_msgs);

--- a/src/test/test-models/bad/binomial_coefficient_sample.stan
+++ b/src/test/test-models/bad/binomial_coefficient_sample.stan
@@ -1,0 +1,6 @@
+data {
+  real y;
+}
+model {
+  y ~ binomial_coefficient(5);
+}

--- a/src/test/test-models/bad/ccdf-sample.stan
+++ b/src/test/test-models/bad/ccdf-sample.stan
@@ -1,0 +1,6 @@
+data {
+  vector[3] y;
+}
+model {
+  y ~ weibull_ccdf(1,1);
+}

--- a/src/test/test-models/bad/cdf-sample.stan
+++ b/src/test/test-models/bad/cdf-sample.stan
@@ -1,0 +1,6 @@
+data {
+  real y;
+}
+model {
+  y ~ normal_cdf(1, 1);
+}

--- a/src/test/test-models/bad/multiply_sample.stan
+++ b/src/test/test-models/bad/multiply_sample.stan
@@ -1,0 +1,6 @@
+data {
+  real y;
+}
+model {
+  y ~ multiply(3);
+}

--- a/src/test/unit/lang/parser/statement_grammar_test.cpp
+++ b/src/test/unit/lang/parser/statement_grammar_test.cpp
@@ -66,3 +66,14 @@ TEST(langParserStatementGrammar, assignRealToIntMessage) {
   test_throws("assign_real_to_int",
               "PARSER EXPECTED: <expression assignable to left-hand side>");
 }
+
+TEST(langParserStatementGrammar, useCdfWithSamplingNotation) {
+  test_throws("cdf-sample",
+              "CDF and CCDF functions may not be used with sampling notation.");
+  test_throws("ccdf-sample",
+              "CDF and CCDF functions may not be used with sampling notation.");
+  test_throws("multiply_sample",
+              "Only distribution names can be used with sampling (~) notation");
+  test_throws("binomial_coefficient_sample",
+              "Only distribution names can be used with sampling (~) notation");
+}

--- a/src/test/unit/lang/parser/statement_grammar_test.cpp
+++ b/src/test/unit/lang/parser/statement_grammar_test.cpp
@@ -34,17 +34,17 @@ TEST(langParserStatementGrammar, validateAllowSample) {
 TEST(langParserStatementGrammarDef, jacobianAdjustmentWarning) {
   test_parsable("validate_jacobian_warning_good");
   test_warning("validate_jacobian_warning1",
-               "you must call increment_log_prob() with the log absolute determinant");
+               "If so, you need to call increment_log_prob() with the log");
   test_warning("validate_jacobian_warning2",
-               "you must call increment_log_prob() with the log absolute determinant");
+               "If so, you need to call increment_log_prob() with the log");
   test_warning("validate_jacobian_warning3",
-               "you must call increment_log_prob() with the log absolute determinant");
+               "If so, you need to call increment_log_prob() with the log");
   test_warning("validate_jacobian_warning4",
-               "you must call increment_log_prob() with the log absolute determinant");
+               "If so, you need to call increment_log_prob() with the log");
   test_warning("validate_jacobian_warning5",
-               "you must call increment_log_prob() with the log absolute determinant");
+               "If so, you need to call increment_log_prob() with the log");
   test_warning("validate_jacobian_warning6",
-               "you must call increment_log_prob() with the log absolute determinant");
+               "If so, you need to call increment_log_prob() with the log");
 }
 
 TEST(langParserStatementGrammarDef, comparisonsInBoundsTest) {
@@ -77,3 +77,4 @@ TEST(langParserStatementGrammar, useCdfWithSamplingNotation) {
   test_throws("binomial_coefficient_sample",
               "Only distribution names can be used with sampling (~) notation");
 }
+

--- a/src/test/unit/lang/utility.hpp
+++ b/src/test/unit/lang/utility.hpp
@@ -149,11 +149,11 @@ void test_warning(const std::string& model_name,
                   const std::string& warning_msg) {
   std::stringstream msgs;
   EXPECT_TRUE(is_parsable_folder(model_name, "good", &msgs));
-  EXPECT_TRUE(msgs.str().find_first_of(warning_msg) != std::string::npos)
-    << std::endl 
+  bool found = msgs.str().find(warning_msg) != std::string::npos;
+  EXPECT_TRUE(found) << std::endl 
     << "FOUND: " << msgs.str() 
     << std::endl
-    << "EXPECTED: " << warning_msg
+    << "EXPECTED (as substring): " << warning_msg
     << std::endl;
 }
 


### PR DESCRIPTION
#### Summary:

#### Intended Effect:

1. Raise warning from Stan parser when attempting to use CDF or known non-distribution with `_log` suffix with sampling notation.

2.  Soften the "Jacobian-required" message to a warning conditioned on checking non-linearity (same file, so I couldn't pass it up).

3.  Fix bug in warnings tests in parser test utiliy leading to false negatives on warnings test (still no idea why the old way didn't work --- maybe a macro resolution syntax issue?).

#### How to Verify:

1. New models tickling new warnings in parser unit test for statement grammar.

2. Unit test for warning in statement grammar.

3.  Revised test for Jacobian messages in statement grammar unit test will fail as before (but not as the test was written before), but the revised test will pass.

#### Side Effects:

None (models wouldn't compile before and will fail with warning message now)

#### Documentation:

None --- this brings behavior in line with doc.

#### Reviewer Suggestions:

Anyone.