### PR TITLE
Feature/issue 1383 versions

### DIFF
--- a/lib/stan_math_2.6.3/.gitignore
+++ b/lib/stan_math_2.6.3/.gitignore
@@ -1,5 +1,3 @@
-
-
 # /
 /*.dSYM
 
@@ -38,6 +36,7 @@ stan.kdev4
 !/test/*.hpp
 !/test/*.cpp
 !/test/*.stan
+
 ## generated tests
 /test/prob/*/*_generated_*_test.cpp
 ## lib files

--- a/lib/stan_math_2.6.3/stan/math/version.hpp
+++ b/lib/stan_math_2.6.3/stan/math/version.hpp
@@ -3,12 +3,12 @@
 
 #include <string>
 
-#ifndef STRING_EXPAND
-#define STRING_EXPAND(s) #s
+#ifndef STAN_STRING_EXPAND
+#define STAN_STRING_EXPAND(s) #s
 #endif
 
-#ifndef STRING
-#define STRING(s) STRING_EXPAND(s)
+#ifndef STAN_STRING
+#define STAN_STRING(s) STAN_STRING_EXPAND(s)
 #endif
 
 #define STAN_MATH_MAJOR 2
@@ -19,13 +19,13 @@ namespace stan {
   namespace math {
 
     /** Major version number for Stan math library. */
-    const std::string MAJOR_VERSION = STRING(STAN_MATH_MAJOR);
+    const std::string MAJOR_VERSION = STAN_STRING(STAN_MATH_MAJOR);
 
     /** Minor version number for Stan math library. */
-    const std::string MINOR_VERSION = STRING(STAN_MATH_MINOR);
+    const std::string MINOR_VERSION = STAN_STRING(STAN_MATH_MINOR);
 
     /** Patch version for Stan math library. */
-    const std::string PATCH_VERSION = STRING(STAN_MATH_PATCH);
+    const std::string PATCH_VERSION = STAN_STRING(STAN_MATH_PATCH);
 
   }
 }

--- a/lib/stan_math_2.6.3/stan/math/version.hpp
+++ b/lib/stan_math_2.6.3/stan/math/version.hpp
@@ -2,8 +2,14 @@
 #define STAN_MATH_VERSION_HPP
 
 #include <string>
+
+#ifndef STRING_EXPAND
 #define STRING_EXPAND(s) #s
+#endif
+
+#ifndef STRING
 #define STRING(s) STRING_EXPAND(s)
+#endif
 
 #define STAN_MATH_MAJOR 2
 #define STAN_MATH_MINOR 6

--- a/lib/stan_math_2.6.3/stan/math/version.hpp
+++ b/lib/stan_math_2.6.3/stan/math/version.hpp
@@ -2,18 +2,24 @@
 #define STAN_MATH_VERSION_HPP
 
 #include <string>
+#define STRING_EXPAND(s) #s
+#define STRING(s) STRING_EXPAND(s)
+
+#define STAN_MATH_MAJOR 2
+#define STAN_MATH_MINOR 6
+#define STAN_MATH_PATCH 3
 
 namespace stan {
   namespace math {
 
     /** Major version number for Stan math library. */
-    const std::string MAJOR_VERSION = "2";
+    const std::string MAJOR_VERSION = STRING(STAN_MATH_MAJOR);
 
     /** Minor version number for Stan math library. */
-    const std::string MINOR_VERSION = "6";
+    const std::string MINOR_VERSION = STRING(STAN_MATH_MINOR);
 
     /** Patch version for Stan math library. */
-    const std::string PATCH_VERSION = "3";
+    const std::string PATCH_VERSION = STRING(STAN_MATH_PATCH);
 
   }
 }

--- a/make/manual
+++ b/make/manual
@@ -1,9 +1,9 @@
 .PHONY: manual $(STANAPI_HOME)src/docs/stan-reference/stan-reference.tex $(STANAPI_HOME)src/docs/stan-reference/stan-functions.txt
 
