### PR TITLE
feature/issue 1587 increase max dropped gradients

### DIFF
--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -282,10 +282,10 @@ namespace stan {
           } catch (std::exception& e) {
             this->write_error_msg_(print_stream, e);
             n_monte_carlo_drop += 1;
-            if (n_monte_carlo_drop >= n_monte_carlo_grad) {
+            if (n_monte_carlo_drop >= 5*n_monte_carlo_grad) {
               const char* name = "The number of dropped evaluations";
               const char* msg1 = "has reached its maximum amount (";
-              int y = n_monte_carlo_grad;
+              int y = 5*n_monte_carlo_grad;
               const char* msg2 = "). Your model may be either severely "
                 "ill-conditioned or misspecified.";
               stan::math::domain_error(function, name, y, msg1, msg2);

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -264,10 +264,10 @@ namespace stan {
           } catch (std::exception& e) {
             this->write_error_msg_(print_stream, e);
             n_monte_carlo_drop += 1;
-            if (n_monte_carlo_drop >= n_monte_carlo_grad) {
+            if (n_monte_carlo_drop >= 5*n_monte_carlo_grad) {
               const char* name = "The number of dropped evaluations";
               const char* msg1 = "has reached its maximum amount (";
-              int y = n_monte_carlo_grad;
+              int y = 5*n_monte_carlo_grad;
               const char* msg2 = "). Your model may be either severely "
                 "ill-conditioned or misspecified.";
               stan::math::domain_error(function, name, y, msg1, msg2);

--- a/src/test/unit/variational/gradient_warn_test.cpp
+++ b/src/test/unit/variational/gradient_warn_test.cpp
@@ -28,7 +28,7 @@ public:
 
     advi_meanfield_ = new stan::variational::advi<stan_model, stan::variational::normal_meanfield, rng_t>
       (*model_, cont_params_,
-       2, 100, 0.1,
+       1, 100, 0.1,
        base_rng_,
        100, 1,
        &print_stream_,


### PR DESCRIPTION
#### Summary:
Sets the max number to be 5*grad_samples—the intuition being that we allow 5 dropped gradients per grad_sample, and so that it still scales with the size of the mini batch.

#### Intended Effect:
Allows dropped gradients by default; prior to this with `grad_samples=1` (default) no dropped gradients are allowed.

#### How to Verify:
Run any model that ends up dropping a gradient with the default argument (`grad_samples=1`), c.f., unit test `gradient_warn_test.cpp`.

#### Side Effects:
None

#### Documentation:
None

#### Reviewer Suggestions:
None