### PR TITLE
Change argument of eta_adagrad to eta

### DIFF
--- a/src/stan/services/arguments/arg_variational.hpp
+++ b/src/stan/services/arguments/arg_variational.hpp
@@ -6,7 +6,7 @@
 #include <stan/services/arguments/arg_variational_algo.hpp>
 #include <stan/services/arguments/arg_variational_iter.hpp>
 #include <stan/services/arguments/arg_variational_num_samples.hpp>
-#include <stan/services/arguments/arg_variational_eta_adagrad.hpp>
+#include <stan/services/arguments/arg_variational_eta.hpp>
 #include <stan/services/arguments/arg_tolerance.hpp>
 #include <stan/services/arguments/arg_variational_eval_elbo.hpp>
 #include <stan/services/arguments/arg_variational_output_samples.hpp>
@@ -30,7 +30,7 @@ namespace stan {
                                  "Number of samples for Monte Carlo estimate "
                                  "of ELBO (objective function)",
                                  100));
-        _subarguments.push_back(new arg_variational_eta_adagrad());
+        _subarguments.push_back(new arg_variational_eta());
         _subarguments.push_back(new arg_tolerance("tol_rel_obj",
           "Convergence tolerance on the relative norm of the objective", 1e-2));
         _subarguments.push_back(new arg_variational_eval_elbo("eval_elbo",

--- a/src/stan/services/arguments/arg_variational_eta.hpp
+++ b/src/stan/services/arguments/arg_variational_eta.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_SERVICES_ARGUMENTS_VARIATIONAL_ETA_ADAGRAD_HPP
-#define STAN_SERVICES_ARGUMENTS_VARIATIONAL_ETA_ADAGRAD_HPP
+#ifndef STAN_SERVICES_ARGUMENTS_VARIATIONAL_ETA_HPP
+#define STAN_SERVICES_ARGUMENTS_VARIATIONAL_ETA_HPP
 
 #include <stan/services/arguments/singleton_argument.hpp>
 
@@ -7,12 +7,12 @@ namespace stan {
 
   namespace services {
 
-    class arg_variational_eta_adagrad: public real_argument {
+    class arg_variational_eta: public string_argument {
     public:
-      arg_variational_eta_adagrad(): real_argument() {
-        _name = "eta_adagrad";
-        _description = "Stepsize weighting parameter for variational iteration";
-        _validity = "0 < eta_adagrad <= 1.0";
+      arg_variational_eta(): string_argument() {
+        _name = "eta";
+        _description = "Stepsize scaling parameter for variational inference";
+        _validity = "0 < eta <= 1.0";
         _default = "0.1";
         _default_value = 0.1;
         _constrained = true;


### PR DESCRIPTION
#### Summary:
Changes an argument name of variational inference, from `eta_adagrad` to `eta`. This follows the greek argument convention used in MCMC, and abstracts away from ADVI's tie to a particular learning rate. To be reviewed in combination with https://github.com/stan-dev/cmdstan/pull/166.

Part of a round of pull requests, splitting out #1590. See #1590 for the blueprint.

Note: I don't suggest we merge this request now, but the request will serve as discussion on whether 1. we should allow these sorts of changes; 2. implement it with backwards-compatibility; 3. wait until Stan 3.0.

#### Intended Effect:
None

#### How to Verify:
Run unit tests as typically.

#### Side Effects:
None

#### Documentation:
- [x] CmdStan (see https://github.com/stan-dev/cmdstan/pull/166)

#### Reviewer Suggestions:
None