### PR TITLE
updating makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -71,7 +71,7 @@ include make/cpplint  # cpplint
 ##
 # Dependencies
 ##
-ifneq (,$(filter-out test-headers generate-tests clean% %-test %.d,$(MAKECMDGOALS)))
+ifneq (,$(filter-out test-headers generate-tests clean% %-test math-% %.d,$(MAKECMDGOALS)))
   -include $(addsuffix .d,$(subst $(EXE),,$(MAKECMDGOALS)))
 endif
 


### PR DESCRIPTION
#### Summary:

Fixes makefile target for updating the math library.

#### How to Verify:

Try something like:
```
> make math-update/develop
```

Under the current branch, it tries to check out a branch `develop.d` (from our dependency makefile magic) and also `develop`. This fixes the problem.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

No one.