### PR TITLE
Removing a lot of CppLint warnings

### DIFF
--- a/src/stan/interface/callback/noop_callback.hpp
+++ b/src/stan/interface/callback/noop_callback.hpp
@@ -10,7 +10,7 @@ namespace stan {
       class noop_callback: public callback {
       public:
         noop_callback() {}
-        void operator()() { };
+        void operator()() { }
       };
 
     }

--- a/src/stan/interface/recorder/csv.hpp
+++ b/src/stan/interface/recorder/csv.hpp
@@ -1,10 +1,12 @@
 #ifndef STAN_INTERFACE_RECORDER_CSV_HPP
 #define STAN_INTERFACE_RECORDER_CSV_HPP
 
+#include <stan/interface/recorder/recorder.hpp>
 #include <stan/math/prim/scal/meta/index_type.hpp>
 #include <stan/math/prim/arr/meta/index_type.hpp>
 #include <ostream>
-#include <stan/interface/recorder/recorder.hpp>
+#include <string>
+#include <vector>
 
 namespace stan {
   namespace interface {

--- a/src/stan/interface/recorder/filtered_values.hpp
+++ b/src/stan/interface/recorder/filtered_values.hpp
@@ -1,10 +1,12 @@
 #ifndef STAN_INTERFACE_RECORDER_FILTERED_VALUES_HPP
 #define STAN_INTERFACE_RECORDER_FILTERED_VALUES_HPP
 
-#include <ostream>
-#include <stdexcept>
 #include <stan/interface/recorder/recorder.hpp>
 #include <stan/interface/recorder/values.hpp>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace stan {
   namespace interface {

--- a/src/stan/interface/recorder/messages.hpp
+++ b/src/stan/interface/recorder/messages.hpp
@@ -1,8 +1,10 @@
 #ifndef STAN_INTERFACE_RECORDER_MESSAGES_HPP
 #define STAN_INTERFACE_RECORDER_MESSAGES_HPP
 
-#include <ostream>
 #include <stan/interface/recorder/recorder.hpp>
+#include <ostream>
+#include <string>
+#include <vector>
 
 namespace stan {
   namespace interface {

--- a/src/stan/interface/recorder/noop.hpp
+++ b/src/stan/interface/recorder/noop.hpp
@@ -2,6 +2,8 @@
 #define STAN_INTERFACE_RECORDER_NOOP_HPP
 
 #include <stan/interface/recorder/recorder.hpp>
+#include <string>
+#include <vector>
 
 namespace stan {
   namespace interface {
@@ -9,11 +11,10 @@ namespace stan {
 
       class noop: public recorder {
       public:
-
         template <class T>
-        void operator()(const std::vector<T>& x) {};
-        void operator()(const std::string x) {};
-        void operator()() {};
+        void operator()(const std::vector<T>& x) {}
+        void operator()(const std::string x) {}
+        void operator()() {}
         bool is_recording() const { return false; }
       };
 

--- a/src/stan/interface/recorder/recorder.hpp
+++ b/src/stan/interface/recorder/recorder.hpp
@@ -10,10 +10,10 @@ namespace stan {
 
       class recorder {
       public:
-        virtual ~recorder() {};
+        virtual ~recorder() {}
         // Can't enforce this method with a pure virtual function
-        //template <class T>
-        //virtual void operator()(const std::vector<T>& x) = 0;
+        // template <class T>
+        // virtual void operator()(const std::vector<T>& x) = 0;
         virtual void operator()(const std::string x) = 0;
         virtual void operator()() = 0;
         virtual bool is_recording() const = 0;

--- a/src/stan/interface/recorder/sum_values.hpp
+++ b/src/stan/interface/recorder/sum_values.hpp
@@ -1,14 +1,15 @@
 #ifndef STAN_INTERFACE_RECORDER_SUM_VALUES_HPP
 #define STAN_INTERFACE_RECORDER_SUM_VALUES_HPP
 
-#include <stdexcept>
 #include <stan/interface/recorder/recorder.hpp>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace stan {
   namespace interface {
     namespace recorder {
       class sum_values: public recorder {
-
       public:
         explicit sum_values(const size_t N)
           : N_(N), m_(0), skip_(0), sum_(N_, 0.0) { }

--- a/src/stan/interface/recorder/values.hpp
+++ b/src/stan/interface/recorder/values.hpp
@@ -1,9 +1,11 @@
 #ifndef STAN_INTERFACE_RECORDER_VALUES_HPP
 #define STAN_INTERFACE_RECORDER_VALUES_HPP
 
+#include <stan/interface/recorder/recorder.hpp>
 #include <ostream>
 #include <stdexcept>
-#include <stan/interface/recorder/recorder.hpp>
+#include <string>
+#include <vector>
 
 namespace stan {
   namespace interface {

--- a/src/stan/interface/var_context_factory/dump_factory.hpp
+++ b/src/stan/interface/var_context_factory/dump_factory.hpp
@@ -4,6 +4,7 @@
 #include <stan/interface/var_context_factory/var_context_factory.hpp>
 #include <stan/io/dump.hpp>
 #include <fstream>
+#include <string>
 
 namespace stan {
   namespace interface {
@@ -17,7 +18,8 @@ namespace stan {
                                      std::fstream::in);
 
           if (source_stream.fail()) {
-            std::string message("dump_factory Error: the file " + source + " does not exist.");
+            std::string message("dump_factory Error: the file "
+                                + source + " does not exist.");
             throw std::runtime_error(message);
           }
 

--- a/src/stan/io/json/json_parser.hpp
+++ b/src/stan/io/json/json_parser.hpp
@@ -210,7 +210,7 @@ namespace stan {
             try {
               std::string ss_str = ss.str();
               x = boost::lexical_cast<double>(ss_str);
-              if (x == 0) 
+              if (x == 0)
                 io::validate_zero_buf(ss_str);
             } catch (const boost::bad_lexical_cast & ) {
               throw json_exception("number exceeds double range");

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -313,7 +313,8 @@ namespace stan {
        * @return Eigen::Matrix made up of the next scalars.
        */
       inline matrix_t matrix(size_t m, size_t n) {
-        if (m == 0 || n == 0) return matrix_t(m,n);
+        if (m == 0 || n == 0)
+          return matrix_t(m, n);
         return map_matrix_t(&scalar_ptr_increment(m*n), m, n);
       }
 
@@ -328,7 +329,8 @@ namespace stan {
        * @return Matrix made up of the next scalars.
        */
       inline matrix_t matrix_constrain(size_t m, size_t n) {
-        if (m == 0 || n == 0) return matrix_t(m,n);
+        if (m == 0 || n == 0)
+          return matrix_t(m, n);
         return map_matrix_t(&scalar_ptr_increment(m*n), m, n);
       }
 
@@ -345,7 +347,8 @@ namespace stan {
        * @return Matrix made up of the next scalars.
        */
       inline matrix_t matrix_constrain(size_t m, size_t n, T& /*lp*/) {
-        if (m == 0 || n == 0) return matrix_t(m,n);
+        if (m == 0 || n == 0)
+          return matrix_t(m, n);
         return map_matrix_t(&scalar_ptr_increment(m*n), m, n);
       }
 

--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -73,7 +73,7 @@ namespace stan {
     public:
       stan_csv_reader() {}
       ~stan_csv_reader() {}
-      
+
       static bool read_metadata(std::istream& in, stan_csv_metadata& metadata,
                                 std::ostream* out) {
         std::stringstream ss;

--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -197,7 +197,8 @@ namespace stan {
         for (size_t i = 0; i < x.dimss_.size(); ++i)
           for (size_t j = 0; j < x.dimss_[i].size(); ++j)
             indexes.push_back(x.dimss_[i][j]);  // wasteful copy, could use refs
-        generate_indexed_expr<false>(expr_string, indexes, base_type, e_num_dims, o_);
+        generate_indexed_expr<false>(expr_string, indexes, base_type,
+                                     e_num_dims, o_);
       }
       void operator()(const integrate_ode& fx) const {
         o_ << "integrate_ode("
@@ -228,7 +229,8 @@ namespace stan {
         if (fx.name_ == "logical_or" || fx.name_ == "logical_and") {
           o_ << "(primitive_value(";
           boost::apply_visitor(*this, fx.args_[0].expr_);
-          o_ << ") " << ((fx.name_ == "logical_or") ? "||" : "&&") << " primitive_value(";
+          o_ << ") " << ((fx.name_ == "logical_or") ? "||" : "&&")
+             << " primitive_value(";
           boost::apply_visitor(*this, fx.args_[1].expr_);
           o_ << "))";
           return;
@@ -335,8 +337,10 @@ namespace stan {
 
     void generate_typedefs(std::ostream& o) {
       generate_typedef("Eigen::Matrix<double,Eigen::Dynamic,1>", "vector_d", o);
-      generate_typedef("Eigen::Matrix<double,1,Eigen::Dynamic>", "row_vector_d", o);
-      generate_typedef("Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>", "matrix_d", o);
+      generate_typedef("Eigen::Matrix<double,1,Eigen::Dynamic>",
+                       "row_vector_d", o);
+      generate_typedef("Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>",
+                       "matrix_d", o);
       o << EOL;
     }
 
@@ -400,8 +404,10 @@ namespace stan {
                                         const std::string& var_name,
                                         const std::string& base_type,
                                         const std::vector<expression>& dims,
-                                        const expression& type_arg1 = expression(),
-                                        const expression& type_arg2 = expression()) {
+                                        const expression& type_arg1
+                                          = expression(),
+                                        const expression& type_arg2
+                                          = expression()) {
       o << INDENT2
         << "context__.validate_dims("
         << '"' << stage << '"'
@@ -438,37 +444,48 @@ namespace stan {
         generate_validate_context_size(o_, stage_, x.name_, "double", x.dims_);
       }
       void operator()(vector_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "vector_d", x.dims_, x.M_);
+        generate_validate_context_size(o_, stage_, x.name_, "vector_d",
+                                       x.dims_, x.M_);
       }
       void operator()(row_vector_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "row_vector_d", x.dims_, x.N_);
+        generate_validate_context_size(o_, stage_, x.name_, "row_vector_d",
+                                       x.dims_, x.N_);
       }
       void operator()(unit_vector_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "vector_d", x.dims_, x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "vector_d",
+                                       x.dims_, x.K_);
       }
       void operator()(simplex_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "vector_d", x.dims_, x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "vector_d",
+                                       x.dims_, x.K_);
       }
       void operator()(ordered_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "vector_d", x.dims_, x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "vector_d",
+                                       x.dims_, x.K_);
       }
       void operator()(positive_ordered_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "vector_d", x.dims_, x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "vector_d",
+                                       x.dims_, x.K_);
       }
       void operator()(matrix_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "matrix_d", x.dims_, x.M_, x.N_);
+        generate_validate_context_size(o_, stage_, x.name_, "matrix_d",
+                                       x.dims_, x.M_, x.N_);
       }
       void operator()(cholesky_factor_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "matrix_d", x.dims_, x.M_, x.N_);
+        generate_validate_context_size(o_, stage_, x.name_, "matrix_d",
+                                       x.dims_, x.M_, x.N_);
       }
       void operator()(cholesky_corr_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "matrix_d", x.dims_, x.K_, x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "matrix_d",
+                                       x.dims_, x.K_, x.K_);
       }
       void operator()(cov_matrix_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "matrix_d", x.dims_, x.K_, x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "matrix_d",
+                                       x.dims_, x.K_, x.K_);
       }
       void operator()(corr_matrix_var_decl const& x) const {
-        generate_validate_context_size(o_, stage_, x.name_, "matrix_d", x.dims_, x.K_, x.K_);
+        generate_validate_context_size(o_, stage_, x.name_, "matrix_d",
+                                       x.dims_, x.K_, x.K_);
       }
     };
 
@@ -571,9 +588,10 @@ namespace stan {
           is_var_(is_var) {
       }
       template <typename D>
-      void generate_initialize_array_bounded(const D& x, const std::string& base_type,
+      void generate_initialize_array_bounded(const D& x,
+                                             const std::string& base_type,
                                              const std::string& read_fun_prefix,
-                                             const std::vector<expression>& dim_args) const {
+                                const std::vector<expression>& dim_args) const {
         std::vector<expression> read_args;
         std::string read_fun(read_fun_prefix);
         if (has_lub(x)) {
@@ -589,64 +607,105 @@ namespace stan {
         }
         for (size_t i = 0; i < dim_args.size(); ++i)
           read_args.push_back(dim_args[i]);
-        generate_initialize_array(base_type, read_fun, read_args, x.name_, x.dims_);
+        generate_initialize_array(base_type, read_fun, read_args,
+                                  x.name_, x.dims_);
       }
       void operator()(const nil& /*x*/) const { }
       void operator()(const int_var_decl& x) const {
-        generate_initialize_array("int", "integer", EMPTY_EXP_VECTOR, x.name_, x.dims_);
+        generate_initialize_array("int", "integer", EMPTY_EXP_VECTOR,
+                                  x.name_, x.dims_);
       }
       void operator()(const double_var_decl& x) const {
         std::vector<expression> read_args;
-        generate_initialize_array_bounded(x, is_var_?"T__":"double", "scalar", read_args);
+        generate_initialize_array_bounded(x,
+                                          is_var_ ? "T__" : "double",
+                                          "scalar", read_args);
       }
       void operator()(const vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.M_);
-        generate_initialize_array_bounded(x, is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d", "vector", read_args);
+        generate_initialize_array_bounded(x,
+                                          is_var_
+                                          ? "Eigen::Matrix"
+                                          "<T__,Eigen::Dynamic,1> "
+                                          : "vector_d",
+                                          "vector", read_args);
       }
       void operator()(const row_vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.N_);
-        generate_initialize_array_bounded(x, is_var_?"Eigen::Matrix<T__,1,Eigen::Dynamic> ":"row_vector_d", "row_vector", read_args);
+        generate_initialize_array_bounded(x,
+                                          is_var_
+                                          ? "Eigen::Matrix"
+                                          "<T__,1,Eigen::Dynamic> "
+                                          : "row_vector_d",
+                                          "row_vector", read_args);
       }
       void operator()(const matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.M_);
         read_args.push_back(x.N_);
-        generate_initialize_array_bounded(x, is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> ":"matrix_d", "matrix", read_args);
+        generate_initialize_array_bounded(x,
+                                          is_var_
+                                          ? "Eigen::Matrix"
+                                          "<T__,Eigen::Dynamic,Eigen::Dynamic> "
+                                          : "matrix_d",
+                                          "matrix", read_args);
       }
       void operator()(const unit_vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d", "unit_vector", read_args, x.name_, x.dims_);
+        generate_initialize_array(is_var_
+                                  ? "Eigen::Matrix"
+                                  "<T__,Eigen::Dynamic,1> "
+                                  : "vector_d",
+                                  "unit_vector", read_args, x.name_, x.dims_);
       }
       void operator()(const simplex_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d", "simplex", read_args, x.name_, x.dims_);
+        generate_initialize_array(is_var_
+                                  ? "Eigen::Matrix"
+                                  "<T__,Eigen::Dynamic,1> "
+                                  : "vector_d",
+                                  "simplex", read_args, x.name_, x.dims_);
       }
       void operator()(const ordered_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d", "ordered", read_args, x.name_, x.dims_);
+        generate_initialize_array(is_var_
+                                  ? "Eigen::Matrix"
+                                  "<T__,Eigen::Dynamic,1> "
+                                  : "vector_d",
+                                  "ordered", read_args, x.name_, x.dims_);
       }
       void operator()(const positive_ordered_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,1> ":"vector_d", "positive_ordered", read_args, x.name_, x.dims_);
+        generate_initialize_array(is_var_
+                                  ? "Eigen::Matrix"
+                                  "<T__,Eigen::Dynamic,1> "
+                                  : "vector_d",
+                                  "positive_ordered", read_args,
+                                  x.name_, x.dims_);
       }
       void operator()(const cholesky_factor_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.M_);
         read_args.push_back(x.N_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> ":"matrix_d",
-                                  "cholesky_factor", read_args, x.name_, x.dims_);
+        generate_initialize_array(is_var_
+                                  ? "Eigen::Matrix"
+                                  "<T__,Eigen::Dynamic,Eigen::Dynamic> "
+                                  : "matrix_d",
+                                  "cholesky_factor", read_args,
+                                  x.name_, x.dims_);
       }
       void operator()(const cholesky_corr_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
         generate_initialize_array(is_var_
-                                  ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
+                                  ? "Eigen::Matrix"
+                                  "<T__,Eigen::Dynamic,Eigen::Dynamic> "
                                   : "matrix_d",
                                   "cholesky_corr", read_args, x.name_, x.dims_);
       }
@@ -654,20 +713,26 @@ namespace stan {
       void operator()(const cov_matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> ":"matrix_d",
+        generate_initialize_array(is_var_
+                                  ? "Eigen::Matrix"
+                                  "<T__,Eigen::Dynamic,Eigen::Dynamic> "
+                                  : "matrix_d",
                                   "cov_matrix", read_args, x.name_, x.dims_);
       }
       void operator()(const corr_matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array(is_var_?"Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> ":"matrix_d",
+        generate_initialize_array(is_var_
+                                  ? "Eigen::Matrix"
+                                  "<T__,Eigen::Dynamic,Eigen::Dynamic> "
+                                  : "matrix_d",
                                   "corr_matrix", read_args, x.name_, x.dims_);
       }
       void generate_initialize_array(const std::string& var_type,
                                      const std::string& read_type,
                                      const std::vector<expression>& read_args,
                                      const std::string& name,
-                                     const std::vector<expression>& dims)  const {
+                                   const std::vector<expression>& dims)  const {
         if (declare_vars_) {
           o_ << INDENT2;
           for (size_t i = 0; i < dims.size(); ++i) o_ << "vector<";
@@ -715,14 +780,16 @@ namespace stan {
 
             if (i < dims.size() - 1) {
               generate_indent(i + 2, o_);
-              o_ << name_dims << ".resize(dim" << "_" << name << "_" << i << "__);"
+              o_ << name_dims << ".resize(dim" << "_"
+                 << name << "_" << i << "__);"
                  << EOL;
               name_dims.append("[k_").append(to_string(i)).append("__]");
             }
 
             generate_indent(i + 2, o_);
             if (i == dims.size() - 1) {
-              o_ << name_dims << ".reserve(dim_" << name << "_" << i << "__);" << EOL;
+              o_ << name_dims << ".reserve(dim_" << name
+                 << "_" << i << "__);" << EOL;
               generate_indent(i + 2, o_);
             }
 
@@ -737,7 +804,8 @@ namespace stan {
 
               // w Jacobian
               generate_indent(i + 4, o_);
-              o_ << name_dims << ".push_back(in__." << read_type << "_constrain(";
+              o_ << name_dims << ".push_back(in__."
+                 << read_type << "_constrain(";
               for (size_t j = 0; j < read_args.size(); ++j) {
                 if (j > 0) o_ << ",";
                 generate_expression(read_args[j], o_);
@@ -752,7 +820,8 @@ namespace stan {
 
               // w/o Jacobian
               generate_indent(i + 4, o_);
-              o_ << name_dims << ".push_back(in__." << read_type << "_constrain(";
+              o_ << name_dims << ".push_back(in__."
+                 << read_type << "_constrain(";
               for (size_t j = 0; j < read_args.size(); ++j) {
                 if (j > 0) o_ << ",";
                 generate_expression(read_args[j], o_);
@@ -1031,7 +1100,8 @@ namespace stan {
         ctor_args.push_back(x.M_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,1> "
-                      : (is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
+                      : (is_var_
+                         ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(row_vector_var_decl const& x) const {
@@ -1049,7 +1119,8 @@ namespace stan {
         ctor_args.push_back(x.M_);
         ctor_args.push_back(x.N_);
         declare_array(is_fun_return_
-                      ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,Eigen::Dynamic> "
+                      ? "Eigen::Matrix<fun_scalar_t__,"
+                      "Eigen::Dynamic,Eigen::Dynamic> "
                       : (is_var_
                          ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
                          : "matrix_d"),
@@ -1060,7 +1131,8 @@ namespace stan {
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,1> "
-                      : (is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
+                      : (is_var_
+                         ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(simplex_var_decl const& x) const {
@@ -1068,7 +1140,8 @@ namespace stan {
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,1> "
-                      : (is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
+                      : (is_var_
+                         ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(ordered_var_decl const& x) const {
@@ -1076,7 +1149,8 @@ namespace stan {
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,1> "
-                      : (is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
+                      : (is_var_
+                         ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(positive_ordered_var_decl const& x) const {
@@ -1084,7 +1158,8 @@ namespace stan {
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
                       ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,1> "
-                      : (is_var_ ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
+                      : (is_var_
+                         ? "Eigen::Matrix<T__,Eigen::Dynamic,1> " : "vector_d"),
                       ctor_args, x.name_, x.dims_);
       }
       void operator()(cholesky_factor_var_decl const& x) const {
@@ -1092,7 +1167,8 @@ namespace stan {
         ctor_args.push_back(x.M_);
         ctor_args.push_back(x.N_);
         declare_array(is_fun_return_
-                      ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,Eigen::Dynamic> "
+                      ? "Eigen::Matrix<fun_scalar_t__,"
+                      "Eigen::Dynamic,Eigen::Dynamic> "
                       : (is_var_
                          ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
                          : "matrix_d"),
@@ -1112,7 +1188,8 @@ namespace stan {
         ctor_args.push_back(x.K_);
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
-                      ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,Eigen::Dynamic> "
+                      ? "Eigen::Matrix<fun_scalar_t__,"
+                      "Eigen::Dynamic,Eigen::Dynamic> "
                       : (is_var_
                          ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
                          : "matrix_d"),
@@ -1123,7 +1200,8 @@ namespace stan {
         ctor_args.push_back(x.K_);
         ctor_args.push_back(x.K_);
         declare_array(is_fun_return_
-                      ? "Eigen::Matrix<fun_scalar_t__,Eigen::Dynamic,Eigen::Dynamic> "
+                      ? "Eigen::Matrix<fun_scalar_t__,"
+                      "Eigen::Dynamic,Eigen::Dynamic> "
                       : (is_var_
                          ? "Eigen::Matrix<T__,Eigen::Dynamic,Eigen::Dynamic> "
                          : "matrix_d"),
@@ -1141,7 +1219,7 @@ namespace stan {
       }
 
       void generate_void_statement(const std::string& name) const {
-        o_ << "(void) " << name << ";   // dummy to suppress unused var warning";
+        o_ << "(void) " << name << ";  // dummy to suppress unused var warning";
       }
 
       // var_decl     -> type[0] name init_args[0] ;
@@ -1291,7 +1369,9 @@ namespace stan {
       void generate_init(const T& x) const {
         generate_indent(indent_, o_);
         o_ << "stan::math::initialize(" << x.name_ << ", "
-           << (is_var_ ? "DUMMY_VAR__" : "std::numeric_limits<double>::quiet_NaN()")
+           << (is_var_
+               ? "DUMMY_VAR__"
+               : "std::numeric_limits<double>::quiet_NaN()")
            << ");"
            << EOL;
       }
@@ -1302,7 +1382,8 @@ namespace stan {
                                      std::ostream& o,
                                      bool is_var,
                                      bool is_fun_return) {
-      generate_local_var_init_nan_visgen vis(indent, is_var, is_fun_return, indent, o);
+      generate_local_var_init_nan_visgen vis(indent, is_var, is_fun_return,
+                                             indent, o);
       for (size_t i = 0; i < vs.size(); ++i)
         boost::apply_visitor(vis, vs[i].decl_);
     }
@@ -1579,7 +1660,8 @@ namespace stan {
           o_ << " < ";
           generate_expression(x.truncation_.low_.expr_, o_);  // low
                                                               // bound
-          o_ << ") lp_accum__.add(-std::numeric_limits<double>::infinity());"  << EOL;
+          o_ << ") lp_accum__.add(-std::numeric_limits<double>::infinity());"
+             << EOL;
         }
         if (x.truncation_.has_high()) {
           generate_indent(indent_, o_);
@@ -1589,7 +1671,8 @@ namespace stan {
           o_ << " > ";
           generate_expression(x.truncation_.high_.expr_, o_);  // low
           // bound
-          o_ << ") lp_accum__.add(-std::numeric_limits<double>::infinity());" << EOL;
+          o_ << ") lp_accum__.add(-std::numeric_limits<double>::infinity());"
+             << EOL;
         }
         // generate log denominator for case where bounds test pass
         if (x.truncation_.has_low() || x.truncation_.has_high()) {
@@ -1597,7 +1680,8 @@ namespace stan {
           o_ << "else ";
         }
         if (x.truncation_.has_low() && x.truncation_.has_high()) {
-          // T[L,U]: -log_diff_exp(Dist_cdf_log(U|params),Dist_cdf_log(L|Params))
+          // T[L,U]: -log_diff_exp(Dist_cdf_log(U|params),
+          //                       Dist_cdf_log(L|Params))
           o_ << "lp_accum__.add(-log_diff_exp(";
           o_ << x.dist_.family_ << "_cdf_log(";
           generate_expression(x.truncation_.high_.expr_, o_);
@@ -1653,9 +1737,8 @@ namespace stan {
         }
 
         for (size_t i = 0; i < x.statements_.size(); ++i)
-          generate_statement(x.statements_[i], indent, o_, include_sampling_, is_var_,
-                             is_fun_return_);
-
+          generate_statement(x.statements_[i], indent, o_, include_sampling_,
+                             is_var_, is_fun_return_);
         if (has_local_vars) {
           generate_indent(indent_, o_);
           o_ << "}" << EOL;
@@ -1752,7 +1835,9 @@ namespace stan {
       bool operator()(const nil& st) const { return false; }
       bool operator()(const assignment& st) const { return true; }
       bool operator()(const sample& st) const { return true; }
-      bool operator()(const increment_log_prob_statement& t) const  { return true; }
+      bool operator()(const increment_log_prob_statement& t) const {
+        return true;
+      }
       bool operator()(const expression& st) const  { return true; }
       bool operator()(const statements& st) const  { return false; }
       bool operator()(const for_statement& st) const  { return true; }
@@ -1812,7 +1897,8 @@ namespace stan {
         << EOL;
       generate_comment("Next line prevents compiler griping about no return",
                        indent + 1, o);
-      o << "throw std::runtime_error(\"*** IF YOU SEE THIS, PLEASE REPORT A BUG ***\");"
+      o << "throw std::runtime_error"
+        << "(\"*** IF YOU SEE THIS, PLEASE REPORT A BUG ***\");"
         << EOL;
       generate_indent(indent, o);
       o << "}"
@@ -1826,7 +1912,8 @@ namespace stan {
                                     bool is_var,
                                     bool is_fun_return) {
       generate_try(indent, o);
-      generate_statement(s, indent+1, o, include_sampling, is_var, is_fun_return);
+      generate_statement(s, indent+1, o, include_sampling,
+                         is_var, is_fun_return);
       generate_catch_throw_located(indent, o);
     }
 
@@ -1838,7 +1925,8 @@ namespace stan {
                                      bool is_fun_return) {
       generate_try(indent, o);
       for (size_t i = 0; i < ss.size(); ++i)
-        generate_statement(ss[i], indent + 1, o, include_sampling, is_var, is_fun_return);
+        generate_statement(ss[i], indent + 1, o, include_sampling,
+                           is_var, is_fun_return);
       generate_catch_throw_located(indent, o);
     }
 
@@ -1857,7 +1945,8 @@ namespace stan {
         << EOL2;
 
       // use this dummy for inits
-      o << INDENT2 << "T__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());"
+      o << INDENT2
+        << "T__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());"
         << EOL;
       o << INDENT2 << "(void) DUMMY_VAR__;  // suppress unused var warning"
         << EOL2;
@@ -1875,14 +1964,15 @@ namespace stan {
       o << EOL;
 
       generate_comment("transformed parameters", 2, o);
-      generate_local_var_decls(p.derived_decl_.first, 2, o, is_var, is_fun_return);
+      generate_local_var_decls(p.derived_decl_.first, 2, o, is_var,
+                               is_fun_return);
       generate_init_vars(p.derived_decl_.first, 2, o);
       o << EOL;
 
 
       bool include_sampling = true;
-      generate_located_statements(p.derived_decl_.second, 2, o, include_sampling,
-                                  is_var, is_fun_return);
+      generate_located_statements(p.derived_decl_.second, 2, o,
+                                  include_sampling, is_var, is_fun_return);
       o << EOL;
 
       generate_validate_transformed_params(p.derived_decl_.first, 2, o);
@@ -1908,15 +1998,19 @@ namespace stan {
       o << INDENT2 << "return lp_accum__.sum();" << EOL2;
       o << INDENT << "} // log_prob()" << EOL2;
 
-      o << INDENT << "template <bool propto, bool jacobian, typename T_>" << EOL;
-      o << INDENT << "T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r," << EOL;
+      o << INDENT
+        << "template <bool propto, bool jacobian, typename T_>" << EOL;
+      o << INDENT
+        << "T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r," << EOL;
       o << INDENT << "           std::ostream* pstream = 0) const {" << EOL;
       o << INDENT << "  std::vector<T_> vec_params_r;" << EOL;
       o << INDENT << "  vec_params_r.reserve(params_r.size());" << EOL;
       o << INDENT << "  for (int i = 0; i < params_r.size(); ++i)" << EOL;
       o << INDENT << "    vec_params_r.push_back(params_r(i));" << EOL;
       o << INDENT << "  std::vector<int> vec_params_i;" << EOL;
-      o << INDENT << "  return log_prob<propto,jacobian,T_>(vec_params_r, vec_params_i, pstream);" << EOL;
+      o << INDENT
+        << "  return log_prob<propto,jacobian,T_>(vec_params_r, "
+        << "vec_params_i, pstream);" << EOL;
       o << INDENT << "}" << EOL2;
     }
 
@@ -1926,14 +2020,16 @@ namespace stan {
       explicit dump_member_var_visgen(std::ostream& o)
         : visgen(o),
           var_resizer_(var_resizing_visgen(o)),
-          var_size_validator_(var_size_validating_visgen(o, "data initialization")) {
+          var_size_validator_(var_size_validating_visgen(o,
+                                                    "data initialization")) {
       }
       void operator()(nil const& /*x*/) const { }  // dummy
       void operator()(int_var_decl const& x) const {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_i__ = context__.vals_i(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2
+           << "vals_i__ = context__.vals_i(\"" << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         size_t indentation = 1;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
@@ -1963,7 +2059,8 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2
+           << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         size_t indentation = 1;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
@@ -1974,7 +2071,9 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {" << EOL;
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+             << EOL;
         }
         generate_indent(indentation+1, o_);
         o_ << x.name_;
@@ -1991,12 +2090,14 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_resizer_(x);
         var_size_validator_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2
+           << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         o_ << INDENT2 << "size_t " << x.name_ << "_i_vec_lim__ = ";
         generate_expression(x.M_, o_);
         o_ << ";" << EOL;
-        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < " << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
+        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < "
+           << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
         size_t indentation = 2;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
           size_t dim = dims.size() - dim_up - 1U;
@@ -2006,7 +2107,9 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {" << EOL;
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+             << EOL;
         }
         generate_indent(indentation+1, o_);
         o_ << x.name_;
@@ -2025,12 +2128,14 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2
+           << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         o_ << INDENT2 << "size_t " << x.name_ << "_i_vec_lim__ = ";
         generate_expression(x.N_, o_);
         o_ << ";" << EOL;
-        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < " << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
+        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < "
+           << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
         size_t indentation = 2;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
           size_t dim = dims.size() - dim_up - 1U;
@@ -2040,7 +2145,9 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {" << EOL;
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+             << EOL;
         }
         generate_indent(indentation+1, o_);
         o_ << x.name_;
@@ -2059,12 +2166,14 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2
+           << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         o_ << INDENT2 << "size_t " << x.name_ << "_i_vec_lim__ = ";
         generate_expression(x.K_, o_);
         o_ << ";" << EOL;
-        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < " << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
+        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < "
+           << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
         size_t indentation = 2;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
           size_t dim = dims.size() - dim_up - 1U;
@@ -2074,7 +2183,9 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {" << EOL;
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+             << EOL;
         }
         generate_indent(indentation+1, o_);
         o_ << x.name_;
@@ -2093,12 +2204,14 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2
+           << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         o_ << INDENT2 << "size_t " << x.name_ << "_i_vec_lim__ = ";
         generate_expression(x.K_, o_);
         o_ << ";" << EOL;
-        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < " << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
+        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < "
+           << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
         size_t indentation = 2;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
           size_t dim = dims.size() - dim_up - 1U;
@@ -2108,7 +2221,9 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {" << EOL;
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+             << EOL;
         }
         generate_indent(indentation+1, o_);
         o_ << x.name_;
@@ -2127,12 +2242,14 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2
+           << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         o_ << INDENT2 << "size_t " << x.name_ << "_i_vec_lim__ = ";
         generate_expression(x.K_, o_);
         o_ << ";" << EOL;
-        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < " << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
+        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < "
+           << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
         size_t indentation = 2;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
           size_t dim = dims.size() - dim_up - 1U;
@@ -2142,7 +2259,9 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {" << EOL;
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+             << EOL;
         }
         generate_indent(indentation+1, o_);
         o_ << x.name_;
@@ -2161,12 +2280,14 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2
+           << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         o_ << INDENT2 << "size_t " << x.name_ << "_i_vec_lim__ = ";
         generate_expression(x.K_, o_);
         o_ << ";" << EOL;
-        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < " << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
+        o_ << INDENT2 << "for (size_t " << "i_vec__ = 0; " << "i_vec__ < "
+           << x.name_ << "_i_vec_lim__; ++i_vec__) {" << EOL;
         size_t indentation = 2;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
           size_t dim = dims.size() - dim_up - 1U;
@@ -2176,7 +2297,9 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {" << EOL;
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+             << EOL;
         }
         generate_indent(indentation+1, o_);
         o_ << x.name_;
@@ -2195,7 +2318,8 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2 << "vals_r__ = context__.vals_r(\""
+           << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         o_ << INDENT2 << "size_t " << x.name_ << "_m_mat_lim__ = ";
         generate_expression(x.M_, o_);
@@ -2203,8 +2327,10 @@ namespace stan {
         o_ << INDENT2 << "size_t " << x.name_ << "_n_mat_lim__ = ";
         generate_expression(x.N_, o_);
         o_ << ";" << EOL;
-        o_ << INDENT2 << "for (size_t " << "n_mat__ = 0; " << "n_mat__ < " << x.name_ << "_n_mat_lim__; ++n_mat__) {" << EOL;
-        o_ << INDENT3 << "for (size_t " << "m_mat__ = 0; " << "m_mat__ < " << x.name_ << "_m_mat_lim__; ++m_mat__) {" << EOL;
+        o_ << INDENT2 << "for (size_t " << "n_mat__ = 0; " << "n_mat__ < "
+           << x.name_ << "_n_mat_lim__; ++n_mat__) {" << EOL;
+        o_ << INDENT3 << "for (size_t " << "m_mat__ = 0; " << "m_mat__ < "
+           << x.name_ << "_m_mat_lim__; ++m_mat__) {" << EOL;
         size_t indentation = 3;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
           size_t dim = dims.size() - dim_up - 1U;
@@ -2214,7 +2340,9 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {" << EOL;
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+             << EOL;
         }
         generate_indent(indentation+1, o_);
         o_ << x.name_;
@@ -2230,17 +2358,23 @@ namespace stan {
         o_ << INDENT2 << "}" << EOL;
       }
       void operator()(corr_matrix_var_decl const& x) const {
-        // FIXME: cut-and-paste of cov_matrix, very slightly different from matrix
+        // FIXME: cut-and-paste of cov_matrix,
+        //        very slightly different from matrix
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2
+           << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         o_ << INDENT2 << "size_t " << x.name_ << "_k_mat_lim__ = ";
         generate_expression(x.K_, o_);
         o_ << ";" << EOL;
-        o_ << INDENT2 << "for (size_t " << "n_mat__ = 0; " << "n_mat__ < " << x.name_ << "_k_mat_lim__; ++n_mat__) {" << EOL;
-        o_ << INDENT3 << "for (size_t " << "m_mat__ = 0; " << "m_mat__ < " << x.name_ << "_k_mat_lim__; ++m_mat__) {" << EOL;
+        o_ << INDENT2
+           << "for (size_t " << "n_mat__ = 0; " << "n_mat__ < " << x.name_
+           << "_k_mat_lim__; ++n_mat__) {" << EOL;
+        o_ << INDENT3
+           << "for (size_t " << "m_mat__ = 0; " << "m_mat__ < " << x.name_
+           << "_k_mat_lim__; ++m_mat__) {" << EOL;
         size_t indentation = 3;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
           size_t dim = dims.size() - dim_up - 1U;
@@ -2250,7 +2384,9 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {" << EOL;
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+             << EOL;
         }
         generate_indent(indentation+1, o_);
         o_ << x.name_;
@@ -2270,7 +2406,8 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2 << "vals_r__ = context__.vals_r(\""
+           << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
 
         o_ << INDENT2 << "size_t " << x.name_ << "_m_mat_lim__ = ";
@@ -2281,8 +2418,10 @@ namespace stan {
         generate_expression(x.N_, o_);
         o_ << ";" << EOL;
 
-        o_ << INDENT2 << "for (size_t " << "n_mat__ = 0; " << "n_mat__ < " << x.name_ << "_n_mat_lim__; ++n_mat__) {" << EOL;
-        o_ << INDENT3 << "for (size_t " << "m_mat__ = 0; " << "m_mat__ < " << x.name_ << "_m_mat_lim__; ++m_mat__) {" << EOL;
+        o_ << INDENT2 << "for (size_t " << "n_mat__ = 0; " << "n_mat__ < "
+           << x.name_ << "_n_mat_lim__; ++n_mat__) {" << EOL;
+        o_ << INDENT3 << "for (size_t " << "m_mat__ = 0; " << "m_mat__ < "
+           << x.name_ << "_m_mat_lim__; ++m_mat__) {" << EOL;
 
         size_t indentation = 3;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
@@ -2293,7 +2432,8 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
              << EOL;
         }
         generate_indent(indentation+1, o_);
@@ -2315,7 +2455,8 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2 << "vals_r__ = context__.vals_r(\""
+           << x.name_ << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
 
         o_ << INDENT2 << "size_t " << x.name_ << "_m_mat_lim__ = ";
@@ -2326,8 +2467,10 @@ namespace stan {
         generate_expression(x.K_, o_);
         o_ << ";" << EOL;
 
-        o_ << INDENT2 << "for (size_t " << "n_mat__ = 0; " << "n_mat__ < " << x.name_ << "_n_mat_lim__; ++n_mat__) {" << EOL;
-        o_ << INDENT3 << "for (size_t " << "m_mat__ = 0; " << "m_mat__ < " << x.name_ << "_m_mat_lim__; ++m_mat__) {" << EOL;
+        o_ << INDENT2 << "for (size_t " << "n_mat__ = 0; " << "n_mat__ < "
+           << x.name_ << "_n_mat_lim__; ++n_mat__) {" << EOL;
+        o_ << INDENT3 << "for (size_t " << "m_mat__ = 0; " << "m_mat__ < "
+           << x.name_ << "_m_mat_lim__; ++m_mat__) {" << EOL;
 
         size_t indentation = 3;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
@@ -2338,7 +2481,8 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
              << EOL;
         }
         generate_indent(indentation+1, o_);
@@ -2359,13 +2503,16 @@ namespace stan {
         std::vector<expression> dims = x.dims_;
         var_size_validator_(x);
         var_resizer_(x);
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");" << EOL;
+        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << x.name_ << "\");"
+           << EOL;
         o_ << INDENT2 << "pos__ = 0;" << EOL;
         o_ << INDENT2 << "size_t " << x.name_ << "_k_mat_lim__ = ";
         generate_expression(x.K_, o_);
         o_ << ";" << EOL;
-        o_ << INDENT2 << "for (size_t " << "n_mat__ = 0; " << "n_mat__ < " << x.name_ << "_k_mat_lim__; ++n_mat__) {" << EOL;
-        o_ << INDENT3 << "for (size_t " << "m_mat__ = 0; " << "m_mat__ < " << x.name_ << "_k_mat_lim__; ++m_mat__) {" << EOL;
+        o_ << INDENT2 << "for (size_t " << "n_mat__ = 0; " << "n_mat__ < "
+           << x.name_ << "_k_mat_lim__; ++n_mat__) {" << EOL;
+        o_ << INDENT3 << "for (size_t " << "m_mat__ = 0; " << "m_mat__ < "
+           << x.name_ << "_k_mat_lim__; ++m_mat__) {" << EOL;
         size_t indentation = 3;
         for (size_t dim_up = 0U; dim_up < dims.size(); ++dim_up) {
           size_t dim = dims.size() - dim_up - 1U;
@@ -2375,7 +2522,9 @@ namespace stan {
           generate_expression(dims[dim], o_);
           o_ << ";" << EOL;
           generate_indent(indentation, o_);
-          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < " << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {" << EOL;
+          o_ << "for (size_t i_" << dim << "__ = 0; i_" << dim << "__ < "
+             << x.name_ << "_limit_" << dim << "__; ++i_" << dim << "__) {"
+             << EOL;
         }
         generate_indent(indentation+1, o_);
         o_ << x.name_;
@@ -2628,9 +2777,11 @@ namespace stan {
       generate_var_resizing(prog.derived_data_decl_.first, o);
       o << EOL;
 
-      o << INDENT2 << "double DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());"
+      o << INDENT2
+        << "double DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());"
         << EOL;
-      o << INDENT2 << "(void) DUMMY_VAR__;  // suppress unused var warning" << EOL2;
+      o << INDENT2
+        << "(void) DUMMY_VAR__;  // suppress unused var warning" << EOL2;
       generate_init_vars(prog.derived_data_decl_.first, 2, o);
       o << EOL;
 
@@ -2638,7 +2789,8 @@ namespace stan {
       bool is_var = false;
       bool is_fun_return = false;
       generate_located_statements(prog.derived_data_decl_.second,
-                                  2, o, include_sampling, is_var, is_fun_return);
+                                  2, o, include_sampling, is_var,
+                                  is_fun_return);
 
       o << EOL;
       generate_comment("validate transformed data", 2, o);
@@ -2896,8 +3048,10 @@ namespace stan {
         o_ << EOL << INDENT2
            << "if (!(context__.contains_r(\"" << name << "\")))"
            << EOL << INDENT3
-           << "throw std::runtime_error(\"variable " << name << " missing\");" << EOL;
-        o_ << INDENT2 << "vals_r__ = context__.vals_r(\"" << name << "\");" << EOL;
+           << "throw std::runtime_error(\"variable " << name << " missing\");"
+           << EOL;
+        o_ << INDENT2
+           << "vals_r__ = context__.vals_r(\"" << name << "\");" << EOL;
         o_ << INDENT2 << "pos__ = 0U;" << EOL;
       }
     };
@@ -2932,12 +3086,18 @@ namespace stan {
       o << INDENT2 << "params_i__ = writer__.data_i();" << EOL;
       o << INDENT << "}" << EOL2;
 
-      o << INDENT << "void transform_inits(const stan::io::var_context& context," << EOL;
-      o << INDENT << "                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r," << EOL;
-      o << INDENT << "                     std::ostream* pstream__) const {" << EOL;
+      o << INDENT
+        << "void transform_inits(const stan::io::var_context& context," << EOL;
+      o << INDENT
+        << "                     "
+        << "Eigen::Matrix<double,Eigen::Dynamic,1>& params_r," << EOL;
+      o << INDENT
+        << "                     std::ostream* pstream__) const {" << EOL;
       o << INDENT << "  std::vector<double> params_r_vec;" << EOL;
       o << INDENT << "  std::vector<int> params_i_vec;" << EOL;
-      o << INDENT << "  transform_inits(context, params_i_vec, params_r_vec, pstream__);" << EOL;
+      o << INDENT
+        << "  transform_inits(context, params_i_vec, params_r_vec, pstream__);"
+        << EOL;
       o << INDENT << "  params_r.resize(params_r_vec.size());" << EOL;
       o << INDENT << "  for (int i = 0; i < params_r.size(); ++i)" << EOL;
       o << INDENT << "    params_r(i) = params_r_vec[i];" << EOL;
@@ -3257,7 +3417,8 @@ namespace stan {
     void generate_constrained_param_names_method(const program& prog,
                                                  std::ostream& o) {
       o << EOL << INDENT
-        << "void constrained_param_names(std::vector<std::string>& param_names__,"
+        << "void constrained_param_names("
+        << "std::vector<std::string>& param_names__,"
         << EOL << INDENT
         << "                             bool include_tparams__ = true,"
         << EOL << INDENT
@@ -3347,7 +3508,7 @@ namespace stan {
                                                             "*",
                                                             binary_op(x.N_,
                                                                       "+",
-                                                                      int_literal(1))),
+                                                               int_literal(1))),
                                                   "/",
                                                   int_literal(2)),
                                         "+",
@@ -3379,9 +3540,9 @@ namespace stan {
                                                             "*",
                                                             binary_op(x.K_,
                                                                       "-",
-                                                                      int_literal(1))),
-                                                  "/",
-                                                  int_literal(2))));
+                                                               int_literal(1))),
+                               "/",
+                               int_literal(2))));
         generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const corr_matrix_var_decl& x) const {
@@ -3438,7 +3599,8 @@ namespace stan {
     void generate_unconstrained_param_names_method(const program& prog,
                                                    std::ostream& o) {
       o << EOL << INDENT
-        << "void unconstrained_param_names(std::vector<std::string>& param_names__,"
+        << "void unconstrained_param_names("
+        << "std::vector<std::string>& param_names__,"
         << EOL << INDENT
         << "                               bool include_tparams__ = true,"
         << EOL << INDENT
@@ -3486,9 +3648,10 @@ namespace stan {
       }
       // fixme -- reuse cut-and-pasted from other lub reader case
       template <typename D>
-      void generate_initialize_array_bounded(const D& x, const std::string& base_type,
+      void generate_initialize_array_bounded(const D& x,
+                                             const std::string& base_type,
                                              const std::string& read_fun_prefix,
-                                             const std::vector<expression>& dim_args) const {
+                                const std::vector<expression>& dim_args) const {
         std::vector<expression> read_args;
         std::string read_fun(read_fun_prefix);
         if (has_lub(x)) {
@@ -3504,7 +3667,8 @@ namespace stan {
         }
         for (size_t i = 0; i < dim_args.size(); ++i)
           read_args.push_back(dim_args[i]);
-        generate_initialize_array(base_type, read_fun, read_args, x.name_, x.dims_);
+        generate_initialize_array(base_type, read_fun, read_args,
+                                  x.name_, x.dims_);
       }
 
       void operator()(const double_var_decl& x) const {
@@ -3519,7 +3683,8 @@ namespace stan {
       void operator()(const row_vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.N_);
-        generate_initialize_array_bounded(x, "row_vector_d", "row_vector", read_args);
+        generate_initialize_array_bounded(x, "row_vector_d", "row_vector",
+                                          read_args);
       }
       void operator()(const matrix_var_decl& x) const {
         std::vector<expression> read_args;
@@ -3530,49 +3695,57 @@ namespace stan {
       void operator()(const unit_vector_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("vector_d", "unit_vector", read_args, x.name_, x.dims_);
+        generate_initialize_array("vector_d", "unit_vector", read_args,
+                                  x.name_, x.dims_);
       }
       void operator()(const simplex_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("vector_d", "simplex", read_args, x.name_, x.dims_);
+        generate_initialize_array("vector_d", "simplex", read_args,
+                                  x.name_, x.dims_);
       }
       void operator()(const ordered_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("vector_d", "ordered", read_args, x.name_, x.dims_);
+        generate_initialize_array("vector_d", "ordered", read_args,
+                                  x.name_, x.dims_);
       }
       void operator()(const positive_ordered_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("vector_d", "positive_ordered", read_args, x.name_, x.dims_);
+        generate_initialize_array("vector_d", "positive_ordered", read_args,
+                                  x.name_, x.dims_);
       }
       void operator()(const cholesky_factor_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.M_);
         read_args.push_back(x.N_);
-        generate_initialize_array("matrix_d", "cholesky_factor", read_args, x.name_, x.dims_);
+        generate_initialize_array("matrix_d", "cholesky_factor", read_args,
+                                  x.name_, x.dims_);
       }
       void operator()(const cholesky_corr_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("matrix_d", "cholesky_corr", read_args, x.name_, x.dims_);
+        generate_initialize_array("matrix_d", "cholesky_corr", read_args,
+                                  x.name_, x.dims_);
       }
       void operator()(const cov_matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("matrix_d", "cov_matrix", read_args, x.name_, x.dims_);
+        generate_initialize_array("matrix_d", "cov_matrix", read_args,
+                                  x.name_, x.dims_);
       }
       void operator()(const corr_matrix_var_decl& x) const {
         std::vector<expression> read_args;
         read_args.push_back(x.K_);
-        generate_initialize_array("matrix_d", "corr_matrix", read_args, x.name_, x.dims_);
+        generate_initialize_array("matrix_d", "corr_matrix", read_args,
+                                  x.name_, x.dims_);
       }
       void generate_initialize_array(const std::string& var_type,
                                      const std::string& read_type,
                                      const std::vector<expression>& read_args,
                                      const std::string& name,
-                                     const std::vector<expression>& dims) const {
+                                     const std::vector<expression>& dims) const{
         if (dims.size() == 0) {
           generate_indent(2, o_);
           o_ << var_type << " ";
@@ -3756,9 +3929,11 @@ namespace stan {
       o << INDENT << "                 std::vector<double>& vars__," << EOL;
       o << INDENT << "                 bool include_tparams__ = true," << EOL;
       o << INDENT << "                 bool include_gqs__ = true," << EOL;
-      o << INDENT << "                 std::ostream* pstream__ = 0) const {" << EOL;
+      o << INDENT
+        << "                 std::ostream* pstream__ = 0) const {" << EOL;
       o << INDENT2 << "vars__.resize(0);" << EOL;
-      o << INDENT2 << "stan::io::reader<double> in__(params_r__,params_i__);" << EOL;
+      o << INDENT2
+        << "stan::io::reader<double> in__(params_r__,params_i__);"<< EOL;
       o << INDENT2 << "static const char* function__ = \""
         << model_name << "_namespace::write_array\";" << EOL;
       suppress_warning(INDENT2, "function__", o);
@@ -3785,11 +3960,12 @@ namespace stan {
       o << INDENT2 << "stan::math::accumulator<double> lp_accum__;" << EOL2;
       bool is_var = false;
       bool is_fun_return = false;
-      generate_local_var_decls(prog.derived_decl_.first, 2, o, is_var, is_fun_return);
+      generate_local_var_decls(prog.derived_decl_.first, 2, o, is_var,
+                               is_fun_return);
       o << EOL;
       bool include_sampling = false;
-      generate_located_statements(prog.derived_decl_.second, 2, o, include_sampling,
-                                  is_var, is_fun_return);
+      generate_located_statements(prog.derived_decl_.second, 2, o,
+                                  include_sampling, is_var, is_fun_return);
       o << EOL;
 
       generate_comment("validate transformed parameters", 2, o);
@@ -3808,13 +3984,16 @@ namespace stan {
                                is_var, is_fun_return);
 
       o << EOL;
-      o << INDENT2 << "double DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());" << EOL;
-      o << INDENT2 << "(void) DUMMY_VAR__;  // suppress unused var warning" << EOL2;
+      o << INDENT2
+        << "double DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());"
+        << EOL;
+      o << INDENT2 << "(void) DUMMY_VAR__;  // suppress unused var warning"
+        << EOL2;
       generate_init_vars(prog.generated_decl_.first, 2, o);
 
       o << EOL;
-      generate_located_statements(prog.generated_decl_.second, 2, o, include_sampling,
-                                  is_var, is_fun_return);
+      generate_located_statements(prog.generated_decl_.second, 2, o,
+                                  include_sampling, is_var, is_fun_return);
       o << EOL;
 
       generate_comment("validate generated quantities", 2, o);
@@ -3831,17 +4010,25 @@ namespace stan {
 
       o << INDENT << "template <typename RNG>" << EOL;
       o << INDENT << "void write_array(RNG& base_rng," << EOL;
-      o << INDENT << "                 Eigen::Matrix<double,Eigen::Dynamic,1>& params_r," << EOL;
-      o << INDENT << "                 Eigen::Matrix<double,Eigen::Dynamic,1>& vars," << EOL;
+      o << INDENT
+        << "                 Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,"
+        << EOL;
+      o << INDENT
+        << "                 Eigen::Matrix<double,Eigen::Dynamic,1>& vars,"
+        << EOL;
       o << INDENT << "                 bool include_tparams = true," << EOL;
       o << INDENT << "                 bool include_gqs = true," << EOL;
-      o << INDENT << "                 std::ostream* pstream = 0) const {" << EOL;
-      o << INDENT << "  std::vector<double> params_r_vec(params_r.size());" << EOL;
+      o << INDENT
+        << "                 std::ostream* pstream = 0) const {" << EOL;
+      o << INDENT
+        << "  std::vector<double> params_r_vec(params_r.size());" << EOL;
       o << INDENT << "  for (int i = 0; i < params_r.size(); ++i)" << EOL;
       o << INDENT << "    params_r_vec[i] = params_r(i);" << EOL;
       o << INDENT << "  std::vector<double> vars_vec;" << EOL;
       o << INDENT << "  std::vector<int> params_i_vec;" << EOL;
-      o << INDENT << "  write_array(base_rng,params_r_vec,params_i_vec,vars_vec,include_tparams,include_gqs,pstream);" << EOL;
+      o << INDENT
+        << "  write_array(base_rng,params_r_vec,params_i_vec,"
+        << "vars_vec,include_tparams,include_gqs,pstream);" << EOL;
       o << INDENT << "  vars.resize(vars_vec.size());" << EOL;
       o << INDENT << "  for (int i = 0; i < vars.size(); ++i)" << EOL;
       o << INDENT << "    vars(i) = vars_vec[i];" << EOL;

--- a/src/stan/model/prob_grad.hpp
+++ b/src/stan/model/prob_grad.hpp
@@ -1,10 +1,9 @@
 #ifndef STAN_MODEL_PROB_GRAD_HPP
 #define STAN_MODEL_PROB_GRAD_HPP
 
+#include <stan/io/csv_writer.hpp>
 #include <utility>
 #include <vector>
-
-#include <stan/io/csv_writer.hpp>
 
 namespace stan {
 
@@ -16,21 +15,18 @@ namespace stan {
      * Models extending this base helper class.
      */
     class prob_grad {
-
     protected:
-
       size_t num_params_r__;
-      std::vector<std::pair<int,int> > param_ranges_i__;
+      std::vector<std::pair<int, int> > param_ranges_i__;
 
     public:
-
-      prob_grad(size_t num_params_r)
+      explicit prob_grad(size_t num_params_r)
         : num_params_r__(num_params_r),
-          param_ranges_i__(std::vector<std::pair<int,int> >(0)) {
+          param_ranges_i__(std::vector<std::pair<int, int> >(0)) {
       }
 
       prob_grad(size_t num_params_r,
-                std::vector<std::pair<int,int> >& param_ranges_i)
+                std::vector<std::pair<int, int> >& param_ranges_i)
         : num_params_r__(num_params_r),
           param_ranges_i__(param_ranges_i) {
       }
@@ -45,10 +41,9 @@ namespace stan {
         return param_ranges_i__.size();
       }
 
-      inline std::pair<int,int> param_range_i(size_t idx) const {
+      inline std::pair<int, int> param_range_i(size_t idx) const {
         return param_ranges_i__[idx];
       }
-
     };
   }
 }

--- a/src/stan/model/util.hpp
+++ b/src/stan/model/util.hpp
@@ -151,7 +151,8 @@ namespace stan {
         lp
           = model
           .template log_prob<true,
-                             jacobian_adjust_transform>(ad_params_r, params_i, msgs)
+                             jacobian_adjust_transform>(ad_params_r,
+                                                        params_i, msgs)
           .val();
       } catch (std::exception &ex) {
         stan::math::recover_memory();
@@ -184,7 +185,7 @@ namespace stan {
                          std::ostream* msgs = 0) {
       using std::vector;
       using stan::math::var;
-      
+
       Eigen::Matrix<var, Eigen::Dynamic, 1> ad_params_r(params_r.size());
       for (size_t i = 0; i < model.num_params_r(); ++i) {
         stan::math::var var_i(params_r[i]);

--- a/src/stan/optimization/bfgs_update.hpp
+++ b/src/stan/optimization/bfgs_update.hpp
@@ -9,8 +9,8 @@ namespace stan {
              int DimAtCompile = Eigen::Dynamic>
     class BFGSUpdate_HInv {
     public:
-      typedef Eigen::Matrix<Scalar,DimAtCompile,1> VectorT;
-      typedef Eigen::Matrix<Scalar,DimAtCompile,DimAtCompile> HessianT;
+      typedef Eigen::Matrix<Scalar, DimAtCompile, 1> VectorT;
+      typedef Eigen::Matrix<Scalar, DimAtCompile, DimAtCompile> HessianT;
 
       /**
        * Update the inverse Hessian approximation.
@@ -31,13 +31,12 @@ namespace stan {
         skyk = yk.dot(sk);
         rhok = 1.0/skyk;
 
-        Hupd.noalias() = HessianT::Identity(yk.size(),yk.size())
-                                        - rhok*sk*yk.transpose();
+        Hupd.noalias() = HessianT::Identity(yk.size(), yk.size())
+                                        - rhok * sk * yk.transpose();
         if (reset) {
           B0fact = yk.squaredNorm()/skyk;
           _Hk.noalias() = ((1.0/B0fact)*Hupd)*Hupd.transpose();
-        }
-        else {
+        } else {
           B0fact = 1.0;
           _Hk = Hupd*_Hk*Hupd.transpose();
         }

--- a/src/stan/optimization/lbfgs_update.hpp
+++ b/src/stan/optimization/lbfgs_update.hpp
@@ -1,12 +1,10 @@
 #ifndef STAN_OPTIMIZATION_LBFGS_UPDATE_HPP
 #define STAN_OPTIMIZATION_LBFGS_UPDATE_HPP
 
-#include <vector>
-
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/circular_buffer.hpp>
-
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <vector>
 
 namespace stan {
   namespace optimization {
@@ -19,9 +17,9 @@ namespace stan {
              int DimAtCompile = Eigen::Dynamic>
     class LBFGSUpdate {
     public:
-      typedef Eigen::Matrix<Scalar,DimAtCompile,1> VectorT;
-      typedef Eigen::Matrix<Scalar,DimAtCompile,DimAtCompile> HessianT;
-      typedef boost::tuple<Scalar,VectorT,VectorT> UpdateT;
+      typedef Eigen::Matrix<Scalar, DimAtCompile, 1> VectorT;
+      typedef Eigen::Matrix<Scalar, DimAtCompile, DimAtCompile> HessianT;
+      typedef boost::tuple<Scalar, VectorT, VectorT> UpdateT;
 
       LBFGSUpdate(size_t L = 5) : _buf(L) {}
 
@@ -53,8 +51,7 @@ namespace stan {
         if (reset) {
           B0fact = yk.squaredNorm()/skyk;
           _buf.clear();
-        }
-        else {
+        } else {
           B0fact = 1.0;
         }
 
@@ -62,7 +59,7 @@ namespace stan {
         Scalar invskyk = 1.0/skyk;
         _gammak = skyk/yk.squaredNorm();
         _buf.push_back();
-        _buf.back() = boost::tie(invskyk,yk,sk);
+        _buf.back() = boost::tie(invskyk, yk, sk);
 
         return B0fact;
       }
@@ -77,7 +74,8 @@ namespace stan {
        **/
       inline void search_direction(VectorT &pk, const VectorT &gk) const {
         std::vector<Scalar> alphas(_buf.size());
-        typename boost::circular_buffer<UpdateT>::const_reverse_iterator buf_rit;
+        typename
+          boost::circular_buffer<UpdateT>::const_reverse_iterator buf_rit;
         typename boost::circular_buffer<UpdateT>::const_iterator buf_it;
         typename std::vector<Scalar>::const_iterator alpha_it;
         typename std::vector<Scalar>::reverse_iterator alpha_rit;

--- a/src/stan/optimization/newton.hpp
+++ b/src/stan/optimization/newton.hpp
@@ -1,11 +1,11 @@
 #ifndef STAN_OPTIMIZATION_NEWTON_HPP
 #define STAN_OPTIMIZATION_NEWTON_HPP
 
+#include <stan/model/util.hpp>
 #include <Eigen/Dense>
 #include <Eigen/Cholesky>
 #include <Eigen/Eigenvalues>
-
-#include <stan/model/util.hpp>
+#include <vector>
 
 namespace stan {
 
@@ -39,9 +39,9 @@ namespace stan {
         std::vector<double> hessian;
 
         double f0
-          = stan::model::grad_hess_log_prob<true,false>(model,
-                                                        params_r, params_i,
-                                                        gradient, hessian);
+          = stan::model::grad_hess_log_prob<true, false>(model,
+                                                         params_r, params_i,
+                                                         gradient, hessian);
         matrix_d H(params_r.size(), params_r.size());
         for (size_t i = 0; i < hessian.size(); i++) {
           H(i) = hessian[i];
@@ -65,9 +65,9 @@ namespace stan {
           for (size_t i = 0; i < params_r.size(); i++)
             new_params_r[i] = params_r[i] - step_size * g[i];
           try {
-            f1 = stan::model::log_prob_grad<true,false>(model,
-                                                        new_params_r,
-                                                        params_i, gradient);
+            f1 = stan::model::log_prob_grad<true, false>(model,
+                                                         new_params_r,
+                                                         params_i, gradient);
           } catch (std::exception& e) {
             // FIXME:  this is not a good way to handle a general exception
             f1 = -1e100;

--- a/src/stan/services/arguments/arg_adapt.hpp
+++ b/src/stan/services/arguments/arg_adapt.hpp
@@ -2,7 +2,6 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_ADAPT_HPP
 
 #include <stan/services/arguments/categorical_argument.hpp>
-
 #include <stan/services/arguments/arg_adapt_engaged.hpp>
 #include <stan/services/arguments/arg_adapt_gamma.hpp>
 #include <stan/services/arguments/arg_adapt_delta.hpp>
@@ -13,15 +12,10 @@
 #include <stan/services/arguments/arg_adapt_window.hpp>
 
 namespace stan {
-
   namespace services {
-
     class arg_adapt: public categorical_argument {
-
     public:
-
       arg_adapt() {
-
         _name = "adapt";
         _description = "Warmup Adaptation";
 
@@ -33,14 +27,10 @@ namespace stan {
         _subarguments.push_back(new arg_adapt_init_buffer());
         _subarguments.push_back(new arg_adapt_term_buffer());
         _subarguments.push_back(new arg_adapt_window());
-
       }
-
     };
 
-  } // services
-
-} // stan
-
+  }  // services
+}  // stan
 #endif
 

--- a/src/stan/services/arguments/arg_adapt_delta.hpp
+++ b/src/stan/services/arguments/arg_adapt_delta.hpp
@@ -8,9 +8,7 @@ namespace stan {
   namespace services {
 
     class arg_adapt_delta: public real_argument {
-
     public:
-
       arg_adapt_delta(): real_argument() {
         _name = "delta";
         _description = "Adaptation target acceptance statistic";
@@ -21,14 +19,12 @@ namespace stan {
         _good_value = 0.5;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return 0 < value && value < 1; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_adapt_engaged.hpp
+++ b/src/stan/services/arguments/arg_adapt_engaged.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_adapt_engaged: public bool_argument {
-
     public:
-
       arg_adapt_engaged(): bool_argument() {
         _name = "engaged";
         _description = "Adaptation engaged?";
@@ -20,13 +17,11 @@ namespace stan {
         _constrained = false;
         _good_value = 1;
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_adapt_gamma.hpp
+++ b/src/stan/services/arguments/arg_adapt_gamma.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_adapt_gamma: public real_argument {
-
     public:
-
       arg_adapt_gamma(): real_argument() {
         _name = "gamma";
         _description = "Adaptation regularization scale";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_adapt_init_buffer.hpp
+++ b/src/stan/services/arguments/arg_adapt_init_buffer.hpp
@@ -2,28 +2,24 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_ADAPT_INIT_BUFFER_HPP
 
 #include <stan/services/arguments/singleton_argument.hpp>
+#include <string>
 
 namespace stan {
-
   namespace services {
 
     class arg_adapt_init_buffer: public u_int_argument {
-
     public:
-
       arg_adapt_init_buffer(): u_int_argument() {
         _name = "init_buffer";
         _description = std::string("Width of initial fast adaptation interval");
         _default = "75";
         _default_value = 75;
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_adapt_kappa.hpp
+++ b/src/stan/services/arguments/arg_adapt_kappa.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_adapt_kappa: public real_argument {
-
     public:
-
       arg_adapt_kappa(): real_argument() {
         _name = "kappa";
         _description = "Adaptation relaxation exponent";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_adapt_t0.hpp
+++ b/src/stan/services/arguments/arg_adapt_t0.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_adapt_t0: public real_argument {
-
     public:
-
       arg_adapt_t0(): real_argument() {
         _name = "t0";
         _description = "Adaptation iteration offset";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_adapt_term_buffer.hpp
+++ b/src/stan/services/arguments/arg_adapt_term_buffer.hpp
@@ -2,28 +2,24 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_ADAPT_TERM_BUFFER_HPP
 
 #include <stan/services/arguments/singleton_argument.hpp>
+#include <string>
 
 namespace stan {
-
   namespace services {
 
     class arg_adapt_term_buffer: public u_int_argument {
-
     public:
-
       arg_adapt_term_buffer(): u_int_argument() {
         _name = "term_buffer";
         _description = std::string("Width of final fast adaptation interval");
         _default = "50";
         _default_value = 50;
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_adapt_window.hpp
+++ b/src/stan/services/arguments/arg_adapt_window.hpp
@@ -4,26 +4,21 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_adapt_window: public u_int_argument {
-
     public:
-
       arg_adapt_window(): u_int_argument() {
         _name = "window";
         _description = "Initial width of slow adaptation interval";
         _default = "25";
         _default_value = 25;
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_bfgs.hpp
+++ b/src/stan/services/arguments/arg_bfgs.hpp
@@ -2,37 +2,47 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_BFGS_HPP
 
 #include <stan/services/arguments/categorical_argument.hpp>
-
 #include <stan/services/arguments/arg_init_alpha.hpp>
 #include <stan/services/arguments/arg_tolerance.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_bfgs: public categorical_argument {
-
     public:
-
       arg_bfgs() {
-
         _name = "bfgs";
         _description = "BFGS with linesearch";
 
         _subarguments.push_back(new arg_init_alpha());
-        _subarguments.push_back(new arg_tolerance("tol_obj","Convergence tolerance on absolute changes in objective function value",1e-12));
-        _subarguments.push_back(new arg_tolerance("tol_rel_obj","Convergence tolerance on relative changes in objective function value",1e+4));
-        _subarguments.push_back(new arg_tolerance("tol_grad","Convergence tolerance on the norm of the gradient",1e-8));
-        _subarguments.push_back(new arg_tolerance("tol_rel_grad","Convergence tolerance on the relative norm of the gradient",1e+7));
-        _subarguments.push_back(new arg_tolerance("tol_param","Convergence tolerance on changes in parameter value",1e-8));
-
+        _subarguments.push_back(
+          new arg_tolerance("tol_obj",
+                            "Convergence tolerance on absolute changes "
+                            "in objective function value",
+                            1e-12));
+        _subarguments.push_back(
+          new arg_tolerance("tol_rel_obj",
+                            "Convergence tolerance on relative changes "
+                            "in objective function value",
+                            1e+4));
+        _subarguments.push_back(
+          new arg_tolerance("tol_grad",
+                            "Convergence tolerance on the norm of the gradient",
+                            1e-8));
+        _subarguments.push_back(
+          new arg_tolerance("tol_rel_grad",
+                            "Convergence tolerance on the relative norm "
+                            "of the gradient",
+                            1e+7));
+        _subarguments.push_back(
+          new arg_tolerance("tol_param",
+                            "Convergence tolerance on changes "
+                            "in parameter value",
+                            1e-8));
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
-

--- a/src/stan/services/arguments/arg_data.hpp
+++ b/src/stan/services/arguments/arg_data.hpp
@@ -6,26 +6,19 @@
 #include <stan/services/arguments/arg_data_file.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_data: public categorical_argument {
-
     public:
-
       arg_data(): categorical_argument() {
-
         _name = "data";
         _description = "Input data options";
 
         _subarguments.push_back(new arg_data_file());
-
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_data_file.hpp
+++ b/src/stan/services/arguments/arg_data_file.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_data_file: public string_argument {
-
     public:
-
       arg_data_file(): string_argument() {
         _name = "file";
         _description = "Input data file";
@@ -20,12 +17,10 @@ namespace stan {
         _constrained = false;
         _good_value = "good";
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_dense_e.hpp
+++ b/src/stan/services/arguments/arg_dense_e.hpp
@@ -4,25 +4,18 @@
 #include <stan/services/arguments/unvalued_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_dense_e: public unvalued_argument {
-
     public:
-
       arg_dense_e() {
-
         _name = "dense_e";
         _description = "Euclidean manifold with dense metric";
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_diag_e.hpp
+++ b/src/stan/services/arguments/arg_diag_e.hpp
@@ -4,25 +4,18 @@
 #include <stan/services/arguments/unvalued_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_diag_e: public unvalued_argument {
-
     public:
-
       arg_diag_e() {
-
         _name = "diag_e";
         _description = "Euclidean manifold with diag metric";
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_diagnose.hpp
+++ b/src/stan/services/arguments/arg_diagnose.hpp
@@ -2,31 +2,23 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_DIAGNOSE_HPP
 
 #include <stan/services/arguments/categorical_argument.hpp>
-
 #include <stan/services/arguments/arg_test.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_diagnose: public categorical_argument {
-
     public:
-
       arg_diagnose() {
-
         _name = "diagnose";
         _description = "Model diagnostics";
 
         _subarguments.push_back(new arg_test());
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_diagnostic_file.hpp
+++ b/src/stan/services/arguments/arg_diagnostic_file.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_diagnostic_file: public string_argument {
-
     public:
-
       arg_diagnostic_file(): string_argument() {
         _name = "diagnostic_file";
         _description = "Auxiliary output file for diagnostic information";
@@ -20,12 +17,10 @@ namespace stan {
         _constrained = false;
         _good_value = "good";
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_engine.hpp
+++ b/src/stan/services/arguments/arg_engine.hpp
@@ -7,15 +7,11 @@
 #include <stan/services/arguments/arg_nuts.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_engine: public list_argument {
-
     public:
-
       arg_engine() {
-
         _name = "engine";
         _description = "Engine for Hamiltonian Monte Carlo";
 
@@ -24,14 +20,11 @@ namespace stan {
 
         _default_cursor = 1;
         _cursor = _default_cursor;
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_fail.hpp
+++ b/src/stan/services/arguments/arg_fail.hpp
@@ -4,25 +4,18 @@
 #include <stan/services/arguments/unvalued_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_fail: public unvalued_argument {
-
     public:
-
       arg_fail() {
-
         _name = "fail";
         _description = "Dummy argument to induce failures for testing";
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_fixed_param.hpp
+++ b/src/stan/services/arguments/arg_fixed_param.hpp
@@ -4,25 +4,18 @@
 #include <stan/services/arguments/unvalued_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_fixed_param: public unvalued_argument {
-
     public:
-
       arg_fixed_param() {
-
         _name = "fixed_param";
         _description = "Fixed Parameter Sampler";
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_history_size.hpp
+++ b/src/stan/services/arguments/arg_history_size.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_history_size: public int_argument {
-
     public:
-
       arg_history_size(): int_argument() {
         _name = "history_size";
         _description = "Amount of history to keep for L-BFGS";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2;
         _bad_value = -1;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(int value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_hmc.hpp
+++ b/src/stan/services/arguments/arg_hmc.hpp
@@ -2,22 +2,17 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_HMC_HPP
 
 #include <stan/services/arguments/categorical_argument.hpp>
-
 #include <stan/services/arguments/arg_engine.hpp>
 #include <stan/services/arguments/arg_metric.hpp>
 #include <stan/services/arguments/arg_stepsize.hpp>
 #include <stan/services/arguments/arg_stepsize_jitter.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_hmc: public categorical_argument {
-
     public:
-
       arg_hmc() {
-
         _name = "hmc";
         _description = "Hamiltonian Monte Carlo";
 
@@ -25,14 +20,11 @@ namespace stan {
         _subarguments.push_back(new arg_metric());
         _subarguments.push_back(new arg_stepsize());
         _subarguments.push_back(new arg_stepsize_jitter());
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_id.hpp
+++ b/src/stan/services/arguments/arg_id.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_id: public int_argument {
-
     public:
-
       arg_id(): int_argument() {
         _name = "id";
         _description = "Unique process identifier";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(int value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_init.hpp
+++ b/src/stan/services/arguments/arg_init.hpp
@@ -2,15 +2,13 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_INIT_HPP
 
 #include <stan/services/arguments/singleton_argument.hpp>
+#include <string>
 
 namespace stan {
-
   namespace services {
 
     class arg_init: public string_argument {
-
     public:
-
       arg_init(): string_argument() {
         _name = "init";
         _description = std::string("Initialization method: ")
@@ -22,12 +20,10 @@ namespace stan {
         _constrained = false;
         _good_value = "../src/test/test-models/test_model.init.R";
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_init_alpha.hpp
+++ b/src/stan/services/arguments/arg_init_alpha.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_init_alpha: public real_argument {
-
     public:
-
       arg_init_alpha(): real_argument() {
         _name = "init_alpha";
         _description = "Line search step size for first iteration";
@@ -21,14 +18,12 @@ namespace stan {
         _good_value = 1.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_int_time.hpp
+++ b/src/stan/services/arguments/arg_int_time.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_int_time: public real_argument {
-
     public:
-
       arg_int_time(): real_argument() {
         _name = "int_time";
         _description = "Total integration time for Hamiltonian evolution";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_iter.hpp
+++ b/src/stan/services/arguments/arg_iter.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_iter: public int_argument {
-
     public:
-
       arg_iter(): int_argument() {
         _name = "iter";
         _description = "Total number of iterations";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(int value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_lbfgs.hpp
+++ b/src/stan/services/arguments/arg_lbfgs.hpp
@@ -2,31 +2,23 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_LBFGS_HPP
 
 #include <stan/services/arguments/arg_bfgs.hpp>
-
 #include <stan/services/arguments/arg_history_size.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_lbfgs: public arg_bfgs {
-
     public:
-
       arg_lbfgs() {
-
         _name = "lbfgs";
         _description = "LBFGS with linesearch";
 
         _subarguments.push_back(new arg_history_size());
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_max_depth.hpp
+++ b/src/stan/services/arguments/arg_max_depth.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_max_depth: public int_argument {
-
     public:
-
       arg_max_depth(): int_argument() {
         _name = "max_depth";
         _description = "Maximum tree depth";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(int value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_method.hpp
+++ b/src/stan/services/arguments/arg_method.hpp
@@ -2,22 +2,17 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_METHOD_HPP
 
 #include <stan/services/arguments/list_argument.hpp>
-
 #include <stan/services/arguments/arg_sample.hpp>
 #include <stan/services/arguments/arg_optimize.hpp>
 #include <stan/services/arguments/arg_variational.hpp>
 #include <stan/services/arguments/arg_diagnose.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_method: public list_argument {
-
     public:
-
       arg_method() {
-
         _name = "method";
         _description = "Analysis method (Note that method= is optional)";
 
@@ -28,13 +23,10 @@ namespace stan {
 
         _default_cursor = 0;
         _cursor = _default_cursor;
-
       }
-
     };
 
-  } // services
-
+  }  // services
 }  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_metric.hpp
+++ b/src/stan/services/arguments/arg_metric.hpp
@@ -2,21 +2,16 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_METRIC_HPP
 
 #include <stan/services/arguments/list_argument.hpp>
-
 #include <stan/services/arguments/arg_unit_e.hpp>
 #include <stan/services/arguments/arg_diag_e.hpp>
 #include <stan/services/arguments/arg_dense_e.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_metric: public list_argument {
-
     public:
-
       arg_metric() {
-
         _name = "metric";
         _description = "Geometry of base manifold";
 
@@ -26,14 +21,11 @@ namespace stan {
 
         _default_cursor = 1;
         _cursor = _default_cursor;
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_newton.hpp
+++ b/src/stan/services/arguments/arg_newton.hpp
@@ -4,25 +4,18 @@
 #include <stan/services/arguments/categorical_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_newton: public categorical_argument {
-
     public:
-
       arg_newton() {
-
         _name = "newton";
         _description = "Newton's method";
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_num_samples.hpp
+++ b/src/stan/services/arguments/arg_num_samples.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_num_samples: public int_argument {
-
     public:
-
       arg_num_samples(): int_argument() {
         _name = "num_samples";
         _description = "Number of sampling iterations";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(int value) { return value >= 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_num_warmup.hpp
+++ b/src/stan/services/arguments/arg_num_warmup.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_num_warmup: public int_argument {
-
     public:
-
       arg_num_warmup(): int_argument() {
         _name = "num_warmup";
         _description = "Number of warmup iterations";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(int value) { return value >= 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_nuts.hpp
+++ b/src/stan/services/arguments/arg_nuts.hpp
@@ -2,31 +2,23 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_NUTS_HPP
 
 #include <stan/services/arguments/categorical_argument.hpp>
-
 #include <stan/services/arguments/arg_max_depth.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_nuts: public categorical_argument {
-
     public:
-
       arg_nuts() {
-
         _name = "nuts";
         _description = "The No-U-Turn Sampler";
 
         _subarguments.push_back(new arg_max_depth());
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_optimize.hpp
+++ b/src/stan/services/arguments/arg_optimize.hpp
@@ -2,35 +2,27 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_OPTIMIZE_HPP
 
 #include <stan/services/arguments/categorical_argument.hpp>
-
 #include <stan/services/arguments/arg_optimize_algo.hpp>
 #include <stan/services/arguments/arg_iter.hpp>
 #include <stan/services/arguments/arg_save_iterations.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_optimize: public categorical_argument {
-
     public:
-
       arg_optimize() {
-
         _name = "optimize";
         _description = "Point estimation";
 
         _subarguments.push_back(new arg_optimize_algo());
         _subarguments.push_back(new arg_iter());
         _subarguments.push_back(new arg_save_iterations());
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_optimize_algo.hpp
+++ b/src/stan/services/arguments/arg_optimize_algo.hpp
@@ -2,21 +2,16 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_OPTIMIZE_ALGO_HPP
 
 #include <stan/services/arguments/list_argument.hpp>
-
 #include <stan/services/arguments/arg_bfgs.hpp>
 #include <stan/services/arguments/arg_lbfgs.hpp>
 #include <stan/services/arguments/arg_newton.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_optimize_algo: public list_argument {
-
     public:
-
       arg_optimize_algo() {
-
         _name = "algorithm";
         _description = "Optimization algorithm";
 
@@ -26,14 +21,11 @@ namespace stan {
 
         _default_cursor = 1;
         _cursor = _default_cursor;
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_output.hpp
+++ b/src/stan/services/arguments/arg_output.hpp
@@ -2,35 +2,27 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_OUTPUT_HPP
 
 #include <stan/services/arguments/categorical_argument.hpp>
-
 #include <stan/services/arguments/arg_output_file.hpp>
 #include <stan/services/arguments/arg_diagnostic_file.hpp>
 #include <stan/services/arguments/arg_refresh.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_output: public categorical_argument {
-
     public:
-
       arg_output() {
-
         _name = "output";
         _description = "File output options";
 
         _subarguments.push_back(new arg_output_file());
         _subarguments.push_back(new arg_diagnostic_file());
         _subarguments.push_back(new arg_refresh());
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_output_file.hpp
+++ b/src/stan/services/arguments/arg_output_file.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_output_file: public string_argument {
-
     public:
-
       arg_output_file(): string_argument() {
         _name = "file";
         _description = "Output file";
@@ -20,12 +17,10 @@ namespace stan {
         _constrained = false;
         _good_value = "good";
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_random.hpp
+++ b/src/stan/services/arguments/arg_random.hpp
@@ -2,31 +2,23 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_RANDOM_HPP
 
 #include <stan/services/arguments/categorical_argument.hpp>
-
 #include <stan/services/arguments/arg_seed.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_random: public categorical_argument {
-
     public:
-
       arg_random() {
-
         _name = "random";
         _description = "Random number configuration";
 
         _subarguments.push_back(new arg_seed());
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_refresh.hpp
+++ b/src/stan/services/arguments/arg_refresh.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_refresh: public int_argument {
-
     public:
-
       arg_refresh(): int_argument() {
         _name = "refresh";
         _description = "Number of interations between screen updates";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(int value) { return value >= 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_rwm.hpp
+++ b/src/stan/services/arguments/arg_rwm.hpp
@@ -4,25 +4,18 @@
 #include <stan/services/arguments/categorical_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_rwm: public categorical_argument {
-
     public:
-
       arg_rwm() {
-
         _name = "rwm";
         _description = "Random Walk Metropolis Monte Carlo";
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_sample.hpp
+++ b/src/stan/services/arguments/arg_sample.hpp
@@ -2,7 +2,6 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_SAMPLE_HPP
 
 #include <stan/services/arguments/categorical_argument.hpp>
-
 #include <stan/services/arguments/arg_num_samples.hpp>
 #include <stan/services/arguments/arg_num_warmup.hpp>
 #include <stan/services/arguments/arg_save_warmup.hpp>
@@ -11,15 +10,11 @@
 #include <stan/services/arguments/arg_sample_algo.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_sample: public categorical_argument {
-
     public:
-
       arg_sample() {
-
         _name = "sample";
         _description = "Bayesian inference with Markov Chain Monte Carlo";
 
@@ -29,14 +24,11 @@ namespace stan {
         _subarguments.push_back(new arg_thin());
         _subarguments.push_back(new arg_adapt());
         _subarguments.push_back(new arg_sample_algo());
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_sample_algo.hpp
+++ b/src/stan/services/arguments/arg_sample_algo.hpp
@@ -2,20 +2,15 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_SAMPLE_ALGO_HPP
 
 #include <stan/services/arguments/list_argument.hpp>
-
 #include <stan/services/arguments/arg_hmc.hpp>
 #include <stan/services/arguments/arg_fixed_param.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_sample_algo: public list_argument {
-
     public:
-
       arg_sample_algo() {
-
         _name = "algorithm";
         _description = "Sampling algorithm";
 
@@ -24,14 +19,11 @@ namespace stan {
 
         _default_cursor = 0;
         _cursor = _default_cursor;
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_save_iterations.hpp
+++ b/src/stan/services/arguments/arg_save_iterations.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_save_iterations: public bool_argument {
-
     public:
-
       arg_save_iterations(): bool_argument() {
         _name = "save_iterations";
         _description = "Stream optimization progress to output?";
@@ -20,13 +17,11 @@ namespace stan {
         _constrained = false;
         _good_value = 1;
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_save_warmup.hpp
+++ b/src/stan/services/arguments/arg_save_warmup.hpp
@@ -8,9 +8,7 @@ namespace stan {
   namespace services {
 
     class arg_save_warmup: public bool_argument {
-
     public:
-
       arg_save_warmup(): bool_argument() {
         _name = "save_warmup";
         _description = "Stream warmup samples to output?";
@@ -20,13 +18,11 @@ namespace stan {
         _constrained = false;
         _good_value = 1;
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_seed.hpp
+++ b/src/stan/services/arguments/arg_seed.hpp
@@ -8,9 +8,7 @@ namespace stan {
   namespace services {
 
     class arg_seed: public u_int_argument {
-
     public:
-
       arg_seed(): u_int_argument() {
         _name = "seed";
         _description = "Random number generator seed";
@@ -20,13 +18,11 @@ namespace stan {
         _constrained = false;
         _good_value = 18383;
         _value = _default_value;
-      };
-
+      }
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_static.hpp
+++ b/src/stan/services/arguments/arg_static.hpp
@@ -2,31 +2,23 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_STATIC_HPP
 
 #include <stan/services/arguments/categorical_argument.hpp>
-
 #include <stan/services/arguments/arg_int_time.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_static: public categorical_argument {
-
     public:
-
       arg_static() {
-
         _name = "static";
         _description = "Static integration time";
 
         _subarguments.push_back(new arg_int_time());
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_stepsize.hpp
+++ b/src/stan/services/arguments/arg_stepsize.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_stepsize: public real_argument {
-
     public:
-
       arg_stepsize(): real_argument() {
         _name = "stepsize";
         _description = "Step size for discrete evolution";
@@ -21,14 +18,12 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_stepsize_jitter.hpp
+++ b/src/stan/services/arguments/arg_stepsize_jitter.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_stepsize_jitter: public real_argument {
-
     public:
-
       arg_stepsize_jitter(): real_argument() {
         _name = "stepsize_jitter";
         _description = "Uniformly random jitter of the stepsize, in percent";
@@ -21,14 +18,12 @@ namespace stan {
         _good_value = 0.5;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return 0 <= value && value <= 1; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_test.hpp
+++ b/src/stan/services/arguments/arg_test.hpp
@@ -2,19 +2,14 @@
 #define STAN_SERVICES_ARGUMENTS_ARG_TEST_HPP
 
 #include <stan/services/arguments/list_argument.hpp>
-
 #include <stan/services/arguments/arg_test_gradient.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_test: public list_argument {
-
     public:
-
       arg_test() {
-
         _name = "test";
         _description = "Diagnostic test";
 
@@ -22,14 +17,11 @@ namespace stan {
 
         _default_cursor = 0;
         _cursor = _default_cursor;
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_test_grad_eps.hpp
+++ b/src/stan/services/arguments/arg_test_grad_eps.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_test_grad_eps: public real_argument {
-
     public:
-
       arg_test_grad_eps(): real_argument() {
         _name = "epsilon";
         _description = "Finite difference step size";
@@ -21,14 +18,12 @@ namespace stan {
         _good_value = 1e-6;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_test_grad_err.hpp
+++ b/src/stan/services/arguments/arg_test_grad_err.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_test_grad_err: public real_argument {
-
     public:
-
       arg_test_grad_err(): real_argument() {
         _name = "error";
         _description = "Error threshold";
@@ -21,14 +18,12 @@ namespace stan {
         _good_value = 1e-6;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_test_gradient.hpp
+++ b/src/stan/services/arguments/arg_test_gradient.hpp
@@ -6,28 +6,21 @@
 #include <stan/services/arguments/arg_test_grad_err.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_test_gradient: public categorical_argument {
-
     public:
-
       arg_test_gradient() {
-
         _name = "gradient";
         _description = "Check model gradient against finite differences";
 
         _subarguments.push_back(new arg_test_grad_eps());
         _subarguments.push_back(new arg_test_grad_err());
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_thin.hpp
+++ b/src/stan/services/arguments/arg_thin.hpp
@@ -4,13 +4,10 @@
 #include <stan/services/arguments/singleton_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_thin: public int_argument {
-
     public:
-
       arg_thin(): int_argument() {
         _name = "thin";
         _description = "Period between saved samples";
@@ -21,15 +18,13 @@ namespace stan {
         _good_value = 2.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(int value) { return value > 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/arg_tolerance.hpp
+++ b/src/stan/services/arguments/arg_tolerance.hpp
@@ -1,19 +1,17 @@
 #ifndef STAN_SERVICES_ARGUMENTS_ARG_TOLERANCE_HPP
 #define STAN_SERVICES_ARGUMENTS_ARG_TOLERANCE_HPP
 
-#include <boost/lexical_cast.hpp>
-
 #include <stan/services/arguments/singleton_argument.hpp>
+#include <boost/lexical_cast.hpp>
+#include <string>
 
 namespace stan {
-
   namespace services {
 
     class arg_tolerance : public real_argument {
-
     public:
-
-      arg_tolerance(const char *name, const char *desc, double def) : real_argument() {
+      arg_tolerance(const char *name, const char *desc, double def)
+        : real_argument() {
         _name = name;
         _description = desc;
         _validity = "0 <= tol";
@@ -23,14 +21,12 @@ namespace stan {
         _good_value = 1.0;
         _bad_value = -1.0;
         _value = _default_value;
-      };
+      }
 
       bool is_valid(double value) { return value >= 0; }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/arg_unit_e.hpp
+++ b/src/stan/services/arguments/arg_unit_e.hpp
@@ -4,25 +4,18 @@
 #include <stan/services/arguments/unvalued_argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class arg_unit_e: public unvalued_argument {
-
     public:
-
       arg_unit_e() {
-
         _name = "unit_e";
         _description = "Euclidean manifold with unit metric";
-
       }
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
 

--- a/src/stan/services/arguments/argument.hpp
+++ b/src/stan/services/arguments/argument.hpp
@@ -11,7 +11,6 @@ namespace stan {
 
     class argument {
     public:
-
       argument()
         : indent_width(2),
           help_width(20) { }
@@ -31,8 +30,10 @@ namespace stan {
         return _description;
       }
 
-      virtual void print(std::ostream* s, const int depth, const std::string prefix) = 0;
-      virtual void print_help(std::ostream* s, const int depth, const bool recurse) = 0;
+      virtual void print(std::ostream* s, const int depth,
+                         const std::string prefix) = 0;
+      virtual void print_help(std::ostream* s, const int depth,
+                              const bool recurse) = 0;
 
       virtual bool parse_args(std::vector<std::string>& args,
                               std::ostream* out,
@@ -41,7 +42,7 @@ namespace stan {
         return true;
       }
 
-      virtual void probe_args(argument* base_arg, std::stringstream& s) {};
+      virtual void probe_args(argument* base_arg, std::stringstream& s) {}
 
       virtual void find_arg(std::string name,
                             std::string prefix,
@@ -51,14 +52,14 @@ namespace stan {
         }
       }
 
-      static void split_arg(const std::string& arg, std::string& name, std::string& value) {
+      static void split_arg(const std::string& arg, std::string& name,
+                            std::string& value) {
         size_t pos = arg.find('=');
 
         if (pos != std::string::npos) {
           name = arg.substr(0, pos);
           value = arg.substr(pos + 1, arg.size() - pos);
-        }
-        else {
+        } else {
           name = arg;
           value = "";
         }
@@ -80,7 +81,6 @@ namespace stan {
       int help_width;
     };
 
-  } // services
-} // stan
+  }  // services
+}  // stan
 #endif
-

--- a/src/stan/services/arguments/argument_parser.hpp
+++ b/src/stan/services/arguments/argument_parser.hpp
@@ -1,23 +1,19 @@
 #ifndef STAN_SERVICES_ARGUMENTS_ARGUMENT_PARSER_HPP
 #define STAN_SERVICES_ARGUMENTS_ARGUMENT_PARSER_HPP
 
-#include <string>
-#include <vector>
-#include <cstring>
-
 #include <stan/services/arguments/argument.hpp>
 #include <stan/services/arguments/arg_method.hpp>
 #include <stan/services/error_codes.hpp>
+#include <cstring>
+#include <string>
+#include <vector>
 
 namespace stan {
-
   namespace services {
 
     class argument_parser {
-
     public:
-
-      argument_parser(std::vector<argument*>& valid_args)
+      explicit argument_parser(std::vector<argument*>& valid_args)
         : _arguments(valid_args),
           _help_flag(false),
           _method_flag(false) {
@@ -28,7 +24,6 @@ namespace stan {
                       const char* argv[],
                       std::ostream* out = 0,
                       std::ostream* err = 0) {
-
         if (argc == 1) {
           print_usage(out, argv[0]);
           return error_codes::USAGE;
@@ -47,7 +42,6 @@ namespace stan {
         std::vector<argument*> unset_args = _arguments;
 
         while (good_arg) {
-
           if (args.size() == 0)
             break;
 
@@ -56,14 +50,13 @@ namespace stan {
 
           // Check for method arguments entered without the method= prefix
           if (!_method_flag) {
-
-            list_argument* method = dynamic_cast<list_argument*>(_arguments.front());
+            list_argument* method
+              = dynamic_cast<list_argument*>(_arguments.front());
 
             if (method->valid_value(cat_name)) {
               cat_name = "method=" + cat_name;
               args.back() = cat_name;
             }
-
           }
 
           std::string val_name;
@@ -75,19 +68,18 @@ namespace stan {
 
           std::vector<argument*>::iterator arg_it;
 
-          for (arg_it = unset_args.begin(); arg_it != unset_args.end(); ++arg_it) {
-            if ( (*arg_it)->name() == cat_name) {
+          for (arg_it = unset_args.begin();
+               arg_it != unset_args.end(); ++arg_it) {
+            if ((*arg_it)->name() == cat_name) {
               args.pop_back();
               valid_arg &= (*arg_it)->parse_args(args, out, err, _help_flag);
               good_arg = true;
               break;
-            }
-            else if ( (*arg_it)->name() == val_name) {
+            } else if ((*arg_it)->name() == val_name) {
               valid_arg &= (*arg_it)->parse_args(args, out, err, _help_flag);
               good_arg = true;
               break;
             }
-
           }
 
           if (good_arg) unset_args.erase(arg_it);
@@ -107,8 +99,8 @@ namespace stan {
           }
 
           if (!good_arg && err) {
-
-            *err << cat_name << " is either mistyped or misplaced." << std::endl;
+            *err << cat_name << " is either mistyped or misplaced."
+                 << std::endl;
 
             std::vector<std::string> valid_paths;
 
@@ -117,7 +109,9 @@ namespace stan {
             }
 
             if (valid_paths.size()) {
-              *err << "Perhaps you meant one of the following valid configurations?" << std::endl;
+              *err << "Perhaps you meant one of the following "
+                   << "valid configurations?"
+                   << std::endl;
               for (size_t i = 0; i < valid_paths.size(); ++i)
                 *err << "  " << valid_paths.at(i) << std::endl;
             }
@@ -141,7 +135,6 @@ namespace stan {
         for (size_t i = 0; i < _arguments.size(); ++i) {
           _arguments.at(i)->print(s, 0, prefix);
         }
-
       }
 
       void print_help(std::ostream* s, bool recurse) {
@@ -171,7 +164,8 @@ namespace stan {
         std::vector<argument*>::iterator arg_it = _arguments.begin();
         list_argument* method = dynamic_cast<list_argument*>(*arg_it);
 
-        for (std::vector<argument*>::iterator value_it = method->values().begin();
+        for (std::vector<argument*>::iterator value_it
+               = method->values().begin();
              value_it != method->values().end(); ++value_it) {
           *s << std::setw(width)
              << indent + (*value_it)->name()
@@ -200,7 +194,6 @@ namespace stan {
         *s << std::endl;
         *s << "See " << executable << " <arg1> [ help | help-all ] "
            << "for details on individual arguments." << std::endl << std::endl;
-
       }
 
       argument* arg(std::string name) {
@@ -216,21 +209,18 @@ namespace stan {
       }
 
     protected:
-
       std::vector<argument*>& _arguments;
 
       // We can also check for, and warn the user of, deprecated arguments
-      //std::vector<argument*> deprecated_arguments;
-      // check_arg_conflict // Ensure non-zero intersection of valid and deprecated arguments
+      // std::vector<argument*> deprecated_arguments;
+      // check_arg_conflict
+      // Ensure non-zero intersection of valid and deprecated arguments
 
       bool _help_flag;
       bool _method_flag;
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
-

--- a/src/stan/services/arguments/argument_probe.hpp
+++ b/src/stan/services/arguments/argument_probe.hpp
@@ -1,40 +1,30 @@
 #ifndef STAN_SERVICES_ARGUMENTS_ARGUMENT_PROBE_HPP
 #define STAN_SERVICES_ARGUMENTS_ARGUMENT_PROBE_HPP
 
+#include <stan/services/arguments/argument.hpp>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
-
-#include <stan/services/arguments/argument.hpp>
 
 namespace stan {
-
   namespace services {
 
     class argument_probe {
-
     public:
-
-      argument_probe(std::vector<argument*>& valid_args)
+      explicit argument_probe(std::vector<argument*>& valid_args)
         : _arguments(valid_args) {}
 
       void probe_args(std::stringstream& s) {
-
         for (std::vector<argument*>::iterator arg_it = _arguments.begin();
              arg_it != _arguments.end(); ++arg_it)
           (*arg_it)->probe_args(*arg_it, s);
-
       }
 
     protected:
-
       std::vector<argument*>& _arguments;
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif
-

--- a/src/stan/services/arguments/categorical_argument.hpp
+++ b/src/stan/services/arguments/categorical_argument.hpp
@@ -1,17 +1,15 @@
 #ifndef STAN_SERVICES_ARGUMENTS_CATEGORICAL_ARGUMENT_HPP
 #define STAN_SERVICES_ARGUMENTS_CATEGORICAL_ARGUMENT_HPP
 
-#include <vector>
 #include <stan/services/arguments/argument.hpp>
+#include <string>
+#include <vector>
 
 namespace stan {
-
   namespace services {
 
     class categorical_argument: public argument {
-
     public:
-
       virtual ~categorical_argument() {
         for (std::vector<argument*>::iterator it = _subarguments.begin();
              it != _subarguments.end(); ++it) {
@@ -33,7 +31,6 @@ namespace stan {
       }
 
       void print_help(std::ostream* s, const int depth, const bool recurse) {
-
         if (!s)
           return;
 
@@ -58,16 +55,13 @@ namespace stan {
                  it != _subarguments.end(); ++it)
               (*it)->print_help(s, depth + 1, true);
           }
-        }
-        else {
+        } else {
           *s << std::endl;
         }
-
       }
 
       bool parse_args(std::vector<std::string>& args, std::ostream* out,
                       std::ostream* err, bool& help_flag) {
-
         bool good_arg = true;
         bool valid_arg = true;
 
@@ -99,7 +93,7 @@ namespace stan {
             valid_arg = true;
           for (std::vector<argument*>::iterator it = _subarguments.begin();
                it != _subarguments.end(); ++it) {
-            if ( (*it)->name() == cat_name) {
+            if ((*it)->name() == cat_name) {
               args.pop_back();
               valid_arg &= (*it)->parse_args(args, out, err, help_flag);
               good_arg = true;
@@ -114,7 +108,7 @@ namespace stan {
           }
         }
         return valid_arg;
-      };
+      }
 
       virtual void probe_args(argument* base_arg, std::stringstream& s) {
         for (std::vector<argument*>::iterator it = _subarguments.begin();
@@ -126,14 +120,12 @@ namespace stan {
       void find_arg(std::string name,
                     std::string prefix,
                     std::vector<std::string>& valid_paths) {
-
         argument::find_arg(name, prefix, valid_paths);
 
         prefix += _name + " ";
         for (std::vector<argument*>::iterator it = _subarguments.begin();
              it != _subarguments.end(); ++it)
           (*it)->find_arg(name, prefix, valid_paths);
-
       }
 
       std::vector<argument*>& subarguments() {
@@ -149,13 +141,10 @@ namespace stan {
       }
 
     protected:
-
       std::vector<argument*> _subarguments;
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/list_argument.hpp
+++ b/src/stan/services/arguments/list_argument.hpp
@@ -1,31 +1,28 @@
 #ifndef STAN_SERVICES_ARGUMENTS_LIST_ARGUMENT_HPP
 #define STAN_SERVICES_ARGUMENTS_LIST_ARGUMENT_HPP
 
-#include <iostream>
 #include <stan/services/arguments/valued_argument.hpp>
 #include <stan/services/arguments/arg_fail.hpp>
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace stan {
-
   namespace services {
 
     class list_argument: public valued_argument {
-
     public:
-
       list_argument() {
         _value_type = "list element";
       }
 
       ~list_argument() {
-
         for (std::vector<argument*>::iterator it = _values.begin();
              it != _values.end(); ++it) {
           delete *it;
         }
 
         _values.clear();
-
       }
 
       void print(std::ostream* s, int depth, const std::string prefix) {
@@ -47,61 +44,54 @@ namespace stan {
 
       bool parse_args(std::vector<std::string>& args, std::ostream* out,
                       std::ostream* err, bool& help_flag) {
-
-        if(args.size() == 0) return true;
+        if (args.size() == 0)
+          return true;
 
         std::string name;
         std::string value;
         split_arg(args.back(), name, value);
 
-        if(_name == "help") {
+        if (_name == "help") {
           print_help(out, 0, false);
           help_flag |= true;
           args.clear();
           return false;
-        }
-        else if(_name == "help-all") {
+        } else if (_name == "help-all") {
           print_help(out, 0, true);
           help_flag |= true;
           args.clear();
           return false;
-        }
-        else if(_name == name) {
-
+        } else if (_name == name) {
           args.pop_back();
 
           bool good_arg = false;
           bool valid_arg = true;
 
           for (size_t i = 0; i < _values.size(); ++i) {
-            if( _values.at(i)->name() != value) continue;
+            if ( _values.at(i)->name() != value) continue;
 
             _cursor = i;
-            valid_arg &= _values.at(_cursor)->parse_args(args, out, err, help_flag);
+            valid_arg
+              &= _values.at(_cursor)->parse_args(args, out, err, help_flag);
             good_arg = true;
             break;
           }
 
-          if(!good_arg) {
-
-            if(err) {
-              *err << value << " is not a valid value for \"" << _name << "\"" << std::endl;
-              *err << std::string(indent_width, ' ') << "Valid values:" << print_valid() << std::endl;
+          if (!good_arg) {
+            if (err) {
+              *err << value << " is not a valid value for \""
+                   << _name << "\"" << std::endl;
+              *err << std::string(indent_width, ' ')
+                   << "Valid values:" << print_valid() << std::endl;
             }
-
             args.clear();
           }
-
           return valid_arg && good_arg;
-
         }
-
         return true;
-
-      };
+      }
 
       virtual void probe_args(argument* base_arg, std::stringstream& s) {
-
         for (size_t i = 0; i < _values.size(); ++i) {
           _cursor = i;
 
@@ -120,13 +110,11 @@ namespace stan {
 
         _values.pop_back();
         _cursor = _default_cursor;
-
       }
 
       void find_arg(std::string name,
                     std::string prefix,
                     std::vector<std::string>& valid_paths) {
-
         if (name == _name) {
           valid_paths.push_back(prefix + _name + "=<list_element>");
         }
@@ -137,7 +125,6 @@ namespace stan {
           std::string value_prefix = prefix + (*it)->name() + " ";
           (*it)->find_arg(name, prefix, valid_paths);
         }
-
       }
 
       bool valid_value(std::string name) {
@@ -149,7 +136,7 @@ namespace stan {
       }
 
       argument* arg(std::string name) {
-        if(name == _values.at(_cursor)->name())
+        if (name == _values.at(_cursor)->name())
           return _values.at(_cursor);
         else
           return 0;
@@ -172,22 +159,18 @@ namespace stan {
           valid_values += ", " + (*it)->name();
 
         return valid_values;
-
       }
 
       bool is_default() { return _cursor == _default_cursor; }
 
     protected:
-
       int _cursor;
       int _default_cursor;
 
       std::vector<argument*> _values;
-
     };
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/singleton_argument.hpp
+++ b/src/stan/services/arguments/singleton_argument.hpp
@@ -1,12 +1,13 @@
 #ifndef STAN_SERVICES_ARGUMENTS_SINGLETON_ARGUMENT_HPP
 #define STAN_SERVICES_ARGUMENTS_SINGLETON_ARGUMENT_HPP
 
-#include <iostream>
-#include <boost/lexical_cast.hpp>
 #include <stan/services/arguments/valued_argument.hpp>
+#include <boost/lexical_cast.hpp>
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace stan {
-
   namespace services {
 
     template <typename T>
@@ -42,9 +43,7 @@ namespace stan {
 
     template<typename T>
     class singleton_argument: public valued_argument {
-
     public:
-
       singleton_argument(): _validity("All") {
         _constrained = false;
         _name = "";
@@ -54,7 +53,6 @@ namespace stan {
       singleton_argument(const std::string name): _validity("All") {
         _name = name;
       }
-
 
       bool parse_args(std::vector<std::string>& args, std::ostream* out,
                       std::ostream* err, bool& help_flag) {
@@ -73,13 +71,11 @@ namespace stan {
         split_arg(args.back(), name, value);
 
         if (_name == name) {
-
           args.pop_back();
 
           T proposed_value = boost::lexical_cast<T>(value);
 
           if (!set_value(proposed_value)) {
-
             if (err) {
               *err << proposed_value << " is not a valid value for "
                    << "\"" << _name << "\"" << std::endl;
@@ -90,13 +86,11 @@ namespace stan {
             args.clear();
             return false;
           }
-
         }
         return true;
       }
 
       virtual void probe_args(argument* base_arg, std::stringstream& s) {
-
         s << "good" << std::endl;
         _value = _good_value;
         base_arg->print(&s, 0, "");
@@ -110,7 +104,6 @@ namespace stan {
         }
 
         _value = _default_value;
-
       }
 
       void find_arg(std::string name,
@@ -124,12 +117,10 @@ namespace stan {
       T value() { return _value; }
 
       bool set_value(const T& value) {
-
         if (is_valid(value)) {
           _value = value;
           return true;
         }
-
         return false;
       }
 
@@ -145,9 +136,7 @@ namespace stan {
         return _value == _default_value;
       }
 
-
     protected:
-
       std::string _validity;
       virtual bool is_valid(T value) { return true; }
 
@@ -158,7 +147,6 @@ namespace stan {
 
       T _good_value;
       T _bad_value;
-
     };
 
     typedef singleton_argument<double> real_argument;
@@ -167,8 +155,7 @@ namespace stan {
     typedef singleton_argument<bool> bool_argument;
     typedef singleton_argument<std::string> string_argument;
 
-  } // services
-
-} // stan
+  }  // services
+}  // stan
 
 #endif

--- a/src/stan/services/arguments/unvalued_argument.hpp
+++ b/src/stan/services/arguments/unvalued_argument.hpp
@@ -1,24 +1,23 @@
 #ifndef STAN_SERVICES_ARGUMENTS_UNVALUED_ARGUMENT_HPP
 #define STAN_SERVICES_ARGUMENTS_UNVALUED_ARGUMENT_HPP
-#include <iostream>
 
-#include <vector>
 #include <stan/services/arguments/argument.hpp>
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace stan {
-
   namespace services {
 
     class unvalued_argument: public argument {
-
     public:
-
       unvalued_argument()
         : _is_present(false) {}
 
       void print(std::ostream* s, const int depth, const std::string prefix) {}
 
-      void print_help(std::ostream* s, const int depth, const bool recurse = false) {
+      void print_help(std::ostream* s, const int depth,
+                      const bool recurse = false) {
         if (!s)
           return;
 
@@ -28,7 +27,6 @@ namespace stan {
         *s << indent << _name << std::endl;
         *s << indent << subindent << _description << std::endl;
         *s << std::endl;
-
       }
 
       bool parse_args(std::vector<std::string>& args, std::ostream* out,
@@ -45,7 +43,7 @@ namespace stan {
 
         _is_present = true;
         return true;
-      };
+      }
 
       bool is_present() {
         return _is_present;
@@ -55,6 +53,7 @@ namespace stan {
       bool _is_present;
     };
 
-  } // services
-} // stan
+  }  // services
+}  // stan
+
 #endif

--- a/src/stan/services/arguments/valued_argument.hpp
+++ b/src/stan/services/arguments/valued_argument.hpp
@@ -2,28 +2,28 @@
 #define STAN_SERVICES_ARGUMENTS_VALUED_ARGUMENT_HPP
 
 #include <stan/services/arguments/argument.hpp>
+#include <string>
 
 namespace stan {
-
   namespace services {
 
     class valued_argument: public argument {
-
     public:
-
-      virtual void print(std::ostream* s, const int depth, const std::string prefix) {
+      virtual void print(std::ostream* s, const int depth,
+                         const std::string prefix) {
         if (!s)
           return;
 
         std::string indent(compute_indent(depth), ' ');
 
         *s << prefix << indent << _name << " = " << print_value();
-        if(is_default())
+        if (is_default())
           *s << " (Default)";
         *s << std::endl;
       }
 
-      virtual void print_help(std::ostream* s, const int depth, const bool recurse = false) {
+      virtual void print_help(std::ostream* s, const int depth,
+                              const bool recurse = false) {
         if (!s)
           return;
 
@@ -32,10 +32,10 @@ namespace stan {
 
         *s << indent << _name << "=<" << _value_type << ">" << std::endl;
         *s << indent << subindent << _description << std::endl;
-        *s << indent << subindent << "Valid values:" << print_valid() << std::endl;
+        *s << indent << subindent << "Valid values:"
+           << print_valid() << std::endl;
         *s << indent << subindent << "Defaults to " << _default << std::endl;
         *s << std::endl;
-
       }
 
       virtual std::string print_value() = 0;
@@ -43,12 +43,11 @@ namespace stan {
       virtual bool is_default() = 0;
 
     protected:
-
       std::string _default;
       std::string _value_type;
-
     };
 
-  } // services
-} // stan
+  }  // services
+}  // stan
+
 #endif

--- a/src/stan/services/init/init_nuts.hpp
+++ b/src/stan/services/init/init_nuts.hpp
@@ -22,10 +22,15 @@ namespace stan {
           (algorithm->arg("hmc")->arg("engine")->arg("nuts"));
 
         double epsilon
-          = dynamic_cast<stan::services::real_argument*>(hmc->arg("stepsize"))->value();
+          = dynamic_cast<stan::services::real_argument*>(hmc->arg("stepsize"))
+          ->value();
         double epsilon_jitter
-          = dynamic_cast<stan::services::real_argument*>(hmc->arg("stepsize_jitter"))->value();
-        int max_depth = dynamic_cast<stan::services::int_argument*>(base->arg("max_depth"))->value();
+          = dynamic_cast<stan::services::real_argument*>(
+                                                 hmc->arg("stepsize_jitter"))
+          ->value();
+        int max_depth
+          = dynamic_cast<stan::services::int_argument*>(base->arg("max_depth"))
+          ->value();
 
         dynamic_cast<Sampler*>(sampler)->set_nominal_stepsize(epsilon);
         dynamic_cast<Sampler*>(sampler)->set_stepsize_jitter(epsilon_jitter);

--- a/src/stan/services/init/init_static_hmc.hpp
+++ b/src/stan/services/init/init_static_hmc.hpp
@@ -13,7 +13,6 @@ namespace stan {
       template<class Sampler>
       bool init_static_hmc(stan::mcmc::base_mcmc* sampler,
                            stan::services::argument* algorithm) {
-
         stan::services::categorical_argument* hmc
           = dynamic_cast<stan::services::categorical_argument*>
           (algorithm->arg("hmc"));
@@ -29,9 +28,11 @@ namespace stan {
           = dynamic_cast<stan::services::real_argument*>
           (hmc->arg("stepsize_jitter"))->value();
         double int_time
-          = dynamic_cast<stan::services::real_argument*>(base->arg("int_time"))->value();
+          = dynamic_cast<stan::services::real_argument*>(base->arg("int_time"))
+          ->value();
 
-        dynamic_cast<Sampler*>(sampler)->set_nominal_stepsize_and_T(epsilon, int_time);
+        dynamic_cast<Sampler*>(sampler)
+          ->set_nominal_stepsize_and_T(epsilon, int_time);
         dynamic_cast<Sampler*>(sampler)->set_stepsize_jitter(epsilon_jitter);
 
         return true;

--- a/src/stan/services/init/init_windowed_adapt.hpp
+++ b/src/stan/services/init/init_windowed_adapt.hpp
@@ -25,7 +25,7 @@ namespace stan {
           = dynamic_cast<u_int_argument*>(adapt->arg("term_buffer"))->value();
         unsigned int window
           = dynamic_cast<u_int_argument*>(adapt->arg("window"))->value();
-        
+
         dynamic_cast<Sampler*>(sampler)
           ->set_window_params(num_warmup, init_buffer, term_buffer, window, o);
 

--- a/src/stan/services/init/initialize_state.hpp
+++ b/src/stan/services/init/initialize_state.hpp
@@ -143,7 +143,8 @@ namespace stan {
         if (!boost::math::isfinite(init_log_prob)) {
           if (output)
             *output << "Rejecting initial value:" << std::endl
-                    << "  Log probability evaluates to log(0), i.e. negative infinity."
+                    << "  Log probability evaluates to log(0), "
+                    << "i.e. negative infinity."
                     << std::endl
                     << "  Stan can't start sampling from this initial value."
                     << std::endl;
@@ -153,7 +154,8 @@ namespace stan {
           if (!boost::math::isfinite(init_grad(i))) {
             if (output)
               *output << "Rejecting initial value:" << std::endl
-                      << "  Gradient evaluated at the initial value is not finite."
+                      << "  Gradient evaluated at the initial value "
+                      << "is not finite."
                       << std::endl
                       << "  Stan can't start sampling from this initial value."
                       << std::endl;
@@ -191,7 +193,8 @@ namespace stan {
        *                            right size and set to 0.
        * @param[in,out] model       the model. Side effects on model? I'm not
        *                            quite sure
-       * @param[in,out] base_rng    the random number generator. State may change.
+       * @param[in,out] base_rng    the random number generator.
+       *                            State may change.
        * @param[in,out] output      output stream for messages
        */
       template <class Model, class RNG>
@@ -241,20 +244,21 @@ namespace stan {
        *
        * @param[in]     source      a string that the context_factory can
        *                            interpret and provide a valid var_context
-       * @param[in]     R           a double to specify the range of random inits
+       * @param[in]     R           a double to specify the range of
+       *                            random inits
        * @param[out]    cont_params the initialized state. This should be the
        *                            right size and set to 0.
        * @param[in,out] model       the model. Side effects on model? I'm not
        *                            quite sure
-       * @param[in,out] base_rng    the random number generator. State may change.
+       * @param[in,out] base_rng    the random number generator.
+       *                            State may change.
        * @param[in,out] output      output stream for messages
        * @param[in,out] context_factory  an instantiated factory that implements
        *                            the concept of a context_factory. This has
        *                            one method that takes a string.
-       * @param[in]     enable_random_init if true, it allows partially specifying
-                                    inits, otherwise not
+       * @param[in]                 enable_random_init if true, it allows
+       *                            partially specifying inits, otherwise not
        */
-
       template <class ContextFactory, class Model, class RNG>
       bool initialize_state_source_and_random(const std::string& source,
                                               double R,
@@ -331,7 +335,8 @@ namespace stan {
        *                            right size and set to 0.
        * @param[in,out] model       the model. Side effects on model? I'm not
        *                            quite sure
-       * @param[in,out] base_rng    the random number generator. State may change.
+       * @param[in,out] base_rng    the random number generator.
+       *                            State may change.
        * @param[in,out] output      output stream for messages
        * @param[in,out] context_factory  an instantiated factory that implements
        *                            the concept of a context_factory. This has
@@ -391,20 +396,22 @@ namespace stan {
       /**
        * Creates the initial state.
        *
-       * @param[in]     init        init can either be "0", a number as a string,
-       *                            or a filename.
+       * @param[in]     init        init can either be "0", a number as a
+       *                            string, or a filename.
        * @param[out]    cont_params the initialized state. This should be the
        *                            right size and set to 0.
        * @param[in,out] model       the model. Side effects on model? I'm not
        *                            quite sure
-       * @param[in,out] base_rng    the random number generator. State may change.
+       * @param[in,out] base_rng    the random number generator.
+       *                            State may change.
        * @param[in,out] output      output stream for messages
        * @param[in,out] context_factory  an instantiated factory that implements
        *                            the concept of a context_factory. This has
        *                            one method that takes a string.
        * @param[in] enable_random_init true or false.
-       * @param[in] R               a double for the range of generating random inits.
-       *                            it's used for randomly generating partial inits
+       * @param[in] R               a double for the range of generating
+       *                            random inits. it's used for randomly
+       *                            generating partial inits
        */
       template <class ContextFactory, class Model, class RNG>
       bool initialize_state(const std::string& init,

--- a/src/stan/services/io/write_error_msg.hpp
+++ b/src/stan/services/io/write_error_msg.hpp
@@ -10,19 +10,22 @@ namespace stan {
 
       void write_error_msg(std::ostream* error_stream,
                            const std::exception& e) {
-
-        if (!error_stream) return;
+        if (!error_stream)
+          return;
 
         *error_stream << std::endl
-                      << "Informational Message: The current Metropolis proposal is about to be"
-                      << " rejected because of the following issue:"
+                      << "Informational Message: The current Metropolis"
+                      << " proposal is about to be rejected because of"
+                      << " the following issue:"
                       << std::endl
                       << e.what() << std::endl
-                      << "If this warning occurs sporadically, such as for highly constrained"
-                      << " variable types like covariance matrices, then the sampler is fine,"
+                      << "If this warning occurs sporadically, such as"
+                      << " for highly constrained variable types like"
+                      << " covariance matrices, then the sampler is fine,"
                       << std::endl
-                      << "but if this warning occurs often then your model may be either"
-                      << " severely ill-conditioned or misspecified."
+                      << "but if this warning occurs often then your model"
+                      << " may be either severely ill-conditioned or"
+                      << " misspecified."
                       << std::endl;
       }
 

--- a/src/stan/services/io/write_iteration.hpp
+++ b/src/stan/services/io/write_iteration.hpp
@@ -1,9 +1,9 @@
 #ifndef STAN_SERVICES_IO_WRITE_ITERATION_HPP
 #define STAN_SERVICES_IO_WRITE_ITERATION_HPP
 
+#include <stan/services/io/write_iteration_csv.hpp>
 #include <ostream>
 #include <vector>
-#include <stan/services/io/write_iteration_csv.hpp>
 
 namespace stan {
   namespace services {

--- a/src/stan/services/io/write_stan.hpp
+++ b/src/stan/services/io/write_stan.hpp
@@ -1,20 +1,24 @@
 #ifndef STAN_SERVICES_IO_WRITE_STAN_HPP
 #define STAN_SERVICES_IO_WRITE_STAN_HPP
 
+#include <stan/version.hpp>
 #include <ostream>
 #include <string>
-#include <stan/version.hpp>
 
 namespace stan {
   namespace services {
     namespace io {
 
       void write_stan(std::ostream* s, const std::string prefix = "") {
-        if (!s) return;
+        if (!s)
+          return;
 
-        *s << prefix << " stan_version_major = " << stan::MAJOR_VERSION << std::endl;
-        *s << prefix << " stan_version_minor = " << stan::MINOR_VERSION << std::endl;
-        *s << prefix << " stan_version_patch = " << stan::PATCH_VERSION << std::endl;
+        *s << prefix
+           << " stan_version_major = " << stan::MAJOR_VERSION << std::endl;
+        *s << prefix
+           << " stan_version_minor = " << stan::MINOR_VERSION << std::endl;
+        *s << prefix
+           << " stan_version_patch = " << stan::PATCH_VERSION << std::endl;
       }
 
     }

--- a/src/stan/services/mcmc/print_progress.hpp
+++ b/src/stan/services/mcmc/print_progress.hpp
@@ -1,10 +1,11 @@
 #ifndef STAN_SERVICES_MCMC_PRINT_PROGRESS_HPP
 #define STAN_SERVICES_MCMC_PRINT_PROGRESS_HPP
 
+#include <stan/services/io/do_print.hpp>
 #include <cmath>
 #include <iomanip>
-#include <stan/services/io/do_print.hpp>
 #include <iostream>
+#include <string>
 
 namespace stan {
   namespace services {
@@ -18,7 +19,7 @@ namespace stan {
                           const std::string prefix,
                           const std::string suffix,
                           std::ostream& o) {
-        int it_print_width = std::ceil(std::log10((double) finish));
+        int it_print_width = std::ceil(std::log10(static_cast<double>(finish)));
         if (io::do_print(m, (start + m + 1 == finish), refresh)) {
           o << prefix;
           o << "Iteration: ";

--- a/src/stan/services/mcmc/run_markov_chain.hpp
+++ b/src/stan/services/mcmc/run_markov_chain.hpp
@@ -4,13 +4,15 @@
 #include <stan/mcmc/base_mcmc.hpp>
 #include <stan/io/mcmc_writer.hpp>
 #include <stan/services/mcmc/print_progress.hpp>
+#include <string>
 
 namespace stan {
   namespace services {
     namespace mcmc {
 
       template <class Model, class RNG, class StartTransitionCallback,
-                class SampleRecorder, class DiagnosticRecorder, class MessageRecorder>
+                class SampleRecorder, class DiagnosticRecorder,
+                class MessageRecorder>
       void run_markov_chain(stan::mcmc::base_mcmc* sampler,
                             const int num_iterations,
                             const int start,
@@ -19,9 +21,9 @@ namespace stan {
                             const int refresh,
                             const bool save,
                             const bool warmup,
-                            stan::io::mcmc_writer <Model,
-                            SampleRecorder, DiagnosticRecorder, MessageRecorder>&
-                            writer,
+                            stan::io::mcmc_writer<
+                               Model, SampleRecorder,
+                               DiagnosticRecorder, MessageRecorder>& writer,
                             stan::mcmc::sample& init_s,
                             Model& model,
                             RNG& base_rng,
@@ -40,9 +42,7 @@ namespace stan {
             writer.write_sample_params(base_rng, init_s, *sampler, model);
             writer.write_diagnostic_params(init_s, sampler);
           }
-
         }
-
       }
 
     }

--- a/src/stan/services/mcmc/sample.hpp
+++ b/src/stan/services/mcmc/sample.hpp
@@ -4,21 +4,24 @@
 #include <stan/mcmc/base_mcmc.hpp>
 #include <stan/io/mcmc_writer.hpp>
 #include <stan/services/mcmc/run_markov_chain.hpp>
+#include <string>
 
 namespace stan {
   namespace services {
     namespace mcmc {
 
       template <class Model, class RNG, class StartTransitionCallback,
-                class SampleRecorder, class DiagnosticRecorder, class MessageRecorder>
+                class SampleRecorder, class DiagnosticRecorder,
+                class MessageRecorder>
       void sample(stan::mcmc::base_mcmc* sampler,
                   int num_warmup,
                   int num_samples,
                   int num_thin,
                   int refresh,
                   bool save,
-                  stan::io::mcmc_writer
-                  <Model,SampleRecorder,DiagnosticRecorder,MessageRecorder>& writer,
+                  stan::io::mcmc_writer<
+                    Model, SampleRecorder, DiagnosticRecorder, MessageRecorder>&
+                    writer,
                   stan::mcmc::sample& init_s,
                   Model& model,
                   RNG& base_rng,
@@ -27,8 +30,8 @@ namespace stan {
                   std::ostream& o,
                   StartTransitionCallback& callback) {
         run_markov_chain<Model, RNG, StartTransitionCallback,
-                         SampleRecorder, DiagnosticRecorder, MessageRecorder>
-          (sampler, num_samples, num_warmup,
+                         SampleRecorder, DiagnosticRecorder, MessageRecorder>(
+           sampler, num_samples, num_warmup,
            num_warmup + num_samples, num_thin,
            refresh, save, false,
            writer,

--- a/src/stan/services/mcmc/warmup.hpp
+++ b/src/stan/services/mcmc/warmup.hpp
@@ -4,21 +4,24 @@
 #include <stan/mcmc/base_mcmc.hpp>
 #include <stan/io/mcmc_writer.hpp>
 #include <stan/services/mcmc/run_markov_chain.hpp>
+#include <string>
 
 namespace stan {
   namespace services {
     namespace mcmc {
 
       template <class Model, class RNG, class StartTransitionCallback,
-                class SampleRecorder, class DiagnosticRecorder, class MessageRecorder>
+                class SampleRecorder, class DiagnosticRecorder,
+                class MessageRecorder>
       void warmup(stan::mcmc::base_mcmc* sampler,
                   int num_warmup,
                   int num_samples,
                   int num_thin,
                   int refresh,
                   bool save,
-                  stan::io::mcmc_writer
-                  <Model, SampleRecorder, DiagnosticRecorder, MessageRecorder>& writer,
+                  stan::io::mcmc_writer<
+                    Model, SampleRecorder, DiagnosticRecorder, MessageRecorder>&
+                    writer,
                   stan::mcmc::sample& init_s,
                   Model& model,
                   RNG& base_rng,

--- a/src/stan/services/optimization/do_bfgs_optimize.hpp
+++ b/src/stan/services/optimization/do_bfgs_optimize.hpp
@@ -17,7 +17,7 @@ namespace stan {
   namespace services {
     namespace optimization {
 
-      template<typename ModelT,typename BFGSOptimizerT,typename RNGT,
+      template<typename ModelT, typename BFGSOptimizerT, typename RNGT,
                typename StartIterationCallback>
       int do_bfgs_optimize(ModelT &model, BFGSOptimizerT &bfgs,
                            RNGT &base_rng,
@@ -32,7 +32,8 @@ namespace stan {
         lp = bfgs.logp();
 
         if (notice_stream)
-          (*notice_stream) << "initial log joint probability = " << lp << std::endl;
+          *notice_stream << "initial log joint probability = "
+                         << lp << std::endl;
         if (output_stream && save_iterations) {
           io::write_iteration(*output_stream, model, base_rng,
                               lp, cont_vector, disc_vector, output_stream);
@@ -57,7 +58,10 @@ namespace stan {
           lp = bfgs.logp();
           bfgs.params_r(cont_vector);
 
-          if (notice_stream && (io::do_print(bfgs.iter_num(), ret != 0 || !bfgs.note().empty(),refresh))) {
+          if (notice_stream
+              && (io::do_print(bfgs.iter_num(),
+                               ret != 0 || !bfgs.note().empty(),
+                               refresh))) {
             (*notice_stream) << " " << std::setw(7) << bfgs.iter_num() << " ";
             (*notice_stream) << " " << std::setw(12) << std::setprecision(6)
                       << lp << " ";
@@ -84,11 +88,12 @@ namespace stan {
         int return_code;
         if (ret >= 0) {
           if (notice_stream)
-            (*notice_stream) << "Optimization terminated normally: " << std::endl;
+            *notice_stream << "Optimization terminated normally: " << std::endl;
           return_code = stan::services::error_codes::OK;
         } else {
           if (notice_stream)
-            (*notice_stream) << "Optimization terminated with error: " << std::endl;
+            *notice_stream << "Optimization terminated with error: "
+                           << std::endl;
           return_code = stan::services::error_codes::SOFTWARE;
         }
         if (notice_stream)
@@ -101,4 +106,3 @@ namespace stan {
   }
 }
 #endif
-


### PR DESCRIPTION
#### Summary:

Removes a lot of CppLint warnings.
There are a handful that take a little more care that should come in a different pull request.

#### Intended Effect:

Clean up warnings.

#### How to Verify:

All tests should still run without any issues.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

Bob. If you don't like the way I broke apart lines in `src/stan/lang/generator.hpp`, just revert `e445439081c`. (`> git revert e445439081c`) I left all the changes to that file as one commit.

Almost everything is whitespace related. There were a few includes and extraneous semicolons.