### PR TITLE
fixed a few typos

### DIFF
--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -748,7 +748,7 @@ model {
 The constraint \code{lower=0} in the declaration of \code{sigma}
 constrains the value to be greater than or equal to 0.  With no prior
 in the model block, the effect is an improper prior on non-negative
-real numbers.  Althogh a more informative prior may be added, improper
+real numbers.  Although a more informative prior may be added, improper
 priors are acceptable as long as they lead to proper posteriors.
 
 In the model above, \code{x} is an $N \times K$ matrix of predictors
@@ -968,7 +968,7 @@ without such constraints, or boundary-avoid priors should be used (see
 
 \subsection{Fat-Tailed Priors and ``Default'' Priors}
 
-A reasonable alternative if we want to accomodate outliers is to use a
+A reasonable alternative if we want to accommodate outliers is to use a
 prior that concentrates most of mass around the area where values are
 expected to be, but still leaves a lot of mass in its tails.  The
 usual choice in such a situation is to use a Cauchy distribution for a
@@ -1400,7 +1400,7 @@ the probability is needed only up to a proportion.
 \subsubsection{Ordered Probit}
 
 An ordered probit model could be coded in exactly the same way by
-swapping the cumultive logistic (\code{inv\_logit}) for the cumulative
+swapping the cumulative logistic (\code{inv\_logit}) for the cumulative
 normal (\code{Phi}).
 %
 
@@ -2287,7 +2287,7 @@ normal distribution.
 \noindent
 Times series data come arranged in temporal order.  This chapter
 presents two kinds of time series models, regression-like models such
-as autogression and moving average models, and hidden Markov models. 
+as autoregressive and moving average models, and hidden Markov models. 
 
 \refchapter{gaussian-processes} presents Gaussian processes, which may
 also be used for time-series (and spatial) data.
@@ -2867,7 +2867,7 @@ The first assignment rescales \code{h\_std} to have a
 $\distro{Normal}(0,\sigma)$ distribution and temporarily assigns it to
 \code{h}.  The second assignment rescales \code{h[1]} so that its
 prior differs from that of \code{h[2]} through \code{h[T]}.  The next
-assignment supplies a \code{mu} offset, so that \code{h[2]} throgh
+assignment supplies a \code{mu} offset, so that \code{h[2]} through
 \code{h[T]} are now distributed $\distro{Normal}(\mu,\sigma)$; note
 that this shift must be done after the rescaling of \code{h[1]}.  The
 final loop adds in the moving average so that \code{h[2]} through
@@ -3758,7 +3758,7 @@ model {
 }
 \end{stancode}
 %
-The log probabilty term is derived by taking
+The log probability term is derived by taking
 %
 \begin{eqnarray*}
 \log p_Y(y | \theta,\mu,\sigma) & = & \log\!\left( 0.3 \times \distro{Normal}(y|-1,2) \, + \,
@@ -3834,7 +3834,7 @@ sum of exponentials of those values.
 \section{Zero-Inflated and Hurdle Models}\label{zero-inflated.section}
 
 Zero-inflated and hurdle models both provide mixtures of a Poisson and
-Bernoulli probabilty mass function to allow more flexiblity in
+Bernoulli probability mass function to allow more flexibility in
 modeling the probability of a zero outcome.  Zero-inflated models, as
 defined by \citet{Lambert:1992}, add additional probability mass to
 the outcome of zero.  Hurdle models, on the other hand, are formulated
@@ -4584,7 +4584,7 @@ model {
 \end{stancode}
 \vspace*{-6pt}
 \caption{\small\it A probabilistic formulation of the Lincoln-Petersen
-population estimator for pulation size based on data from a one-step
+estimator for population size based on data from a one-step
 mark-recapture study.  The lower bound on $N$ is necessary to
 efficiently eliminate impossible values.}%
 \label{lincoln-petersen-model.figure}
@@ -4595,7 +4595,7 @@ directly coded in Stan as shown in \reffigure{lincoln-petersen-model}.
 The Lincoln-Petersen estimate is the maximum likelihood estimate (MLE)
 for this model.
 
-To enusre the MLE is the Lincoln-Petersen estimate, an improper
+To ensure the MLE is the Lincoln-Petersen estimate, an improper
 uniform prior for $N$ is used; this could (and should) be replaced
 with a more informative prior if possible based on knowledge of the
 population under study.
@@ -4690,10 +4690,10 @@ this quantity is defined recursively by
 The base case arises because if an animal was captured in the last
 time period, the probability it is never captured again is 1 because
 there are no more capture periods.  The recursive case defining
-$\chi_{t}$ in terms of $\chi_{t+1}$ involves two possibiliites: (1)
+$\chi_{t}$ in terms of $\chi_{t+1}$ involves two possibilities: (1)
 not surviving to the next time period, with probability $(1 -
-\phi_t)$, or (2) suriviving to the next time period with probability
-$\phi_t$, not being captured in the next time period with probabilty
+\phi_t)$, or (2) surviving to the next time period with probability
+$\phi_t$, not being captured in the next time period with probability
 $(1 - p_{t+1})$, and not being captured again after being alive in
 period $t+1$ with probability $\chi_{t+1}$. 
 
@@ -4791,7 +4791,7 @@ generated quantities {
 \subsubsection{Identifiability}
 
 The parameters $\phi_2$ and $p_3$, the probability of death at time 2
-and probabilty of capture at time 3 are not identifiable, because both
+and probability of capture at time 3 are not identifiable, because both
 may be used to account for lack of capture at time 3.  Their product,
 $\beta_3 = \phi_2 \, p_3$, is identified.  The Stan model defines
 \code{beta3} as a generated quantity.  Unidentified parameters pose a
@@ -4965,7 +4965,7 @@ on the convention of the first-capture and last-capture functions
 returning 0 for \code{first} if an individual is never captured.
 
 The inner loop for individual \code{i} first increments the log
-probability based on the survival of the individual with proability
+probability based on the survival of the individual with probability
 \code{phi[t-1]}.  The outcome of 1 is fixed because the individual
 must survive between the first and last capture (i.e., no zombies).
 Note that the loop starts after the first capture, because all
@@ -5001,7 +5001,7 @@ generated quantities {
 The parameter \code{p[1]} is also not modeled and will just be uniform
 between 0 and 1.  A more finely articulated model might have a
 hierarchical or time-series component, in which case \code{p[1]} would
-be an unknown intial condition and both \code{phi[T-1]} and
+be an unknown initial condition and both \code{phi[T-1]} and
 \code{p[T]} could be identified.
 
 \subsubsection{Population Size Estimates}
@@ -5064,7 +5064,7 @@ Humans are often given the task of coding (equivalently rating or
 annotating) data.  For example, journal or grant reviewers rate
 submissions, a political study may code campaign commercials as to
 whether they are attack ads or not, a natural language processing
-study might annotate Tweets as to whehter they are positive or
+study might annotate Tweets as to whether they are positive or
 negative in overall sentiment, or a dentist looking at an X-ray
 classifies a patient as having a cavity or not.  In all of these
 cases, the data coders play the role of the diagnostic tests and all
@@ -5090,7 +5090,7 @@ items (patients), and $K$ categories (condition statuses) to annotate,
 with $y_{i,j} \in 1{:}K$ being the rating provided by rater $j$ for
 item $i$.  In a diagnostic test setting for a particular condition,
 the raters are diagnostic procedures and often $K=2$, with values
-signaling the presense or absence of the condition.%
+signaling the presence or absence of the condition.%
 %
 \footnote{Diagnostic procedures are often ordinal, as in stages of
   cancer in oncological diagnosis or the severity of a cavity in
@@ -5135,7 +5135,7 @@ y_{i,j} \sim \distro{Categorical}(\theta_{j,\pi_{z[i]}}).
 \subsubsection{Priors and Hierarchical Modeling}
 
 Dawid and Skene provided maximum likelihood estimates for $\theta$ and
-$\pi$, which allows them to generate probabilty estimates for each $z_i$.
+$\pi$, which allows them to generate probability estimates for each $z_i$.
 
 To mimic Dawid and Skene's maximum likelihood model, the parameters
 $\theta_{j,k}$ and $\pi$ can be given uniform priors over
@@ -5445,7 +5445,7 @@ using vectorized notation, would yield a likelihood
 \]
 There's no direct way to encode this in Stan.  
 
-A full datatabse type structure could be used, as in the sparse
+A full database type structure could be used, as in the sparse
 example, but this is inefficient, wasting space for unnecessary
 indices and not allowing vector-based density operations.  A better
 way to code this data is as a single list of values, with a separate
@@ -5637,7 +5637,7 @@ situation, a hierarchical prior may be used for the covariance matrices.
 Two problems make it pretty much impossible to perform full Bayesian
 inference for clustering models, the lack of parameter identifiability
 and the extreme multimodality of the posteriors.  There is additional
-discussion related to the non-identifiability due to label swtiching
+discussion related to the non-identifiability due to label switching
 in \refsection{label-switching-problematic}.
 
 \subsection{Non-Identifiability}
@@ -5685,7 +5685,7 @@ which labels for items are observed.%
   mixture models present a problem, whereas there is no such problem
   for classification.  Despite the difficulties with full Bayesian
   inference for clustering, researchers continue to use it, often in
-  an explorata data analysis setting rather than for predictive
+  an exploratory data analysis setting rather than for predictive
   modeling.}
 
 Multinomial mixture models are referred to as ``naive Bayes'' because
@@ -6481,7 +6481,7 @@ data points in seconds.
 ``Automatic relevance determination'' is the term used in machine
 learning corresponding to the term ``hierarchical modeling'' in
 statistics.  In either case, the idea is that hyperparameters are
-estimated from data (in Bayesian inference, via the joint posteiror
+estimated from data (in Bayesian inference, via the joint posterior
 distribution) rather than being preset.
 
 For multivariate inputs $x \in \reals^D$, the squared exponential
@@ -6862,7 +6862,7 @@ A pure logistic Gaussian process regression would not include a noise
 term in the definition of the covariance matrix.  This can be
 implemented by simply removing the noise term(s) \code{sigma\_sq} from
 the definition of \code{Sigma}.  Probit regression can be coded by
-subsituting the probit link for the logit.%
+substituting the probit link for the logit.%
 %
 \footnote{Although it is possible to implement probit regression by
   including the noise term \code{sigma\_sq} and then quantizing
@@ -7174,7 +7174,7 @@ transform, which in this case is
 
 In the case of a multivariate transform, the log of the Jacobian of
 the transform must be added to the log probability accumulator (see
-the subsection of \refsection{change-of-variables} on multivarate
+the subsection of \refsection{change-of-variables} on multivariate
 changes of variables for more precise definitions of multivariate
 transforms and Jacobians).  In Stan, this can be coded as follows in
 the general case where the Jacobian is not a full matrix.
@@ -7827,11 +7827,11 @@ generator.
 \begin{stancode}
 /**
  * Return a data matrix of specified size with rows 
- * correspdonding to items and the first column filled 
+ * corresponding to items and the first column filled 
  * with the value 1 to represent the intercept and the 
  * remaining columns randomly filled with unit-normal draws.
  *
- * @param N Number of rows correspdong to data items
+ * @param N Number of rows corresponding to data items
  * @param K Number of predictors, counting the intercept, per
  *          item.
  * @return Simulated predictor matrix.
@@ -7976,7 +7976,7 @@ value of the system parameter ($\theta$).
 Given a value of the parameter $\theta$ and an initial state $y(t_0)$
 at time $t_0$, it is possible to solve the equations numerically to
 calculate $y(t)$ for any given time $t$.  The rest of this chapter
-shows how Stan is able to provide the functionalty to specify and
+shows how Stan is able to provide the functionality to specify and
 solve a system of ODEs.
 
 
@@ -8014,13 +8014,13 @@ All of the arguments to such a function must be provided in exactly
 the order shown above.  This may require passing in zero-length
 arrays for data or parameters if the system does not involve data or
 parameters.  A full example for the simple harmonic oscillator, which
-does not depend on any constant data variables, is provided in
-in \reffigure{sho-trajectory}.
+does not depend on any constant data variables, is provided in 
+\reffigure{sho-trajectory}.
 
 \subsection{Data versus Parameters}
 
 Unlike other functions, a function describing a system of ODEs is
-limited as to the origins of variables its arguments.  In particular,
+limited as to the origins of variables in its arguments.  In particular,
 the time \code{t}, real data \code{x}, and integer data \code{x\_int}
 must be expressions that only involve data or transformed data
 variables.  The initial state \code{y} or the parameters \code{theta}
@@ -8291,7 +8291,7 @@ and $\lambda_2=-1000000000$ as it does in the neighborhood of
 $\lambda_1=0$ and $\lambda_2=0$, and so on for ever more far-ranging
 values.
 
-The maringal posterior $p(\lambda_1,\lambda_2|y)$ for this model is
+The marginal posterior $p(\lambda_1,\lambda_2|y)$ for this model is
 thus improper.%
 %
 \footnote{The marginal posterior $p(\sigma|y)$ for $\sigma$ is proper
@@ -8521,7 +8521,7 @@ with varying location).  Unlike the approaching of pinning $\alpha_K =
 0$, the prior-based approach models the $K$ outcomes symmetrically
 rather than modeling $K-1$ outcomes relative to the $K$-th.  The
 pinned parameterization, on the other hand, is usually more efficient
-statisticaly because it does not have the extra degree of (prior
+statistically because it does not have the extra degree of (prior
 constrained) wiggle room.
 
 
@@ -8615,7 +8615,7 @@ neighborhoods of multiple local maxima according to the probability
 masses. In Gibbs sampling, it is unlikely for $\mu_1$
 to move to a new mode when sampled conditioned on the current values
 of $\mu_2$ and $\theta$. For HMC and NUTS, the problem is that the
-sampler gets stuck in one of the two ``bowls'' arounds the modes and
+sampler gets stuck in one of the two ``bowls'' around the modes and
 cannot gather enough energy from random momentum assignment to move
 from one mode to another.
 
@@ -8635,7 +8635,7 @@ One common strategy is to impose a constraint on the parameters that
 identifies the components.  For instance, we might consider
 constraining $\mu_1 < \mu_2$ in the two-component normal mixture model
 discussed above.  A problem that can arise from such an approach is
-when there is substantial probabilty mass for the opposite ordering
+when there is substantial probability mass for the opposite ordering
 $\mu_1 > \mu_2$.  In these cases, the posteriors are affected by
 the constraint and true posterior uncertainty in $\mu_1$ and $\mu_2$
 is not captured by the model with the constraint.  In addition,
@@ -8758,7 +8758,7 @@ $\mbox{logit}^{-1}(x_n \beta) \rightarrow 1$.
 
 With separability, there is no maximum to the likelihood and hence no
 maximum likelihood estimate.  From the Bayesian perspective, the
-posterior is improper and therefor the marginal posterior mean for
+posterior is improper and therefore the marginal posterior mean for
 $\beta_k$ is also not defined.  The usual solution to this problem in
 Bayesian models is to include a proper prior for $\beta$, which
 ensures a proper posterior.
@@ -8784,7 +8784,7 @@ $\psi$ at all points in $[0,1]$.
 
 With an improper posterior, it is theoretically impossible to properly
 explore the posterior. However, Gibbs sampling as performed by BUGS
-and JAGS, although still ineable to properly sample from such an
+and JAGS, although still unable to properly sample from such an
 improper posterior, behaves quite differently in practice than the
 Hamiltonian Monte Carlo sampling performed by Stan when faced with an
 example such as the two intercept model discussed in


### PR DESCRIPTION
Fixed some minor typos in the manual - mostly misspellings and redundant words, all in src/docs/stan-reference/programming.tex

Althogh -> Although
accomodate -> accommodate
cumultive -> cumulative
autogression -> autoregressive
throgh -> through
probabilty -> probability
flexiblity -> flexibility
pulation -> population
enusre -> ensure
possibiliites -> possibilities
suriviving -> surviving
intial -> initial
whehter -> whether
presense -> presence
datatabse -> database
swtiching -> switching
exploratora -> exploratory
posteiror -> posterior
subsituting -> substituting
multivarate -> multivariate
correspdonding -> corresponding
correspdong -> corresponding
functionalty -> functionality
maringal -> marginal
statisticaly -> statistically
arounds -> around
probabilty -> probability
therefor -> therefore
ineable -> unable
