### PR TITLE
Reordered makefile dependencies

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -47,10 +47,6 @@ STANC_TESTS := $(patsubst src/%_test.cpp,%$(EXE),$(STANC_TESTS_HEADERS))
 $(STANC_TESTS_O) : bin/libstanc.a
 $(STANC_TESTS) : LDLIBS += $(LDLIBS_STANC)
 
-
-
-
-
 ##
 # Rule for generating dependencies.
 ##
@@ -123,24 +119,30 @@ $(patsubst %.stan,%.hpp,$(TEST_MODELS)) : %.hpp : %.stan test/test-models/stanc$
 ##
 # Explicitly specify dependencies for tests that depend on the generated C++ of Stan programs.
 ##
+src/test/performance/logistic_test.cpp: src/test/test-models/performance/logistic.hpp
 src/test/unit/lang/generator_test.cpp: src/test/test-models/good/lang/test_lp.hpp
 src/test/unit/lang/parser_generator_test.cpp: $(patsubst %.stan,%.hpp,$(shell find src/test/test-models/good/parser-generator -type f -name '*.stan'))
-
-src/test/unit/model/util_test.cpp: src/test/test-models/good/model/valid.hpp src/test/test-models/good/model/domain_fail.hpp
-
+src/test/unit/lang/reject/reject_func_call_generated_quantities_test.cpp: src/test/test-models/good/lang/reject_func_call_generated_quantities.hpp
+src/test/unit/lang/reject/reject_func_call_model_test.cpp: src/test/test-models/good/lang/reject_func_call_model.hpp
+src/test/unit/lang/reject/reject_func_call_transformed_data_test.cpp: src/test/test-models/good/lang/reject_func_call_transformed_data.hpp
+src/test/unit/lang/reject/reject_func_call_transformed_parameters_test.cpp: src/test/test-models/good/lang/reject_func_call_transformed_parameters.hpp
+src/test/unit/lang/reject/reject_generated_quantities_test.cpp: src/test/test-models/good/lang/reject_generated_quantities.hpp
+src/test/unit/lang/reject/reject_model_test.cpp: src/test/test-models/good/lang/reject_model.hpp
+src/test/unit/lang/reject/reject_mult_args_test.cpp: src/test/test-models/good/lang/reject_mult_args.hpp
+src/test/unit/lang/reject/reject_transformed_data_test.cpp: src/test/test-models/good/lang/reject_transformed_data.hpp
+src/test/unit/lang/reject/reject_transformed_parameters_test.cpp: src/test/test-models/good/lang/reject_transformed_parameters.hpp
 src/test/unit/mcmc/hmc/hamiltonians/base_hamiltonian_test.cpp: src/test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp
-src/test/unit/mcmc/hmc/hamiltonians/unit_e_metric_test.cpp: src/test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp
-src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp: src/test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp
 src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp: src/test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp
+src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp: src/test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp
+src/test/unit/mcmc/hmc/hamiltonians/unit_e_metric_test.cpp: src/test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp
 src/test/unit/mcmc/hmc/integrators/expl_leapfrog_test.cpp: src/test/test-models/good/mcmc/hmc/integrators/command.hpp
 src/test/unit/mcmc/hmc/integrators/expl_leapfrog2_test.cpp: src/test/test-models/good/mcmc/hmc/integrators/gauss.hpp
-
+src/test/unit/model/util_test.cpp: src/test/test-models/good/model/valid.hpp src/test/test-models/good/model/domain_fail.hpp
 src/test/unit/optimization/bfgs_linesearch_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp
 src/test/unit/optimization/bfgs_minimizer_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp
 src/test/unit/optimization/bfgs_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp
 src/test/unit/optimization/bfgs_update_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp
 src/test/unit/optimization/lbfgs_update_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp
-
 src/test/unit/services/init/command_init_test.cpp: src/test/test-models/good/services/test_lp.hpp
 src/test/unit/services/io/write_iteration_test.cpp: src/test/test-models/good/services/test_lp.hpp
 src/test/unit/services/mcmc/sample_test.cpp: src/test/test-models/good/services/test_lp.hpp
@@ -148,21 +150,6 @@ src/test/unit/services/mcmc/warmup_test.cpp: src/test/test-models/good/services/
 src/test/unit/services/optimize/do_bfgs_optimize_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp
 src/test/unit/services/sample/generate_transitions_test.cpp: src/test/test-models/good/services/test_lp.hpp
 src/test/unit/services/sample/mcmc_writer_test.cpp: src/test/test-models/good/io_example.hpp
-
-src/test/unit/lang/reject/reject_mult_args_test.cpp: src/test/test-models/good/lang/reject_mult_args.hpp
-
-src/test/unit/lang/reject/reject_model_test.cpp: src/test/test-models/good/lang/reject_model.hpp
-src/test/unit/lang/reject/reject_func_call_model_test.cpp: src/test/test-models/good/lang/reject_func_call_model.hpp
-
-src/test/unit/lang/reject/reject_transformed_data_test.cpp: src/test/test-models/good/lang/reject_transformed_data.hpp
-src/test/unit/lang/reject/reject_func_call_transformed_data_test.cpp: src/test/test-models/good/lang/reject_func_call_transformed_data.hpp
-
-src/test/unit/lang/reject/reject_transformed_parameters_test.cpp: src/test/test-models/good/lang/reject_transformed_parameters.hpp
-src/test/unit/lang/reject/reject_func_call_transformed_parameters_test.cpp: src/test/test-models/good/lang/reject_func_call_transformed_parameters.hpp
-
-src/test/unit/lang/reject/reject_generated_quantities_test.cpp: src/test/test-models/good/lang/reject_generated_quantities.hpp
-src/test/unit/lang/reject/reject_func_call_generated_quantities_test.cpp: src/test/test-models/good/lang/reject_func_call_generated_quantities.hpp
-
 src/test/unit/variational/advi_univar_no_constraint_test.cpp: src/test/test-models/good/variational/univariate_no_constraint.hpp
 src/test/unit/variational/advi_univar_with_constraint_test.cpp: src/test/test-models/good/variational/univariate_with_constraint.hpp
 src/test/unit/variational/advi_multivar_no_constraint_test.cpp: src/test/test-models/good/variational/multivariate_no_constraint.hpp
@@ -179,7 +166,6 @@ src/test/unit/variational/hier_logistic_cp_test.cpp: src/test/test-models/good/v
 ##
 test/integration/compile_models$(EXE) : $(patsubst %.stan,%.hpp-test,$(shell find src/test/test-models/good -type f -name '*.stan'))
 
-src/test/performance/logistic_test.cpp: src/test/test-models/performance/logistic.hpp
 
 test_name = $(shell echo $(1) | sed 's,_[0-9]\{5\},_test.hpp,g')
 


### PR DESCRIPTION
#### Summary:

Clean up make/tests.
- Removed some blank lines
- Reordered things to be in alphabetical order

#### Intended Effect:

Just cleaning code.

#### How to Verify:

Look at the file.

#### Side Effects:

None.

#### Documentation:

N/A

#### Reviewer Suggestions: 

No one.