### PR TITLE
stan-reference: fix many typos

### DIFF
--- a/src/docs/stan-reference/advanced.tex
+++ b/src/docs/stan-reference/advanced.tex
@@ -245,7 +245,7 @@ coefficients, rather than the sum of their squares,
 r(\beta) = \lambda \sum_{k=1}^K | \beta_k |.
 \]
 The lasso is also called L1 shrinkage due to its relation to the L1
-norm, which is also known as taxicab distance or Manattan distance.
+norm, which is also known as taxicab distance or Manhattan distance.
 
 Because the derivative of the penalty does not depend on the value of
 the $\beta_k$,
@@ -1848,7 +1848,7 @@ The $n$-sphere is the set of points $x \in \reals^n$ such that
 
 \subsection{Unit Vector Inverse Transform}
 
-To parametrize unit length vectors, we use hyperspherical coordinates.
+To parameterize unit length vectors, we use hyperspherical coordinates.
 The unconstrained vector $y \in \reals^{n-1}$ is a set of angles which
 relates to the unit vector as follows:
 \begin{eqnarray*}

--- a/src/docs/stan-reference/algorithms.tex
+++ b/src/docs/stan-reference/algorithms.tex
@@ -428,7 +428,7 @@ so that they do not influence the final covariance estimate.
 
 If the mass matrix is specified to be dense, then regularized
 covariance estimates will be carried out, regularizing the estimate to
-a diagonal matrix, whihc is itself regularized toward a unit matrix.
+a diagonal matrix, which is itself regularized toward a unit matrix.
 
 Variances or covariances are estimated using Welford accumulators
 to avoid a loss of precision over many floating point operations.

--- a/src/docs/stan-reference/introduction.tex
+++ b/src/docs/stan-reference/introduction.tex
@@ -69,7 +69,7 @@ The PyStan home page is
 \subsubsection{MatlabStan}
 
 MatlabStan is the MATLAB interface to Stan.  Unlike RStan and PyStan,
-MatlabStan currently wraps aq CmdStan process.  The
+MatlabStan currently wraps a CmdStan process.  The
 MatlabStan home page is
 %
 \begin{quote}
@@ -162,7 +162,7 @@ may be treated as random, and among the random variables, some are
 observed and some are unknown and need to be estimated or used for
 posterior predictive inference.  Observed random variables are
 declared as data and unobserved random variables are declared as
