### PR TITLE
Cpplint warnings to 0!

### DIFF
--- a/src/stan/io/json/json_data_handler.hpp
+++ b/src/stan/io/json/json_data_handler.hpp
@@ -223,6 +223,7 @@ namespace stan {
         incr_dim_size();
       }
 
+      // NOLINTNEXTLINE(runtime/int)
       void number_long(long n) {
         set_last_dim();
         if (is_int_) {
@@ -233,6 +234,7 @@ namespace stan {
         incr_dim_size();
       }
 
+      // NOLINTNEXTLINE(runtime/int)
       void number_unsigned_long(unsigned long n) {
         set_last_dim();
         if (is_int_) {

--- a/src/stan/io/json/json_handler.hpp
+++ b/src/stan/io/json/json_handler.hpp
@@ -73,6 +73,7 @@ namespace stan {
        *
        * @param n Value to handle.
        */
+      // NOLINTNEXTLINE(runtime/int)
       virtual void number_long(long n) { }
 
       /**
@@ -80,6 +81,7 @@ namespace stan {
        *
        * @param n Value to handle.
        */
+      // NOLINTNEXTLINE(runtime/int)
       virtual void number_unsigned_long(unsigned long n) { }
 
       /**

--- a/src/stan/io/json/json_parser.hpp
+++ b/src/stan/io/json/json_parser.hpp
@@ -187,8 +187,9 @@ namespace stan {
 
           if (is_integer) {
             if (is_positive) {
-              unsigned long n;
+              unsigned long n;  // NOLINT(runtime/int)
               try {
+                // NOLINTNEXTLINE(runtime/int)
                 n = boost::lexical_cast<unsigned long>(ss.str());
               } catch (const boost::bad_lexical_cast & ) {
                 throw json_exception("number exceeds integer range");
@@ -196,8 +197,9 @@ namespace stan {
               ss >> n;
               h_.number_unsigned_long(n);
             } else {
-              long n;
+              long n;  // NOLINT(runtime/int)
               try {
+                // NOLINTNEXTLINE(runtime/int)
                 n = boost::lexical_cast<unsigned long>(ss.str());
               } catch (const boost::bad_lexical_cast & ) {
                 throw json_exception("number exceeds integer range");

--- a/src/stan/optimization/lbfgs_update.hpp
+++ b/src/stan/optimization/lbfgs_update.hpp
@@ -19,6 +19,7 @@ namespace stan {
     public:
       typedef Eigen::Matrix<Scalar, DimAtCompile, 1> VectorT;
       typedef Eigen::Matrix<Scalar, DimAtCompile, DimAtCompile> HessianT;
+      // NOLINTNEXTLINE(build/include_what_you_use)
       typedef boost::tuple<Scalar, VectorT, VectorT> UpdateT;
 
       explicit LBFGSUpdate(size_t L = 5) : _buf(L) {}


### PR DESCRIPTION
#### Summary:

Gets cpplint warnings down to 0.

#### Intended Effect:

Removes cpplint warnings by any means necessary. =). I nolinted the remaining issues.

#### How to Verify:

Run cpplint! We should have 0 warnings now.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

@bob-carpenter. I was slightly lazy and didn't look too carefully at the json code. I've `NOLINT`ed it for now.

If we need to fix it, I think we could open up a new issue to take care of it.