### PR TITLE
Bugfix fix full rank dimension when calculating gradient

### DIFF
--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -251,7 +251,7 @@ namespace stan {
 
         // Initialize everything to zero
         Eigen::VectorXd mu_grad = Eigen::VectorXd::Zero(dimension_);
-        Eigen::VectorXd L_grad  = Eigen::MatrixXd::Zero(dimension_, dimension_);
+        Eigen::MatrixXd L_grad  = Eigen::MatrixXd::Zero(dimension_, dimension_);
         double tmp_lp = 0.0;
         Eigen::VectorXd tmp_mu_grad = Eigen::VectorXd::Zero(dimension_);
         Eigen::VectorXd eta = Eigen::VectorXd::Zero(dimension_);


### PR DESCRIPTION
#### Summary:
This fixes the failed unit test that @syclik noted in a [cmdstan pull request](https://github.com/stan-dev/cmdstan/pull/117), caused by dimensions not matching when calculating the gradient of the ELBO.

#### Intended Effect:
Unit test passes.

#### How to Verify:
In cmdstan:
```{bash}
make test/interface/services/argument_configuration_test
test/interface/services/argument_configuration_test
```

#### Side Effects:
None

#### Documentation:
None

#### Reviewer Suggestions:
@syclik 