-parameters (including transformed parametrs, generated quantities, and
+parameters (including transformed parameters, generated quantities, and
 local variables depending on them).  For the unobserved random
 variables, it is possible to sample them either marginally or jointly,
 estimate their means and variance, or plug them in for downstream
@@ -327,7 +327,7 @@ data.
 Stan implements a general, black-box form of variational inference,
 which provide an approximate posterior distribution.  Variational
 inference provides estimates of posterior means and uncertainty
-througha parametric approximation of a posterior that is optimized for
+through a parametric approximation of a posterior that is optimized for
 its fit to the true posterior.  Variational inference can be much for
 estimating posterior means and marginal variances than MCMC.  See
 \refchapter{vi-algorithms} for more information.

--- a/src/docs/stan-reference/process.tex
+++ b/src/docs/stan-reference/process.tex
@@ -4,7 +4,7 @@
 
 This chapter describes the software development lifecycle (SDLC) for
 Stan, RStan, CmdStan, and PyStan. The layout and content very closely
-follow the R regularoty compliance and validation document
+follow the R regulatory compliance and validation document
 \citep[Section~6]{RProject:2014}.
 
 \section{Operational Overview}
@@ -12,7 +12,7 @@ follow the R regularoty compliance and validation document
 The development, release, and maintenance of Stan is a collaborative
 process involving the Stan development team.  The team covers multiple
 statistical and computational disciplines and its members are based at
-both academic insitutions and industrial labs.
+both academic institutions and industrial labs.
 
 Communication among team members takes place in several venues.  Most
 discussions take place openly on the Stan developers group, often
@@ -29,7 +29,7 @@ place concurrently with development and source control.%
 %
 \footnote{The issue tracker for feature requests and bug reports is
   hosted by GitHub.  Full information on reading and making issue
-  reques4ts is available from \url{http://mc-stan.org/issues.html}.}
+  requests is available from \url{http://mc-stan.org/issues.html}.}
 %
 Bigger design issues and discussions that should be preserved take
 place on the project Wiki.%
@@ -53,7 +53,7 @@ meetups for the public in locations including London and New York.%
   organized through \url{http://www.meetup.com/Stan-Users-NYC/}.}
 
 The Stan project employs standard software development, code review,
-and testing methododologies, as described on the project Wiki pages
+and testing methodologies, as described on the project Wiki pages
 and later in this chapter.
 
 Stan's C++ library and the CmdStan interface are released under the
@@ -159,7 +159,7 @@ the Python unit testing framework unittest%
 \footnote{See
   \url{http://cran.r-project.org/web/packages/RUnit/index.html}.}
 
-The point of unit testing is to test the program ar the application
+The point of unit testing is to test the program at the application
 programmer interface (API) level, not the end-to-end functional level.  
 
 The tests are run automatically when pull requests are created through
@@ -194,7 +194,7 @@ Cloning in Git provides a complete copy of all version history,
 including every commit to every branch since the beginning of the
 project.  
 
-User feedback is accomodated through three channels. First, and most
+User feedback is accommodated through three channels. First, and most
 formally, there is an issue tracker for each of Stan C++, CmdStan,
 RStan and PyStan, which allows users to submit formal bug reports or
 make feature requests.  Any user bug report is reviewed by the
@@ -215,7 +215,7 @@ OS, and Linux before release.
 \subsection{Functional Testing}
 
 In addition to unit testing at the individual function level, Stan
-undergores rigorous end-to-end testing of its model fitting
+undergoes rigorous end-to-end testing of its model fitting
 functionality. Models with known answers are evaluated for both speed
 and accuracy. Models without analytic solutions are evaluated in terms
 of MCMC error.  
@@ -330,7 +330,7 @@ academic, not-for-profit, and industrial laboratories.
 Most of Stan's developers have Ph.D. degrees, some have Master's
 degrees, and some are currently enrolled as undergraduate or graduate
 students. All of the developers with advanced degrees have published
-extnesively in peer reviewed journals. Several have written books on
+extensively in peer reviewed journals. Several have written books on
 statistics and/or computing. Many members of the core development team
 were well known internationally outside of their contributions to Stan.
 The group overall is widely acknowledged as leading experts in
@@ -363,7 +363,7 @@ account basis.
 The version control system is hosted by GitHub
 (\url{http://github.com}). Due to Git's distributed nature, each
 developer maintains a complete record of the entire project's commit
-history. Everything is openly available, but priveleges to modify the
+history. Everything is openly available, but privileges to modify the
 existing branches is restricted to the core developers. Any change to
 the code base is easily reversed through Git.
 

--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -69,7 +69,7 @@ pseudo-random number generators.  These operate by generating a
 sequence of random numbers based on a ``seed.''  Stan (and other
 languages like R) can use time-based methods to generate a seed based
 on the time and date, or seeds can be provided to Stan (or R) in the
-form ofintegers.  Stan writes out the seed used to generate the
+form of integers.  Stan writes out the seed used to generate the
 data as well as the version number of the Stan software so that
 results can be reproduced at a later date.%
 %
@@ -888,7 +888,7 @@ random walk.
 
 Estimates near boundaries for interval-constrained parameters
 typically signal that the prior is not appropriate for the model.  It
-can also cause numerical problems with underflow and overlow when
+can also cause numerical problems with underflow and overflow when
 sampling or optimizing.
 
 \subsection{``Uninformative'' Proper Priors}
@@ -1855,7 +1855,7 @@ variables are constrained to $(0,\infty)$ by their declarations.
 
 
 
-\section{Priors for Identifiabilty}\label{priors-for-identification.section}
+\section{Priors for Identifiability}\label{priors-for-identification.section}
 
 \subsection{Location and Scale Invariance}
 
@@ -2408,7 +2408,7 @@ model {
 %
 The Cholesky factor of the covariance matrix is then reconstructed as
 a local variable and used in the model by scaling the Cholesky factor
-of the correatlion matrices. The regression coefficients get a prior
+of the correlation matrices. The regression coefficients get a prior
 all at once by converting the matrix \code{beta} to a vector.
 
 If required, the full correlation or covariance matrices may be
@@ -2419,7 +2419,7 @@ block.
 \subsection{Multivariate Probit Regression}
 
 The multivariate probit model generates sequences of boolean variables
-by applying a step function to the output of a seemingly urelated
+by applying a step function to the output of a seemingly unrelated
 regression.
 
 The observations $y_n$ are $D$-vectors of boolean values (coded 0 for
@@ -2452,7 +2452,7 @@ Multivariate probit regression can be coded in Stan using the trick
 introduced by \cite{AlbertChib:1993}, where the underlying continuous
 value vectors $y_n$ are coded as truncated parameters.  The key to
 coding the model in Stan is declaring the latent vector $z$ in two
-parts, based on whether the correspdonding value of $y$ is 0 or 1.
+parts, based on whether the corresponding value of $y$ is 0 or 1.
 Otherwise, the model is identical to the seemingly unrelated
 regression model in the previous section.
 
@@ -5238,7 +5238,7 @@ The definition of \code{prob\_uncaptured}, from the functions block,
 is
 %
 \begin{stancode}
-funtions {
+functions {
   ...
   vector prob_uncaptured(int T, vector p, vector phi) {
     vector[T] chi;
@@ -5299,7 +5299,7 @@ information in the CJS model is conditional on the first capture.
 
 In the inner loop, the observed capture status \code{y[i,t]} for
 individual \code{i} at time \code{t} has a Bernoulli distribution
-based on the capture probabilty \code{p[t]} at time \code{t}.
+based on the capture probability \code{p[t]} at time \code{t}.
 
 After the inner loop, the probability of an animal never being seen
 again after being observed at time \code{last[i]} is included, because
@@ -6061,7 +6061,7 @@ The specification for naive Bayes in the previous sections have used a ragged
 array notation for the words $w$.  Because Stan does not support
 ragged arrays, the models are coded using an alternative strategy that
 provides an index for each word in a global list of words.   The data
-is organized as follows, with the word arrays layed out in a column and each
+is organized as follows, with the word arrays laid out in a column and each
 assigned to its document in a second column.
 %
 \begin{center}
@@ -7540,7 +7540,7 @@ transformed parameters {
   vector[K] J_diag;  // diagonals of Jacobian matrix
   ... 
   ... compute J[k,k] = d.v[k] / d.u[k] ...
-  incement_log_prob(sum(log(J_diag)));
+  increment_log_prob(sum(log(J_diag)));
   ...
 \end{stancode}
 
@@ -9007,7 +9007,7 @@ current parameter values and the ones without collapsed components.
 It may help to use a smaller step size during warmup, a stronger prior
 on each mixture component's membership responsibility.  A more extreme
 measure is to include additional mixture components to deal with the
-possiblity that some of them may collapse.
+possibility that some of them may collapse.
 
 In general, it is very difficult to recover exactly the right $K$
 mixture components in a mixture model as $K$ increases beyond one


### PR DESCRIPTION
Fix a number of typos across a few chapters of the manual.