### PR TITLE
Bugfix/issue 1506 intel 14 parser

### DIFF
--- a/lib/boost_1.58.0/boost/phoenix/core/actor.hpp
+++ b/lib/boost_1.58.0/boost/phoenix/core/actor.hpp
@@ -209,6 +209,12 @@ namespace boost { namespace phoenix
             return *this;
         }
 
+#ifdef __INTEL_COMPILER 
+/* Intel compiler cannot currently compile return type on assignment
+ * operator declared below.  See:
+ * https://software.intel.com/en-us/articles/boost-compiler-error-class-has-no-member-type
+ */ 
+#else 
         template <typename A0>
         typename proto::result_of::make_expr<
             proto::tag::assign
@@ -220,6 +226,7 @@ namespace boost { namespace phoenix
         {
             return proto::make_expr<proto::tag::assign, phoenix_domain>(this->proto_expr_, a0);
         }
+#endif
 
         template <typename A0>
         typename proto::result_of::make_expr<

--- a/lib/boost_1.58.0/boost/phoenix/core/actor.hpp
+++ b/lib/boost_1.58.0/boost/phoenix/core/actor.hpp
@@ -209,17 +209,17 @@ namespace boost { namespace phoenix
             return *this;
         }
 
-        template <typename A0>
-        typename proto::result_of::make_expr<
-            proto::tag::assign
-          , phoenix_domain
-          , proto_base_expr
-          , A0
-        >::type const
-        operator=(A0 const & a0) const
-        {
-            return proto::make_expr<proto::tag::assign, phoenix_domain>(this->proto_expr_, a0);
-        }
+        // template <typename A0>
+        // typename proto::result_of::make_expr<
+        //     proto::tag::assign
+        //   , phoenix_domain
+        //   , proto_base_expr
+        //   , A0
+        // >::type const
+        // operator=(A0 const & a0) const
+        // {
+        //     return proto::make_expr<proto::tag::assign, phoenix_domain>(this->proto_expr_, a0);
+        // }
 
         template <typename A0>
         typename proto::result_of::make_expr<

--- a/lib/boost_1.58.0/boost/phoenix/core/actor.hpp
+++ b/lib/boost_1.58.0/boost/phoenix/core/actor.hpp
@@ -209,17 +209,17 @@ namespace boost { namespace phoenix
             return *this;
         }
 
-        // template <typename A0>
-        // typename proto::result_of::make_expr<
-        //     proto::tag::assign
-        //   , phoenix_domain
-        //   , proto_base_expr
-        //   , A0
-        // >::type const
-        // operator=(A0 const & a0) const
-        // {
-        //     return proto::make_expr<proto::tag::assign, phoenix_domain>(this->proto_expr_, a0);
-        // }
+        template <typename A0>
+        typename proto::result_of::make_expr<
+            proto::tag::assign
+          , phoenix_domain
+          , proto_base_expr
+          , A0
+        >::type const
+        operator=(A0 const & a0) const
+        {
+            return proto::make_expr<proto::tag::assign, phoenix_domain>(this->proto_expr_, a0);
+        }
 
         template <typename A0>
         typename proto::result_of::make_expr<

--- a/src/stan/lang/grammars/bare_type_grammar_def.hpp
+++ b/src/stan/lang/grammars/bare_type_grammar_def.hpp
@@ -88,7 +88,7 @@ namespace stan {
       array_dims_r.name("array dimensions,\n"
              "    e.g., empty (not an array) [] (1D array) or [,] (2D array)");
       array_dims_r
-        %= eps[_val = 0]
+        %= eps[set_val_f(_val, 0)]
         >> - (lit('[')[set_val_f(_val, 1)]
               > *(lit(',')[increment_val_f(_val)])
               > end_bare_types_r);

--- a/src/stan/lang/grammars/bare_type_grammar_def.hpp
+++ b/src/stan/lang/grammars/bare_type_grammar_def.hpp
@@ -33,68 +33,72 @@ namespace stan {
 
   namespace lang {
 
-     template <typename Iterator>
-     bare_type_grammar<Iterator>::bare_type_grammar(variable_map& var_map,
-                                                    std::stringstream& error_msgs)
-       : bare_type_grammar::base_type(bare_type_r),
-         var_map_(var_map),
-         error_msgs_(error_msgs)
-     {
-      using boost::spirit::qi::_1;
-      using boost::spirit::qi::char_;
+    struct set_val {
+      template <class> struct result;
+      template <typename F, typename T1, typename T2>
+      struct result<F(T1, T2)> { typedef void type; };
+      template <typename T1, typename T2>
+      void operator()(T1& lhs,
+                      const T2& rhs) const {
+        lhs = rhs;
+      }
+    };
+    boost::phoenix::function<set_val> set_val_f;
+
+    struct increment_val {
+      template <class> struct result;
+      template <typename F, typename T1>
+      struct result<F(T1)> { typedef void type; };
+      template <typename T1>
+      void operator()(T1& lhs) const {
+        lhs += 1;
+      }
+    };
+    boost::phoenix::function<increment_val> increment_val_f;
+
+    template <typename Iterator>
+    bare_type_grammar<Iterator>::bare_type_grammar(variable_map& var_map,
+                                           std::stringstream& error_msgs)
+      : bare_type_grammar::base_type(bare_type_r),
+        var_map_(var_map),
+        error_msgs_(error_msgs) {
       using boost::spirit::qi::eps;
-      using boost::spirit::qi::lexeme;
       using boost::spirit::qi::lit;
-      using boost::spirit::qi::no_skip;
-      using boost::spirit::qi::_pass;
       using boost::spirit::qi::_val;
 
-      using boost::spirit::qi::labels::_a;
-      using boost::spirit::qi::labels::_r1;
-      using boost::spirit::qi::labels::_r2;
-
-      using boost::spirit::qi::on_error;
-      using boost::spirit::qi::fail;
-      using boost::spirit::qi::rethrow;
-      using namespace boost::spirit::qi::labels;
-
       bare_type_r.name("bare type definition\n"
-                       "   (no dimensions or constraints, just commas,\n"
-                       "   e.g. real[,] for a 2D array or int for a single integer,\n"
-                       "   and constrained types such as cov_matrix not allowed)");
+               "   (no dimensions or constraints, just commas,\n"
+               "   e.g. real[,] for a 2D array or int for a single integer,\n"
+               "   and constrained types such as cov_matrix not allowed)");
       bare_type_r
-        %=
-        type_identifier_r
-        >> array_dims_r
-        ;
+        %= type_identifier_r
+        >> array_dims_r;
 
       type_identifier_r.name("bare type identifier\n"
-                             "    legal values: void, int, real, vector, row_vector, matrix");
+                "  legal values: void, int, real, vector, row_vector, matrix");
+
       type_identifier_r
-        %=
-        lit("void")[_val = VOID_T]
-        | lit("int")[_val = INT_T]
-        | lit("real")[_val = DOUBLE_T]
-        | lit("vector")[_val = VECTOR_T]
-        | lit("row_vector")[_val = ROW_VECTOR_T]
-        | lit("matrix")[_val = MATRIX_T]
-        ;
+        %= lit("void")[set_val_f(_val, VOID_T)]
+        | lit("int")[set_val_f(_val, INT_T)]
+        | lit("real")[set_val_f(_val, DOUBLE_T)]
+        | lit("vector")[set_val_f(_val, VECTOR_T)]
+        | lit("row_vector")[set_val_f(_val, ROW_VECTOR_T)]
+        | lit("matrix")[set_val_f(_val, MATRIX_T)];
 
       array_dims_r.name("array dimensions,\n"
-                        "    e.g., empty (not an array) [] (1D array) or [,] (2D array)");
+             "    e.g., empty (not an array) [] (1D array) or [,] (2D array)");
       array_dims_r
-        %=
-        eps[_val = 0]
-        >> - ( lit('[')[_val = 1]
-               > *(lit(',')[_val += 1])
-               > end_bare_types_r
-               );
+        %= eps[_val = 0]
+        >> - (lit('[')[set_val_f(_val, 1)]
+              > *(lit(',')[increment_val_f(_val)])
+              > end_bare_types_r);
 
-      end_bare_types_r.name("comma to indicate more dimensions or ] to end type declaration");
+      end_bare_types_r.name("comma to indicate more dimensions"
+                            " or ] to end type declaration");
       end_bare_types_r
         %= lit(']');
+    }
 
-     }
   }
 }
 #endif

