### PR TITLE
Feature/issue 445 deprecate model write csv

### DIFF
--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -4,6 +4,9 @@
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include <stan/version.hpp>
+#include <stan/lang/ast.hpp>
+
 #include <cstddef>
 #include <iostream>
 #include <ostream>
@@ -11,9 +14,6 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#include <stan/version.hpp>
-#include <stan/lang/ast.hpp>
 
 namespace stan {
 
@@ -64,7 +64,7 @@ namespace stan {
     struct visgen {
       typedef void result_type;
       std::ostream& o_;
-      visgen(std::ostream& o) : o_(o) { }
+      explicit visgen(std::ostream& o) : o_(o) { }
     };
 
     void generate_start_namespace(std::string name,
@@ -78,7 +78,7 @@ namespace stan {
 
     void generate_comment(std::string const& msg, int indent,
                           std::ostream& o) {
-      generate_indent(indent,o);
+      generate_indent(indent, o);
       o << "// " << msg        << EOL;
     }
 
@@ -104,8 +104,8 @@ namespace stan {
     template <bool isLHS>
     void generate_indexed_expr(const std::string& expr,
                                const std::vector<expression> indexes,
-                               base_expr_type base_type, // may have more dims
-                               size_t e_num_dims, // array dims
+                               base_expr_type base_type,  // may have more dims
+                               size_t e_num_dims,  // array dims
                                std::ostream& o) {
       size_t ai_size = indexes.size();
       if (ai_size == 0) {
@@ -119,9 +119,9 @@ namespace stan {
         o << expr;
         for (size_t n = 0; n < ai_size; ++n) {
           o << ',';
-          generate_expression(indexes[n],o);
+          generate_expression(indexes[n], o);
           o << ',';
-          generate_quoted_string(expr,o);
+          generate_quoted_string(expr, o);
           o << ',' << (n+1) << ')';
         }
       } else {
@@ -130,17 +130,17 @@ namespace stan {
         o << expr;
         for (size_t n = 0; n < ai_size - 2; ++n) {
           o << ',';
-          generate_expression(indexes[n],o);
+          generate_expression(indexes[n], o);
           o << ',';
-          generate_quoted_string(expr,o);
+          generate_quoted_string(expr, o);
           o << ',' << (n+1) << ')';
         }
         o << ',';
-        generate_expression(indexes[ai_size - 2U],o);
+        generate_expression(indexes[ai_size - 2U], o);
         o << ',';
-        generate_expression(indexes[ai_size - 1U],o);
+        generate_expression(indexes[ai_size - 1U], o);
         o << ',';
-        generate_quoted_string(expr,o);
+        generate_quoted_string(expr, o);
         o << ',' << (ai_size-1U) << ')';
       }
     }
@@ -158,7 +158,7 @@ namespace stan {
     }
 
     struct expression_visgen : public visgen {
-      expression_visgen(std::ostream& o) : visgen(o) {  }
+      explicit expression_visgen(std::ostream& o) : visgen(o) {  }
       void operator()(nil const& /*x*/) const {
         o_ << "nil";
       }
@@ -167,7 +167,7 @@ namespace stan {
         std::string num_str = boost::lexical_cast<std::string>(x.val_);
         o_ << num_str;
         if (num_str.find_first_of("eE.") == std::string::npos)
-          o_ << ".0"; // trailing 0 to ensure C++ makes it a double
+          o_ << ".0";  // trailing 0 to ensure C++ makes it a double
       }
       void operator()(const array_literal& x) const {
         o_ << "stan::math::new_array<";
@@ -186,18 +186,18 @@ namespace stan {
       void operator()(const variable& v) const { o_ << v.name_; }
       void operator()(int n) const { o_ << static_cast<long>(n); }
       void operator()(double x) const { o_ << x; }
-      void operator()(const std::string& x) const { o_ << x; } // identifiers
+      void operator()(const std::string& x) const { o_ << x; }  // identifiers
       void operator()(const index_op& x) const {
         std::stringstream expr_o;
-        generate_expression(x.expr_,expr_o);
+        generate_expression(x.expr_, expr_o);
         std::string expr_string = expr_o.str();
         std::vector<expression> indexes;
         size_t e_num_dims = x.expr_.expression_type().num_dims_;
         base_expr_type base_type = x.expr_.expression_type().base_type_;
         for (size_t i = 0; i < x.dimss_.size(); ++i)
           for (size_t j = 0; j < x.dimss_[i].size(); ++j)
-            indexes.push_back(x.dimss_[i][j]); // wasteful copy, could use refs
-        generate_indexed_expr<false>(expr_string,indexes,base_type,e_num_dims, o_);
+            indexes.push_back(x.dimss_[i][j]);  // wasteful copy, could use refs
+        generate_indexed_expr<false>(expr_string, indexes, base_type, e_num_dims, o_);
       }
       void operator()(const integrate_ode& fx) const {
         o_ << "integrate_ode("
@@ -278,7 +278,7 @@ namespace stan {
       o << '"';
       for (size_t i = 0; i < s.size(); ++i) {
         if (s[i] == '"' || s[i] == '\\' || s[i] == '\'' )
-          o << '\\'; // escape
+          o << '\\';
         o << s[i];
       }
       o << '"';
@@ -287,18 +287,17 @@ namespace stan {
     static void print_quoted_expression(std::ostream& o,
                                         const expression& e) {
       std::stringstream ss;
-      generate_expression(e,ss);
-      print_string_literal(o,ss.str());
+      generate_expression(e, ss);
+      print_string_literal(o, ss.str());
     }
 
     struct printable_visgen : public visgen {
-      printable_visgen(std::ostream& o) : visgen(o) {  }
+      explicit printable_visgen(std::ostream& o) : visgen(o) {  }
       void operator()(const std::string& s) const {
-        print_string_literal(o_,s);
+        print_string_literal(o_, s);
       }
       void operator()(const expression& e) const {
         generate_expression(e, o_);
-        // print_quoted_expression(o_,e);
       }
     };
 
@@ -317,14 +316,14 @@ namespace stan {
 
 
     void generate_usings(std::ostream& o) {
-      generate_using("std::istream",o);
-      generate_using("std::string",o);
-      generate_using("std::stringstream",o);
-      generate_using("std::vector",o);
-      generate_using("stan::io::dump",o);
-      generate_using("stan::math::lgamma",o);
-      generate_using("stan::model::prob_grad",o);
-      generate_using_namespace("stan::math",o);
+      generate_using("std::istream", o);
+      generate_using("std::string", o);
+      generate_using("std::stringstream", o);
+      generate_using("std::vector", o);
+      generate_using("stan::io::dump", o);
+      generate_using("stan::math::lgamma", o);
+      generate_using("stan::model::prob_grad", o);
+      generate_using_namespace("stan::math", o);
       o << EOL;
     }
 
@@ -335,9 +334,9 @@ namespace stan {
     }
 
     void generate_typedefs(std::ostream& o) {
-      generate_typedef("Eigen::Matrix<double,Eigen::Dynamic,1>","vector_d",o);
-      generate_typedef("Eigen::Matrix<double,1,Eigen::Dynamic>","row_vector_d",o);
-      generate_typedef("Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>","matrix_d",o);
+      generate_typedef("Eigen::Matrix<double,Eigen::Dynamic,1>", "vector_d", o);
+      generate_typedef("Eigen::Matrix<double,1,Eigen::Dynamic>", "row_vector_d", o);
+      generate_typedef("Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>", "matrix_d", o);
       o << EOL;
     }
 
@@ -346,8 +345,8 @@ namespace stan {
     }
 
     void generate_includes(std::ostream& o) {
-      generate_include("stan/model/model_header.hpp",o);
-      generate_include("stan/services/command.hpp",o);
+      generate_include("stan/model/model_header.hpp", o);
+      generate_include("stan/services/command.hpp", o);
       o << EOL;
     }
 
@@ -372,20 +371,20 @@ namespace stan {
                               const expression& type_arg2 = expression()) {
       for (size_t i = 0; i < dims.size(); ++i) {
         o << '(';
-        generate_expression(dims[i].expr_,o);
+        generate_expression(dims[i].expr_, o);
         o << ',';
-        generate_type(base_type,dims,dims.size()- i - 1,o);
+        generate_type(base_type, dims, dims.size()- i - 1, o);
       }
 
       o << '(';
       if (!is_nil(type_arg1)) {
-        generate_expression(type_arg1.expr_,o);
+        generate_expression(type_arg1.expr_, o);
         if (!is_nil(type_arg2)) {
           o << ',';
-          generate_expression(type_arg2.expr_,o);
+          generate_expression(type_arg2.expr_, o);
         }
       } else if (!is_nil(type_arg2.expr_)) {
-        generate_expression(type_arg2.expr_,o);
+        generate_expression(type_arg2.expr_, o);
       } else {
         o << '0';
       }
@@ -412,14 +411,14 @@ namespace stan {
         << ", context__.to_vec(";
       for (size_t i = 0; i < dims.size(); ++i) {
         if (i > 0) o << ",";
-        generate_expression(dims[i].expr_,o);
+        generate_expression(dims[i].expr_, o);
       }
       if (!is_nil(type_arg1)) {
         if (dims.size() > 0) o << ",";
-        generate_expression(type_arg1.expr_,o);
+        generate_expression(type_arg1.expr_, o);
         if (!is_nil(type_arg2)) {
           o << ",";
-          generate_expression(type_arg2.expr_,o);
+          generate_expression(type_arg2.expr_, o);
         }
       }
       o << "));"
@@ -432,45 +431,45 @@ namespace stan {
         : visgen(o),
           stage_(stage) {
       }
-      void operator()(nil const& /*x*/) const { } // dummy
+      void operator()(nil const& /*x*/) const { }  // dummy
       void operator()(int_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"int",x.dims_);
+        generate_validate_context_size(o_, stage_, x.name_, "int", x.dims_);
       }
       void operator()(double_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"double",x.dims_);
+        generate_validate_context_size(o_, stage_, x.name_, "double", x.dims_);
       }
       void operator()(vector_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"vector_d",x.dims_,x.M_);
+        generate_validate_context_size(o_, stage_, x.name_, "vector_d", x.dims_, x.M_);
       }
       void operator()(row_vector_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"row_vector_d",x.dims_,x.N_);
+        generate_validate_context_size(o_, stage_, x.name_, "row_vector_d", x.dims_, x.N_);
       }
       void operator()(unit_vector_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"vector_d",x.dims_,x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "vector_d", x.dims_, x.K_);
       }
       void operator()(simplex_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"vector_d",x.dims_,x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "vector_d", x.dims_, x.K_);
       }
       void operator()(ordered_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"vector_d",x.dims_,x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "vector_d", x.dims_, x.K_);
       }
       void operator()(positive_ordered_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"vector_d",x.dims_,x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "vector_d", x.dims_, x.K_);
       }
       void operator()(matrix_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"matrix_d",x.dims_,x.M_,x.N_);
+        generate_validate_context_size(o_, stage_, x.name_, "matrix_d", x.dims_, x.M_, x.N_);
       }
       void operator()(cholesky_factor_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"matrix_d",x.dims_,x.M_,x.N_);
+        generate_validate_context_size(o_, stage_, x.name_, "matrix_d", x.dims_, x.M_, x.N_);
       }
       void operator()(cholesky_corr_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"matrix_d",x.dims_,x.K_,x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "matrix_d", x.dims_, x.K_, x.K_);
       }
       void operator()(cov_matrix_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"matrix_d",x.dims_,x.K_,x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "matrix_d", x.dims_, x.K_, x.K_);
       }
       void operator()(corr_matrix_var_decl const& x) const {
-        generate_validate_context_size(o_,stage_,x.name_,"matrix_d",x.dims_,x.K_,x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "matrix_d", x.dims_, x.K_, x.K_);
       }
     };
 
@@ -480,9 +479,9 @@ namespace stan {
                                     std::ostream& o) {
       o << INDENT2;
       o << "validate_non_negative_index(\"" << var_name << "\", ";
-      print_quoted_expression(o,expr);
+      print_quoted_expression(o, expr);
       o << ", ";
-      generate_expression(expr,o);
+      generate_expression(expr, o);
       o << ");" << EOL;
     }
 
@@ -494,63 +493,62 @@ namespace stan {
                                  const expression& type_arg2 = expression()) {
       // validate all dims are positive
       for (size_t i = 0; i < dims.size(); ++i)
-        generate_validate_positive(var_name,dims[i],o);
+        generate_validate_positive(var_name, dims[i], o);
       if (!is_nil(type_arg1))
-        generate_validate_positive(var_name,type_arg1,o);
+        generate_validate_positive(var_name, type_arg1, o);
       if (!is_nil(type_arg2))
-        generate_validate_positive(var_name,type_arg2,o);
+        generate_validate_positive(var_name, type_arg2, o);
 
       // define variable with initializer
       o << INDENT2
         << var_name << " = ";
-      generate_type(base_type,dims,dims.size(),o);
-      generate_initializer(o,base_type,dims,type_arg1,type_arg2);
-
+      generate_type(base_type, dims, dims.size(), o);
+      generate_initializer(o, base_type, dims, type_arg1, type_arg2);
     }
 
     struct var_resizing_visgen : public visgen {
-      var_resizing_visgen(std::ostream& o)
+      explicit var_resizing_visgen(std::ostream& o)
         : visgen(o) {
       }
-      void operator()(nil const& /*x*/) const { } // dummy
+      void operator()(nil const& /*x*/) const { }  // dummy
       void operator()(int_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"int",x.dims_);
+        generate_initialization(o_, x.name_, "int", x.dims_);
       }
       void operator()(double_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"double",x.dims_);
+        generate_initialization(o_, x.name_, "double", x.dims_);
       }
       void operator()(vector_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"vector_d",x.dims_,x.M_);
+        generate_initialization(o_, x.name_, "vector_d", x.dims_, x.M_);
       }
       void operator()(row_vector_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"row_vector_d",x.dims_,x.N_);
+        generate_initialization(o_, x.name_, "row_vector_d", x.dims_, x.N_);
       }
       void operator()(unit_vector_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"vector_d",x.dims_,x.K_);
+        generate_initialization(o_, x.name_, "vector_d", x.dims_, x.K_);
       }
       void operator()(simplex_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"vector_d",x.dims_,x.K_);
