### PR TITLE
Feature/advi lp

### DIFF
--- a/src/test/unit/variational/hier_logistic_test.cpp
+++ b/src/test/unit/variational/hier_logistic_test.cpp
@@ -92,6 +92,14 @@ TEST_F(advi_test, hier_logistic_constraint_meanfield) {
   EXPECT_EQ(0, advi_->run(1, 2e4));
   SUCCEED() << "expecting it to compile and run without problems";
   EXPECT_NE("", output_stream_.str());
+  double lp;
+  std::string line;
+  while (std::getline(output_stream_, line)) {
+    std::stringstream line_ss(line);
+    line_ss >> lp;
+    EXPECT_FALSE(std::fabs(lp) < 0.0001)
+      << "lp (" << lp << ") should not be 0.0";
+  }
   SUCCEED() << "expecting it to output values";
 }
 

--- a/src/test/unit/variational/hier_logistic_test.cpp
+++ b/src/test/unit/variational/hier_logistic_test.cpp
@@ -91,7 +91,6 @@ private:
 TEST_F(advi_test, hier_logistic_constraint_meanfield) {
   EXPECT_EQ(0, advi_->run(1, 2e4));
   SUCCEED() << "expecting it to compile and run without problems";
-  output_stream_ << "  ";
   EXPECT_NE("", output_stream_.str());
   SUCCEED() << "expecting it to output values";
 }

--- a/src/test/unit/variational/hier_logistic_test.cpp
+++ b/src/test/unit/variational/hier_logistic_test.cpp
@@ -88,13 +88,17 @@ private:
   Eigen::VectorXd cont_params_;
 };
 
-
 TEST_F(advi_test, hier_logistic_constraint_meanfield) {
   EXPECT_EQ(0, advi_->run(1, 2e4));
   SUCCEED() << "expecting it to compile and run without problems";
+  output_stream_ << "  ";
+  EXPECT_NE("", output_stream_.str());
+  SUCCEED() << "expecting it to output values";
 }
 
 TEST_F(advi_test, hier_logistic_constraint_meanfield_no_streams) {
   EXPECT_EQ(0, advi_null_streams_->run(1, 2e4));
   SUCCEED() << "expecting it to compile and run without problems";
+  EXPECT_EQ("", output_stream_.str());
+  SUCCEED() << "expecting it to not output values";
 }


### PR DESCRIPTION
#### Summary:
Calculates log probabilities when writing to output for variational inference, in order to be consistent with sample and optimize (for now, before any refactoring which will happen after 2.7.0).

#### Intended Effect:
N/A

#### How to Verify:
Run models by building them, then running them, e.g. `make examples/bernoulli/bernoulli && cd examples/bernoulli && ./bernoulli variational data file=bernoulli.data.R`.

#### Side Effects:
N/A

#### Documentation:
See [cmdstan pull request](https://github.com/stan-dev/cmdstan/pull/125)

#### Reviewer Suggestions:
N/A