### PR TITLE
replace deprecated function abs by fabs

### DIFF
--- a/src/docs/stan-reference/advanced.tex
+++ b/src/docs/stan-reference/advanced.tex
@@ -275,7 +275,7 @@ data {
 model {
   // ...
   for (k in 1:K)
-    increment_log_prob(- lambda * abs(beta[k]));
+    increment_log_prob(- lambda * fabs(beta[k]));
 }
 \end{stancode}
 


### PR DESCRIPTION
Replace `abs` by `fabs` in lasso example.