### PR TITLE
Cpplint for recent changes to services

### DIFF
--- a/src/stan/services/mcmc/sample.hpp
+++ b/src/stan/services/mcmc/sample.hpp
@@ -29,15 +29,17 @@ namespace stan {
                   const std::string& suffix,
                   std::ostream& o,
                   StartTransitionCallback& callback) {
-        stan::services::sample::generate_transitions<Model, RNG, StartTransitionCallback,
-                                                     SampleRecorder, DiagnosticRecorder, MessageRecorder>(
-                                                                                                          sampler, num_samples, num_warmup,
-                                                                                                          num_warmup + num_samples, num_thin,
-                                                                                                          refresh, save, false,
-                                                                                                          writer,
-                                                                                                          init_s, model, base_rng,
-                                                                                                          prefix, suffix, o,
-                                                                                                          callback);
+        stan::services::sample::generate_transitions<Model, RNG,
+                                                     StartTransitionCallback,
+                                                     SampleRecorder,
+                                                     DiagnosticRecorder,
+                                                     MessageRecorder>
+          (sampler, num_samples, num_warmup, num_warmup + num_samples, num_thin,
+           refresh, save, false,
+           writer,
+           init_s, model, base_rng,
+           prefix, suffix, o,
+           callback);
       }
 
     }

--- a/src/stan/services/mcmc/warmup.hpp
+++ b/src/stan/services/mcmc/warmup.hpp
@@ -30,7 +30,8 @@ namespace stan {
                   std::ostream& o,
                   StartTransitionCallback& callback) {
         sample::generate_transitions<Model, RNG, StartTransitionCallback,
-                                     SampleRecorder, DiagnosticRecorder, MessageRecorder>
+                                     SampleRecorder, DiagnosticRecorder,
+                                     MessageRecorder>
           (sampler, num_warmup, 0, num_warmup + num_samples, num_thin,
            refresh, save, true,
            writer,


### PR DESCRIPTION
#### Summary:

Removes a handful of cpplint warnings by changing whitespace.

#### Intended Effect:

Reduces the number of cpplint warnings.

#### How to Verify:

Run cpplint.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

None.