### PR TITLE
Fix typo in initialize_state.hpp

### DIFF
--- a/src/stan/services/init/initialize_state.hpp
+++ b/src/stan/services/init/initialize_state.hpp
@@ -219,7 +219,7 @@ namespace stan {
         if (num_init_tries > MAX_INIT_TRIES) {
           std::stringstream R_ss, MAX_INIT_TRIES_ss;
           R_ss << -R;
-          MAX_INIT_TRIES_ss << MAX_INIT_TRIES_ss;
+          MAX_INIT_TRIES_ss << MAX_INIT_TRIES;
 
           writer();
           writer();


### PR DESCRIPTION
Visual Studio choked on this. Not sure why the other compilers didn't. 

Looks like @syclik has been working on this most recently.