### PR TITLE
Added explicit keyword to constructors with one argument

### DIFF
--- a/src/stan/optimization/bfgs.hpp
+++ b/src/stan/optimization/bfgs.hpp
@@ -146,7 +146,7 @@ namespace stan {
         }
       }
 
-      BFGSMinimizer(FunctorType &f) : _func(f) { }
+      explicit BFGSMinimizer(FunctorType &f) : _func(f) { }
 
       void initialize(const VectorT &x0) {
         int ret;

--- a/src/stan/optimization/lbfgs_update.hpp
+++ b/src/stan/optimization/lbfgs_update.hpp
@@ -21,7 +21,7 @@ namespace stan {
       typedef Eigen::Matrix<Scalar, DimAtCompile, DimAtCompile> HessianT;
       typedef boost::tuple<Scalar, VectorT, VectorT> UpdateT;
 
-      LBFGSUpdate(size_t L = 5) : _buf(L) {}
+      explicit LBFGSUpdate(size_t L = 5) : _buf(L) {}
 
       /**
        * Set the number of inverse Hessian updates to keep.

--- a/src/stan/services/arguments/argument.hpp
+++ b/src/stan/services/arguments/argument.hpp
@@ -15,7 +15,7 @@ namespace stan {
         : indent_width(2),
           help_width(20) { }
 
-      explicit argument(const std::string name)
+      explicit argument(const std::string& name)
         : _name(name),
           indent_width(2),
           help_width(20) { }
@@ -31,7 +31,7 @@ namespace stan {
       }
 
       virtual void print(std::ostream* s, const int depth,
-                         const std::string prefix) = 0;
+                         const std::string& prefix) = 0;
       virtual void print_help(std::ostream* s, const int depth,
                               const bool recurse) = 0;
 
@@ -44,8 +44,8 @@ namespace stan {
 
       virtual void probe_args(argument* base_arg, std::stringstream& s) {}
 
-      virtual void find_arg(std::string name,
-                            std::string prefix,
+      virtual void find_arg(const std::string& name,
+                            const std::string& prefix,
                             std::vector<std::string>& valid_paths) {
         if (name == _name) {
           valid_paths.push_back(prefix + _name);
@@ -65,7 +65,7 @@ namespace stan {
         }
       }
 
-      virtual argument* arg(const std::string name) {
+      virtual argument* arg(const std::string& name) {
         return 0;
       }
 

--- a/src/stan/services/arguments/argument.hpp
+++ b/src/stan/services/arguments/argument.hpp
@@ -15,7 +15,7 @@ namespace stan {
         : indent_width(2),
           help_width(20) { }
 
-      argument(const std::string name)
+      explicit argument(const std::string name)
         : _name(name),
           indent_width(2),
           help_width(20) { }

--- a/src/stan/services/arguments/argument_parser.hpp
+++ b/src/stan/services/arguments/argument_parser.hpp
@@ -128,7 +128,7 @@ namespace stan {
           error_codes::OK : error_codes::USAGE;
       }
 
-      void print(std::ostream* s, const std::string prefix = "") {
+      void print(std::ostream* s, const std::string& prefix = "") {
         if (!s)
           return;
 
@@ -196,7 +196,7 @@ namespace stan {
            << "for details on individual arguments." << std::endl << std::endl;
       }
 
-      argument* arg(std::string name) {
+      argument* arg(const std::string& name) {
         for (std::vector<argument*>::iterator it = _arguments.begin();
              it != _arguments.end(); ++it)
           if ( name == (*it)->name() )

--- a/src/stan/services/arguments/categorical_argument.hpp
+++ b/src/stan/services/arguments/categorical_argument.hpp
@@ -19,7 +19,7 @@ namespace stan {
         _subarguments.clear();
       }
 
-      void print(std::ostream* s, const int depth, const std::string prefix) {
+      void print(std::ostream* s, const int depth, const std::string& prefix) {
         if (!s)
           return;
         std::string indent(compute_indent(depth), ' ');
@@ -117,22 +117,22 @@ namespace stan {
         }
       }
 
-      void find_arg(std::string name,
-                    std::string prefix,
+      void find_arg(const std::string& name,
+                    const std::string& prefix,
                     std::vector<std::string>& valid_paths) {
         argument::find_arg(name, prefix, valid_paths);
 
-        prefix += _name + " ";
+        std::string new_prefix = prefix + _name + " ";
         for (std::vector<argument*>::iterator it = _subarguments.begin();
              it != _subarguments.end(); ++it)
-          (*it)->find_arg(name, prefix, valid_paths);
+          (*it)->find_arg(name, new_prefix, valid_paths);
       }
 
       std::vector<argument*>& subarguments() {
         return _subarguments;
       }
 
-      argument* arg(const std::string name) {
+      argument* arg(const std::string& name) {
         for (std::vector<argument*>::iterator it = _subarguments.begin();
              it != _subarguments.end(); ++it)
           if ( name == (*it)->name() )

--- a/src/stan/services/arguments/list_argument.hpp
+++ b/src/stan/services/arguments/list_argument.hpp
@@ -25,7 +25,7 @@ namespace stan {
         _values.clear();
       }
 
-      void print(std::ostream* s, int depth, const std::string prefix) {
+      void print(std::ostream* s, int depth, const std::string& prefix) {
         valued_argument::print(s, depth, prefix);
         _values.at(_cursor)->print(s, depth + 1, prefix);
       }
@@ -112,22 +112,21 @@ namespace stan {
         _cursor = _default_cursor;
       }
 
-      void find_arg(std::string name,
-                    std::string prefix,
+      void find_arg(const std::string& name,
+                    const std::string& prefix,
                     std::vector<std::string>& valid_paths) {
         if (name == _name) {
           valid_paths.push_back(prefix + _name + "=<list_element>");
         }
 
-        prefix += _name + "=";
         for (std::vector<argument*>::iterator it = _values.begin();
              it != _values.end(); ++it) {
-          std::string value_prefix = prefix + (*it)->name() + " ";
-          (*it)->find_arg(name, prefix, valid_paths);
+          std::string value_prefix = prefix + _name + "=" + (*it)->name() + " ";
+          (*it)->find_arg(name, new_prefix, valid_paths);
         }
       }
 
-      bool valid_value(std::string name) {
+      bool valid_value(const std::string& name) {
         for (std::vector<argument*>::iterator it = _values.begin();
              it != _values.end(); ++it)
           if (name == (*it)->name())
@@ -135,7 +134,7 @@ namespace stan {
         return false;
       }
 
-      argument* arg(std::string name) {
+      argument* arg(const std::string& name) {
         if (name == _values.at(_cursor)->name())
           return _values.at(_cursor);
         else

--- a/src/stan/services/arguments/list_argument.hpp
+++ b/src/stan/services/arguments/list_argument.hpp
@@ -122,7 +122,7 @@ namespace stan {
         for (std::vector<argument*>::iterator it = _values.begin();
              it != _values.end(); ++it) {
           std::string value_prefix = prefix + _name + "=" + (*it)->name() + " ";
-          (*it)->find_arg(name, new_prefix, valid_paths);
+          (*it)->find_arg(name, value_prefix, valid_paths);
         }
       }
 

--- a/src/stan/services/arguments/singleton_argument.hpp
+++ b/src/stan/services/arguments/singleton_argument.hpp
@@ -44,13 +44,13 @@ namespace stan {
     template<typename T>
     class singleton_argument: public valued_argument {
     public:
-      explicit singleton_argument(): _validity("All") {
+      singleton_argument(): _validity("All") {
         _constrained = false;
         _name = "";
         _value_type = type_name<T>::name();
       }
 
-      singleton_argument(const std::string name): _validity("All") {
+      explicit singleton_argument(const std::string name): _validity("All") {
         _name = name;
       }
 
@@ -106,8 +106,8 @@ namespace stan {
         _value = _default_value;
       }
 
-      void find_arg(std::string name,
-                    std::string prefix,
+      void find_arg(const std::string& name,
+                    const std::string& prefix,
                     std::vector<std::string>& valid_paths) {
         if (name == _name) {
           valid_paths.push_back(prefix + _name + "=<" + _value_type + ">");

--- a/src/stan/services/arguments/singleton_argument.hpp
+++ b/src/stan/services/arguments/singleton_argument.hpp
@@ -44,7 +44,7 @@ namespace stan {
     template<typename T>
     class singleton_argument: public valued_argument {
     public:
-      singleton_argument(): _validity("All") {
+      explicit singleton_argument(): _validity("All") {
         _constrained = false;
         _name = "";
         _value_type = type_name<T>::name();

--- a/src/stan/services/arguments/unvalued_argument.hpp
+++ b/src/stan/services/arguments/unvalued_argument.hpp
@@ -14,7 +14,7 @@ namespace stan {
       unvalued_argument()
         : _is_present(false) {}
 
-      void print(std::ostream* s, const int depth, const std::string prefix) {}
+      void print(std::ostream* s, const int depth, const std::string& prefix) {}
 
       void print_help(std::ostream* s, const int depth,
                       const bool recurse = false) {

--- a/src/stan/services/arguments/valued_argument.hpp
+++ b/src/stan/services/arguments/valued_argument.hpp
@@ -10,7 +10,7 @@ namespace stan {
     class valued_argument: public argument {
     public:
       virtual void print(std::ostream* s, const int depth,
-                         const std::string prefix) {
+                         const std::string& prefix) {
         if (!s)
           return;
 

--- a/src/test/integration/services/arguments/argument_test.cpp
+++ b/src/test/integration/services/arguments/argument_test.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 
 class test_arg_impl : public stan::services::argument {
-  void print(std::ostream* s, int depth, const std::string prefix) {}
+  void print(std::ostream* s, int depth, const std::string& prefix) {}
   void print_help(std::ostream* s, int depth, bool recurse) {}
 };
 


### PR DESCRIPTION
#### Summary:

Adds the `explicit` keyword to constructors with one argument.

#### Intended Effect:

Code cleanup. Matches closer to #1361.

#### How to Verify:

Visually inspect the code for correctness.

#### Side Effects:

I don't foresee any problems, but may trickle upstream to CmdStan.

#### Documentation:

None required.

#### Reviewer Suggestions: 

@betanalpha 