### PR TITLE
squashing doxygen warnings

### DIFF
--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -111,7 +111,7 @@ namespace stan {
        *
        * @param names_r  names for each element
        * @param values_r a vector of double values for all elements
-       * @param dims_r   a vector of dimensions
+       * @param dim_r   a vector of dimensions
        */
       array_var_context(const std::vector<std::string>& names_r,
                         const std::vector<double>& values_r,
@@ -124,7 +124,7 @@ namespace stan {
        *
        * @param names_i  names for each element
        * @param values_i a vector of integer values for all elements
-       * @param dims_i   a vector of dimensions
+       * @param dim_i   a vector of dimensions
        */
       array_var_context(const std::vector<std::string>& names_i,
                         const std::vector<int>& values_i,

--- a/src/stan/lang/grammars/functions_grammar_def.hpp
+++ b/src/stan/lang/grammars/functions_grammar_def.hpp
@@ -48,7 +48,9 @@ namespace stan {
   namespace lang {
 
     struct validate_non_void_arg_function {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
       void operator()(const expr_type& arg_type,
@@ -65,7 +67,9 @@ namespace stan {
     validate_non_void_arg_f;
 
     struct set_void_function {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4>
       struct result<F(T1, T2, T3, T4)> { typedef void type; };
       void operator()(const expr_type& return_type,
@@ -86,7 +90,9 @@ namespace stan {
     boost::phoenix::function<set_void_function> set_void_function_f;
 
     struct set_allows_sampling_origin {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
       void operator()(const std::string& identifier,
@@ -116,7 +122,9 @@ namespace stan {
     set_allows_sampling_origin_f;
 
     struct validate_declarations {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4>
       struct result<F(T1, T2, T3, T4)> { typedef void type; };
       void operator()(bool& pass,
@@ -144,7 +152,9 @@ namespace stan {
     boost::phoenix::function<validate_declarations> validate_declarations_f;
 
     struct add_function_signature {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3,
                 typename T4, typename T5>
       struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
@@ -225,7 +235,9 @@ namespace stan {
     boost::phoenix::function<add_function_signature> add_function_signature_f;
 
     struct validate_return_type {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
       void operator()(function_decl_def& decl,
@@ -261,7 +273,9 @@ namespace stan {
 
 
     struct unscope_variables {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2>
       struct result<F(T1, T2)> { typedef void type; };
       void operator()(function_decl_def& decl,
@@ -276,7 +290,9 @@ namespace stan {
 
 
     struct add_fun_var {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4>
       struct result<F(T1, T2, T3, T4)> { typedef void type; };
       // each type derived from base_var_decl gets own instance

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -84,7 +84,9 @@ namespace stan {
 
     // see bare_type_grammar_def.hpp for original
     struct set_val4 {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2>
       struct result<F(T1, T2)> { typedef void type; };
       template <typename T1, typename T2>
@@ -96,7 +98,9 @@ namespace stan {
     boost::phoenix::function<set_val4> set_val4_f;
 
     struct validate_return_allowed {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
       void operator()(var_origin origin,
@@ -116,7 +120,9 @@ namespace stan {
     boost::phoenix::function<validate_return_allowed> validate_return_allowed_f;
 
     struct validate_void_return_allowed {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
       void operator()(var_origin origin,
@@ -139,7 +145,9 @@ namespace stan {
 
 
     struct validate_assignment {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3,
                 typename T4, typename T5>
       struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
@@ -243,7 +251,9 @@ namespace stan {
     boost::phoenix::function<validate_assignment> validate_assignment_f;
 
     struct validate_sample {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4>
       struct result<F(T1, T2, T3, T4)> { typedef void type; };
 
@@ -433,7 +443,9 @@ namespace stan {
     boost::phoenix::function<validate_sample> validate_sample_f;
 
     struct expression_as_statement {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
       void operator()(bool& pass,
@@ -474,7 +486,9 @@ namespace stan {
     boost::phoenix::function<expression_as_statement> expression_as_statement_f;
 
     struct unscope_locals {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2>
       struct result<F(T1, T2)> { typedef void type; };
       void operator()(const std::vector<var_decl>& var_decls,
@@ -486,7 +500,9 @@ namespace stan {
     boost::phoenix::function<unscope_locals> unscope_locals_f;
 
     struct add_while_condition {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4>
       struct result<F(T1, T2, T3, T4)> { typedef void type; };
       void operator()(while_statement& ws,
@@ -506,7 +522,9 @@ namespace stan {
     boost::phoenix::function<add_while_condition> add_while_condition_f;
 
     struct add_while_body {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2>
       struct result<F(T1, T2)> { typedef void type; };
       void operator()(while_statement& ws,
@@ -517,7 +535,9 @@ namespace stan {
     boost::phoenix::function<add_while_body> add_while_body_f;
 
     struct add_loop_identifier {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4,
                 typename T5>
       struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
@@ -540,7 +560,9 @@ namespace stan {
     boost::phoenix::function<add_loop_identifier> add_loop_identifier_f;
 
     struct remove_loop_identifier {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2>
       struct result<F(T1, T2)> { typedef void type; };
       void operator()(const std::string& name,
@@ -551,7 +573,9 @@ namespace stan {
     boost::phoenix::function<remove_loop_identifier> remove_loop_identifier_f;
 
     struct validate_int_expr2 {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 
@@ -571,7 +595,9 @@ namespace stan {
     boost::phoenix::function<validate_int_expr2> validate_int_expr2_f;
 
     struct validate_allow_sample {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 
@@ -593,7 +619,9 @@ namespace stan {
     boost::phoenix::function<validate_allow_sample> validate_allow_sample_f;
 
     struct validate_non_void_expression {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 
@@ -611,7 +639,9 @@ namespace stan {
     validate_non_void_expression_f;
 
     struct add_line_number {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
       template <typename T, typename It>
@@ -625,7 +655,9 @@ namespace stan {
     boost::phoenix::function<add_line_number> add_line_number_f;
 
     struct set_void_return {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1>
       struct result<F(T1)> { typedef void type; };
       void operator()(return_statement& s) const {
@@ -635,7 +667,9 @@ namespace stan {
     boost::phoenix::function<set_void_return> set_void_return_f;
 
     struct set_no_op {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1>
       struct result<F(T1)> { typedef void type; };
       void operator()(no_op_statement& s) const {

--- a/src/stan/lang/grammars/term_grammar_def.hpp
+++ b/src/stan/lang/grammars/term_grammar_def.hpp
@@ -70,7 +70,9 @@ namespace stan {
 
    // see bare_type_grammar_def.hpp for original
     struct set_val5 {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2>
       struct result<F(T1, T2)> { typedef void type; };
       template <typename T1, typename T2>
@@ -82,7 +84,9 @@ namespace stan {
     boost::phoenix::function<set_val5> set_val5_f;
 
     struct validate_integrate_ode {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4>
       struct result<F(T1, T2, T3, T4)> { typedef void type; };
 
@@ -181,7 +185,9 @@ namespace stan {
     boost::phoenix::function<validate_integrate_ode> validate_integrate_ode_f;
 
     struct set_fun_type {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2>
       struct result<F(T1, T2)> { typedef fun type; };
 
@@ -200,7 +206,9 @@ namespace stan {
 
 
     struct set_fun_type_named {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3,
                 typename T4, typename T5>
       struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
@@ -296,7 +304,9 @@ namespace stan {
     boost::phoenix::function<set_fun_type_named> set_fun_type_named_f;
 
     struct exponentiation_expr {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3,
                 typename T4, typename T5>
       struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
@@ -331,7 +341,9 @@ namespace stan {
     boost::phoenix::function<exponentiation_expr> exponentiation_f;
 
     struct multiplication_expr {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 
@@ -357,7 +369,9 @@ namespace stan {
     void generate_expression(const expression& e, std::ostream& o);
 
     struct division_expr {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 
@@ -412,7 +426,9 @@ namespace stan {
     boost::phoenix::function<division_expr> division_f;
 
     struct modulus_expr {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4>
       struct result<F(T1, T2, T3, T4)> { typedef void type; };
 
@@ -443,7 +459,9 @@ namespace stan {
     boost::phoenix::function<modulus_expr> modulus_f;
 
     struct left_division_expr {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4>
       struct result<F(T1, T2, T3, T4)> { typedef void type; };
 
@@ -473,7 +491,9 @@ namespace stan {
     boost::phoenix::function<left_division_expr> left_division_f;
 
     struct elt_multiplication_expr {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 
@@ -497,7 +517,9 @@ namespace stan {
     boost::phoenix::function<elt_multiplication_expr> elt_multiplication_f;
 
     struct elt_division_expr {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 
@@ -526,7 +548,9 @@ namespace stan {
     // so. Phoenix will be switching to BOOST_TYPEOF. In the meantime,
     // we will use a phoenix::function below:
     struct negate_expr {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4>
       struct result<F(T1, T2, T3, T4)> { typedef void type; };
 
@@ -549,7 +573,9 @@ namespace stan {
     boost::phoenix::function<negate_expr> negate_expr_f;
 
     struct logical_negate_expr {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 
@@ -572,7 +598,9 @@ namespace stan {
     boost::phoenix::function<logical_negate_expr> logical_negate_expr_f;
 
     struct transpose_expr {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 
@@ -600,7 +628,9 @@ namespace stan {
     }
 
     struct add_expression_dimss {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3, typename T4>
       struct result<F(T1, T2, T3, T4)> { typedef void type; };
       void operator()(expression& expression,
@@ -635,7 +665,9 @@ namespace stan {
     boost::phoenix::function<add_expression_dimss> add_expression_dimss_f;
 
     struct set_var_type {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3,
                 typename T4, typename T5>
       struct result<F(T1, T2, T3, T4, T5)> { typedef void type; };
@@ -675,7 +707,9 @@ namespace stan {
     };
     boost::phoenix::function<set_var_type> set_var_type_f;
     struct validate_int_expr3 {
+      //! @cond Doxygen_Suppress
       template <class> struct result;
+      //! @endcond
       template <typename F, typename T1, typename T2, typename T3>
       struct result<F(T1, T2, T3)> { typedef void type; };
 

--- a/src/stan/lang/rethrow_located.hpp
+++ b/src/stan/lang/rethrow_located.hpp
@@ -80,7 +80,7 @@ namespace stan {
      * the specified exception, adding the specified line number to
      * the specified exception's message.
      *
-     * @parem[in] e Original exception.
+     * @param[in] e Original exception.
      * @param[in] line Line number in Stan source program where
      * exception originated.
      */

--- a/src/stan/services/init/initialize_state.hpp
+++ b/src/stan/services/init/initialize_state.hpp
@@ -256,8 +256,6 @@ namespace stan {
        * @param[in,out] context_factory  an instantiated factory that implements
        *                            the concept of a context_factory. This has
        *                            one method that takes a string.
-       * @param[in]                 enable_random_init if true, it allows
-       *                            partially specifying inits, otherwise not
        */
       template <class ContextFactory, class Model, class RNG>
       bool initialize_state_source_and_random(const std::string& source,
@@ -341,6 +339,10 @@ namespace stan {
        * @param[in,out] context_factory  an instantiated factory that implements
        *                            the concept of a context_factory. This has
        *                            one method that takes a string.
+       * @param[in] enable_random_init true or false
+       * @param[in] R               a double for the range of generating
+       *                            random inits. it's used for randomly
+       *                            generating partial inits
        */
       template <class ContextFactory, class Model, class RNG>
       bool initialize_state_source(const std::string source,
@@ -409,7 +411,7 @@ namespace stan {
        *                            the concept of a context_factory. This has
        *                            one method that takes a string.
        * @param[in] enable_random_init true or false.
-       * @param[in] R               a double for the range of generating
+       * @param[in] init_r          a double for the range of generating
        *                            random inits. it's used for randomly
        *                            generating partial inits
        */

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -115,8 +115,8 @@ namespace stan {
       /**
        * Calculates the "black box" gradient of the ELBO.
        *
-       * @tparam Q         class of variational distribution
-       * @param  elbo_grad gradient of ELBO with respect to variational parameters
+       * @param variational variational distribution
+       * @param elbo_grad gradient of ELBO with respect to variational parameters
        */
       void calc_ELBO_grad(const Q& variational, Q& elbo_grad) const {
         static const char* function =
@@ -137,7 +137,7 @@ namespace stan {
       /**
        * Runs stochastic gradient ascent with Adagrad.
        *
-       * @tparam Q              class of variational distribution
+       * @param  variational    variational distribution
        * @param  tol_rel_obj    relative tolerance parameter for convergence
        * @param  max_iterations max number of iterations to run algorithm
        */

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -225,12 +225,12 @@ namespace stan {
        * parallel. It uses the same gradient computed from a set of Monte Carlo
        * samples
        *
-       * @tparam M                     class of model
-       * @tparam BaseRNG               class of random number generator
-       * @param  elbo_grad             parameters to store "blackbox" gradient
-       * @param  cont_params           continuous parameters
-       * @param  n_monte_carlo_grad    number of samples for gradient computation
-       * @param  print_stream          stream for convergence assessment output
+       * @param elbo_grad             parameters to store "blackbox" gradient
+       * @param m                     model
+       * @param cont_params           continuous parameters
+       * @param n_monte_carlo_grad    number of samples for gradient computation
+       * @param rng                   random number generator
+       * @param print_stream          stream for convergence assessment output
        */
       template <class M, class BaseRNG>
       void calc_grad(normal_fullrank& elbo_grad,

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -211,11 +211,11 @@ namespace stan {
        * It uses the same gradient computed from a set of Monte Carlo
        * samples.
        *
-       * @tparam M                     class of model
-       * @tparam BaseRNG               class of random number generator
        * @param  elbo_grad             parameters to store "blackbox" gradient
+       * @param  m                     model
        * @param  cont_params           continuous parameters
        * @param  n_monte_carlo_grad    number of samples for gradient computation
+       * @param  rng                   random number generator
        * @param  print_stream          stream for convergence assessment output
        */
       template <class M, class BaseRNG>


### PR DESCRIPTION
#### Summary:

Removes all doxygen warnings.

#### How to Verify:

Run doxygen.

#### Side Effects:

None. No change to code.

#### Documentation:

All doc.

#### Reviewer Suggestions: 

No one.