--- a/src/stan/lang/grammars/expression07_grammar_def.hpp
+++ b/src/stan/lang/grammars/expression07_grammar_def.hpp
@@ -44,16 +44,15 @@ namespace stan {
     struct validate_expr_type3 {
       template <class> struct result;
 
-      template <typename F, typename T1, typename T2>
-      struct result<F(T1, T2)> { typedef bool type; };
+      template <typename F, typename T1, typename T2, typename T3>
+      struct result<F(T1, T2, T3)> { typedef void type; };
 
-      bool operator()(const expression& expr,
+      void operator()(const expression& expr,
+                      bool& pass,
                       std::ostream& error_msgs) const {
-        if (expr.expression_type().is_ill_formed()) {
+        pass = !expr.expression_type().is_ill_formed();
+        if (!pass)
           error_msgs << "expression is ill formed" << std::endl;
-          return false;
-        }
-        return true;
       }
     };
     boost::phoenix::function<validate_expr_type3> validate_expr_type3_f;
@@ -80,14 +79,15 @@ namespace stan {
       template <class> struct result;
 
       template <typename F, typename T1, typename T2, typename T3>
-      struct result<F(T1, T2, T3)> { typedef expression type; };
+      struct result<F(T1, T2, T3)> { typedef void type; };
 
-      expression operator()(expression& expr1,
-                            const expression& expr2,
-                            std::ostream& error_msgs) const {
+      void operator()(expression& expr1,
+                      const expression& expr2,
+                      std::ostream& error_msgs) const {
         if (expr1.expression_type().is_primitive()
             && expr2.expression_type().is_primitive()) {
-          return expr1 += expr2;
+          expr1 += expr2;
+          return;
         }
         std::vector<expression> args;
         args.push_back(expr1);
@@ -95,8 +95,7 @@ namespace stan {
         set_fun_type3 sft;
         fun f("add", args);
         sft(f, error_msgs);
-        return expression(f);
-        return expr1 += expr2;
+        expr1 = expression(f);
       }
     };
     boost::phoenix::function<addition_expr3> addition3_f;
@@ -105,14 +104,15 @@ namespace stan {
     struct subtraction_expr3 {
       template <class> struct result; 
       template <typename F, typename T1, typename T2, typename T3>
-      struct result<F(T1, T2, T3)> { typedef expression type; };
+      struct result<F(T1, T2, T3)> { typedef void type; };
 
-      expression operator()(expression& expr1,
-                            const expression& expr2,
-                            std::ostream& error_msgs) const {
+      void operator()(expression& expr1,
+                      const expression& expr2,
+                      std::ostream& error_msgs) const {
         if (expr1.expression_type().is_primitive()
             && expr2.expression_type().is_primitive()) {
-          return expr1 -= expr2;
+          expr1 -= expr2;
+          return;
         }
         std::vector<expression> args;
         args.push_back(expr1);
@@ -120,7 +120,7 @@ namespace stan {
         set_fun_type3 sft;
         fun f("subtract", args);
         sft(f, error_msgs);
-        return expression(f);
+        expr1 = expression(f);
       }
     };
     boost::phoenix::function<subtraction_expr3> subtraction3_f;
@@ -129,8 +129,8 @@ namespace stan {
 
     template <typename Iterator>
     expression07_grammar<Iterator>::expression07_grammar(variable_map& var_map,
-                                                         std::stringstream& error_msgs,
-                                                         expression_grammar<Iterator>& eg)
+                                             std::stringstream& error_msgs,
+                                             expression_grammar<Iterator>& eg)
       : expression07_grammar::base_type(expression07_r),
         var_map_(var_map),
         error_msgs_(error_msgs),
@@ -144,19 +144,17 @@ namespace stan {
 
       expression07_r.name("expression");
       expression07_r
-        =  term_g(_r1)
+        %=  term_g(_r1)
             [_val = _1]
-        > *( ( lit('+')
-               > term_g(_r1) // expression07_r
-                [_val = addition3_f(_val, _1, boost::phoenix::ref(error_msgs))] )
-              |
-              ( lit('-')
-                > term_g(_r1) // expression07_r
-                [_val = subtraction3_f(_val, _1, boost::phoenix::ref(error_msgs))] )
-              )
-        > eps[_pass = validate_expr_type3_f(_val, boost::phoenix::ref(error_msgs_))]
-        ;
-
+        > *((lit('+')
+             > term_g(_r1)
+               [addition3_f(_val, _1, boost::phoenix::ref(error_msgs))])
+            |
+            (lit('-')
+             > term_g(_r1)
+             [subtraction3_f(_val, _1, boost::phoenix::ref(error_msgs))]))
+        > eps[validate_expr_type3_f(_val, _pass, 
+                                    boost::phoenix::ref(error_msgs_))];
     }
 
   }

--- a/src/stan/lang/grammars/expression07_grammar_def.hpp
+++ b/src/stan/lang/grammars/expression07_grammar_def.hpp
@@ -41,6 +41,19 @@ namespace stan {
 
   namespace lang {
 
+    // see bare_type_grammar_def.hpp for original
+    struct set_val2 {
+      template <class> struct result;
+      template <typename F, typename T1, typename T2>
+      struct result<F(T1, T2)> { typedef void type; };
+      template <typename T1, typename T2>
+      void operator()(T1& lhs,
+                      const T2& rhs) const {
+        lhs = rhs;
+      }
+    };
+    boost::phoenix::function<set_val2> set_val2_f;
+
     struct validate_expr_type3 {
       template <class> struct result;
 
@@ -145,7 +158,7 @@ namespace stan {
       expression07_r.name("expression");
       expression07_r
         %=  term_g(_r1)
-            [_val = _1]
+            [set_val2_f(_val, _1)]
         > *((lit('+')
              > term_g(_r1)
                [addition3_f(_val, _1, boost::phoenix::ref(error_msgs))])

--- a/src/stan/lang/grammars/expression07_grammar_def.hpp
+++ b/src/stan/lang/grammars/expression07_grammar_def.hpp
@@ -115,7 +115,7 @@ namespace stan {
 
 
     struct subtraction_expr3 {
-      template <class> struct result; 
+      template <class> struct result;
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 
@@ -166,7 +166,7 @@ namespace stan {
             (lit('-')
              > term_g(_r1)
              [subtraction3_f(_val, _1, boost::phoenix::ref(error_msgs))]))
-        > eps[validate_expr_type3_f(_val, _pass, 
+        > eps[validate_expr_type3_f(_val, _pass,
                                     boost::phoenix::ref(error_msgs_))];
     }
 

--- a/src/stan/lang/grammars/expression_grammar_def.hpp
+++ b/src/stan/lang/grammars/expression_grammar_def.hpp
@@ -5,11 +5,7 @@
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 #include <boost/lexical_cast.hpp>
-
 #include <boost/spirit/include/classic_position_iterator.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_function.hpp>
 #include <boost/spirit/include/phoenix_fusion.hpp>
@@ -78,10 +74,9 @@ namespace stan {
 
    struct binary_op_expr {
      template <class> struct result;
-     template <typename F, typename T1, typename T2, typename T3, typename T4, typename T5>
+     template <typename F, typename T1, typename T2, typename T3,
+               typename T4, typename T5>
      struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
-     // template <typename T1, typename T2, typename T3, typename T4, typename T5>
-     // struct result { typedef void type; };
 
      void operator()(expression& expr1,
                             const expression& expr2,
@@ -113,12 +108,11 @@ namespace stan {
 
     template <typename Iterator>
     expression_grammar<Iterator>::expression_grammar(variable_map& var_map,
-                                                     std::stringstream& error_msgs)
+                                             std::stringstream& error_msgs)
       : expression_grammar::base_type(expression_r),
         var_map_(var_map),
         error_msgs_(error_msgs),
-        expression07_g(var_map, error_msgs, *this)
-    {
+        expression07_g(var_map, error_msgs, *this) {
       using boost::spirit::qi::_1;
       using boost::spirit::qi::char_;
       using boost::spirit::qi::double_;
@@ -136,8 +130,8 @@ namespace stan {
       expression_r
         = expression14_r(_r1)[set_val3_f(_val, _1)]
         > *(lit("||")
-            > expression14_r(_r1) 
-              [binary_op_f(_val,_1, "||", "logical_or",
+            > expression14_r(_r1)
+              [binary_op_f(_val, _1, "||", "logical_or",
                            boost::phoenix::ref(error_msgs))]);
 
       expression14_r.name("expression");
@@ -157,8 +151,8 @@ namespace stan {
                             boost::phoenix::ref(error_msgs))])
               |
               (lit("!=")
-               > expression09_r(_r1)  
-                 [binary_op_f(_val,_1, "!=", "logical_neq",
+               > expression09_r(_r1)
+                 [binary_op_f(_val, _1, "!=", "logical_neq",
                               boost::phoenix::ref(error_msgs))]));
 
       expression09_r.name("expression");
@@ -166,11 +160,11 @@ namespace stan {
         = expression07_g(_r1)[set_val3_f(_val, _1)]
         > *((lit("<=")
              > expression07_g(_r1)
-               [binary_op_f(_val,_1, "<", "logical_lte",
+               [binary_op_f(_val, _1, "<", "logical_lte",
                             boost::phoenix::ref(error_msgs))])
             | (lit("<")
                > expression07_g(_r1)
-                 [binary_op_f(_val,_1, "<=", "logical_lt",
+                 [binary_op_f(_val, _1, "<=", "logical_lt",
                               boost::phoenix::ref(error_msgs))])
             | (lit(">=")
                > expression07_g(_r1)

--- a/src/stan/lang/grammars/expression_grammar_def.hpp
+++ b/src/stan/lang/grammars/expression_grammar_def.hpp
@@ -42,8 +42,20 @@
 #include <stdexcept>
 
 namespace stan {
-
   namespace lang {
+
+    // see bare_type_grammar_def.hpp for original
+    struct set_val3 {
+      template <class> struct result;
+      template <typename F, typename T1, typename T2>
+      struct result<F(T1, T2)> { typedef void type; };
+      template <typename T1, typename T2>
+      void operator()(T1& lhs,
+                      const T2& rhs) const {
+        lhs = rhs;
+      }
+    };
+    boost::phoenix::function<set_val3> set_val3_f;
 
 
     // FIXME: cut and paste from term grammar, having trouble w. includes
@@ -122,54 +134,54 @@ namespace stan {
 
       expression_r.name("expression");
       expression_r
-        = expression14_r(_r1) [_val = _1]
-        > *( lit("||")
-             > expression14_r(_r1)  [ binary_op_f(_val,_1, "||", "logical_or",
-                                                   boost::phoenix::ref(error_msgs))]
-             );
+        = expression14_r(_r1)[set_val3_f(_val, _1)]
+        > *(lit("||")
+            > expression14_r(_r1) 
+              [binary_op_f(_val,_1, "||", "logical_or",
+                           boost::phoenix::ref(error_msgs))]);
 
       expression14_r.name("expression");
       expression14_r
-        = expression10_r(_r1) [_val = _1]
-        > *( lit("&&")
-             > expression10_r(_r1)  [ binary_op_f(_val, _1, "&&", "logical_and",
-                                                   boost::phoenix::ref(error_msgs))]
-             );
+        = expression10_r(_r1)[set_val3_f(_val, _1)]
+        > *(lit("&&")
+            > expression10_r(_r1)
+              [binary_op_f(_val, _1, "&&", "logical_and",
+                           boost::phoenix::ref(error_msgs))]);
 
       expression10_r.name("expression");
       expression10_r
-        = expression09_r(_r1) [_val = _1]
-        > *( ( lit("==")
-               > expression09_r(_r1)  [ binary_op_f(_val, _1, "==", "logical_eq",
-                                                       boost::phoenix::ref(error_msgs))] )
+        = expression09_r(_r1)[set_val3_f(_val, _1)]
+        > *((lit("==")
+             > expression09_r(_r1)
+               [binary_op_f(_val, _1, "==", "logical_eq",
+                            boost::phoenix::ref(error_msgs))])
               |
-              ( lit("!=")
-                > expression09_r(_r1)  [binary_op_f(_val,_1, "!=", "logical_neq",
-                                                      boost::phoenix::ref(error_msgs))] )
-              );
+              (lit("!=")
+               > expression09_r(_r1)  
+                 [binary_op_f(_val,_1, "!=", "logical_neq",
+                              boost::phoenix::ref(error_msgs))]));
 
       expression09_r.name("expression");
       expression09_r
-        = expression07_g(_r1) [_val = _1]
-        > *( ( lit("<=")
-               > expression07_g(_r1)  [ binary_op_f(_val,_1, "<", "logical_lte",
-                                                      boost::phoenix::ref(error_msgs))] )
-              |
-              ( lit("<")
-                > expression07_g(_r1)  [binary_op_f(_val,_1, "<=", "logical_lt",
-                                                      boost::phoenix::ref(error_msgs))] )
-              |
-              ( lit(">=")
-                > expression07_g(_r1)  [binary_op_f(_val, _1, ">", "logical_gte",
-                                                      boost::phoenix::ref(error_msgs))] )
-              |
-              ( lit(">")
-                > expression07_g(_r1)  [binary_op_f(_val, _1, ">=", "logical_gt",
-                                                      boost::phoenix::ref(error_msgs))] )
-              );
-
+        = expression07_g(_r1)[set_val3_f(_val, _1)]
+        > *((lit("<=")
+             > expression07_g(_r1)
+               [binary_op_f(_val,_1, "<", "logical_lte",
+                            boost::phoenix::ref(error_msgs))])
+            | (lit("<")
+               > expression07_g(_r1)
+                 [binary_op_f(_val,_1, "<=", "logical_lt",
+                              boost::phoenix::ref(error_msgs))])
+            | (lit(">=")
+               > expression07_g(_r1)
+                 [binary_op_f(_val, _1, ">", "logical_gte",
+                              boost::phoenix::ref(error_msgs))])
+            | (lit(">")
+               > expression07_g(_r1)
+                 [binary_op_f(_val, _1, ">=", "logical_gt",
+                              boost::phoenix::ref(error_msgs))]));
     }
+
   }
 }
-
 #endif

--- a/src/stan/lang/grammars/functions_grammar_def.hpp
+++ b/src/stan/lang/grammars/functions_grammar_def.hpp
@@ -27,6 +27,7 @@
 #include <stan/lang/grammars/whitespace_grammar.hpp>
 
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -60,7 +61,8 @@ namespace stan {
                      << std::endl;
       }
     };
-    boost::phoenix::function<validate_non_void_arg_function> validate_non_void_arg_f;
+    boost::phoenix::function<validate_non_void_arg_function>
+    validate_non_void_arg_f;
 
     struct set_void_function {
       template <class> struct result;
@@ -90,7 +92,8 @@ namespace stan {
       void operator()(const std::string& identifier,
                       bool& allow_sampling,
                       int& origin) const {
-        bool is_void_function_origin = (origin == void_function_argument_origin);
+        bool is_void_function_origin
+          = (origin == void_function_argument_origin);
         if (ends_with("_lp", identifier)) {
           allow_sampling = true;
           origin = is_void_function_origin
@@ -109,7 +112,8 @@ namespace stan {
         }
       }
     };
-    boost::phoenix::function<set_allows_sampling_origin> set_allows_sampling_origin_f;
+    boost::phoenix::function<set_allows_sampling_origin>
+    set_allows_sampling_origin_f;
 
     struct validate_declarations {
       template <class> struct result;
@@ -141,12 +145,15 @@ namespace stan {
 
     struct add_function_signature {
       template <class> struct result;
-      template <typename F, typename T1, typename T2, typename T3, typename T4, typename T5>
+      template <typename F, typename T1, typename T2, typename T3,
+                typename T4, typename T5>
       struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
-      static bool fun_exists(const std::set<std::pair<std::string,
-                                                      function_signature_t> >& existing,
-                             const std::pair<std::string, function_signature_t>& name_sig) {
-        for (std::set<std::pair<std::string, function_signature_t> >::const_iterator it
+      static bool fun_exists(
+             const std::set<std::pair<std::string,
+                                      function_signature_t> >& existing,
+             const std::pair<std::string, function_signature_t>& name_sig) {
+        for (std::set<std::pair<std::string,
+                                function_signature_t> >::const_iterator it
                = existing.begin();
              it != existing.end();
              ++it)
@@ -156,42 +163,45 @@ namespace stan {
         return false;
       }
       void operator()(const function_decl_def& decl,
-                      bool& pass,
-                      std::set<std::pair<std::string,
-                                         function_signature_t> >& functions_declared,
-                      std::set<std::pair<std::string,
-                                         function_signature_t> >& functions_defined,
-                      std::ostream& error_msgs) const {
-
+              bool& pass,
+              std::set<std::pair<std::string,
+                                 function_signature_t> >& functions_declared,
+              std::set<std::pair<std::string,
+                                 function_signature_t> >& functions_defined,
+              std::ostream& error_msgs) const {
         // build up representations
         expr_type result_type(decl.return_type_.base_type_,
                               decl.return_type_.num_dims_);
         std::vector<expr_type> arg_types;
         for (size_t i = 0; i < decl.arg_decls_.size(); ++i)
-          arg_types.push_back(expr_type(decl.arg_decls_[i].arg_type_.base_type_,
-                                        decl.arg_decls_[i].arg_type_.num_dims_));
+          arg_types.push_back(
+                      expr_type(decl.arg_decls_[i].arg_type_.base_type_,
+                                decl.arg_decls_[i].arg_type_.num_dims_));
         function_signature_t sig(result_type, arg_types);
         std::pair<std::string, function_signature_t> name_sig(decl.name_, sig);
 
         // check that not already declared if just declaration
         if (decl.body_.is_no_op_statement()
-            && fun_exists(functions_declared,name_sig)) {
-          error_msgs << "Parse Error.  Function already declared, name=" << decl.name_;
+            && fun_exists(functions_declared, name_sig)) {
+          error_msgs << "Parse Error.  Function already declared, name="
+                     << decl.name_;
           pass = false;
           return;
         }
 
         // check not already user defined
         if (fun_exists(functions_defined, name_sig)) {
-          error_msgs << "Parse Error.  Function already defined, name=" << decl.name_;
+          error_msgs << "Parse Error.  Function already defined, name="
+                     << decl.name_;
           pass = false;
           return;
         }
 
         // check not already system defined
-        if (!fun_exists(functions_declared,name_sig)
+        if (!fun_exists(functions_declared, name_sig)
             && function_signatures::instance().is_defined(decl.name_, sig)) {
-          error_msgs << "Parse Error.  Function system defined, name=" << decl.name_;
+          error_msgs << "Parse Error.  Function system defined, name="
+                     << decl.name_;
           pass = false;
           return;
         }
@@ -201,7 +211,7 @@ namespace stan {
             functions_declared.insert(name_sig);
             function_signatures::instance()
               .add(decl.name_,
-                   result_type,arg_types);
+                   result_type, arg_types);
             function_signatures::instance()
               .set_user_defined(name_sig);
         }
@@ -229,10 +239,11 @@ namespace stan {
           return;
         }
 
-        if (ends_with("_log",decl.name_)
+        if (ends_with("_log", decl.name_)
             && !decl.return_type_.is_primitive_double()) {
             pass = false;
-            error_msgs << "Require real return type for functions ending in _log.";
+            error_msgs << "Require real return type for functions"
+                       << " ending in _log.";
         }
       }
     };
@@ -280,7 +291,7 @@ namespace stan {
           error_msgs << "; attempt to redeclare as function argument";
 
           error_msgs << "; original declaration as ";
-          print_var_origin(error_msgs,vm.get_origin(decl.name_));
+          print_var_origin(error_msgs, vm.get_origin(decl.name_));
 
           error_msgs << std::endl;
           return;
@@ -302,83 +313,68 @@ namespace stan {
         functions_declared_(),
         functions_defined_(),
         error_msgs_(error_msgs),
-        statement_g(var_map_,error_msgs_),
-        bare_type_g(var_map_,error_msgs_) {
+        statement_g(var_map_, error_msgs_),
+        bare_type_g(var_map_, error_msgs_) {
       using boost::spirit::qi::_1;
       using boost::spirit::qi::char_;
       using boost::spirit::qi::eps;
       using boost::spirit::qi::lexeme;
       using boost::spirit::qi::lit;
-      using boost::spirit::qi::no_skip;
       using boost::spirit::qi::_pass;
       using boost::spirit::qi::_val;
-
       using boost::spirit::qi::labels::_a;
       using boost::spirit::qi::labels::_b;
-      using boost::spirit::qi::labels::_r1;
-      using boost::spirit::qi::labels::_r2;
-
-      using boost::spirit::qi::on_error;
-      using boost::spirit::qi::fail;
-      using boost::spirit::qi::rethrow;
-      using namespace boost::spirit::qi::labels;
 
       functions_r.name("function declarations and definitions");
       functions_r
-        %= ( lit("functions")  // block, so doesn't need guard to not be continued
-             > lit("{") )
+        %= (lit("functions") > lit("{"))
         >> *function_r
         > lit('}')
-        > eps[ validate_declarations_f(_pass,
-                                       boost::phoenix::ref(functions_declared_),
-                                       boost::phoenix::ref(functions_defined_),
-                                       boost::phoenix::ref(error_msgs_) ) ]
-        ;
+        > eps[validate_declarations_f(_pass,
+                                      boost::phoenix::ref(functions_declared_),
+                                      boost::phoenix::ref(functions_defined_),
+                                      boost::phoenix::ref(error_msgs_))];
       // locals: _a = allow sampling, _b = origin (function, rng/lp)
       function_r.name("function declaration or definition");
       function_r
-        %= bare_type_g[ set_void_function_f(_1, _b, _pass,
-                                            boost::phoenix::ref(error_msgs_)) ]
-        > identifier_r[ set_allows_sampling_origin_f(_1, _a, _b) ]
+        %= bare_type_g[set_void_function_f(_1, _b, _pass,
+                                           boost::phoenix::ref(error_msgs_))]
+        > identifier_r[set_allows_sampling_origin_f(_1, _a, _b)]
         > lit('(')
         > arg_decls_r
         > close_arg_decls_r
-        > eps [ scope_lp_f(boost::phoenix::ref(var_map_)) ]
+        > eps[scope_lp_f(boost::phoenix::ref(var_map_))]
         > statement_g(_a, _b, true)
-        > eps [ unscope_variables_f(_val,
-                                     boost::phoenix::ref(var_map_)) ]
-        > eps [ validate_return_type_f(_val, _pass,
-                                        boost::phoenix::ref(error_msgs_)) ]
-        > eps [ add_function_signature_f(_val, _pass,
-                                          boost::phoenix::ref(functions_declared_),
-                                          boost::phoenix::ref(functions_defined_),
-                                          boost::phoenix::ref(error_msgs_) ) ]
-        ;
+        > eps[unscope_variables_f(_val, boost::phoenix::ref(var_map_))]
+        > eps[validate_return_type_f(_val, _pass,
+                                     boost::phoenix::ref(error_msgs_))]
+        > eps[add_function_signature_f(_val, _pass,
+                                       boost::phoenix::ref(functions_declared_),
+                                       boost::phoenix::ref(functions_defined_),
+                                       boost::phoenix::ref(error_msgs_))];
 
-      close_arg_decls_r.name("argument declaration or close paren ) to end argument declarations");
+      close_arg_decls_r.name("argument declaration or close paren )"
+                             " to end argument declarations");
       close_arg_decls_r %= lit(')');
 
       arg_decls_r.name("function argument declaration sequence");
       arg_decls_r
         %= arg_decl_r % ','
-        | eps
-        ;
+        | eps;
 
       arg_decl_r.name("function argument declaration");
       arg_decl_r
-        %= bare_type_g [ validate_non_void_arg_f(_1, _pass,
-                                                 boost::phoenix::ref(error_msgs_)) ]
+        %= bare_type_g[validate_non_void_arg_f(_1, _pass,
+                                       boost::phoenix::ref(error_msgs_))]
         > identifier_r
-        > eps[ add_fun_var_f(_val, _pass,
-                              boost::phoenix::ref(var_map_),
-                              boost::phoenix::ref(error_msgs_)) ]
-        ;
+        > eps[add_fun_var_f(_val, _pass,
+                            boost::phoenix::ref(var_map_),
+                            boost::phoenix::ref(error_msgs_))];
 
       identifier_r.name("identifier");
       identifier_r
         %= lexeme[char_("a-zA-Z")
                    >> *char_("a-zA-Z0-9_.")];
-
     }
 
   }

--- a/src/stan/lang/grammars/statement_2_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_2_grammar_def.hpp
@@ -51,8 +51,10 @@ namespace stan {
                       bool& pass,
                       std::stringstream& error_msgs) const {
         if (!e.expression_type().is_primitive()) {
-          error_msgs << "conditions in if-else statement must be primitive int or real;"
-                     << " found type=" << e.expression_type() << std::endl;
+          error_msgs << "conditions in if-else statement must be"
+                     << " primitive int or real;"
+                     << " found type=" << e.expression_type()
+                     << std::endl;
           pass = false;
           return;
         }
@@ -61,7 +63,8 @@ namespace stan {
         return;
       }
     };
-    boost::phoenix::function<add_conditional_condition> add_conditional_condition_f;
+    boost::phoenix::function<add_conditional_condition>
+    add_conditional_condition_f;
 
     struct add_conditional_body {
       template <class> struct result;
@@ -78,21 +81,19 @@ namespace stan {
 
     template <typename Iterator>
     statement_2_grammar<Iterator>::statement_2_grammar(variable_map& var_map,
-                                                       std::stringstream& error_msgs,
-                                                       statement_grammar<Iterator>& sg)
+                                           std::stringstream& error_msgs,
+                                           statement_grammar<Iterator>& sg)
       : statement_2_grammar::base_type(statement_2_r),
         var_map_(var_map),
         error_msgs_(error_msgs),
         expression_g(var_map, error_msgs),
-        statement_g(sg)
-    {
+        statement_g(sg) {
       using boost::spirit::qi::_1;
       using boost::spirit::qi::char_;
       using boost::spirit::qi::lit;
       using boost::spirit::qi::no_skip;
       using boost::spirit::qi::_pass;
       using boost::spirit::qi::_val;
-
       using boost::spirit::qi::labels::_r1;
       using boost::spirit::qi::labels::_r2;
       using boost::spirit::qi::labels::_r3;
@@ -102,8 +103,7 @@ namespace stan {
       // set to true if sample_r are allowed
       statement_2_r.name("statement");
       statement_2_r
-        %= conditional_statement_r(_r1, _r2, _r3)
-        ;
+        %= conditional_statement_r(_r1, _r2, _r3);
 
 
       conditional_statement_r.name("if-else statement");
@@ -124,14 +124,10 @@ namespace stan {
                                             boost::phoenix::ref(error_msgs_))]
              > lit(')')
              > statement_g(_r1, _r2, _r3)
-               [add_conditional_body_f(_val, _1)]
-             )
-        > - ((lit("else") >> no_skip[!char_("a-zA-Z0-9_")])
-             > statement_g(_r1, _r2, _r3)
-               [add_conditional_body_f(_val, _1)]
-             )
-        ;
-
+               [add_conditional_body_f(_val, _1)])
+        > -((lit("else") >> no_skip[!char_("a-zA-Z0-9_")])
+            > statement_g(_r1, _r2, _r3)
+              [add_conditional_body_f(_val, _1)]);
     }
 
   }

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -588,6 +588,26 @@ namespace stan {
     };
     boost::phoenix::function<add_line_number> add_line_number_f;
 
+    struct set_void_return {
+      template <class> struct result;
+      template <typename F, typename T1>
+      struct result<F(T1)> { typedef void type; };
+      void operator()(return_statement& s) const {
+        s = return_statement();
+      }
+    };
+    boost::phoenix::function<set_void_return> set_void_return_f;
+
+    struct set_no_op {
+      template <class> struct result;
+      template <typename F, typename T1>
+      struct result<F(T1)> { typedef void type; };
+      void operator()(no_op_statement& s) const {
+        s = no_op_statement();
+      }
+    };
+    boost::phoenix::function<set_no_op> set_no_op_f;
+
     template <typename Iterator>
     statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
                                                std::stringstream& error_msgs)
@@ -808,13 +828,13 @@ namespace stan {
       // _r1 = var origin
       void_return_statement_r.name("void return statement");
       void_return_statement_r
-        = lit("return")[_val = expression()]
-        >> lit(';') [validate_void_return_allowed_f(_r1, _pass,
+        = lit("return")[set_void_return_f(_val)]  // = expression()]
+        >> lit(';')[validate_void_return_allowed_f(_r1, _pass,
                                         boost::phoenix::ref(error_msgs_))];
 
       no_op_statement_r.name("no op statement");
       no_op_statement_r
-        %= lit(';') [_val = no_op_statement()];  // ok to re-use instance
+        %= lit(';')[set_no_op_f(_val)];
     }
 
   }

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -140,7 +140,7 @@ namespace stan {
 
     struct validate_assignment {
       template <class> struct result;
-      template <typename F, typename T1, typename T2, typename T3, 
+      template <typename F, typename T1, typename T2, typename T3,
                 typename T4, typename T5>
       struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
 
@@ -646,7 +646,7 @@ namespace stan {
 
     template <typename Iterator>
     statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
-                                                   std::stringstream& error_msgs)
+                                           std::stringstream& error_msgs)
       : statement_grammar::base_type(statement_r),
         var_map_(var_map),
         error_msgs_(error_msgs),
@@ -718,8 +718,9 @@ namespace stan {
         > eps[ validate_allow_sample_f(_r1, _pass,
                                        boost::phoenix::ref(error_msgs_)) ]
         > lit('(')
-        > expression_g(_r2) [validate_non_void_expression_f(_1, _pass,
-                                                            boost::phoenix::ref(error_msgs_))]
+        > expression_g(_r2)
+          [validate_non_void_expression_f(_1, _pass,
+                                          boost::phoenix::ref(error_msgs_))]
         > lit(')')
         > lit(';');
 

--- a/src/stan/lang/grammars/term_grammar_def.hpp
+++ b/src/stan/lang/grammars/term_grammar_def.hpp
@@ -632,7 +632,7 @@ namespace stan {
 
     struct set_var_type {
       template <class> struct result;
-      template <typename F, typename T1, typename T2, typename T3, 
+      template <typename F, typename T1, typename T2, typename T3,
                 typename T4, typename T5>
       struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
       void operator()(variable& var_expr, expression& val, variable_map& vm,

--- a/src/stan/lang/grammars/var_decls_grammar_def.hpp
+++ b/src/stan/lang/grammars/var_decls_grammar_def.hpp
@@ -306,7 +306,7 @@ namespace stan {
 
     struct validate_decl_constraints {
       template <class> struct result;
-      template <typename F, typename T1, typename T2, typename T3, 
+      template <typename F, typename T1, typename T2, typename T3,
                 typename T4, typename T5>
       struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
 

--- a/src/stan/lang/grammars/var_decls_grammar_def.hpp
+++ b/src/stan/lang/grammars/var_decls_grammar_def.hpp
@@ -556,10 +556,10 @@ namespace stan {
 
     struct empty_range {
       template <class> struct result;
-      template <typename F, typename T1>
-      struct result<F(T1)> { typedef range type; };
-      range operator()(std::stringstream& /*error_msgs*/) const {
-        return range();
+      template <typename F, typename T1, typename T2>
+      struct result<F(T1, T2)> { typedef void type; };
+      void operator()(range& r, std::stringstream& /*error_msgs*/) const {
+        r = range();
       }
     };
     boost::phoenix::function<empty_range> empty_range_f;
@@ -938,7 +938,7 @@ namespace stan {
 
       range_brackets_int_r.name("integer range expression pair, brackets");
       range_brackets_int_r
-        = lit('<') [_val = empty_range_f(boost::phoenix::ref(error_msgs_))]
+        = lit('<') [empty_range_f(_val, boost::phoenix::ref(error_msgs_))]
         >> (
             ((lit("lower")
               >> lit('=')
@@ -962,7 +962,7 @@ namespace stan {
 
       range_brackets_double_r.name("real range expression pair, brackets");
       range_brackets_double_r
-        = lit('<') [_val = empty_range_f(boost::phoenix::ref(error_msgs_))]
+        = lit('<')[empty_range_f(_val, boost::phoenix::ref(error_msgs_))]
         > (
            ((lit("lower")
              > lit('=')

--- a/src/stan/lang/rethrow_located.hpp
+++ b/src/stan/lang/rethrow_located.hpp
@@ -73,7 +73,6 @@ namespace stan {
       const char* what() const throw() {
         return what_.c_str();
       }
-
     };
 
     /**


### PR DESCRIPTION
#### Summary:

* Remove all uses of lazy evaluation of assignment (operator=) from semantic actions in the grammar

* ifdef out the offending bit of code in the Boost lib for the Intel compiler (yes, this involved changing Boost);  see  https://software.intel.com/en-us/articles/boost-compiler-error-class-has-no-member-type

* remove all the remaining lint from the grammars

#### Intended Effect:

Allow Stan to be compiled with Intel 14 compiler.

#### How to Verify:

Verifying the intended effect requires an Intel compiler, but it should be enough to verify that it passes unit tests.  No behavior should have changed --- this is purely refactoring.

#### Side Effects:

That definition of `operator=` is now invisible for clients using our copy of Boost.  This is very unlikely to be a problem.

#### Documentation:

Nothing user facing.

#### Reviewer Suggestions:

Anyone.