### PR TITLE
Silencing warning from new clang++

### DIFF
--- a/make/os_mac
+++ b/make/os_mac
@@ -16,6 +16,7 @@ endif
 ifeq (clang++,$(CC_TYPE))
   CFLAGS_GTEST += -Wc++11-extensions
   CFLAGS_GTEST += -Wno-c++11-long-long
+  CFLAGS += -Wno-unknown-warning-option
   CFLAGS += -Wno-unused-function
   CFLAGS += -Wno-tautological-compare
   CFLAGS += -Wno-c++11-long-long

--- a/make/os_mac
+++ b/make/os_mac
@@ -20,6 +20,7 @@ ifeq (clang++,$(CC_TYPE))
   CFLAGS += -Wno-tautological-compare
   CFLAGS += -Wno-c++11-long-long
   CFLAGS += -Wsign-compare
+  CFLAGS += -Wno-unused-local-typedef
   ifeq (true,$(C++11))
     CFLAGS += -stdlib=libc++ -std=c++11
   endif


### PR DESCRIPTION
#### Summary:

Squashes warning from updated compiler on Mac.

#### Intended Effect:

Silences a new warning due to updated toolchain. To silence the cause is going to be more difficult than I'm willing to undertake now.

#### How to Verify:

Run 
```
> ./runTests.py src/test/unit/lang/reject/reject_func_call_model_test.cpp
```

#### Side Effects:

We'll need to see if this breaks on an older clang++. I'm on it.

#### Documentation:

None.

#### Reviewer Suggestions:

None.