+        generate_initialization(o_, x.name_, "vector_d", x.dims_, x.K_);
       }
       void operator()(ordered_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"vector_d",x.dims_,x.K_);
+        generate_initialization(o_, x.name_, "vector_d", x.dims_, x.K_);
       }
       void operator()(positive_ordered_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"vector_d",x.dims_,x.K_);
+        generate_initialization(o_, x.name_, "vector_d", x.dims_, x.K_);
       }
       void operator()(matrix_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"matrix_d",x.dims_,x.M_,x.N_);
+        generate_initialization(o_, x.name_, "matrix_d", x.dims_, x.M_, x.N_);
       }
       void operator()(cholesky_factor_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"matrix_d",x.dims_,x.M_,x.N_);
+        generate_initialization(o_, x.name_, "matrix_d", x.dims_, x.M_, x.N_);
       }
       void operator()(cholesky_corr_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"matrix_d",x.dims_,x.K_,x.K_);
+        generate_initialization(o_, x.name_, "matrix_d", x.dims_, x.K_, x.K_);
       }
       void operator()(cov_matrix_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"matrix_d",x.dims_,x.K_,x.K_);
+        generate_initialization(o_, x.name_, "matrix_d", x.dims_, x.K_, x.K_);
       }
       void operator()(corr_matrix_var_decl const& x) const {
-        generate_initialization(o_,x.name_,"matrix_d",x.dims_,x.K_,x.K_);
+        generate_initialization(o_, x.name_, "matrix_d", x.dims_, x.K_, x.K_);
       }
     };
 
@@ -592,58 +590,58 @@ namespace stan {
         }
         for (size_t i = 0; i < dim_args.size(); ++i)
           read_args.push_back(dim_args[i]);
-        generate_initialize_array(base_type,read_fun,read_args,x.name_,x.dims_);
+        generate_initialize_array(base_type, read_fun, read_args, x.name_, x.dims_);
       }
       void operator()(const nil& /*x*/) const { }
       void operator()(const int_var_decl& x) const {
-        generate_initialize_array("int","integer",EMPTY_EXP_VECTOR,x.name_,x.dims_);
+        generate_initialize_array("int", "integer", EMPTY_EXP_VECTOR, x.name_, x.dims_);
       }
       void operator()(const double_var_decl& x) const {
         std::vector<expression> read_args;
-        generate_initialize_array_bounded(x,is_var_?"T__":"double","scalar",read_args);
+        generate_initialize_array_bounded(x, is_var_?"T__":"double", "scalar", read_args);
       }
       void operator()(const vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.M_);
-        generate_initialize_array_bounded(x,is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d","vector",read_args);
+        generate_initialize_array_bounded(x, is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d", "vector", read_args);
       }
       void operator()(const row_vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.N_);
-        generate_initialize_array_bounded(x,is_var_?"Eigen::Matrix<T__,1,Eigen::Dynamic> ":"row_vector_d","row_vector",read_args);
+        generate_initialize_array_bounded(x, is_var_?"Eigen::Matrix<T__,1,Eigen::Dynamic> ":"row_vector_d", "row_vector", read_args);
       }
       void operator()(const matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.M_);
         read_args.push_back(x.N_);
