### PR TITLE
set BIT variable on windows conditionally depending on 32 or 64 bit

### DIFF
--- a/make/os_win
+++ b/make/os_win
@@ -17,7 +17,9 @@ EXE = .exe
 O_STANC = 3
 CFLAGS_GTEST += -DGTEST_HAS_PTHREAD=0
 PATH_SEPARATOR = '\'
-ifeq ($(PROCESSOR_ARCHITECTURE)$(PROCESSOR_ARCHITECTURE6432),x86)
+## Detecting Process Bitness:
+## http://blogs.msdn.com/b/david.wang/archive/2006/03/26/howto-detect-process-bitness.aspx
+ifeq ($(PROCESSOR_ARCHITECTURE)$(PROCESSOR_ARCHITEW6432),x86)
   BIT=32
 else
   BIT=64

--- a/make/os_win
+++ b/make/os_win
@@ -17,7 +17,11 @@ EXE = .exe
 O_STANC = 3
 CFLAGS_GTEST += -DGTEST_HAS_PTHREAD=0
 PATH_SEPARATOR = '\'
-BIT = 64
+ifeq ($(PROCESSOR_ARCHITECTURE)$(PROCESSOR_ARCHITECTURE6432),x86)
+  BIT=32
+else
+  BIT=64
+endif
 ifeq (g++,$(CC_TYPE))
   CFLAGS += -m$(BIT)
   CFLAGS += -Wno-unused-function


### PR DESCRIPTION
#### Summary:

set BIT variable on windows conditionally on running on a 32bit or 64bit machine; this triggers the -m$BIT variable to be set correctly for g++ based (Rtools) windows builds

#### Intended Effect:

fix the makefile on windows for 32bit machines. Currently Stan generates 64bit binaries on 32bit machines. Not good.

#### How to Verify:

Run some test for example on a win 32bit machine and a win 64bit machine.

#### Side Effects:

None for Stan, but this change should be propagated to stan-math & cmdstan.

#### Documentation:

None.

#### Reviewer Suggestions:
@syclik 