-MAJOR_VERSION := $(shell grep MAJOR_VERSION $(STANAPI_HOME)src/stan/version.hpp | sed -e 's/.*\"\([^]]*\)\".*/\1/g')
-MINOR_VERSION := $(shell grep MINOR_VERSION $(STANAPI_HOME)src/stan/version.hpp | sed -e 's/.*\"\([^]]*\)\".*/\1/g')
-PATCH_VERSION := $(shell grep PATCH_VERSION $(STANAPI_HOME)src/stan/version.hpp | sed -e 's/.*\"\([^]]*\)\".*/\1/g')
-VERSION_STRING := $(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
+STAN_MAJOR := $(shell grep "\#define STAN_MAJOR" $(STANAPI_HOME)src/stan/version.hpp | sed -e 's/.*STAN_MAJOR \(.*\)/\1/')
+STAN_MINOR := $(shell grep "\#define STAN_MINOR" $(STANAPI_HOME)src/stan/version.hpp | sed -e 's/.*STAN_MINOR \(.*\)/\1/')
+STAN_PATCH := $(shell grep "\#define STAN_PATCH" $(STANAPI_HOME)src/stan/version.hpp | sed -e 's/.*STAN_PATCH \(.*\)/\1/')
+VERSION_STRING := $(STAN_MAJOR).$(STAN_MINOR).$(STAN_PATCH)
 
 manual: $(STANAPI_HOME)src/docs/stan-reference/stan-reference.pdf $(STANAPI_HOME)src/docs/stan-reference/stan-functions.txt
 	@mkdir -p doc/

--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -1419,7 +1419,10 @@ Stan's \Cpp implementation.  These are
 %
 \begin{quote}
 \code{var},
-\code{fvar}
+\code{fvar},
+\code{STAN\_MAJOR},
+\code{STAN\_MINOR},
+\code{STAN\_PATCH}
 \end{quote}
 %
 

--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -1422,7 +1422,7 @@ Stan's \Cpp implementation.  These are
 \code{fvar},
 \code{STAN\_MAJOR},
 \code{STAN\_MINOR},
-\code{STAN\_PATCH}
+\code{STAN\_PATCH},
 \code{STAN\_MATH\_MAJOR},
 \code{STAN\_MATH\_MINOR},
 \code{STAN\_MATH\_PATCH}

--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -1423,6 +1423,9 @@ Stan's \Cpp implementation.  These are
 \code{STAN\_MAJOR},
 \code{STAN\_MINOR},
 \code{STAN\_PATCH}
+\code{STAN\_MATH\_MAJOR},
+\code{STAN\_MATH\_MINOR},
+\code{STAN\_MATH\_PATCH}
 \end{quote}
 %
 

--- a/src/stan/lang/grammars/var_decls_grammar_def.hpp
+++ b/src/stan/lang/grammars/var_decls_grammar_def.hpp
@@ -399,6 +399,10 @@ namespace stan {
         reserve("generated");
 
         reserve("var");
+        reserve("fvar");
+        reserve("STAN_MAJOR");
+        reserve("STAN_MINOR");
+        reserve("STAN_PATCH");
 
         reserve("alignas");
         reserve("alignof");

--- a/src/stan/lang/grammars/var_decls_grammar_def.hpp
+++ b/src/stan/lang/grammars/var_decls_grammar_def.hpp
@@ -403,6 +403,9 @@ namespace stan {
         reserve("STAN_MAJOR");
         reserve("STAN_MINOR");
         reserve("STAN_PATCH");
+        reserve("STAN_MATH_MAJOR");
+        reserve("STAN_MATH_MINOR");
+        reserve("STAN_MATH_PATCH");
 
         reserve("alignas");
         reserve("alignof");

--- a/src/stan/version.hpp
+++ b/src/stan/version.hpp
@@ -2,17 +2,23 @@
 #define STAN_VERSION_HPP
 
 #include <string>
+#define STRING_EXPAND(s) #s
+#define STRING(s) STRING_EXPAND(s)
+
+#define STAN_MAJOR 2
+#define STAN_MINOR 6
+#define STAN_PATCH 3
 
 namespace stan {
 
   /** Major version number for Stan package. */
-  const std::string MAJOR_VERSION = "2";
+  const std::string MAJOR_VERSION = STRING(STAN_MAJOR);
 
   /** Minor version number for Stan package. */
-  const std::string MINOR_VERSION = "6";
+  const std::string MINOR_VERSION = STRING(STAN_MINOR);
 
   /** Patch version for Stan package. */
-  const std::string PATCH_VERSION = "3";
+  const std::string PATCH_VERSION = STRING(STAN_PATCH);
 
 }
 

--- a/src/stan/version.hpp
+++ b/src/stan/version.hpp
@@ -3,12 +3,12 @@
 
 #include <string>
 
-#ifndef STRING_EXPAND
-#define STRING_EXPAND(s) #s
+#ifndef STAN_STRING_EXPAND
+#define STAN_STRING_EXPAND(s) #s
 #endif
 
-#ifndef STRING
-#define STRING(s) STRING_EXPAND(s)
+#ifndef STAN_STRING
+#define STAN_STRING(s) STAN_STRING_EXPAND(s)
 #endif
 
 #define STAN_MAJOR 2
@@ -18,13 +18,13 @@
 namespace stan {
 
   /** Major version number for Stan package. */
-  const std::string MAJOR_VERSION = STRING(STAN_MAJOR);
+  const std::string MAJOR_VERSION = STAN_STRING(STAN_MAJOR);
 
   /** Minor version number for Stan package. */
-  const std::string MINOR_VERSION = STRING(STAN_MINOR);
+  const std::string MINOR_VERSION = STAN_STRING(STAN_MINOR);
 
   /** Patch version for Stan package. */
-  const std::string PATCH_VERSION = STRING(STAN_PATCH);
+  const std::string PATCH_VERSION = STAN_STRING(STAN_PATCH);
 
 }
 

--- a/src/stan/version.hpp
+++ b/src/stan/version.hpp
@@ -2,8 +2,14 @@
 #define STAN_VERSION_HPP
 
 #include <string>
+
+#ifndef STRING_EXPAND
 #define STRING_EXPAND(s) #s
+#endif
+
+#ifndef STRING
 #define STRING(s) STRING_EXPAND(s)
+#endif
 
 #define STAN_MAJOR 2
 #define STAN_MINOR 6

--- a/src/test/test-models/bad/reserved/STAN_MAJOR.stan
+++ b/src/test/test-models/bad/reserved/STAN_MAJOR.stan
@@ -1,0 +1,5 @@
+data {
+  real STAN_MAJOR;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/STAN_MATH_MAJOR.stan
+++ b/src/test/test-models/bad/reserved/STAN_MATH_MAJOR.stan
@@ -1,0 +1,5 @@
+data {
+  real STAN_MATH_MAJOR;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/STAN_MATH_MINOR.stan
+++ b/src/test/test-models/bad/reserved/STAN_MATH_MINOR.stan
@@ -1,0 +1,5 @@
+data {
+  real STAN_MATH_MINOR;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/STAN_MATH_PATCH.stan
+++ b/src/test/test-models/bad/reserved/STAN_MATH_PATCH.stan
@@ -1,0 +1,5 @@
+data {
+  real STAN_MATH_PATCH;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/STAN_MINOR.stan
+++ b/src/test/test-models/bad/reserved/STAN_MINOR.stan
@@ -1,0 +1,5 @@
+data {
+  real STAN_MINOR;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/STAN_PATCH.stan
+++ b/src/test/test-models/bad/reserved/STAN_PATCH.stan
@@ -1,0 +1,5 @@
+data {
+  real STAN_PATCH;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/alignas.stan
+++ b/src/test/test-models/bad/reserved/alignas.stan
@@ -1,0 +1,5 @@
+data {
+  real alignas;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/alignof.stan
+++ b/src/test/test-models/bad/reserved/alignof.stan
@@ -1,0 +1,5 @@
+data {
+  real alignof;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/and.stan
+++ b/src/test/test-models/bad/reserved/and.stan
@@ -1,0 +1,5 @@
+data {
+  real and;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/and_eq.stan
+++ b/src/test/test-models/bad/reserved/and_eq.stan
@@ -1,0 +1,5 @@
+data {
+  real and_eq;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/asm.stan
+++ b/src/test/test-models/bad/reserved/asm.stan
@@ -1,0 +1,5 @@
+data {
+  real asm;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/auto.stan
+++ b/src/test/test-models/bad/reserved/auto.stan
@@ -1,0 +1,5 @@
+data {
+  real auto;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/bitand.stan
+++ b/src/test/test-models/bad/reserved/bitand.stan
@@ -1,0 +1,5 @@
+data {
+  real bitand;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/bitor.stan
+++ b/src/test/test-models/bad/reserved/bitor.stan
@@ -1,0 +1,5 @@
+data {
+  real bitor;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/bool.stan
+++ b/src/test/test-models/bad/reserved/bool.stan
@@ -1,0 +1,5 @@
+data {
+  real bool;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/break.stan
+++ b/src/test/test-models/bad/reserved/break.stan
@@ -1,0 +1,5 @@
+data {
+  real break;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/case.stan
+++ b/src/test/test-models/bad/reserved/case.stan
@@ -1,0 +1,5 @@
+data {
+  real case;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/catch.stan
+++ b/src/test/test-models/bad/reserved/catch.stan
@@ -1,0 +1,5 @@
+data {
+  real catch;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/char.stan
+++ b/src/test/test-models/bad/reserved/char.stan
@@ -1,0 +1,5 @@
+data {
+  real char;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/char16_t.stan
+++ b/src/test/test-models/bad/reserved/char16_t.stan
@@ -1,0 +1,5 @@
+data {
+  real char16_t;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/char32_t.stan
+++ b/src/test/test-models/bad/reserved/char32_t.stan
@@ -1,0 +1,5 @@
+data {
+  real char32_t;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/cholesky_factor_corr.stan
+++ b/src/test/test-models/bad/reserved/cholesky_factor_corr.stan
@@ -1,0 +1,5 @@
+data {
+  real cholesky_factor_corr;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/cholesky_factor_cov.stan
+++ b/src/test/test-models/bad/reserved/cholesky_factor_cov.stan
@@ -1,0 +1,5 @@
+data {
+  real cholesky_factor_cov;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/class.stan
+++ b/src/test/test-models/bad/reserved/class.stan
@@ -1,0 +1,5 @@
+data {
+  real class;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/compl.stan
+++ b/src/test/test-models/bad/reserved/compl.stan
@@ -1,0 +1,5 @@
+data {
+  real compl;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/const.stan
+++ b/src/test/test-models/bad/reserved/const.stan
@@ -1,0 +1,5 @@
+data {
+  real const;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/const_cast.stan
+++ b/src/test/test-models/bad/reserved/const_cast.stan
@@ -1,0 +1,5 @@
+data {
+  real const_cast;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/constexpr.stan
+++ b/src/test/test-models/bad/reserved/constexpr.stan
@@ -1,0 +1,5 @@
+data {
+  real constexpr;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/continue.stan
+++ b/src/test/test-models/bad/reserved/continue.stan
@@ -1,0 +1,5 @@
+data {
+  real continue;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/corr_matrix.stan
+++ b/src/test/test-models/bad/reserved/corr_matrix.stan
@@ -1,0 +1,5 @@
+data {
+  real corr_matrix;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/cov_matrix.stan
+++ b/src/test/test-models/bad/reserved/cov_matrix.stan
@@ -1,0 +1,5 @@
+data {
+  real cov_matrix;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/decltype.stan
+++ b/src/test/test-models/bad/reserved/decltype.stan
@@ -1,0 +1,5 @@
+data {
+  real decltype;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/default.stan
+++ b/src/test/test-models/bad/reserved/default.stan
@@ -1,0 +1,5 @@
+data {
+  real default;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/delete.stan
+++ b/src/test/test-models/bad/reserved/delete.stan
@@ -1,0 +1,5 @@
+data {
+  real delete;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/do.stan
+++ b/src/test/test-models/bad/reserved/do.stan
@@ -1,0 +1,5 @@
+data {
+  real do;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/double.stan
+++ b/src/test/test-models/bad/reserved/double.stan
@@ -1,0 +1,5 @@
+data {
+  real double;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/dynamic_cast.stan
+++ b/src/test/test-models/bad/reserved/dynamic_cast.stan
@@ -1,0 +1,5 @@
+data {
+  real dynamic_cast;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/else.stan
+++ b/src/test/test-models/bad/reserved/else.stan
@@ -1,0 +1,5 @@
+data {
+  real else;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/enum.stan
+++ b/src/test/test-models/bad/reserved/enum.stan
@@ -1,0 +1,5 @@
+data {
+  real enum;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/explicit.stan
+++ b/src/test/test-models/bad/reserved/explicit.stan
@@ -1,0 +1,5 @@
+data {
+  real explicit;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/export.stan
+++ b/src/test/test-models/bad/reserved/export.stan
@@ -1,0 +1,5 @@
+data {
+  real export;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/extern.stan
+++ b/src/test/test-models/bad/reserved/extern.stan
@@ -1,0 +1,5 @@
+data {
+  real extern;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/false.stan
+++ b/src/test/test-models/bad/reserved/false.stan
@@ -1,0 +1,5 @@
+data {
+  real false;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/float.stan
+++ b/src/test/test-models/bad/reserved/float.stan
@@ -1,0 +1,5 @@
+data {
+  real float;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/for.stan
+++ b/src/test/test-models/bad/reserved/for.stan
@@ -1,0 +1,5 @@
+data {
+  real for;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/friend.stan
+++ b/src/test/test-models/bad/reserved/friend.stan
@@ -1,0 +1,5 @@
+data {
+  real friend;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/fvar.stan
+++ b/src/test/test-models/bad/reserved/fvar.stan
@@ -1,0 +1,5 @@
+data {
+  real fvar;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/goto.stan
+++ b/src/test/test-models/bad/reserved/goto.stan
@@ -1,0 +1,5 @@
+data {
+  real goto;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/if.stan
+++ b/src/test/test-models/bad/reserved/if.stan
@@ -1,0 +1,5 @@
+data {
+  real if;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/in.stan
+++ b/src/test/test-models/bad/reserved/in.stan
@@ -1,0 +1,5 @@
+data {
+  real in;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/inline.stan
+++ b/src/test/test-models/bad/reserved/inline.stan
@@ -1,0 +1,5 @@
+data {
+  real inline;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/int.stan
+++ b/src/test/test-models/bad/reserved/int.stan
@@ -1,0 +1,5 @@
+data {
+  real int;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/long.stan
+++ b/src/test/test-models/bad/reserved/long.stan
@@ -1,0 +1,5 @@
+data {
+  real long;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/matrix.stan
+++ b/src/test/test-models/bad/reserved/matrix.stan
@@ -1,0 +1,5 @@
+data {
+  real matrix;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/mutable.stan
+++ b/src/test/test-models/bad/reserved/mutable.stan
@@ -1,0 +1,5 @@
+data {
+  real mutable;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/namespace.stan
+++ b/src/test/test-models/bad/reserved/namespace.stan
@@ -1,0 +1,5 @@
+data {
+  real namespace;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/new.stan
+++ b/src/test/test-models/bad/reserved/new.stan
@@ -1,0 +1,5 @@
+data {
+  real new;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/noexcept.stan
+++ b/src/test/test-models/bad/reserved/noexcept.stan
@@ -1,0 +1,5 @@
+data {
+  real noexcept;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/not.stan
+++ b/src/test/test-models/bad/reserved/not.stan
@@ -1,0 +1,5 @@
+data {
+  real not;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/not_eq.stan
+++ b/src/test/test-models/bad/reserved/not_eq.stan
@@ -1,0 +1,5 @@
+data {
+  real not_eq;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/nullptr.stan
+++ b/src/test/test-models/bad/reserved/nullptr.stan
@@ -1,0 +1,5 @@
+data {
+  real nullptr;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/operator.stan
+++ b/src/test/test-models/bad/reserved/operator.stan
@@ -1,0 +1,5 @@
+data {
+  real operator;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/or.stan
+++ b/src/test/test-models/bad/reserved/or.stan
@@ -1,0 +1,5 @@
+data {
+  real or;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/or_eq.stan
+++ b/src/test/test-models/bad/reserved/or_eq.stan
@@ -1,0 +1,5 @@
+data {
+  real or_eq;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/ordered.stan
+++ b/src/test/test-models/bad/reserved/ordered.stan
@@ -1,0 +1,5 @@
+data {
+  real ordered;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/positive_ordered.stan
+++ b/src/test/test-models/bad/reserved/positive_ordered.stan
@@ -1,0 +1,5 @@
+data {
+  real positive_ordered;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/private.stan
+++ b/src/test/test-models/bad/reserved/private.stan
@@ -1,0 +1,5 @@
+data {
+  real private;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/protected.stan
+++ b/src/test/test-models/bad/reserved/protected.stan
@@ -1,0 +1,5 @@
+data {
+  real protected;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/public.stan
+++ b/src/test/test-models/bad/reserved/public.stan
@@ -1,0 +1,5 @@
+data {
+  real public;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/real.stan
+++ b/src/test/test-models/bad/reserved/real.stan
@@ -1,0 +1,5 @@
+data {
+  real real;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/register.stan
+++ b/src/test/test-models/bad/reserved/register.stan
@@ -1,0 +1,5 @@
+data {
+  real register;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/reinterpret_cast.stan
+++ b/src/test/test-models/bad/reserved/reinterpret_cast.stan
@@ -1,0 +1,5 @@
+data {
+  real reinterpret_cast;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/repeat.stan
+++ b/src/test/test-models/bad/reserved/repeat.stan
@@ -1,0 +1,5 @@
+data {
+  real repeat;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/return.stan
+++ b/src/test/test-models/bad/reserved/return.stan
@@ -1,0 +1,5 @@
+data {
+  real return;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/row_vector.stan
+++ b/src/test/test-models/bad/reserved/row_vector.stan
@@ -1,0 +1,5 @@
+data {
+  real row_vector;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/short.stan
+++ b/src/test/test-models/bad/reserved/short.stan
@@ -1,0 +1,5 @@
+data {
+  real short;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/signed.stan
+++ b/src/test/test-models/bad/reserved/signed.stan
@@ -1,0 +1,5 @@
+data {
+  real signed;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/simplex.stan
+++ b/src/test/test-models/bad/reserved/simplex.stan
@@ -1,0 +1,5 @@
+data {
+  real simplex;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/sizeof.stan
+++ b/src/test/test-models/bad/reserved/sizeof.stan
@@ -1,0 +1,5 @@
+data {
+  real sizeof;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/static.stan
+++ b/src/test/test-models/bad/reserved/static.stan
@@ -1,0 +1,5 @@
+data {
+  real static;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/static_assert.stan
+++ b/src/test/test-models/bad/reserved/static_assert.stan
@@ -1,0 +1,5 @@
+data {
+  real static_assert;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/static_cast.stan
+++ b/src/test/test-models/bad/reserved/static_cast.stan
@@ -1,0 +1,5 @@
+data {
+  real static_cast;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/struct.stan
+++ b/src/test/test-models/bad/reserved/struct.stan
@@ -1,0 +1,5 @@
+data {
+  real struct;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/switch.stan
+++ b/src/test/test-models/bad/reserved/switch.stan
@@ -1,0 +1,5 @@
+data {
+  real switch;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/template.stan
+++ b/src/test/test-models/bad/reserved/template.stan
@@ -1,0 +1,5 @@
+data {
+  real template;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/then.stan
+++ b/src/test/test-models/bad/reserved/then.stan
@@ -1,0 +1,5 @@
+data {
+  real then;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/this.stan
+++ b/src/test/test-models/bad/reserved/this.stan
@@ -1,0 +1,5 @@
+data {
+  real this;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/thread_local.stan
+++ b/src/test/test-models/bad/reserved/thread_local.stan
@@ -1,0 +1,5 @@
+data {
+  real thread_local;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/throw.stan
+++ b/src/test/test-models/bad/reserved/throw.stan
@@ -1,0 +1,5 @@
+data {
+  real throw;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/true.stan
+++ b/src/test/test-models/bad/reserved/true.stan
@@ -1,0 +1,5 @@
+data {
+  real true;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/try.stan
+++ b/src/test/test-models/bad/reserved/try.stan
@@ -1,0 +1,5 @@
+data {
+  real try;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/typedef.stan
+++ b/src/test/test-models/bad/reserved/typedef.stan
@@ -1,0 +1,5 @@
+data {
+  real typedef;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/typeid.stan
+++ b/src/test/test-models/bad/reserved/typeid.stan
@@ -1,0 +1,5 @@
+data {
+  real typeid;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/typename.stan
+++ b/src/test/test-models/bad/reserved/typename.stan
@@ -1,0 +1,5 @@
+data {
+  real typename;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/union.stan
+++ b/src/test/test-models/bad/reserved/union.stan
@@ -1,0 +1,5 @@
+data {
+  real union;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/unit_vector.stan
+++ b/src/test/test-models/bad/reserved/unit_vector.stan
@@ -1,0 +1,5 @@
+data {
+  real unit_vector;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/unsigned.stan
+++ b/src/test/test-models/bad/reserved/unsigned.stan
@@ -1,0 +1,5 @@
+data {
+  real unsigned;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/until.stan
+++ b/src/test/test-models/bad/reserved/until.stan
@@ -1,0 +1,5 @@
+data {
+  real until;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/using.stan
+++ b/src/test/test-models/bad/reserved/using.stan
@@ -1,0 +1,5 @@
+data {
+  real using;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/var.stan
+++ b/src/test/test-models/bad/reserved/var.stan
@@ -1,0 +1,5 @@
+data {
+  real var;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/vector.stan
+++ b/src/test/test-models/bad/reserved/vector.stan
@@ -1,0 +1,5 @@
+data {
+  real vector;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/virtual.stan
+++ b/src/test/test-models/bad/reserved/virtual.stan
@@ -1,0 +1,5 @@
+data {
+  real virtual;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/void.stan
+++ b/src/test/test-models/bad/reserved/void.stan
@@ -1,0 +1,5 @@
+data {
+  real void;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/volatile.stan
+++ b/src/test/test-models/bad/reserved/volatile.stan
@@ -1,0 +1,5 @@
+data {
+  real volatile;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/wchar_t.stan
+++ b/src/test/test-models/bad/reserved/wchar_t.stan
@@ -1,0 +1,5 @@
+data {
+  real wchar_t;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/while.stan
+++ b/src/test/test-models/bad/reserved/while.stan
@@ -1,0 +1,5 @@
+data {
+  real while;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/xor.stan
+++ b/src/test/test-models/bad/reserved/xor.stan
@@ -1,0 +1,5 @@
+data {
+  real xor;
+}
+model {
+}

--- a/src/test/test-models/bad/reserved/xor_eq.stan
+++ b/src/test/test-models/bad/reserved/xor_eq.stan
@@ -1,0 +1,5 @@
+data {
+  real xor_eq;
+}
+model {
+}

--- a/src/test/unit/lang/parser/reserved_words_test.cpp
+++ b/src/test/unit/lang/parser/reserved_words_test.cpp
@@ -113,6 +113,18 @@ TEST(parserReservedWords, macro_STAN_PATCH) {
   test_throws("reserved/STAN_PATCH", "variable identifier (name) may not be reserved word");
 }
 
+TEST(parserReservedWords, macro_STAN_MATH_MAJOR) {
+  test_throws("reserved/STAN_MATH_MAJOR", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, macro_STAN_MATH_MINOR) {
+  test_throws("reserved/STAN_MATH_MINOR", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, macro_STAN_MATH_PATCH) {
+  test_throws("reserved/STAN_MATH_PATCH", "variable identifier (name) may not be reserved word");
+}
+
 TEST(parserReservedWords, alignas) {
   test_throws("reserved/alignas", "variable identifier (name) may not be reserved word");
 }

--- a/src/test/unit/lang/parser/reserved_words_test.cpp
+++ b/src/test/unit/lang/parser/reserved_words_test.cpp
@@ -1,0 +1,422 @@
+#include <gtest/gtest.h>
+#include <test/unit/lang/utility.hpp>
+
+TEST(parserReservedWords, for) {
+  test_throws("reserved/for", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, in) {
+  test_throws("reserved/in", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, while) {
+  test_throws("reserved/while", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, repeat) {
+  test_throws("reserved/repeat", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, until) {
+  test_throws("reserved/until", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, if) {
+  test_throws("reserved/if", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, then) {
+  test_throws("reserved/then", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, else) {
+  test_throws("reserved/else", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, true) {
+  test_throws("reserved/true", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, false) {
+  test_throws("reserved/false", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, int) {
+  test_throws("reserved/int", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, real) {
+  test_throws("reserved/real", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, vector) {
+  test_throws("reserved/vector", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, simplex) {
+  test_throws("reserved/simplex", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, unit_vector) {
+  test_throws("reserved/unit_vector", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, ordered) {
+  test_throws("reserved/ordered", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, positive_ordered) {
+  test_throws("reserved/positive_ordered", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, row_vector) {
+  test_throws("reserved/row_vector", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, matrix) {
+  test_throws("reserved/matrix", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, cholesky_factor_corr) {
+  test_throws("reserved/cholesky_factor_corr", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, cholesky_factor_cov) {
+  test_throws("reserved/cholesky_factor_cov", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, corr_matrix) {
+  test_throws("reserved/corr_matrix", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, cov_matrix) {
+  test_throws("reserved/cov_matrix", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, var) {
+  test_throws("reserved/var", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, fvar) {
+  test_throws("reserved/fvar", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, macro_STAN_MAJOR) {
+  test_throws("reserved/STAN_MAJOR", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, macro_STAN_MINOR) {
+  test_throws("reserved/STAN_MINOR", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, macro_STAN_PATCH) {
+  test_throws("reserved/STAN_PATCH", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, alignas) {
+  test_throws("reserved/alignas", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, alignof) {
+  test_throws("reserved/alignof", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, and) {
+  test_throws("reserved/and", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, and_eq) {
+  test_throws("reserved/and_eq", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, asm) {
+  test_throws("reserved/asm", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, auto) {
+  test_throws("reserved/auto", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, bitand) {
+  test_throws("reserved/bitand", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, bitor) {
+  test_throws("reserved/bitor", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, bool) {
+  test_throws("reserved/bool", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, break) {
+  test_throws("reserved/break", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, case) {
+  test_throws("reserved/case", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, catch) {
+  test_throws("reserved/catch", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, char) {
+  test_throws("reserved/char", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, char16_t) {
+  test_throws("reserved/char16_t", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, char32_t) {
+  test_throws("reserved/char32_t", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, class) {
+  test_throws("reserved/class", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, compl) {
+  test_throws("reserved/compl", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, const) {
+  test_throws("reserved/const", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, constexpr) {
+  test_throws("reserved/constexpr", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, const_cast) {
+  test_throws("reserved/const_cast", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, continue) {
+  test_throws("reserved/continue", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, decltype) {
+  test_throws("reserved/decltype", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, default) {
+  test_throws("reserved/default", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, delete) {
+  test_throws("reserved/delete", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, do) {
+  test_throws("reserved/do", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, double) {
+  test_throws("reserved/double", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, dynamic_cast) {
+  test_throws("reserved/dynamic_cast", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, enum) {
+  test_throws("reserved/enum", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, explicit) {
+  test_throws("reserved/explicit", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, export) {
+  test_throws("reserved/export", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, extern) {
+  test_throws("reserved/extern", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, float) {
+  test_throws("reserved/float", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, friend) {
+  test_throws("reserved/friend", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, goto) {
+  test_throws("reserved/goto", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, inline) {
+  test_throws("reserved/inline", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, long) {
+  test_throws("reserved/long", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, mutable) {
+  test_throws("reserved/mutable", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, namespace) {
+  test_throws("reserved/namespace", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, new) {
+  test_throws("reserved/new", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, noexcept) {
+  test_throws("reserved/noexcept", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, not) {
+  test_throws("reserved/not", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, not_eq) {
+  test_throws("reserved/not_eq", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, keyword_nullptr) {
+  test_throws("reserved/nullptr", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, operator) {
+  test_throws("reserved/operator", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, or) {
+  test_throws("reserved/or", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, or_eq) {
+  test_throws("reserved/or_eq", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, private) {
+  test_throws("reserved/private", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, protected) {
+  test_throws("reserved/protected", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, public) {
+  test_throws("reserved/public", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, register) {
+  test_throws("reserved/register", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, reinterpret_cast) {
+  test_throws("reserved/reinterpret_cast", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, return) {
+  test_throws("reserved/return", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, short) {
+  test_throws("reserved/short", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, signed) {
+  test_throws("reserved/signed", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, sizeof) {
+  test_throws("reserved/sizeof", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, static) {
+  test_throws("reserved/static", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, static_assert) {
+  test_throws("reserved/static_assert", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, static_cast) {
+  test_throws("reserved/static_cast", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, struct) {
+  test_throws("reserved/struct", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, switch) {
+  test_throws("reserved/switch", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, template) {
+  test_throws("reserved/template", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, this) {
+  test_throws("reserved/this", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, thread_local) {
+  test_throws("reserved/thread_local", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, throw) {
+  test_throws("reserved/throw", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, try) {
+  test_throws("reserved/try", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, typedef) {
+  test_throws("reserved/typedef", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, typeid) {
+  test_throws("reserved/typeid", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, typename) {
+  test_throws("reserved/typename", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, union) {
+  test_throws("reserved/union", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, unsigned) {
+  test_throws("reserved/unsigned", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, using) {
+  test_throws("reserved/using", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, virtual) {
+  test_throws("reserved/virtual", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, void) {
+  test_throws("reserved/void", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, volatile) {
+  test_throws("reserved/volatile", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, wchar_t) {
+  test_throws("reserved/wchar_t", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, xor) {
+  test_throws("reserved/xor", "variable identifier (name) may not be reserved word");
+}
+
+TEST(parserReservedWords, xor_eq) {
+  test_throws("reserved/xor_eq", "variable identifier (name) may not be reserved word");
+}

--- a/src/test/unit/version_test.cpp
+++ b/src/test/unit/version_test.cpp
@@ -1,0 +1,14 @@
+#include <stan/version.hpp>
+#include <gtest/gtest.h>
+
+TEST(Stan, macro) {
+  EXPECT_EQ(2, STAN_MAJOR);
+  EXPECT_EQ(6, STAN_MINOR);
+  EXPECT_EQ(3, STAN_PATCH);
+}
+
+TEST(Stan, version) {
+  EXPECT_EQ("2", stan::MAJOR_VERSION);
+  EXPECT_EQ("6", stan::MINOR_VERSION);
+  EXPECT_EQ("3", stan::PATCH_VERSION);
+}


### PR DESCRIPTION
#### Summary:

Adds the Stan version as a macro.
* [x] define `STAN_MAJOR`, `STAN_MINOR`, `STAN_PATCH`
* [x] define `STAN_MATH_MAJOR`, `STAN_MATH_MINOR`, `STAN_MATH_PATCH`
* [x] add it to the language parser to check for reserved words
* [x] add to the manual's list of reserved words.

Also added `fvar` as a reserved word.

#### Intended Effect:

Adds versions as macros. The original `const std::string`s are still available.

#### How to Verify:

New unit test:
```
> ./runTests.py src/test/unit/lang/parser/reserved_words_test.cpp
```

#### Side Effects:

Added a few more reserved words.

#### Documentation:

`language.tex` was updated with the keywords.

#### Reviewer Suggestions: 

@bob-carpenter. Can you make sure I categorized the macros correctly in the manual?