### PR TITLE
Fixed make/libstan similiarly to make/tests

### DIFF
--- a/make/libstan
+++ b/make/libstan
@@ -12,6 +12,6 @@ $(TEMPLATE_INSTANTIATION) : bin/%.o : src/%.cpp
 ##
 # Generate dependencies for libraries
 ##
-ifneq (,$(filter-out test-headers clean% %-test %.d,$(MAKECMDGOALS)))
+ifneq (,$(filter $(STANC_TESTS),$(MAKECMDGOALS)))
   -include $(addsuffix .d,$(basename $(TEMPLATE_INSTANTIATION)))
 endif


### PR DESCRIPTION
#### Summary:

Fixes #1618. Issues with makefile.

#### Intended Effect:

Make the Stan makefile a little better.

#### How to Verify:

Everything should work the same way.

#### Side Effects:

Make should run a little quicker, I hope.

#### Documentation:

None required.

#### Reviewer Suggestions: 

No one.