-        generate_initialize_array_bounded(x,is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> ":"matrix_d","matrix",read_args);
+        generate_initialize_array_bounded(x, is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> ":"matrix_d", "matrix", read_args);
       }
       void operator()(const unit_vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d","unit_vector",read_args,x.name_,x.dims_);
+        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d", "unit_vector", read_args, x.name_, x.dims_);
       }
       void operator()(const simplex_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d","simplex",read_args,x.name_,x.dims_);
+        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d", "simplex", read_args, x.name_, x.dims_);
       }
       void operator()(const ordered_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d","ordered",read_args,x.name_,x.dims_);
+        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d", "ordered", read_args, x.name_, x.dims_);
       }
       void operator()(const positive_ordered_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d","positive_ordered",read_args,x.name_,x.dims_);
+        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d", "positive_ordered", read_args, x.name_, x.dims_);
       }
       void operator()(const cholesky_factor_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.M_);
         read_args.push_back(x.N_);
         generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> ":"matrix_d",
-                                  "cholesky_factor",read_args,x.name_,x.dims_);
+                                  "cholesky_factor", read_args, x.name_, x.dims_);
       }
       void operator()(const cholesky_corr_var_decl& x) const {
         std::vector<expression> read_args;
@@ -651,20 +649,20 @@ namespace stan {
         generate_initialize_array(is_var_
                                   ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
                                   : "matrix_d",
-                                  "cholesky_corr",read_args,x.name_,x.dims_);
+                                  "cholesky_corr", read_args, x.name_, x.dims_);
       }
 
       void operator()(const cov_matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
         generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> ":"matrix_d",
-                                  "cov_matrix",read_args,x.name_,x.dims_);
+                                  "cov_matrix", read_args, x.name_, x.dims_);
       }
       void operator()(const corr_matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
         generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> ":"matrix_d",
-                                  "corr_matrix",read_args,x.name_,x.dims_);
+                                  "corr_matrix", read_args, x.name_, x.dims_);
       }
       void generate_initialize_array(const std::string& var_type,
                                      const std::string& read_type,
@@ -739,7 +737,6 @@ namespace stan {
               o_ << "if (jacobian__)" << EOL;
 
               // w Jacobian
-
               generate_indent(i + 4, o_);
               o_ << name_dims << ".push_back(in__." << read_type << "_constrain(";
               for (size_t j = 0; j < read_args.size(); ++j) {
@@ -755,7 +752,6 @@ namespace stan {
               o_ << "else" << EOL;
 
               // w/o Jacobian
-
               generate_indent(i + 4, o_);
               o_ << name_dims << ".push_back(in__." << read_type << "_constrain(";
               for (size_t j = 0; j < read_args.size(); ++j) {
@@ -783,7 +779,7 @@ namespace stan {
         << "stan::io::reader<"
         << (is_var ? "T__" : "double")
         << "> in__(params_r__,params_i__);" << EOL2;
-      init_local_var_visgen vis(declare_vars,is_var,o);
+      init_local_var_visgen vis(declare_vars, is_var, o);
       for (size_t i = 0; i < vs.size(); ++i)
         boost::apply_visitor(vis, vs[i].decl_);
     }
@@ -809,7 +805,6 @@ namespace stan {
       }
       void generate_begin_for_dims(const std::vector<expression>& dims)
         const {
-
         for (size_t i = 0; i < dims.size(); ++i) {
           generate_indent(indents_+i, o_);
           o_ << "for (int k" << i << "__ = 0;"
@@ -836,15 +831,15 @@ namespace stan {
       template <typename T>
       void basic_validate(T const& x) const {
         if (!(x.range_.has_low() || x.range_.has_high()))
-          return; // unconstrained
+          return;  // unconstrained
         generate_begin_for_dims(x.dims_);
         if (x.range_.has_low()) {
           generate_indent(indents_ + x.dims_.size(), o_);
           o_ << "check_greater_or_equal(function__,";
           o_ << "\"";
-          generate_loop_var(x.name_,x.dims_.size());
-          o_ << "\"," ;
-          generate_loop_var(x.name_,x.dims_.size());
+          generate_loop_var(x.name_, x.dims_.size());
+          o_ << "\",";
+          generate_loop_var(x.name_, x.dims_.size());
           o_ << ",";
           generate_expression(x.range_.low_.expr_, o_);
           o_ << ");" << EOL;
@@ -853,9 +848,9 @@ namespace stan {
           generate_indent(indents_ + x.dims_.size(), o_);
           o_ << "check_less_or_equal(function__,";
           o_ << "\"";
-          generate_loop_var(x.name_,x.dims_.size());
+          generate_loop_var(x.name_, x.dims_.size());
           o_ << "\",";
-          generate_loop_var(x.name_,x.dims_.size());
+          generate_loop_var(x.name_, x.dims_.size());
           o_ << ",";
           generate_expression(x.range_.high_.expr_, o_);
           o_ << ");" << EOL;
@@ -884,36 +879,36 @@ namespace stan {
         generate_indent(indents_ + x.dims_.size(), o_);
         o_ << "stan::math::check_" << type_name << "(function__,";
         o_ << "\"";
-        generate_loop_var(x.name_,x.dims_.size());
+        generate_loop_var(x.name_, x.dims_.size());
         o_ << "\",";
-        generate_loop_var(x.name_,x.dims_.size());
+        generate_loop_var(x.name_, x.dims_.size());
         o_ << ");"
            << EOL;
         generate_end_for_dims(x.dims_.size());
       }
       void operator()(unit_vector_var_decl const& x) const {
-        nonbasic_validate(x,"unit_vector");
+        nonbasic_validate(x, "unit_vector");
       }
       void operator()(simplex_var_decl const& x) const {
-        nonbasic_validate(x,"simplex");
+        nonbasic_validate(x, "simplex");
       }
       void operator()(ordered_var_decl const& x) const {
-        nonbasic_validate(x,"ordered");
+        nonbasic_validate(x, "ordered");
       }
       void operator()(positive_ordered_var_decl const& x) const {
-        nonbasic_validate(x,"positive_ordered");
+        nonbasic_validate(x, "positive_ordered");
       }
       void operator()(cholesky_factor_var_decl const& x) const {
-        nonbasic_validate(x,"cholesky_factor");
+        nonbasic_validate(x, "cholesky_factor");
       }
       void operator()(cholesky_corr_var_decl const& x) const {
-        nonbasic_validate(x,"cholesky_factor_corr");
+        nonbasic_validate(x, "cholesky_factor_corr");
       }
       void operator()(cov_matrix_var_decl const& x) const {
-        nonbasic_validate(x,"cov_matrix");
+        nonbasic_validate(x, "cov_matrix");
       }
       void operator()(corr_matrix_var_decl const& x) const {
-        nonbasic_validate(x,"corr_matrix");
+        nonbasic_validate(x, "corr_matrix");
       }
     };
 
@@ -921,15 +916,15 @@ namespace stan {
     void generate_validate_var_decl(const var_decl& decl,
                                     int indent,
                                     std::ostream& o) {
-      validate_var_decl_visgen vis(indent,o);
-      boost::apply_visitor(vis,decl.decl_);
+      validate_var_decl_visgen vis(indent, o);
+      boost::apply_visitor(vis, decl.decl_);
     }
 
     void generate_validate_var_decls(const std::vector<var_decl> decls,
                                      int indent,
                                      std::ostream& o) {
       for (size_t i = 0; i < decls.size(); ++i)
-        generate_validate_var_decl(decls[i],indent,o);
+        generate_validate_var_decl(decls[i], indent, o);
     }
 
     // see _var_decl_visgen cut & paste
@@ -942,10 +937,10 @@ namespace stan {
       }
       void operator()(nil const& /*x*/) const { }
       void operator()(int_var_decl const& x) const {
-        declare_array("int",x.name_,x.dims_.size());
+        declare_array("int", x.name_, x.dims_.size());
       }
       void operator()(double_var_decl const& x) const {
-        declare_array("double",x.name_,x.dims_.size());
+        declare_array("double", x.name_, x.dims_.size());
       }
       void operator()(unit_vector_var_decl const& x) const {
         declare_array(("vector_d"), x.name_, x.dims_.size());
@@ -1001,9 +996,9 @@ namespace stan {
     void generate_member_var_decls(const std::vector<var_decl>& vs,
                                    int indent,
                                    std::ostream& o) {
-      member_var_decl_visgen vis(indent,o);
+      member_var_decl_visgen vis(indent, o);
       for (size_t i = 0; i < vs.size(); ++i)
-        boost::apply_visitor(vis,vs[i].decl_);
+        boost::apply_visitor(vis, vs[i].decl_);
     }
 
     // see member_var_decl_visgen cut & paste
@@ -1023,21 +1018,21 @@ namespace stan {
       void operator()(nil const& /*x*/) const { }
       void operator()(int_var_decl const& x) const {
         std::vector<expression> ctor_args;
-        declare_array("int",ctor_args,x.name_,x.dims_);
+        declare_array("int", ctor_args, x.name_, x.dims_);
       }
       void operator()(double_var_decl const& x) const {
         std::vector<expression> ctor_args;
         declare_array(is_fun_return_
                       ? "fun_scalar_t__"
-                      : ( is_var_ ? "T__" : "double" ),
-                      ctor_args,x.name_,x.dims_);
+                      : (is_var_ ? "T__" : "double"),
+                      ctor_args, x.name_, x.dims_);
       }
       void operator()(vector_var_decl const& x) const {
         std::vector<expression> ctor_args;
         ctor_args.push_back(x.M_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,1> "
-                      : ( is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d" ),
+                      : (is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(row_vector_var_decl const& x) const {
@@ -1045,9 +1040,9 @@ namespace stan {
         ctor_args.push_back(x.N_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,1,Eigen::Dynamic> "
-                      : ( is_var_
-                          ? "Eigen::Matrix<T__,1,Eigen::Dynamic> "
-                          : "row_vector_d" ),
+                      : (is_var_
+                         ? "Eigen::Matrix<T__,1,Eigen::Dynamic> "
+                         : "row_vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(matrix_var_decl const& x) const {
@@ -1056,9 +1051,9 @@ namespace stan {
         ctor_args.push_back(x.N_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,Eigen::Dynamic> "
-                      : ( is_var_
-                          ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
-                          : "matrix_d" ),
+                      : (is_var_
+                         ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
+                         : "matrix_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(unit_vector_var_decl const& x) const {
@@ -1066,7 +1061,7 @@ namespace stan {
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,1> "
-                      : ( is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d" ),
+                      : (is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(simplex_var_decl const& x) const {
@@ -1074,7 +1069,7 @@ namespace stan {
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,1> "
-                      : ( is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
+                      : (is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(ordered_var_decl const& x) const {
@@ -1082,7 +1077,7 @@ namespace stan {
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,1> "
-                      : ( is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d" ),
+                      : (is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(positive_ordered_var_decl const& x) const {
@@ -1090,7 +1085,7 @@ namespace stan {
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,1> "
-                      : ( is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d" ),
+                      : (is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(cholesky_factor_var_decl const& x) const {
@@ -1099,9 +1094,9 @@ namespace stan {
         ctor_args.push_back(x.N_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,Eigen::Dynamic> "
-                      : ( is_var_
-                          ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
-                          : "matrix_d" ),
+                      : (is_var_
+                         ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
+                         : "matrix_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(const cholesky_corr_var_decl& x) const {
@@ -1119,9 +1114,9 @@ namespace stan {
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,Eigen::Dynamic> "
-                      : ( is_var_
-                          ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
-                          : "matrix_d" ),
+                      : (is_var_
+                         ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
+                         : "matrix_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(corr_matrix_var_decl const& x) const {
@@ -1130,9 +1125,9 @@ namespace stan {
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,Eigen::Dynamic> "
-                      : ( is_var_
-                          ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
-                          : "matrix_d" ),
+                      : (is_var_
+                         ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
+                         : "matrix_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void generate_type(const std::string& type,
@@ -1157,14 +1152,14 @@ namespace stan {
                               const std::vector<expression>& ctor_args,
                               const std::vector<expression>& dims,
                               size_t dim) const {
-        if (dim < dims.size()) { // more dims left
-          o_ << '('; // open(1)
+        if (dim < dims.size()) {  // more dims left
+          o_ << '(';  // open(1)
           generate_expression(dims[dim], o_);
           if ((dim + 1 < dims.size()) ||  ctor_args.size() > 0) {
-            o_ << ", ("; // open(2)
-            generate_type(type,dims.size() - dim - 1);
-            generate_init_args(type,ctor_args,dims,dim + 1);
-            o_ << ')'; // close(2)
+            o_ << ", (";  // open(2)
+            generate_type(type, dims.size() - dim - 1);
+            generate_init_args(type, ctor_args, dims, dim + 1);
+            o_ << ')';  // close(2)
           } else if (type == "var") {
             o_ << ", DUMMY_VAR__";
           } else if (type == "int") {
@@ -1174,9 +1169,9 @@ namespace stan {
           } else {
             // shouldn't hit this
           }
-          o_ << ')'; // close(1)
+          o_ << ')';  // close(1)
         } else {
-          if (ctor_args.size() == 0) { // scalar int or real
+          if (ctor_args.size() == 0) {  // scalar int or real
             if (type == "int") {
               o_ << "(0)";
             } else if (type == "double") {
@@ -1186,12 +1181,11 @@ namespace stan {
             } else {
               // shouldn't hit this, either
             }
-          }
-          else if (ctor_args.size() == 1) {// vector
+          } else if (ctor_args.size() == 1) {  // vector
             o_ << '(';
             generate_expression(ctor_args[0], o_);
             o_ << ')';
-          } else if (ctor_args.size() > 1) { // matrix
+          } else if (ctor_args.size() > 1) {  // matrix
             o_ << '(';
             generate_expression(ctor_args[0], o_);
             o_ << ',';
@@ -1204,13 +1198,11 @@ namespace stan {
                          const std::vector<expression>& ctor_args,
                          const std::string& name,
                          const std::vector<expression>& dims) const {
-
         // require double parens to counter "most vexing parse" problem
-
         generate_indent(indents_, o_);
-        generate_type(type,dims.size());
+        generate_type(type, dims.size());
         o_ << ' '  << name;
-        generate_init_args(type,ctor_args,dims,0);
+        generate_init_args(type, ctor_args, dims, 0);
         o_ << ';' << EOL;
         if (dims.size() == 0) {
           generate_indent(indents_, o_);
@@ -1231,9 +1223,9 @@ namespace stan {
                                   std::ostream& o,
                                   bool is_var,
                                   bool is_fun_return) {
-      local_var_decl_visgen vis(indent,is_var,is_fun_return,o);
+      local_var_decl_visgen vis(indent, is_var, is_fun_return, o);
       for (size_t i = 0; i < vs.size(); ++i)
-        boost::apply_visitor(vis,vs[i].decl_);
+        boost::apply_visitor(vis, vs[i].decl_);
     }
 
 
@@ -1311,9 +1303,9 @@ namespace stan {
                                      std::ostream& o,
                                      bool is_var,
                                      bool is_fun_return) {
-      generate_local_var_init_nan_visgen vis(indent,is_var,is_fun_return,indent,o);
+      generate_local_var_init_nan_visgen vis(indent, is_var, is_fun_return, indent, o);
       for (size_t i = 0; i < vs.size(); ++i)
-        boost::apply_visitor(vis,vs[i].decl_);
+        boost::apply_visitor(vis, vs[i].decl_);
     }
 
 
@@ -1383,13 +1375,13 @@ namespace stan {
     void generate_init_vars(const std::vector<var_decl>& vs,
                             int indent,
                             std::ostream& o) {
-      generate_init_vars_visgen vis(indent,o);
+      generate_init_vars_visgen vis(indent, o);
       o << EOL;
       generate_comment("initialize transformed variables to"
                        " avoid seg fault on val access",
-                       indent,o);
+                       indent, o);
       for (size_t i = 0; i < vs.size(); ++i)
-        boost::apply_visitor(vis,vs[i].decl_);
+        boost::apply_visitor(vis, vs[i].decl_);
     }
 
 
@@ -1403,76 +1395,75 @@ namespace stan {
       void operator()(nil const& /*x*/) const { }
       void operator()(int_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
-        validate_array(x.name_,dims,0);
+        validate_array(x.name_, dims, 0);
       }
       void operator()(double_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
-        validate_array(x.name_,dims,0);
+        validate_array(x.name_, dims, 0);
       }
       void operator()(vector_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.M_);
-        validate_array(x.name_,dims,1);
+        validate_array(x.name_, dims, 1);
       }
       void operator()(unit_vector_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
-        validate_array(x.name_,dims,1);
+        validate_array(x.name_, dims, 1);
       }
       void operator()(simplex_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
-        validate_array(x.name_,dims,1);
+        validate_array(x.name_, dims, 1);
       }
       void operator()(ordered_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
-        validate_array(x.name_,dims,1);
+        validate_array(x.name_, dims, 1);
       }
       void operator()(positive_ordered_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
-        validate_array(x.name_,dims,1);
+        validate_array(x.name_, dims, 1);
       }
       void operator()(row_vector_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.N_);
-        validate_array(x.name_,dims,1);
+        validate_array(x.name_, dims, 1);
       }
       void operator()(matrix_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.M_);
         dims.push_back(x.N_);
-        validate_array(x.name_,dims,2);
+        validate_array(x.name_, dims, 2);
       }
       void operator()(cholesky_factor_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.M_);
         dims.push_back(x.N_);
-        validate_array(x.name_,dims,2);
+        validate_array(x.name_, dims, 2);
       }
       void operator()(cholesky_corr_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
         dims.push_back(x.K_);
-        validate_array(x.name_,dims,2);
+        validate_array(x.name_, dims, 2);
       }
       void operator()(cov_matrix_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
         dims.push_back(x.K_);
-        validate_array(x.name_,dims,2);
+        validate_array(x.name_, dims, 2);
       }
       void operator()(corr_matrix_var_decl const& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
         dims.push_back(x.K_);
-        validate_array(x.name_,dims,2);
+        validate_array(x.name_, dims, 2);
       }
       void validate_array(const std::string& name,
                           const std::vector<expression>& dims,
                           size_t matrix_dims) const {
-
         size_t non_matrix_dims = dims.size() - matrix_dims;
 
         for (size_t k = 0; k < dims.size(); ++k) {
@@ -1519,10 +1510,10 @@ namespace stan {
     void generate_validate_transformed_params(const std::vector<var_decl>& vs,
                                               int indent,
                                               std::ostream& o) {
-      generate_comment("validate transformed parameters",indent,o);
-      validate_transformed_params_visgen vis(indent,o);
+      generate_comment("validate transformed parameters", indent, o);
+      validate_transformed_params_visgen vis(indent, o);
       for (size_t i = 0; i < vs.size(); ++i)
-        boost::apply_visitor(vis,vs[i].decl_);
+        boost::apply_visitor(vis, vs[i].decl_);
       o << EOL;
     }
 
@@ -1587,8 +1578,8 @@ namespace stan {
           o_ << "if (";
           generate_expression(x.expr_, o_);
           o_ << " < ";
-          generate_expression(x.truncation_.low_.expr_, o_); // low
-                                                            // bound
+          generate_expression(x.truncation_.low_.expr_, o_);  // low
+                                                              // bound
           o_ << ") lp_accum__.add(-std::numeric_limits<double>::infinity());"  << EOL;
         }
         if (x.truncation_.has_high()) {
@@ -1597,7 +1588,7 @@ namespace stan {
           o_ << "if (";
           generate_expression(x.expr_, o_);
           o_ << " > ";
-          generate_expression(x.truncation_.high_.expr_, o_); // low
+          generate_expression(x.truncation_.high_.expr_, o_);  // low
           // bound
           o_ << ") lp_accum__.add(-std::numeric_limits<double>::infinity());" << EOL;
         }
@@ -1656,14 +1647,14 @@ namespace stan {
         if (has_local_vars) {
           generate_indent(indent_, o_);
           o_ << "{" << EOL;
-          generate_local_var_decls(x.local_decl_,indent, o_,
-                                   is_var_,is_fun_return_);
-          generate_local_var_init_nan(x.local_decl_,indent, o_,
-                                      is_var_,is_fun_return_);
+          generate_local_var_decls(x.local_decl_, indent, o_,
+                                   is_var_, is_fun_return_);
+          generate_local_var_init_nan(x.local_decl_, indent, o_,
+                                      is_var_, is_fun_return_);
         }
 
         for (size_t i = 0; i < x.statements_.size(); ++i)
-          generate_statement(x.statements_[i],indent, o_,include_sampling_,is_var_,
+          generate_statement(x.statements_[i], indent, o_, include_sampling_, is_var_,
                              is_fun_return_);
 
         if (has_local_vars) {
@@ -1716,7 +1707,7 @@ namespace stan {
         generate_expression(x.range_.high_, o_);
         o_ << "; ++" << x.variable_ << ") {" << EOL;
         generate_statement(x.statement_, indent_ + 1, o_, include_sampling_,
-                           is_var_,is_fun_return_);
+                           is_var_, is_fun_return_);
         generate_indent(indent_, o_);
         o_ << "}" << EOL;
       }
@@ -1726,7 +1717,7 @@ namespace stan {
         generate_expression(x.condition_, o_);
         o_ << ")) {" << EOL;
         generate_statement(x.body_, indent_+1, o_, include_sampling_,
-                           is_var_,is_fun_return_);
+                           is_var_, is_fun_return_);
         generate_indent(indent_, o_);
         o_ << "}" << EOL;
       }
@@ -1748,7 +1739,7 @@ namespace stan {
           o_ << " else {" << EOL;
           generate_statement(x.bodies_[x.bodies_.size()-1], indent_ + 1,
                              o_, include_sampling_,
-                             is_var_,is_fun_return_);
+                             is_var_, is_fun_return_);
           generate_indent(indent_, o_);
           o_ << '}';
         }
@@ -1784,13 +1775,13 @@ namespace stan {
                             bool is_var,
                             bool is_fun_return) {
       is_numbered_statement_vis vis_is_numbered;
-      if (boost::apply_visitor(vis_is_numbered,s.statement_)) {
-        generate_indent(indent,o);
+      if (boost::apply_visitor(vis_is_numbered, s.statement_)) {
+        generate_indent(indent, o);
         o << "current_statement_begin__ = " <<  s.begin_line_ << ";"
           << EOL;
       }
-      statement_visgen vis(indent,include_sampling,is_var,is_fun_return, o);
-      boost::apply_visitor(vis,s.statement_);
+      statement_visgen vis(indent, include_sampling, is_var, is_fun_return, o);
+      boost::apply_visitor(vis, s.statement_);
     }
 
     // FIXME:  don't ever call this -- call generate statement instead
@@ -1800,21 +1791,21 @@ namespace stan {
                              bool include_sampling,
                              bool is_var,
                              bool is_fun_return) {
-      statement_visgen vis(indent,include_sampling,is_var,is_fun_return,o);
+      statement_visgen vis(indent, include_sampling, is_var, is_fun_return, o);
       for (size_t i = 0; i < ss.size(); ++i)
-        boost::apply_visitor(vis,ss[i].statement_);
+        boost::apply_visitor(vis, ss[i].statement_);
     }
 
     void generate_try(int indent,
                       std::ostream& o) {
-      generate_indent(indent,o);
+      generate_indent(indent, o);
       o << "try {"
         << EOL;
     }
 
     void generate_catch_throw_located(int indent,
                                       std::ostream& o) {
-      generate_indent(indent,o);
+      generate_indent(indent, o);
       o << "} catch (const std::exception& e) {"
         << EOL;
       generate_indent(indent + 1, o);
@@ -1835,9 +1826,9 @@ namespace stan {
                                     bool include_sampling,
                                     bool is_var,
                                     bool is_fun_return) {
-      generate_try(indent,o);
-      generate_statement(s,indent+1,o,include_sampling,is_var,is_fun_return);
-      generate_catch_throw_located(indent,o);
+      generate_try(indent, o);
+      generate_statement(s, indent+1, o, include_sampling, is_var, is_fun_return);
+      generate_catch_throw_located(indent, o);
     }
 
     void generate_located_statements(const std::vector<statement>& ss,
@@ -1846,18 +1837,16 @@ namespace stan {
                                      bool include_sampling,
                                      bool is_var,
                                      bool is_fun_return) {
-      generate_try(indent,o);
+      generate_try(indent, o);
       for (size_t i = 0; i < ss.size(); ++i)
-        generate_statement(ss[i],indent + 1,o,include_sampling,is_var,is_fun_return);
-      generate_catch_throw_located(indent,o);
+        generate_statement(ss[i], indent + 1, o, include_sampling, is_var, is_fun_return);
+      generate_catch_throw_located(indent, o);
     }
 
 
 
     void generate_log_prob(program const& p,
                            std::ostream& o) {
-
-
       o << EOL;
       o << INDENT << "template <bool propto__, bool jacobian__, typename T__>"
         << EOL;
@@ -1882,22 +1871,22 @@ namespace stan {
       bool is_var = true;
       bool is_fun_return = false;
 
-      generate_comment("model parameters",2,o);
-      generate_local_var_inits(p.parameter_decl_,is_var,true,o);
+      generate_comment("model parameters", 2, o);
+      generate_local_var_inits(p.parameter_decl_, is_var, true, o);
       o << EOL;
 
-      generate_comment("transformed parameters",2,o);
-      generate_local_var_decls(p.derived_decl_.first,2,o,is_var,is_fun_return);
-      generate_init_vars(p.derived_decl_.first,2,o);
+      generate_comment("transformed parameters", 2, o);
+      generate_local_var_decls(p.derived_decl_.first, 2, o, is_var, is_fun_return);
+      generate_init_vars(p.derived_decl_.first, 2, o);
       o << EOL;
 
 
       bool include_sampling = true;
-      generate_located_statements(p.derived_decl_.second,2,o,include_sampling,
-                                  is_var,is_fun_return);
+      generate_located_statements(p.derived_decl_.second, 2, o, include_sampling,
+                                  is_var, is_fun_return);
       o << EOL;
 
-      generate_validate_transformed_params(p.derived_decl_.first,2,o);
+      generate_validate_transformed_params(p.derived_decl_.first, 2, o);
       o << INDENT2
         << "const char* function__ = \"validate transformed params\";"
         << EOL;
@@ -1905,14 +1894,14 @@ namespace stan {
         << "(void) function__; // dummy to suppress unused var warning"
         << EOL;
 
-      generate_validate_var_decls(p.derived_decl_.first,2,o);
+      generate_validate_var_decls(p.derived_decl_.first, 2, o);
 
       o << EOL;
-      generate_comment("model body",2,o);
+      generate_comment("model body", 2, o);
 
 
-      generate_located_statement(p.statement_,2,o,include_sampling,
-                                 is_var,is_fun_return);
+      generate_located_statement(p.statement_, 2, o, include_sampling,
+                                 is_var, is_fun_return);
 
 
       o << EOL;
@@ -1935,12 +1924,12 @@ namespace stan {
     struct dump_member_var_visgen : public visgen {
       var_resizing_visgen var_resizer_;
       var_size_validating_visgen var_size_validator_;
-      dump_member_var_visgen(std::ostream& o)
+      explicit dump_member_var_visgen(std::ostream& o)
         : visgen(o),
           var_resizer_(var_resizing_visgen(o)),
-          var_size_validator_(var_size_validating_visgen(o,"data initialization")) {
+          var_size_validator_(var_size_validating_visgen(o, "data initialization")) {
       }
-      void operator()(nil const& /*x*/) const { } // dummy
+      void operator()(nil const& /*x*/) const { }  // dummy
       void operator()(int_var_decl const& x) const {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
@@ -2429,7 +2418,7 @@ namespace stan {
 
     // know all data is set and range expressions only depend on data
     struct set_param_ranges_visgen : public visgen {
-      set_param_ranges_visgen(std::ostream& o)
+      explicit set_param_ranges_visgen(std::ostream& o)
         : visgen(o) {
       }
       void operator()(const nil& /*x*/) const { }
@@ -2445,7 +2434,7 @@ namespace stan {
         }
         // add range
         generate_indent(x.dims_.size() + 2, o_);
-        o_ << "param_ranges_i__.push_back(std::pair<int,int>(";
+        o_ << "param_ranges_i__.push_back(std::pair<int, int>(";
         generate_expression(x.range_.low_, o_);
         o_ << ", ";
         generate_expression(x.range_.high_, o_);
@@ -2460,13 +2449,13 @@ namespace stan {
         generate_increment(x.dims_);
       }
       void operator()(const vector_var_decl& x) const {
-        generate_increment(x.M_,x.dims_);
+        generate_increment(x.M_, x.dims_);
       }
       void operator()(const row_vector_var_decl& x) const {
-        generate_increment(x.N_,x.dims_);
+        generate_increment(x.N_, x.dims_);
       }
       void operator()(const matrix_var_decl& x) const {
-        generate_increment(x.M_,x.N_,x.dims_);
+        generate_increment(x.M_, x.N_, x.dims_);
       }
       void operator()(const unit_vector_var_decl& x) const {
         // only K-1 vals
@@ -2491,10 +2480,10 @@ namespace stan {
         o_ << ";" << EOL;
       }
       void operator()(const ordered_var_decl& x) const {
-        generate_increment(x.K_,x.dims_);
+        generate_increment(x.K_, x.dims_);
       }
       void operator()(const positive_ordered_var_decl& x) const {
-        generate_increment(x.K_,x.dims_);
+        generate_increment(x.K_, x.dims_);
       }
       void operator()(const cholesky_factor_var_decl& x) const {
         o_ << INDENT2 << "num_params_r__ += ((";
@@ -2589,7 +2578,6 @@ namespace stan {
           generate_expression(dims[i], o_);
         }
         o_ << ";" << EOL;
-
       }
       void generate_increment(expression M, expression N,
                               std::vector<expression> dims) const {
@@ -2607,14 +2595,11 @@ namespace stan {
 
     void generate_set_param_ranges(const std::vector<var_decl>& var_decls,
                                    std::ostream& o) {
-      // o << EOL;
-      // o << INDENT << "void set_param_ranges() {" << EOL;
       o << INDENT2 << "num_params_r__ = 0U;" << EOL;
       o << INDENT2 << "param_ranges_i__.clear();" << EOL;
       set_param_ranges_visgen vis(o);
       for (size_t i = 0; i < var_decls.size(); ++i)
-        boost::apply_visitor(vis,var_decls[i].decl_);
-      // o << INDENT << "}" << EOL;
+        boost::apply_visitor(vis, var_decls[i].decl_);
     }
 
     void generate_constructor(const program& prog,
@@ -2635,11 +2620,11 @@ namespace stan {
       o << INDENT2 << "std::vector<int> vals_i__;" << EOL;
       o << INDENT2 << "std::vector<double> vals_r__;" << EOL;
 
-      generate_member_var_inits(prog.data_decl_,o);
+      generate_member_var_inits(prog.data_decl_, o);
 
       o << EOL;
-      generate_comment("validate data",2,o);
-      generate_validate_var_decls(prog.data_decl_,2,o);
+      generate_comment("validate data", 2, o);
+      generate_validate_var_decls(prog.data_decl_, 2, o);
 
       generate_var_resizing(prog.derived_data_decl_.first, o);
       o << EOL;
@@ -2654,15 +2639,15 @@ namespace stan {
       bool is_var = false;
       bool is_fun_return = false;
       generate_located_statements(prog.derived_data_decl_.second,
-                                  2,o,include_sampling,is_var,is_fun_return);
+                                  2, o, include_sampling, is_var, is_fun_return);
 
       o << EOL;
-      generate_comment("validate transformed data",2,o);
-      generate_validate_var_decls(prog.derived_data_decl_.first,2,o);
+      generate_comment("validate transformed data", 2, o);
+      generate_validate_var_decls(prog.derived_data_decl_.first, 2, o);
 
       o << EOL;
-      generate_comment("set parameter ranges",2,o);
-      generate_set_param_ranges(prog.parameter_decl_,o);
+      generate_comment("set parameter ranges", 2, o);
+      generate_set_param_ranges(prog.parameter_decl_, o);
       // o << EOL << INDENT2 << "set_param_ranges();" << EOL;
 
       o << INDENT << "}" << EOL;
@@ -2670,17 +2655,17 @@ namespace stan {
 
     struct generate_init_visgen : public visgen {
       var_size_validating_visgen var_size_validator_;
-      generate_init_visgen(std::ostream& o)
+      explicit generate_init_visgen(std::ostream& o)
         : visgen(o),
-          var_size_validator_(o,"initialization") {
+          var_size_validator_(o, "initialization") {
       }
-      void operator()(nil const& /*x*/) const { } // dummy
+      void operator()(nil const& /*x*/) const { }  // dummy
       void operator()(int_var_decl const& x) const {
-        generate_check_int(x.name_,x.dims_.size());
+        generate_check_int(x.name_, x.dims_.size());
         var_size_validator_(x);
-        generate_declaration(x.name_,"int",x.dims_);
-        generate_buffer_loop("i",x.name_, x.dims_);
-        generate_write_loop("integer(",x.name_,x.dims_);
+        generate_declaration(x.name_, "int", x.dims_);
+        generate_buffer_loop("i", x.name_, x.dims_);
+        generate_write_loop("integer(", x.name_, x.dims_);
       }
       template <typename D>
       std::string function_args(const std::string& fun_prefix,
@@ -2689,17 +2674,17 @@ namespace stan {
         ss << fun_prefix;
         if (has_lub(x)) {
           ss << "_lub_unconstrain(";
-          generate_expression(x.range_.low_.expr_,ss);
+          generate_expression(x.range_.low_.expr_, ss);
           ss << ',';
-          generate_expression(x.range_.high_.expr_,ss);
+          generate_expression(x.range_.high_.expr_, ss);
           ss << ',';
         } else if (has_lb(x)) {
           ss << "_lb_unconstrain(";
-          generate_expression(x.range_.low_.expr_,ss);
+          generate_expression(x.range_.low_.expr_, ss);
           ss << ',';
         } else if (has_ub(x)) {
           ss << "_ub_unconstrain(";
-          generate_expression(x.range_.high_.expr_,ss);
+          generate_expression(x.range_.high_.expr_, ss);
           ss << ',';
         } else {
           ss << "_unconstrain(";
@@ -2708,92 +2693,92 @@ namespace stan {
       }
 
       void operator()(double_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size());
+        generate_check_double(x.name_, x.dims_.size());
         var_size_validator_(x);
-        generate_declaration(x.name_,"double",x.dims_);
-        generate_buffer_loop("r",x.name_,x.dims_);
-        generate_write_loop(function_args("scalar",x),
+        generate_declaration(x.name_, "double", x.dims_);
+        generate_buffer_loop("r", x.name_, x.dims_);
+        generate_write_loop(function_args("scalar", x),
                             x.name_, x.dims_);
       }
       void operator()(vector_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 1);
+        generate_check_double(x.name_, x.dims_.size() + 1);
         var_size_validator_(x);
-        generate_declaration(x.name_,"vector_d",x.dims_,x.M_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.M_);
-        generate_write_loop(function_args("vector",x),
-                            x.name_,x.dims_);
+        generate_declaration(x.name_, "vector_d", x.dims_, x.M_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.M_);
+        generate_write_loop(function_args("vector", x),
+                            x.name_, x.dims_);
       }
       void operator()(row_vector_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 1);
+        generate_check_double(x.name_, x.dims_.size() + 1);
         var_size_validator_(x);
-        generate_declaration(x.name_,"row_vector_d",x.dims_,x.N_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.N_);
-        generate_write_loop(function_args("row_vector",x),
-                            x.name_,x.dims_);
+        generate_declaration(x.name_, "row_vector_d", x.dims_, x.N_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.N_);
+        generate_write_loop(function_args("row_vector", x),
+                            x.name_, x.dims_);
       }
       void operator()(matrix_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 2);
+        generate_check_double(x.name_, x.dims_.size() + 2);
         var_size_validator_(x);
-        generate_declaration(x.name_,"matrix_d",x.dims_,x.M_,x.N_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.M_,x.N_);
-        generate_write_loop(function_args("matrix",x),
-                            x.name_,x.dims_);
+        generate_declaration(x.name_, "matrix_d", x.dims_, x.M_, x.N_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.M_, x.N_);
+        generate_write_loop(function_args("matrix", x),
+                            x.name_, x.dims_);
       }
       void operator()(unit_vector_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 1);
+        generate_check_double(x.name_, x.dims_.size() + 1);
         var_size_validator_(x);
-        generate_declaration(x.name_,"vector_d",x.dims_,x.K_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.K_);
-        generate_write_loop("unit_vector_unconstrain(",x.name_,x.dims_);
+        generate_declaration(x.name_, "vector_d", x.dims_, x.K_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.K_);
+        generate_write_loop("unit_vector_unconstrain(", x.name_, x.dims_);
       }
       void operator()(simplex_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 1);
+        generate_check_double(x.name_, x.dims_.size() + 1);
         var_size_validator_(x);
-        generate_declaration(x.name_,"vector_d",x.dims_,x.K_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.K_);
-        generate_write_loop("simplex_unconstrain(",x.name_,x.dims_);
+        generate_declaration(x.name_, "vector_d", x.dims_, x.K_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.K_);
+        generate_write_loop("simplex_unconstrain(", x.name_, x.dims_);
       }
       void operator()(ordered_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 1);
+        generate_check_double(x.name_, x.dims_.size() + 1);
         var_size_validator_(x);
-        generate_declaration(x.name_,"vector_d",x.dims_,x.K_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.K_);
-        generate_write_loop("ordered_unconstrain(",x.name_,x.dims_);
+        generate_declaration(x.name_, "vector_d", x.dims_, x.K_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.K_);
+        generate_write_loop("ordered_unconstrain(", x.name_, x.dims_);
       }
       void operator()(positive_ordered_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 1);
+        generate_check_double(x.name_, x.dims_.size() + 1);
         var_size_validator_(x);
-        generate_declaration(x.name_,"vector_d",x.dims_,x.K_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.K_);
-        generate_write_loop("positive_ordered_unconstrain(",x.name_,x.dims_);
+        generate_declaration(x.name_, "vector_d", x.dims_, x.K_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.K_);
+        generate_write_loop("positive_ordered_unconstrain(", x.name_, x.dims_);
       }
       void operator()(cholesky_factor_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 2);
+        generate_check_double(x.name_, x.dims_.size() + 2);
         var_size_validator_(x);
-        generate_declaration(x.name_,"matrix_d",x.dims_,x.M_,x.N_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.M_,x.N_);
-        generate_write_loop("cholesky_factor_unconstrain(",x.name_,x.dims_);
+        generate_declaration(x.name_, "matrix_d", x.dims_, x.M_, x.N_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.M_, x.N_);
+        generate_write_loop("cholesky_factor_unconstrain(", x.name_, x.dims_);
       }
       void operator()(cholesky_corr_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 2);
+        generate_check_double(x.name_, x.dims_.size() + 2);
         var_size_validator_(x);
-        generate_declaration(x.name_,"matrix_d",x.dims_,x.K_,x.K_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.K_,x.K_);
-        generate_write_loop("cholesky_corr_unconstrain(",x.name_,x.dims_);
+        generate_declaration(x.name_, "matrix_d", x.dims_, x.K_, x.K_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.K_, x.K_);
+        generate_write_loop("cholesky_corr_unconstrain(", x.name_, x.dims_);
       }
       void operator()(cov_matrix_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 2);
+        generate_check_double(x.name_, x.dims_.size() + 2);
         var_size_validator_(x);
-        generate_declaration(x.name_,"matrix_d",x.dims_,x.K_,x.K_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.K_,x.K_);
-        generate_write_loop("cov_matrix_unconstrain(",x.name_,x.dims_);
+        generate_declaration(x.name_, "matrix_d", x.dims_, x.K_, x.K_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.K_, x.K_);
+        generate_write_loop("cov_matrix_unconstrain(", x.name_, x.dims_);
       }
       void operator()(corr_matrix_var_decl const& x) const {
-        generate_check_double(x.name_,x.dims_.size() + 2);
+        generate_check_double(x.name_, x.dims_.size() + 2);
         var_size_validator_(x);
-        generate_declaration(x.name_,"matrix_d",x.dims_,x.K_,x.K_);
-        generate_buffer_loop("r",x.name_,x.dims_,x.K_,x.K_);
-        generate_write_loop("corr_matrix_unconstrain(",x.name_,x.dims_);
+        generate_declaration(x.name_, "matrix_d", x.dims_, x.K_, x.K_);
+        generate_buffer_loop("r", x.name_, x.dims_, x.K_, x.K_);
+        generate_write_loop("corr_matrix_unconstrain(", x.name_, x.dims_);
       }
       void generate_write_loop(const std::string& write_method_name,
                                const std::string& var_name,
@@ -2803,7 +2788,7 @@ namespace stan {
            << EOL
            << INDENT3
            << "writer__." << write_method_name;
-        generate_name_dims(var_name,dims.size());
+        generate_name_dims(var_name, dims.size());
         o_ << ");"
            << EOL
            << INDENT2
@@ -2831,10 +2816,10 @@ namespace stan {
                                 const expression& type_arg2 = expression())
       const {
         o_ << INDENT2;
-        generate_type(base_type,dims,dims.size(), o_);
+        generate_type(base_type, dims, dims.size(), o_);
         o_ << ' ' << name;
 
-        generate_initializer(o_,base_type,dims,type_arg1,type_arg2);
+        generate_initializer(o_, base_type, dims, type_arg1, type_arg2);
       }
       void generate_indent_num_dims(size_t base_indent,
                                     const std::vector<expression>& dims,
@@ -2877,7 +2862,7 @@ namespace stan {
           generate_expression(dims[idx].expr_, o_);
           o_ << "; ++i" << idx << "__)" << EOL;
         }
-        generate_indent_num_dims(2U,dims,dim1,dim2);
+        generate_indent_num_dims(2U, dims, dim1, dim2);
         o_ << name;
         for (size_t i = 0; i < dims.size(); ++i)
           o_ << "[i" << i << "__]";
@@ -2960,83 +2945,81 @@ namespace stan {
       o << INDENT << "}" << EOL2;
     }
 
-    // see write_csv_visgen for similar structure
     struct write_dims_visgen : public visgen {
-      write_dims_visgen(std::ostream& o)
+      explicit write_dims_visgen(std::ostream& o)
         : visgen(o) {
       }
       void operator()(const nil& /*x*/) const  { }
       void operator()(const int_var_decl& x) const {
-        generate_dims_array(EMPTY_EXP_VECTOR,x.dims_);
+        generate_dims_array(EMPTY_EXP_VECTOR, x.dims_);
       }
       void operator()(const double_var_decl& x) const {
-        generate_dims_array(EMPTY_EXP_VECTOR,x.dims_);
+        generate_dims_array(EMPTY_EXP_VECTOR, x.dims_);
       }
       void operator()(const vector_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.M_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void operator()(const row_vector_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.N_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void operator()(const matrix_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.M_);
         matrix_args.push_back(x.N_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void operator()(const unit_vector_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void operator()(const simplex_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void operator()(const ordered_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void operator()(const positive_ordered_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void operator()(const cholesky_factor_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.M_);
         matrix_args.push_back(x.N_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void operator()(const cholesky_corr_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
         matrix_args.push_back(x.K_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void operator()(const cov_matrix_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
         matrix_args.push_back(x.K_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void operator()(const corr_matrix_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
         matrix_args.push_back(x.K_);
-        generate_dims_array(matrix_args,x.dims_);
+        generate_dims_array(matrix_args, x.dims_);
       }
       void
       generate_dims_array(const std::vector<expression>& matrix_dims_exprs,
                           const std::vector<expression>& array_dims_exprs)
         const {
-
         o_ << INDENT2 << "dims__.resize(0);" << EOL;
         for (size_t i = 0; i < array_dims_exprs.size(); ++i) {
           o_ << INDENT2 << "dims__.push_back(";
@@ -3051,7 +3034,6 @@ namespace stan {
         }
         o_ << INDENT2 << "dimss__.push_back(dims__);" << EOL;
       }
-
     };
 
     void generate_dims_method(const program& prog,
@@ -3066,24 +3048,23 @@ namespace stan {
 
       // parameters
       for (size_t i = 0; i < prog.parameter_decl_.size(); ++i) {
-        boost::apply_visitor(vis,prog.parameter_decl_[i].decl_);
+        boost::apply_visitor(vis, prog.parameter_decl_[i].decl_);
       }
       // transformed parameters
       for (size_t i = 0; i < prog.derived_decl_.first.size(); ++i) {
-        boost::apply_visitor(vis,prog.derived_decl_.first[i].decl_);
+        boost::apply_visitor(vis, prog.derived_decl_.first[i].decl_);
       }
       // generated quantities
       for (size_t i = 0; i < prog.generated_decl_.first.size(); ++i) {
-        boost::apply_visitor(vis,prog.generated_decl_.first[i].decl_);
+        boost::apply_visitor(vis, prog.generated_decl_.first[i].decl_);
       }
       o << INDENT << "}" << EOL2;
     }
 
 
 
-    // see write_csv_visgen for similar structure
     struct write_param_names_visgen : public visgen {
-      write_param_names_visgen(std::ostream& o)
+      explicit write_param_names_visgen(std::ostream& o)
         : visgen(o) {
       }
       void operator()(const nil& /*x*/) const  { }
@@ -3148,15 +3129,15 @@ namespace stan {
 
       // parameters
       for (size_t i = 0; i < prog.parameter_decl_.size(); ++i) {
-        boost::apply_visitor(vis,prog.parameter_decl_[i].decl_);
+        boost::apply_visitor(vis, prog.parameter_decl_[i].decl_);
       }
       // transformed parameters
       for (size_t i = 0; i < prog.derived_decl_.first.size(); ++i) {
-        boost::apply_visitor(vis,prog.derived_decl_.first[i].decl_);
+        boost::apply_visitor(vis, prog.derived_decl_.first[i].decl_);
       }
       // generated quantities
       for (size_t i = 0; i < prog.generated_decl_.first.size(); ++i) {
-        boost::apply_visitor(vis,prog.generated_decl_.first[i].decl_);
+        boost::apply_visitor(vis, prog.generated_decl_.first[i].decl_);
       }
 
       o << INDENT << "}" << EOL2;
@@ -3164,248 +3145,81 @@ namespace stan {
 
 
 
-    // see write_csv_visgen for similar structure
-    struct write_csv_header_visgen : public visgen {
-      write_csv_header_visgen(std::ostream& o)
-        : visgen(o) {
-      }
-      void operator()(const nil& /*x*/) const  { }
-      void operator()(const int_var_decl& x) const {
-        generate_csv_header_array(EMPTY_EXP_VECTOR,x.name_,x.dims_);
-      }
-      void operator()(const double_var_decl& x) const {
-        generate_csv_header_array(EMPTY_EXP_VECTOR,x.name_,x.dims_);
-      }
-      void operator()(const vector_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.M_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void operator()(const row_vector_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.N_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void operator()(const matrix_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.M_);
-        matrix_args.push_back(x.N_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void operator()(const unit_vector_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.K_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void operator()(const simplex_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.K_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void operator()(const ordered_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.K_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void operator()(const positive_ordered_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.K_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void operator()(const cholesky_factor_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.M_);
-        matrix_args.push_back(x.N_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void operator()(const cholesky_corr_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.K_);
-        matrix_args.push_back(x.K_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void operator()(const cov_matrix_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.K_);
-        matrix_args.push_back(x.K_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void operator()(const corr_matrix_var_decl& x) const {
-        std::vector<expression> matrix_args;
-        matrix_args.push_back(x.K_);
-        matrix_args.push_back(x.K_);
-        generate_csv_header_array(matrix_args,x.name_,x.dims_);
-      }
-      void
-      generate_csv_header_array(const std::vector<expression>& matrix_dims,
-                                const std::string& name,
-                                const std::vector<expression>& dims) const {
-
-        // begin for loop dims
-        std::vector<expression> combo_dims(dims);
-        for (size_t i = 0; i < matrix_dims.size(); ++i)
-          combo_dims.push_back(matrix_dims[i]);
-
-        for (size_t i = combo_dims.size(); i-- > 0; ) {
-          generate_indent(1 + combo_dims.size() - i, o_);
-          o_ << "for (int k_" << i << "__ = 1;"
-             << " k_" << i << "__ <= ";
-          generate_expression(combo_dims[i].expr_, o_);
-          o_ << "; ++k_" << i << "__) {" << EOL; // begin (1)
-        }
-
-        // variable + indices
-        generate_indent(2 + combo_dims.size(), o_);
-        o_ << "writer__.comma();" << EOL;  // only writes comma after first call
-
-        generate_indent(2 + combo_dims.size(), o_);
-        o_ << "o__ << \"" << name << '"';
-        for (size_t i = 0; i < combo_dims.size(); ++i)
-          o_ << " << '.' << k_" << i << "__";
-        o_ << ';' << EOL;
-
-        // end for loop dims
-        for (size_t i = 0; i < combo_dims.size(); ++i) {
-          generate_indent(1 + combo_dims.size() - i, o_);
-          o_ << "}" << EOL; // end (1)
-        }
-      }
-      // void
-      // generate_csv_header_array(const std::vector<expression>& matrix_dims,
-      //                                const std::string& name,
-      //                                const std::vector<expression>& dims) const {
-
-      //   // begin for loop dims
-      //   std::vector<expression> combo_dims(dims);
-      //   for (size_t i = 0; i < matrix_dims.size(); ++i)
-      //     combo_dims.push_back(matrix_dims[i]);
-
-      //   for (size_t i = 0; i < combo_dims.size(); ++i) {
-      //     generate_indent(2 + i, o_);
-      //     o_ << "for (int k_" << i << "__ = 1;"
-      //        << " k_" << i << "__ <= ";
-      //     generate_expression(combo_dims[i].expr_, o_);
-      //     o_ << "; ++k_" << i << "__) {" << EOL; // begin (1)
-      //   }
-
-      //   // variable + indices
-      //   generate_indent(2 + combo_dims.size(), o_);
-      //   o_ << "writer__.comma();" << EOL;  // only writes comma after first call
-
-      //   generate_indent(2 + combo_dims.size(), o_);
-      //   o_ << "o__ << \"" << name << '"';
-      //   for (size_t i = 0; i < combo_dims.size(); ++i)
-      //     o_ << " << '.' << k_" << i << "__";
-      //   o_ << ';' << EOL;
-
-      //   // end for loop dims
-      //   for (size_t i = 0; i < combo_dims.size(); ++i) {
-      //     generate_indent(1 + combo_dims.size() - i, o_);
-      //     o_ << "}" << EOL; // end (1)
-      //   }
-      // }
-    };
-
-
-    void generate_write_csv_header_method(const program& prog,
-                                          std::ostream& o) {
-      write_csv_header_visgen vis(o);
-      o << EOL << INDENT << "void write_csv_header(std::ostream& o__) const {" << EOL;
-      o << INDENT2 << "stan::io::csv_writer writer__(o__);" << EOL;
-
-      // parameters
-      for (size_t i = 0; i < prog.parameter_decl_.size(); ++i) {
-        boost::apply_visitor(vis,prog.parameter_decl_[i].decl_);
-      }
-      // transformed parameters
-      for (size_t i = 0; i < prog.derived_decl_.first.size(); ++i) {
-        boost::apply_visitor(vis,prog.derived_decl_.first[i].decl_);
-      }
-      // generated quantities
-      for (size_t i = 0; i < prog.generated_decl_.first.size(); ++i) {
-        boost::apply_visitor(vis,prog.generated_decl_.first[i].decl_);
-      }
-      o << INDENT2 << "writer__.newline();" << EOL;
-      o << INDENT << "}" << EOL2;
-    }
-
-    // see write_csv_visgen for similar structure
     struct constrained_param_names_visgen : public visgen {
-      constrained_param_names_visgen(std::ostream& o)
+      explicit constrained_param_names_visgen(std::ostream& o)
         : visgen(o) {
       }
       void operator()(const nil& /*x*/) const  { }
       void operator()(const int_var_decl& x) const {
-        generate_param_names_array(EMPTY_EXP_VECTOR,x.name_,x.dims_);
+        generate_param_names_array(EMPTY_EXP_VECTOR, x.name_, x.dims_);
       }
       void operator()(const double_var_decl& x) const {
-        generate_param_names_array(EMPTY_EXP_VECTOR,x.name_,x.dims_);
+        generate_param_names_array(EMPTY_EXP_VECTOR, x.name_, x.dims_);
       }
       void operator()(const vector_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.M_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const row_vector_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.N_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const matrix_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.M_);
         matrix_args.push_back(x.N_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const unit_vector_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const simplex_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const ordered_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const positive_ordered_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const cholesky_factor_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.M_);
         matrix_args.push_back(x.N_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const cholesky_corr_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
         matrix_args.push_back(x.K_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const cov_matrix_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
         matrix_args.push_back(x.K_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const corr_matrix_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
         matrix_args.push_back(x.K_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void
       generate_param_names_array(const std::vector<expression>& matrix_dims,
                                  const std::string& name,
                                  const std::vector<expression>& dims) const {
-
         // begin for loop dims
         std::vector<expression> combo_dims(dims);
         for (size_t i = 0; i < matrix_dims.size(); ++i)
@@ -3416,7 +3230,7 @@ namespace stan {
           o_ << "for (int k_" << i << "__ = 1;"
              << " k_" << i << "__ <= ";
           generate_expression(combo_dims[i].expr_, o_);
-          o_ << "; ++k_" << i << "__) {" << EOL; // begin (1)
+          o_ << "; ++k_" << i << "__) {" << EOL;  // begin (1)
         }
 
         generate_indent(2 + combo_dims.size(), o_);
@@ -3435,10 +3249,9 @@ namespace stan {
         // end for loop dims
         for (size_t i = 0; i < combo_dims.size(); ++i) {
           generate_indent(1 + combo_dims.size() - i, o_);
-          o_ << "}" << EOL; // end (1)
+          o_ << "}" << EOL;  // end (1)
         }
       }
-
     };
 
 
@@ -3456,7 +3269,7 @@ namespace stan {
       constrained_param_names_visgen vis(o);
       // parameters
       for (size_t i = 0; i < prog.parameter_decl_.size(); ++i) {
-        boost::apply_visitor(vis,prog.parameter_decl_[i].decl_);
+        boost::apply_visitor(vis, prog.parameter_decl_[i].decl_);
       }
 
       o << EOL << INDENT2
@@ -3465,7 +3278,7 @@ namespace stan {
 
       // transformed parameters
       for (size_t i = 0; i < prog.derived_decl_.first.size(); ++i) {
-        boost::apply_visitor(vis,prog.derived_decl_.first[i].decl_);
+        boost::apply_visitor(vis, prog.derived_decl_.first[i].decl_);
       }
 
       o << EOL << INDENT2
@@ -3474,59 +3287,58 @@ namespace stan {
 
       // generated quantities
       for (size_t i = 0; i < prog.generated_decl_.first.size(); ++i) {
-        boost::apply_visitor(vis,prog.generated_decl_.first[i].decl_);
+        boost::apply_visitor(vis, prog.generated_decl_.first[i].decl_);
       }
 
       o << INDENT << "}" << EOL2;
     }
 
-    // see write_csv_visgen for similar structure
     struct unconstrained_param_names_visgen : public visgen {
-      unconstrained_param_names_visgen(std::ostream& o)
+      explicit unconstrained_param_names_visgen(std::ostream& o)
         : visgen(o) {
       }
       void operator()(const nil& /*x*/) const  { }
       void operator()(const int_var_decl& x) const {
-        generate_param_names_array(EMPTY_EXP_VECTOR,x.name_,x.dims_);
+        generate_param_names_array(EMPTY_EXP_VECTOR, x.name_, x.dims_);
       }
       void operator()(const double_var_decl& x) const {
-        generate_param_names_array(EMPTY_EXP_VECTOR,x.name_,x.dims_);
+        generate_param_names_array(EMPTY_EXP_VECTOR, x.name_, x.dims_);
       }
       void operator()(const vector_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.M_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const row_vector_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.N_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const matrix_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.M_);
         matrix_args.push_back(x.N_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const unit_vector_var_decl& x) const {
         std::vector<expression> matrix_args;
-        matrix_args.push_back(binary_op(x.K_,"-",int_literal(1)));
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        matrix_args.push_back(binary_op(x.K_, "-", int_literal(1)));
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const simplex_var_decl& x) const {
         std::vector<expression> matrix_args;
-        matrix_args.push_back(binary_op(x.K_,"-",int_literal(1)));
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        matrix_args.push_back(binary_op(x.K_, "-", int_literal(1)));
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const ordered_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const positive_ordered_var_decl& x) const {
         std::vector<expression> matrix_args;
         matrix_args.push_back(x.K_);
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const cholesky_factor_var_decl& x) const {
         // FIXME: cut-and-paste of cov_matrix
@@ -3545,7 +3357,7 @@ namespace stan {
                                                             x.N_),
                                                   "*",
                                                   x.N_)));
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const cholesky_corr_var_decl& x) const {
         // FIXME: cut-and-paste of corr_matrix
@@ -3558,7 +3370,7 @@ namespace stan {
                                                             int_literal(1))),
                                         "/",
                                         int_literal(2)));
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const cov_matrix_var_decl& x) const {
         std::vector<expression> matrix_args;
@@ -3571,7 +3383,7 @@ namespace stan {
                                                                       int_literal(1))),
                                                   "/",
                                                   int_literal(2))));
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const corr_matrix_var_decl& x) const {
         std::vector<expression> matrix_args;
@@ -3582,14 +3394,13 @@ namespace stan {
                                                             int_literal(1))),
                                         "/",
                                         int_literal(2)));
-        generate_param_names_array(matrix_args,x.name_,x.dims_);
+        generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       // FIXME: sharing instead of cut-and-paste from constrained
       void
       generate_param_names_array(const std::vector<expression>& matrix_dims,
                                  const std::string& name,
                                  const std::vector<expression>& dims) const {
-
         // begin for loop dims
         std::vector<expression> combo_dims(dims);
         for (size_t i = 0; i < matrix_dims.size(); ++i)
@@ -3600,7 +3411,7 @@ namespace stan {
           o_ << "for (int k_" << i << "__ = 1;"
              << " k_" << i << "__ <= ";
           generate_expression(combo_dims[i].expr_, o_);
-          o_ << "; ++k_" << i << "__) {" << EOL; // begin (1)
+          o_ << "; ++k_" << i << "__) {" << EOL;  // begin (1)
         }
 
         generate_indent(2 + combo_dims.size(), o_);
@@ -3619,7 +3430,7 @@ namespace stan {
         // end for loop dims
         for (size_t i = 0; i < combo_dims.size(); ++i) {
           generate_indent(1 + combo_dims.size() - i, o_);
-          o_ << "}" << EOL; // end (1)
+          o_ << "}" << EOL;  // end (1)
         }
       }
     };
@@ -3639,7 +3450,7 @@ namespace stan {
       unconstrained_param_names_visgen vis(o);
       // parameters
       for (size_t i = 0; i < prog.parameter_decl_.size(); ++i) {
-        boost::apply_visitor(vis,prog.parameter_decl_[i].decl_);
+        boost::apply_visitor(vis, prog.parameter_decl_[i].decl_);
       }
 
       o << EOL << INDENT2
@@ -3648,7 +3459,7 @@ namespace stan {
 
       // transformed parameters
       for (size_t i = 0; i < prog.derived_decl_.first.size(); ++i) {
-        boost::apply_visitor(vis,prog.derived_decl_.first[i].decl_);
+        boost::apply_visitor(vis, prog.derived_decl_.first[i].decl_);
       }
 
       o << EOL << INDENT2
@@ -3657,348 +3468,22 @@ namespace stan {
 
       // generated quantities
       for (size_t i = 0; i < prog.generated_decl_.first.size(); ++i) {
-        boost::apply_visitor(vis,prog.generated_decl_.first[i].decl_);
+        boost::apply_visitor(vis, prog.generated_decl_.first[i].decl_);
       }
 
-      o << INDENT << "}" << EOL2;
-    }
-
-
-    // see init_member_var_visgen for cut & paste
-    struct write_csv_visgen : public visgen {
-      write_csv_visgen(std::ostream& o)
-        : visgen(o) {
-      }
-      template <typename D>
-      void generate_initialize_array_bounded(const D& x, const std::string& base_type,
-                                             const std::string& read_fun_prefix,
-                                             const std::vector<expression>& dim_args) const {
-        std::vector<expression> read_args;
-        std::string read_fun(read_fun_prefix);
-        if (has_lub(x)) {
-          read_fun += "_lub";
-          read_args.push_back(x.range_.low_);
-          read_args.push_back(x.range_.high_);
-        } else if (has_lb(x)) {
-          read_fun += "_lb";
-          read_args.push_back(x.range_.low_);
-        } else if (has_ub(x)) {
-          read_fun += "_ub";
-          read_args.push_back(x.range_.high_);
-        }
-        for (size_t i = 0; i < dim_args.size(); ++i)
-          read_args.push_back(dim_args[i]);
-        generate_initialize_array(base_type,read_fun,read_args,x.name_,x.dims_);
-      }
-      void operator()(const nil& /*x*/) const { }
-      void operator()(const int_var_decl& x) const {
-        generate_initialize_array("int","integer",EMPTY_EXP_VECTOR,
-                                  x.name_,x.dims_);
-      }
-      void operator()(const double_var_decl& x) const {
-        std::vector<expression> read_args;
-        generate_initialize_array_bounded(x,"double","scalar",read_args);
-      }
-      void operator()(const vector_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.M_);
-        generate_initialize_array_bounded(x,"vector_d","vector",read_args);
-      }
-      void operator()(const row_vector_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.N_);
-        generate_initialize_array_bounded(x,"row_vector_d","row_vector",read_args);
-      }
-      void operator()(const matrix_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.M_);
-        read_args.push_back(x.N_);
-        generate_initialize_array_bounded(x,"matrix_d","matrix",read_args);
-      }
-      void operator()(const unit_vector_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.K_);
-        generate_initialize_array("vector_d","unit_vector",read_args,x.name_,x.dims_);
-      }
-      void operator()(const simplex_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.K_);
-        generate_initialize_array("vector_d","simplex",read_args,x.name_,x.dims_);
-      }
-      void operator()(const ordered_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.K_);
-        generate_initialize_array("vector_d","ordered",read_args,x.name_,x.dims_);
-      }
-      void operator()(const positive_ordered_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.K_);
-        generate_initialize_array("vector_d","positive_ordered",read_args,x.name_,x.dims_);
-      }
-      void operator()(const cholesky_factor_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.M_);
-        read_args.push_back(x.N_);
-        generate_initialize_array("matrix_d","cholesky_factor",read_args,x.name_,x.dims_);
-      }
-      void operator()(const cholesky_corr_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.K_);
-        generate_initialize_array("matrix_d","cholesky_corr",read_args,x.name_,x.dims_);
-      }
-      void operator()(const cov_matrix_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.K_);
-        generate_initialize_array("matrix_d","cov_matrix",read_args,x.name_,x.dims_);
-      }
-      void operator()(const corr_matrix_var_decl& x) const {
-        std::vector<expression> read_args;
-        read_args.push_back(x.K_);
-        generate_initialize_array("matrix_d","corr_matrix",read_args,x.name_,x.dims_);
-      }
-      void generate_initialize_array(const std::string& var_type,
-                                     const std::string& read_type,
-                                     const std::vector<expression>& read_args,
-                                     const std::string& name,
-                                     const std::vector<expression>& dims) const {
-        if (dims.size() == 0) {
-          generate_indent(2, o_);
-          o_ << var_type << " ";
-          o_ << name << " = in__." << read_type  << "_constrain(";
-          for (size_t j = 0; j < read_args.size(); ++j) {
-            if (j > 0) o_ << ",";
-            generate_expression(read_args[j], o_);
-          }
-          o_ << ");" << EOL;
-          o_ << INDENT2 << "writer__.write(" << name << ");" << EOL;
-          return;
-        }
-        o_ << INDENT2;
-        for (size_t i = 0; i < dims.size(); ++i) o_ << "vector<";
-        o_ << var_type;
-        for (size_t i = 0; i < dims.size(); ++i) o_ << "> ";
-        o_ << name << ";" << EOL;
-        std::string name_dims(name);
-        for (size_t i = 0; i < dims.size(); ++i) {
-          generate_indent(i + 2, o_);
-          o_ << "size_t dim_"  << name << "_" << i << "__ = ";
-          generate_expression(dims[i], o_);
-          o_ << ";" << EOL;
-          if (i < dims.size() - 1) {
-            generate_indent(i + 2, o_);
-            o_ << name_dims << ".resize(dim_" << name << "_" << i << "__);"
-               << EOL;
-            name_dims.append("[k_").append(to_string(i)).append("__]");
-          }
-          generate_indent(i + 2, o_);
-          o_ << "for (size_t k_" << i << "__ = 0;"
-             << " k_" << i << "__ < dim_" << name << "_" << i << "__;"
-             << " ++k_" << i << "__) {" << EOL;
-          if (i == dims.size() - 1) {
-            generate_indent(i + 3, o_);
-            o_ << name_dims << ".push_back(in__." << read_type << "_constrain(";
-            for (size_t j = 0; j < read_args.size(); ++j) {
-              if (j > 0) o_ << ",";
-              generate_expression(read_args[j], o_);
-            }
-            o_ << "));" << EOL;
-          }
-        }
-        generate_indent(dims.size() + 2, o_);
-        o_ << "writer__.write(" << name;
-        if (dims.size() > 0) {
-          o_ << '[';
-          for (size_t i = 0; i < dims.size(); ++i) {
-            if (i > 0) o_ << "][";
-            o_ << "k_" << i << "__";
-          }
-          o_ << ']';
-        }
-        o_ << ");" << EOL;
-
-        for (size_t i = dims.size(); i > 0; --i) {
-          generate_indent(i + 1, o_);
-          o_ << "}" << EOL;
-        }
-      }
-    };
-
-
-
-
-    struct write_csv_vars_visgen : public visgen {
-      write_csv_vars_visgen(std::ostream& o)
-        : visgen(o) {
-      }
-      void operator()(const nil& /*x*/) const { }
-      // FIXME: template these out
-      void operator()(const int_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const double_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const vector_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const row_vector_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const matrix_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const unit_vector_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const simplex_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const ordered_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const positive_ordered_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const cholesky_factor_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const cholesky_corr_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const cov_matrix_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void operator()(const corr_matrix_var_decl& x) const {
-        write_array(x.name_,x.dims_);
-      }
-      void write_array(const std::string& name,
-                       const std::vector<expression>& dims) const {
-        if (dims.size() == 0) {
-          o_ << INDENT2 << "writer__.write(" << name << ");" << EOL;
-          return;
-        }
-        for (size_t i = 0; i < dims.size(); ++i) {
-          generate_indent(i + 2, o_);
-          o_ << "for (int k_" << i << "__ = 0;"
-             << " k_" << i << "__ < ";
-          generate_expression(dims[i], o_);
-          o_ << "; ++k_" << i << "__) {" << EOL;
-        }
-
-        generate_indent(dims.size() + 2, o_);
-        o_ << "writer__.write(" << name;
-        if (dims.size() > 0) {
-          o_ << '[';
-          for (size_t i = 0; i < dims.size(); ++i) {
-            if (i > 0) o_ << "][";
-            o_ << "k_" << i << "__";
-          }
-          o_ << ']';
-        }
-        o_ << ");" << EOL;
-
-        for (size_t i = dims.size(); i > 0; --i) {
-          generate_indent(i + 1, o_);
-          o_ << "}" << EOL;
-        }
-      }
-    };
-
-
-    void generate_write_csv_method(const program& prog,
-                                   const std::string& model_name,
-                                   std::ostream& o) {
-      o << INDENT << "template <typename RNG>" << EOL;
-      o << INDENT << "void write_csv(RNG& base_rng__," << EOL;
-      o << INDENT << "               std::vector<double>& params_r__," << EOL;
-      o << INDENT << "               std::vector<int>& params_i__," << EOL;
-      o << INDENT << "               std::ostream& o__," << EOL;
-      o << INDENT << "               std::ostream* pstream__ = 0) const {" << EOL;
-      o << INDENT2 << "stan::io::reader<double> in__(params_r__,params_i__);"
-        << EOL;
-      o << INDENT2 << "stan::io::csv_writer writer__(o__);" << EOL;
-      o << INDENT2 << "static const char* function__ = \""
-        << model_name << "_namespace::write_csv\";" << EOL;
-      suppress_warning(INDENT2, "function__", o);
-
-      // declares, reads, and writes parameters
-      generate_comment("read-transform, write parameters",2,o);
-      write_csv_visgen vis(o);
-      for (size_t i = 0; i < prog.parameter_decl_.size(); ++i)
-        boost::apply_visitor(vis,prog.parameter_decl_[i].decl_);
-
-      // this is for all other values
-      write_csv_vars_visgen vis_writer(o);
-
-      // parameters are guaranteed to satisfy constraints
-
-      o << EOL;
-      generate_comment("declare, define and validate transformed parameters",
-                       2,o);
-      o << INDENT2 <<  "double lp__ = 0.0;" << EOL;
-      suppress_warning(INDENT2, "lp__", o);
-      o << INDENT2 << "stan::math::accumulator<double> lp_accum__;" << EOL2;
-      bool is_var = false;
-      bool is_fun_return = false;
-      generate_local_var_decls(prog.derived_decl_.first,2,o,
-                               is_var,is_fun_return);
-      o << EOL;
-      bool include_sampling = false;
-      generate_located_statements(prog.derived_decl_.second,2,o,include_sampling,
-                                  is_var,is_fun_return);
-      o << EOL;
-
-      generate_validate_var_decls(prog.derived_decl_.first,2,o);
-      o << EOL;
-
-      generate_comment("write transformed parameters",2,o);
-      for (size_t i = 0; i < prog.derived_decl_.first.size(); ++i)
-        boost::apply_visitor(vis_writer, prog.derived_decl_.first[i].decl_);
-      o << EOL;
-
-      generate_comment("declare and define generated quantities",2,o);
-      generate_local_var_decls(prog.generated_decl_.first,2,o,is_var,is_fun_return);
-      o << EOL;
-      generate_located_statements(prog.generated_decl_.second,2,o,include_sampling,
-                                  is_var,is_fun_return);
-      o << EOL;
-
-      generate_comment("validate generated quantities",2,o);
-      generate_validate_var_decls(prog.generated_decl_.first,2,o);
-      o << EOL;
-
-      generate_comment("write generated quantities",2,o);
-      for (size_t i = 0; i < prog.generated_decl_.first.size(); ++i)
-        boost::apply_visitor(vis_writer, prog.generated_decl_.first[i].decl_);
-      if (prog.generated_decl_.first.size() > 0)
-        o << EOL;
-
-      o << INDENT2 << "writer__.newline();" << EOL;
-      o << INDENT << "}" << EOL2;
-
-      o << INDENT << "template <typename RNG>" << EOL;
-      o << INDENT << "void write_csv(RNG& base_rng," << EOL;
-      o << INDENT << "               Eigen::Matrix<double,Eigen::Dynamic,1>& params_r," << EOL;
-      o << INDENT << "               std::ostream& o," << EOL;
-      o << INDENT << "               std::ostream* pstream = 0) const {" << EOL;
-      o << INDENT << "  std::vector<double> params_r_vec(params_r.size());" << EOL;
-      o << INDENT << "  for (int i = 0; i < params_r.size(); ++i)" << EOL;
-      o << INDENT << "    params_r_vec[i] = params_r(i);" << EOL;
-      o << INDENT << "  std::vector<int> params_i_vec;  // dummy" << EOL;
-      o << INDENT << "  write_csv(base_rng, params_r_vec, params_i_vec, o, pstream);" << EOL;
       o << INDENT << "}" << EOL2;
     }
 
 
     // see init_member_var_visgen for cut & paste
     struct write_array_visgen : public visgen {
-      write_array_visgen(std::ostream& o)
+      explicit write_array_visgen(std::ostream& o)
         : visgen(o) {
       }
       void operator()(const nil& /*x*/) const { }
       void operator()(const int_var_decl& x) const {
-        generate_initialize_array("int","integer",EMPTY_EXP_VECTOR,
-                                  x.name_,x.dims_);
+        generate_initialize_array("int", "integer", EMPTY_EXP_VECTOR,
+                                  x.name_, x.dims_);
       }
       // fixme -- reuse cut-and-pasted from other lub reader case
       template <typename D>
@@ -4020,69 +3505,69 @@ namespace stan {
         }
         for (size_t i = 0; i < dim_args.size(); ++i)
           read_args.push_back(dim_args[i]);
-        generate_initialize_array(base_type,read_fun,read_args,x.name_,x.dims_);
+        generate_initialize_array(base_type, read_fun, read_args, x.name_, x.dims_);
       }
 
       void operator()(const double_var_decl& x) const {
         std::vector<expression> read_args;
-        generate_initialize_array_bounded(x,"double","scalar",read_args);
+        generate_initialize_array_bounded(x, "double", "scalar", read_args);
       }
       void operator()(const vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.M_);
-        generate_initialize_array_bounded(x,"vector_d","vector",read_args);
+        generate_initialize_array_bounded(x, "vector_d", "vector", read_args);
       }
       void operator()(const row_vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.N_);
-        generate_initialize_array_bounded(x,"row_vector_d","row_vector",read_args);
+        generate_initialize_array_bounded(x, "row_vector_d", "row_vector", read_args);
       }
       void operator()(const matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.M_);
         read_args.push_back(x.N_);
-        generate_initialize_array_bounded(x,"matrix_d","matrix",read_args);
+        generate_initialize_array_bounded(x, "matrix_d", "matrix", read_args);
       }
       void operator()(const unit_vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("vector_d","unit_vector",read_args,x.name_,x.dims_);
+        generate_initialize_array("vector_d", "unit_vector", read_args, x.name_, x.dims_);
       }
       void operator()(const simplex_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("vector_d","simplex",read_args,x.name_,x.dims_);
+        generate_initialize_array("vector_d", "simplex", read_args, x.name_, x.dims_);
       }
       void operator()(const ordered_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("vector_d","ordered",read_args,x.name_,x.dims_);
+        generate_initialize_array("vector_d", "ordered", read_args, x.name_, x.dims_);
       }
       void operator()(const positive_ordered_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("vector_d","positive_ordered",read_args,x.name_,x.dims_);
+        generate_initialize_array("vector_d", "positive_ordered", read_args, x.name_, x.dims_);
       }
       void operator()(const cholesky_factor_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.M_);
         read_args.push_back(x.N_);
-        generate_initialize_array("matrix_d","cholesky_factor",read_args,x.name_,x.dims_);
+        generate_initialize_array("matrix_d", "cholesky_factor", read_args, x.name_, x.dims_);
       }
       void operator()(const cholesky_corr_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("matrix_d","cholesky_corr",read_args,x.name_,x.dims_);
+        generate_initialize_array("matrix_d", "cholesky_corr", read_args, x.name_, x.dims_);
       }
       void operator()(const cov_matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("matrix_d","cov_matrix",read_args,x.name_,x.dims_);
+        generate_initialize_array("matrix_d", "cov_matrix", read_args, x.name_, x.dims_);
       }
       void operator()(const corr_matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("matrix_d","corr_matrix",read_args,x.name_,x.dims_);
+        generate_initialize_array("matrix_d", "corr_matrix", read_args, x.name_, x.dims_);
       }
       void generate_initialize_array(const std::string& var_type,
                                      const std::string& read_type,
@@ -4136,8 +3621,6 @@ namespace stan {
           generate_indent(i + 1, o_);
           o_ << "}" << EOL;
         }
-
-
       }
     };
 
@@ -4145,81 +3628,80 @@ namespace stan {
 
 
     struct write_array_vars_visgen : public visgen {
-      write_array_vars_visgen(std::ostream& o)
+      explicit write_array_vars_visgen(std::ostream& o)
         : visgen(o) {
       }
       void operator()(const nil& /*x*/) const { }
       // FIXME: template these out
       void operator()(const int_var_decl& x) const {
-        write_array(x.name_,x.dims_,EMPTY_EXP_VECTOR);
+        write_array(x.name_, x.dims_, EMPTY_EXP_VECTOR);
       }
       void operator()(const double_var_decl& x) const {
-        write_array(x.name_,x.dims_,EMPTY_EXP_VECTOR);
+        write_array(x.name_, x.dims_, EMPTY_EXP_VECTOR);
       }
       void operator()(const vector_var_decl& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.M_);
-        write_array(x.name_,dims, EMPTY_EXP_VECTOR);
+        write_array(x.name_, dims, EMPTY_EXP_VECTOR);
       }
       void operator()(const row_vector_var_decl& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.N_);
-        write_array(x.name_,dims, EMPTY_EXP_VECTOR);
+        write_array(x.name_, dims, EMPTY_EXP_VECTOR);
       }
       void operator()(const matrix_var_decl& x) const {
         std::vector<expression> matdims;
         matdims.push_back(x.M_);
         matdims.push_back(x.N_);
-        write_array(x.name_,x.dims_,matdims);
+        write_array(x.name_, x.dims_, matdims);
       }
       void operator()(const unit_vector_var_decl& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
-        write_array(x.name_,dims,EMPTY_EXP_VECTOR);
+        write_array(x.name_, dims, EMPTY_EXP_VECTOR);
       }
       void operator()(const simplex_var_decl& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
-        write_array(x.name_,dims,EMPTY_EXP_VECTOR);
+        write_array(x.name_, dims, EMPTY_EXP_VECTOR);
       }
       void operator()(const ordered_var_decl& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
-        write_array(x.name_,dims,EMPTY_EXP_VECTOR);
+        write_array(x.name_, dims, EMPTY_EXP_VECTOR);
       }
       void operator()(const positive_ordered_var_decl& x) const {
         std::vector<expression> dims(x.dims_);
         dims.push_back(x.K_);
-        write_array(x.name_,dims,EMPTY_EXP_VECTOR);
+        write_array(x.name_, dims, EMPTY_EXP_VECTOR);
       }
       void operator()(const cholesky_factor_var_decl& x) const {
         std::vector<expression> matdims;
         matdims.push_back(x.M_);
         matdims.push_back(x.N_);
-        write_array(x.name_,x.dims_,matdims);
+        write_array(x.name_, x.dims_, matdims);
       }
       void operator()(const cholesky_corr_var_decl& x) const {
         std::vector<expression> matdims;
         matdims.push_back(x.K_);
         matdims.push_back(x.K_);
-        write_array(x.name_,x.dims_,matdims);
+        write_array(x.name_, x.dims_, matdims);
       }
       void operator()(const cov_matrix_var_decl& x) const {
         std::vector<expression> matdims;
         matdims.push_back(x.K_);
         matdims.push_back(x.K_);
-        write_array(x.name_,x.dims_,matdims);
+        write_array(x.name_, x.dims_, matdims);
       }
       void operator()(const corr_matrix_var_decl& x) const {
         std::vector<expression> matdims;
         matdims.push_back(x.K_);
         matdims.push_back(x.K_);
-        write_array(x.name_,x.dims_,matdims);
+        write_array(x.name_, x.dims_, matdims);
       }
       void write_array(const std::string& name,
                        const std::vector<expression>& arraydims,
                        const std::vector<expression>& matdims) const {
-
         std::vector<expression> dims(arraydims);
         for (size_t i = 0; i < matdims.size(); ++i)
           dims.push_back(matdims[i]);
@@ -4283,48 +3765,48 @@ namespace stan {
       suppress_warning(INDENT2, "function__", o);
 
       // declares, reads, and sets parameters
-      generate_comment("read-transform, write parameters",2,o);
+      generate_comment("read-transform, write parameters", 2, o);
       write_array_visgen vis(o);
       for (size_t i = 0; i < prog.parameter_decl_.size(); ++i)
-        boost::apply_visitor(vis,prog.parameter_decl_[i].decl_);
+        boost::apply_visitor(vis, prog.parameter_decl_[i].decl_);
 
       // this is for all other values
       write_array_vars_visgen vis_writer(o);
 
       // writes parameters
       for (size_t i = 0; i < prog.parameter_decl_.size(); ++i)
-        boost::apply_visitor(vis_writer,prog.parameter_decl_[i].decl_);
+        boost::apply_visitor(vis_writer, prog.parameter_decl_[i].decl_);
       o << EOL;
 
       o << INDENT2 << "if (!include_tparams__) return;"
         << EOL;
-      generate_comment("declare and define transformed parameters",2,o);
+      generate_comment("declare and define transformed parameters", 2, o);
       o << INDENT2 <<  "double lp__ = 0.0;" << EOL;
       suppress_warning(INDENT2, "lp__", o);
       o << INDENT2 << "stan::math::accumulator<double> lp_accum__;" << EOL2;
       bool is_var = false;
       bool is_fun_return = false;
-      generate_local_var_decls(prog.derived_decl_.first,2,o,is_var,is_fun_return);
+      generate_local_var_decls(prog.derived_decl_.first, 2, o, is_var, is_fun_return);
       o << EOL;
       bool include_sampling = false;
-      generate_located_statements(prog.derived_decl_.second,2,o,include_sampling,
-                                  is_var,is_fun_return);
+      generate_located_statements(prog.derived_decl_.second, 2, o, include_sampling,
+                                  is_var, is_fun_return);
       o << EOL;
 
-      generate_comment("validate transformed parameters",2,o);
-      generate_validate_var_decls(prog.derived_decl_.first,2,o);
+      generate_comment("validate transformed parameters", 2, o);
+      generate_validate_var_decls(prog.derived_decl_.first, 2, o);
       o << EOL;
 
-      generate_comment("write transformed parameters",2,o);
+      generate_comment("write transformed parameters", 2, o);
       for (size_t i = 0; i < prog.derived_decl_.first.size(); ++i)
         boost::apply_visitor(vis_writer, prog.derived_decl_.first[i].decl_);
       o << EOL;
 
       o << INDENT2 << "if (!include_gqs__) return;"
         << EOL;
-      generate_comment("declare and define generated quantities",2,o);
-      generate_local_var_decls(prog.generated_decl_.first,2,o,
-                               is_var,is_fun_return);
+      generate_comment("declare and define generated quantities", 2, o);
+      generate_local_var_decls(prog.generated_decl_.first, 2, o,
+                               is_var, is_fun_return);
 
       o << EOL;
       o << INDENT2 << "double DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());" << EOL;
@@ -4332,15 +3814,15 @@ namespace stan {
       generate_init_vars(prog.generated_decl_.first, 2, o);
 
       o << EOL;
-      generate_located_statements(prog.generated_decl_.second,2,o,include_sampling,
-                                  is_var,is_fun_return);
+      generate_located_statements(prog.generated_decl_.second, 2, o, include_sampling,
+                                  is_var, is_fun_return);
       o << EOL;
 
-      generate_comment("validate generated quantities",2,o);
-      generate_validate_var_decls(prog.generated_decl_.first,2,o);
+      generate_comment("validate generated quantities", 2, o);
+      generate_validate_var_decls(prog.generated_decl_.first, 2, o);
       o << EOL;
 
-      generate_comment("write generated quantities",2,o);
+      generate_comment("write generated quantities", 2, o);
       for (size_t i = 0; i < prog.generated_decl_.first.size(); ++i)
         boost::apply_visitor(vis_writer, prog.generated_decl_.first[i].decl_);
       if (prog.generated_decl_.first.size() > 0)
@@ -4365,7 +3847,6 @@ namespace stan {
       o << INDENT << "  for (int i = 0; i < vars.size(); ++i)" << EOL;
       o << INDENT << "    vars(i) = vars_vec[i];" << EOL;
       o << INDENT << "}" << EOL2;
-
     }
 
     void generate_model_name_method(const std::string& model_name,
@@ -4436,7 +3917,7 @@ namespace stan {
                            std::ostream& out) {
       if (gen_const)
         out << "const ";
-      generate_bare_type(decl.arg_type_,scalar_t_name,out);
+      generate_bare_type(decl.arg_type_, scalar_t_name, out);
       if (gen_ref)
         out << "&";
       out << " " << decl.name_;
@@ -4522,15 +4003,14 @@ namespace stan {
             out << ", ";
           out << "class RNG";
           continuing_tps = true;
-        }
-        else if (is_lp) {
+        } else if (is_lp) {
           if (continuing_tps)
             out << ", ";
           out << "typename T_lp__, typename T_lp_accum__";
           continuing_tps = true;
         }
         out << ">" << EOL;
-      } else { // no-arg function
+      } else {  // no-arg function
         if (is_rng) {
           // nullary RNG case
           out << "template <class RNG>" << EOL;
@@ -4550,8 +4030,8 @@ namespace stan {
                                               std::ostream& out) {
       out << "inline"
           << EOL;
-      generate_indent(indent,out);
-      generate_bare_type(fun.return_type_,scalar_t_name,out);
+      generate_indent(indent, out);
+      generate_bare_type(fun.return_type_, scalar_t_name, out);
       out << EOL;
     }
 
@@ -4571,7 +4051,7 @@ namespace stan {
       for (size_t i = 0; i < fun.arg_decls_.size(); ++i) {
         std::string template_type_i
           = "T" + boost::lexical_cast<std::string>(i) + "__";
-        generate_arg_decl(true,true,fun.arg_decls_[i],template_type_i,out);
+        generate_arg_decl(true, true, fun.arg_decls_[i], template_type_i, out);
         if (i + 1 < fun.arg_decls_.size()) {
           out << "," << EOL << INDENT;
           for (size_t i = 0; i <= fun.name_.size(); ++i)
@@ -4647,8 +4127,8 @@ namespace stan {
           << "int current_statement_begin__ = -1;"
           << EOL;
 
-      generate_located_statement(fun.body_,1,out,
-                                 include_sampling,is_var,is_fun_return);
+      generate_located_statement(fun.body_, 1, out,
+                                 include_sampling, is_var, is_fun_return);
 
       out << "}"
           << EOL;
@@ -4673,11 +4153,11 @@ namespace stan {
     void generate_propto_default_function(const function_decl_def& fun,
                                           const std::string& scalar_t_name,
                                           std::ostream& out) {
-      generate_function_template_parameters(fun,false,false,false,out);
-      generate_function_inline_return_type(fun,scalar_t_name,0,out);
-      generate_function_name(fun,out);
-      generate_function_arguments(fun,false,false,false,out);
-      generate_propto_default_function_body(fun,out);
+      generate_function_template_parameters(fun, false, false, false, out);
+      generate_function_inline_return_type(fun, scalar_t_name, 0, out);
+      generate_function_name(fun, out);
+      generate_function_arguments(fun, false, false, false, out);
+      generate_propto_default_function_body(fun, out);
     }
 
     /**
@@ -4688,34 +4168,33 @@ namespace stan {
      * ending in one of "_rng", "_lp", or "_log".
      *
      * @param[in] fun function AST object
-     * @param[in,out] out output stream to which function definition
+     * @param[in, out] out output stream to which function definition
      * is written
      */
     void generate_function(const function_decl_def& fun,
                            std::ostream& out) {
-
       bool is_rng = ends_with("_rng", fun.name_);
       bool is_lp = ends_with("_lp", fun.name_);
       bool is_log = ends_with("_log", fun.name_);
       std::string scalar_t_name
         = fun_scalar_type(fun, is_lp);
 
-      generate_function_template_parameters(fun,is_rng,is_lp,is_log,out);
-      generate_function_inline_return_type(fun,scalar_t_name,0,out);
-      generate_function_name(fun,out);
-      generate_function_arguments(fun,is_rng,is_lp,is_log,out);
-      generate_function_body(fun,scalar_t_name,out);
+      generate_function_template_parameters(fun, is_rng, is_lp, is_log, out);
+      generate_function_inline_return_type(fun, scalar_t_name, 0, out);
+      generate_function_name(fun, out);
+      generate_function_arguments(fun, is_rng, is_lp, is_log, out);
+      generate_function_body(fun, scalar_t_name, out);
 
       // need a second function def for default propto=false for _log funs
       if (is_log)
-        generate_propto_default_function(fun,scalar_t_name,out);
+        generate_propto_default_function(fun, scalar_t_name, out);
       out << EOL;
     }
 
     void generate_function_functor(const function_decl_def& fun,
                                    std::ostream& out) {
       if (fun.body_.is_no_op_statement())
-        return;  // forward declaration, so no functor needed
+        return;   // forward declaration, so no functor needed
 
       bool is_rng = ends_with("_rng", fun.name_);
       bool is_lp = ends_with("_lp", fun.name_);
@@ -4724,26 +4203,26 @@ namespace stan {
 
       out << EOL
           << "struct ";
-      generate_function_name(fun,out);
+      generate_function_name(fun, out);
       out << "_functor__ {"
           << EOL;
 
       out << INDENT;
-      generate_function_template_parameters(fun,is_rng,is_lp,is_log,out);
+      generate_function_template_parameters(fun, is_rng, is_lp, is_log, out);
 
       out << INDENT;
-      generate_function_inline_return_type(fun,scalar_t_name,1,out);
+      generate_function_inline_return_type(fun, scalar_t_name, 1, out);
 
       out <<  INDENT
           << "operator()";
-      generate_function_arguments(fun,is_rng,is_lp,is_log,out);
+      generate_function_arguments(fun, is_rng, is_lp, is_log, out);
       out << " const {"
           << EOL;
 
       out << INDENT2
           << "return ";
-      generate_function_name(fun,out);
-      generate_functor_arguments(fun,is_rng,is_lp,is_log,out);
+      generate_function_name(fun, out);
+      generate_functor_arguments(fun, is_rng, is_lp, is_log, out);
       out << ";"
           << EOL;
 
@@ -4759,15 +4238,15 @@ namespace stan {
     void generate_functions(const std::vector<function_decl_def>& funs,
                             std::ostream& out) {
       for (size_t i = 0; i < funs.size(); ++i) {
-        generate_function(funs[i],out);
-        generate_function_functor(funs[i],out);
+        generate_function(funs[i], out);
+        generate_function_functor(funs[i], out);
       }
     }
 
     void generate_member_var_decls_all(const program& prog,
                                        std::ostream& out) {
-      generate_member_var_decls(prog.data_decl_,1,out);
-      generate_member_var_decls(prog.derived_data_decl_.first,1,out);
+      generate_member_var_decls(prog.data_decl_, 1, out);
+      generate_member_var_decls(prog.derived_data_decl_.first, 1, out);
     }
 
     void generate_globals(std::ostream& out) {
@@ -4781,31 +4260,30 @@ namespace stan {
                       std::ostream& out) {
       generate_version_comment(out);
       generate_includes(out);
-      generate_start_namespace(model_name,out);
+      generate_start_namespace(model_name, out);
       generate_usings(out);
       generate_typedefs(out);
       generate_globals(out);
-      generate_functions(prog.function_decl_defs_,out);
-      generate_class_decl(model_name,out);
+      generate_functions(prog.function_decl_defs_, out);
+      generate_class_decl(model_name, out);
       generate_private_decl(out);
-      generate_member_var_decls_all(prog,out);
+      generate_member_var_decls_all(prog, out);
       generate_public_decl(out);
-      generate_constructor(prog,model_name,out);
-      generate_destructor(model_name,out);
-      // generate_set_param_ranges(prog.parameter_decl_,out);
-      generate_init_method(prog.parameter_decl_,out);
-      generate_log_prob(prog,out);
-      generate_param_names_method(prog,out);
-      generate_dims_method(prog,out);
-      generate_write_array_method(prog,model_name,out);
-      generate_write_csv_header_method(prog,out);
-      generate_write_csv_method(prog,model_name,out);
-      generate_model_name_method(model_name,out);
-      generate_constrained_param_names_method(prog,out);
-      generate_unconstrained_param_names_method(prog,out);
+      generate_constructor(prog, model_name, out);
+      generate_destructor(model_name, out);
+      // put back if ever need integer params
+      // generate_set_param_ranges(prog.parameter_decl_, out);
+      generate_init_method(prog.parameter_decl_, out);
+      generate_log_prob(prog, out);
+      generate_param_names_method(prog, out);
+      generate_dims_method(prog, out);
+      generate_write_array_method(prog, model_name, out);
+      generate_model_name_method(model_name, out);
+      generate_constrained_param_names_method(prog, out);
+      generate_unconstrained_param_names_method(prog, out);
       generate_end_class_decl(out);
       generate_end_namespace(out);
-      generate_model_typedef(model_name,out);
+      generate_model_typedef(model_name, out);
     }
 
   }

--- a/src/test/unit/lang/generator_test.cpp
+++ b/src/test/unit/lang/generator_test.cpp
@@ -86,14 +86,6 @@ TEST(lang, logProbPolymorphismDouble) {
   lp2 = model.log_prob<false,false>(params_r_vec, 0);
   EXPECT_FLOAT_EQ(lp1, lp2);
 
-  // only test write_csv for doubles -- no var allowed
-  std::stringstream s1;
-  std::stringstream s2;
-  boost::ecuyer1988 rng(123);
-  model.write_csv(rng,params_r,params_i,s1,0);
-  model.write_csv(rng,params_r_vec,s2,0);
-  EXPECT_EQ(s1.str(), s2.str());
-
   // only test generate_inits for doubles -- no var allowed
   std::string init_txt = "y <- c(-2.9,1.2)";
   std::stringstream init_in(init_txt);
@@ -120,6 +112,7 @@ TEST(lang, logProbPolymorphismDouble) {
   Matrix<double,Dynamic,1> params_r_vec_write(2);
   params_r_vec_write << -3.2, 1.79;
 
+  boost::ecuyer1988 rng(123);
   for (int incl_tp = 0; incl_tp < 2; ++incl_tp) {
     for (int incl_gq = 0; incl_gq < 2; ++incl_gq) { 
       std::vector<double> vars_write;
@@ -181,7 +174,6 @@ TEST(lang, generate_model_typedef) {
                              ss.str()));
 }
 
-// * write_csv
 // * transform_inits
 
 TEST(lang, generate_cpp) {
@@ -230,10 +222,6 @@ TEST(lang, generate_cpp) {
     << "generate_dims_method()";
   EXPECT_EQ(2, count_matches("void write_array(", output.str()))
     << "generate_write_array_method()";
-  EXPECT_EQ(1, count_matches("void write_csv_header(", output.str()))
-    << "generate_write_csv_header_method()";
-  EXPECT_EQ(2, count_matches("void write_csv(", output.str()))
-    << "generate_write_csv_method()";
   EXPECT_EQ(1, count_matches("static std::string model_name()", output.str()))
     << "generate_model_name_method()";
   EXPECT_EQ(1, count_matches("void constrained_param_names(", output.str()))

--- a/src/test/unit/lang/parser_generator_test.cpp
+++ b/src/test/unit/lang/parser_generator_test.cpp
@@ -66,6 +66,6 @@ TEST(unitLang, odeTest) {
   expected = "stan::math::assign(y_hat, "
     "integrate_ode(sho_functor__(), y0, t0, ts, theta, x, x_int, pstream__));";
   test_pg("ode", expected);
-  test_pg_count("ode", expected, 2);
+  test_pg_count("ode", expected, 1);
 }
              


### PR DESCRIPTION
#### Summary:

Remove `write_csv` methods from generated model code.

Remove lots of lint from `generator.hpp`

#### Intended Effect:

Make code easier to maintain and remove buggy code that wrote in the wrong order and was confusing people looking at the program C++ code.

#### How to Verify:

Look at generated model code.  

#### Side Effects:

Any code that might have dependenced on `write_csv()`.  But that code probably would've been broken because the header writer and value writer weren't matched.  These can be replaced with the newer array-based methods.

#### Documentation:

None.

#### Reviewer Suggestions:

Anyone.