### PR TITLE
Updating ps_point and points to use writer callback

### DIFF
--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -1,9 +1,7 @@
 #ifndef STAN_MCMC_HMC_BASE_HMC_HPP
 #define STAN_MCMC_HMC_BASE_HMC_HPP
 
-#include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <boost/random/uniform_01.hpp>
+#include <stan/interface_callbacks/writer/stream_writer.hpp>
 #include <stan/mcmc/base_mcmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 #include <cmath>
@@ -11,6 +9,9 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/random/uniform_01.hpp>
 
 namespace stan {
   namespace mcmc {
@@ -37,7 +38,8 @@ namespace stan {
         if (!o)
           return;
         *o << "# Step size = " << get_nominal_stepsize() << std::endl;
-        z_.write_metric(o);
+        stan::interface_callbacks::writer::stream_writer writer(*o);
+        z_.write_metric(writer);
       }
 
       void get_sampler_diagnostic_names(std::vector<std::string>& model_names,

--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -4,14 +4,14 @@
 #include <stan/interface_callbacks/writer/stream_writer.hpp>
 #include <stan/mcmc/base_mcmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/random/uniform_01.hpp>
 #include <cmath>
 #include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <boost/random/uniform_01.hpp>
 
 namespace stan {
   namespace mcmc {

--- a/src/stan/mcmc/hmc/hamiltonians/dense_e_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/dense_e_point.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MCMC_HMC_HAMILTONIANS_DENSE_E_POINT_HPP
 #define STAN_MCMC_HMC_HAMILTONIANS_DENSE_E_POINT_HPP
 
+#include <stan/interface_callbacks/writer/base_writer.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 
 namespace stan {
@@ -23,21 +24,21 @@ namespace stan {
         fast_matrix_copy_<double>(mInv, z.mInv);
       }
 
-      void write_metric(std::ostream* o) {
-        if (!o)
-          return;
-        *o << "# Elements of inverse mass matrix:" << std::endl;
+      void
+      write_metric(stan::interface_callbacks::writer::base_writer& writer) {
+        writer("# Elements of inverse mass matrix:");
+        std::stringstream mInv_ss;
         for (int i = 0; i < mInv.rows(); ++i) {
-          *o << "# " << mInv(i, 0) << std::flush;
+          mInv_ss.str("");
+          mInv_ss << "# " << mInv(i, 0);
           for (int j = 1; j < mInv.cols(); ++j)
-            *o << ", " << mInv(i, j) << std::flush;
-          *o << std::endl;
+            mInv_ss << ", " << mInv(i, j);
+          writer(mInv_ss.str());
         }
       }
     };
 
   }  // mcmc
-
 }  // stan
 
 #endif

--- a/src/stan/mcmc/hmc/hamiltonians/diag_e_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/diag_e_point.hpp
@@ -4,7 +4,6 @@
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 
 namespace stan {
-
   namespace mcmc {
 
     // Point in a phase space with a base
@@ -22,20 +21,18 @@ namespace stan {
         fast_vector_copy_<double>(mInv, z.mInv);
       }
 
-      void write_metric(std::ostream* o) {
-        if (!o)
-          return;
-
-        *o << "# Diagonal elements of inverse mass matrix:" << std::endl;
-        *o << "# " << mInv(0) << std::flush;
+      void
+      write_metric(stan::interface_callbacks::writer::base_writer& writer) {
+        writer("# Diagonal elements of inverse mass matrix:");
+        std::stringstream mInv_ss;
+        mInv_ss << "# " << mInv(0);
         for (int i = 1; i < mInv.size(); ++i)
-          *o << ", " << mInv(i) << std::flush;
-        *o << std::endl;
+          mInv_ss << ", " << mInv(i);
+        writer(mInv_ss.str());
       }
     };
 
   }  // mcmc
-
 }  // stan
 
 #endif

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -1,14 +1,13 @@
 #ifndef STAN_MCMC_HMC_HAMILTONIANS_PS_POINT_HPP
 #define STAN_MCMC_HMC_HAMILTONIANS_PS_POINT_HPP
 
-#include <boost/lexical_cast.hpp>
+#include <stan/interface_callbacks/writer/base_writer.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-
 #include <string>
 #include <vector>
+#include <boost/lexical_cast.hpp>
 
 namespace stan {
-
   namespace mcmc {
     using Eigen::Dynamic;
 
@@ -26,7 +25,6 @@ namespace stan {
         fast_vector_copy_<double>(p, z.p);
         fast_vector_copy_<double>(g, z.g);
       }
-
 
       ps_point& operator= (const ps_point& z) {
         if (this == &z)
@@ -67,10 +65,14 @@ namespace stan {
           values.push_back(g(i));
       }
 
-      virtual void write_metric(std::ostream* o) {
-        if (!o)
-          return;
-        *o << "# No free parameters for unit metric" << std::endl;
+      /**
+       * Writes the metric
+       *
+       * @param writer writer callback
+       */
+      virtual void
+      write_metric(stan::interface_callbacks::writer::base_writer& writer) {
+        writer("# No free parameters for unit metric");
       }
 
     protected:
@@ -97,7 +99,5 @@ namespace stan {
     };
 
   }  // mcmc
-
 }  // stan
-
 #endif

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -3,9 +3,9 @@
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <boost/lexical_cast.hpp>
 #include <string>
 #include <vector>
-#include <boost/lexical_cast.hpp>
 
 namespace stan {
   namespace mcmc {

--- a/src/test/unit/mcmc/hmc/hamiltonians/ps_point_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/ps_point_test.cpp
@@ -1,9 +1,10 @@
 #include <gtest/gtest.h>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
+#include <stan/interface_callbacks/writer/base_writer.hpp>
+#include <stan/interface_callbacks/writer/stream_writer.hpp>
 #include <test/unit/util.hpp>
 
 namespace stan {
-
   namespace mcmc {
 
     class ps_point_test : public ::testing::Test {
@@ -62,10 +63,9 @@ namespace stan {
       stan::test::capture_std_streams();
 
       ps_point point(2);
-      EXPECT_NO_THROW(point.write_metric(0));
-
       std::stringstream out;
-      EXPECT_NO_THROW(point.write_metric(&out));
+      stan::interface_callbacks::writer::stream_writer writer(out);
+      EXPECT_NO_THROW(point.write_metric(writer));
       EXPECT_EQ("# No free parameters for unit metric\n", out.str());
       
       stan::test::reset_std_streams();


### PR DESCRIPTION
#### Summary:

Use the base_writer in ps_point and *_point classes.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

This is @betanalpha's code. I reviewed it and it's ok.