### PR TITLE
Feature/issue 1679 silence advi tests

### DIFF
--- a/src/test/test-models/stanc.cpp
+++ b/src/test/test-models/stanc.cpp
@@ -10,5 +10,7 @@
  * for invalid arguments.
  */
 int main(int argc, const char* argv[]) {
-  return stanc_helper(argc, argv, NULL, NULL);
+  std::stringstream out_stream;
+  std::stringstream err_stream;
+  return stanc_helper(argc, argv, &out_stream, &err_stream);
 }

--- a/src/test/test-models/stanc.cpp
+++ b/src/test/test-models/stanc.cpp
@@ -1,14 +1,14 @@
 #include <stan/command/stanc_helper.hpp>
 
-/** 
+/**
  * The Stan compiler (stanc).
  *
  * @param argc Number of arguments
  * @param argv Arguments
- * 
+ *
  * @return 0 for success, -1 for exception, -2 for parser failure, -3
  * for invalid arguments.
  */
 int main(int argc, const char* argv[]) {
-  return stanc_helper(argc, argv, &std::cout, &std::cerr);
+  return stanc_helper(argc, argv, NULL, NULL);
 }

--- a/src/test/unit/variational/advi_multivar_no_constraint_test.cpp
+++ b/src/test/unit/variational/advi_multivar_no_constraint_test.cpp
@@ -24,7 +24,8 @@ TEST(advi_test, multivar_no_constraint_fullrank) {
   // Other params
   int n_monte_carlo_grad = 10;
   int n_grad_samples = 1e4;
-  std::ostream* print_stream = &std::cout;
+  std::stringstream output;
+  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(2);
@@ -39,9 +40,9 @@ TEST(advi_test, multivar_no_constraint_fullrank) {
                                                   n_grad_samples,
                                                   100,
                                                   1,
-                                                  print_stream,
-                                                  &std::cout,
-                                                  &std::cout);
+                                                  &output,
+                                                  &output,
+                                                  &output);
 
   // Create some arbitrary variational q() family to calculate the ELBO over
   Eigen::VectorXd mu     = Eigen::VectorXd::Constant(my_model.num_params_r(),
@@ -123,7 +124,7 @@ TEST(advi_test, multivar_no_constraint_fullrank) {
           "Dimension of variational q (2) must match in size";
   EXPECT_THROW_MSG(muL.calc_grad(elbo_grad,
                                  my_model, cont_params, n_monte_carlo_grad,
-                                 base_rng, print_stream),
+                                 base_rng, &output),
                    std::invalid_argument, error);
 }
 
@@ -141,7 +142,8 @@ TEST(advi_test, multivar_no_constraint_meanfield) {
 
   // Other params
   int n_monte_carlo_grad = 10;
-  std::ostream* print_stream = &std::cout;
+  std::stringstream output;
+  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(2);
@@ -156,9 +158,9 @@ TEST(advi_test, multivar_no_constraint_meanfield) {
                                                   1e4, // absurdly high!
                                                   100,
                                                   1,
-                                                  print_stream,
-                                                  &std::cout,
-                                                  &std::cout);
+                                                  &output,
+                                                  &output,
+                                                  &output);
 
   // Create some arbitrary variational q() family to calculate the ELBO over
   Eigen::VectorXd mu  = Eigen::VectorXd::Constant(my_model.num_params_r(),
@@ -232,6 +234,6 @@ TEST(advi_test, multivar_no_constraint_meanfield) {
           "Dimension of variational q (2) must match in size";
   EXPECT_THROW_MSG(musigmatilde.calc_grad(elbo_grad,
                                  my_model, cont_params, n_monte_carlo_grad,
-                                 base_rng, print_stream),
+                                 base_rng, &output),
                    std::invalid_argument, error);
 }

--- a/src/test/unit/variational/advi_multivar_no_constraint_test.cpp
+++ b/src/test/unit/variational/advi_multivar_no_constraint_test.cpp
@@ -25,7 +25,6 @@ TEST(advi_test, multivar_no_constraint_fullrank) {
   int n_monte_carlo_grad = 10;
   int n_grad_samples = 1e4;
   std::stringstream output;
-  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(2);
@@ -143,7 +142,6 @@ TEST(advi_test, multivar_no_constraint_meanfield) {
   // Other params
   int n_monte_carlo_grad = 10;
   std::stringstream output;
-  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(2);

--- a/src/test/unit/variational/advi_multivar_with_constraint_test.cpp
+++ b/src/test/unit/variational/advi_multivar_with_constraint_test.cpp
@@ -25,7 +25,6 @@ TEST(advi_test, multivar_with_constraint_fullrank) {
   int n_monte_carlo_grad = 10;
   int n_monte_carlo_elbo = 1e6;
   std::stringstream output;
-  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(2);
@@ -88,7 +87,6 @@ TEST(advi_test, multivar_with_constraint_meanfield) {
   int n_monte_carlo_grad = 10;
   int n_monte_carlo_elbo = 1e6;
   std::stringstream output;
-  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(2);

--- a/src/test/unit/variational/advi_multivar_with_constraint_test.cpp
+++ b/src/test/unit/variational/advi_multivar_with_constraint_test.cpp
@@ -24,7 +24,8 @@ TEST(advi_test, multivar_with_constraint_fullrank) {
   // Other params
   int n_monte_carlo_grad = 10;
   int n_monte_carlo_elbo = 1e6;
-  std::ostream* print_stream = &std::cout;
+  std::stringstream output;
+  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(2);
@@ -39,9 +40,9 @@ TEST(advi_test, multivar_with_constraint_fullrank) {
                                                   n_monte_carlo_elbo,
                                                   100,
                                                   1,
-                                                  print_stream,
-                                                  &std::cout,
-                                                  &std::cout);
+                                                  &output,
+                                                  &output,
+                                                  &output);
 
   // Create some arbitrary variational q() family to calculate the ELBO over
   Eigen::VectorXd mu     = Eigen::VectorXd::Constant(my_model.num_params_r(),
@@ -86,7 +87,8 @@ TEST(advi_test, multivar_with_constraint_meanfield) {
   // Other params
   int n_monte_carlo_grad = 10;
   int n_monte_carlo_elbo = 1e6;
-  std::ostream* print_stream = &std::cout;
+  std::stringstream output;
+  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(2);
@@ -101,9 +103,9 @@ TEST(advi_test, multivar_with_constraint_meanfield) {
                                                   n_monte_carlo_elbo,
                                                   100,
                                                   1,
-                                                  print_stream,
-                                                  &std::cout,
-                                                  &std::cout);
+                                                  &output,
+                                                  &output,
+                                                  &output);
 
   // Create some arbitrary variational q() family to calculate the ELBO over
   Eigen::VectorXd mu  = Eigen::VectorXd::Constant(my_model.num_params_r(),
@@ -178,6 +180,6 @@ TEST(advi_test, multivar_with_constraint_meanfield) {
           "Dimension of variational q (2) must match in size";
   EXPECT_THROW_MSG(musigmatilde.calc_grad(elbo_grad,
                                  my_model, cont_params, n_monte_carlo_grad,
-                                 base_rng, print_stream),
+                                 base_rng, &output),
                    std::invalid_argument, error);
 }

--- a/src/test/unit/variational/advi_univar_no_constraint_test.cpp
+++ b/src/test/unit/variational/advi_univar_no_constraint_test.cpp
@@ -24,7 +24,6 @@ TEST(advi_test, univar_no_constraint_fullrank) {
   // Other params
   int n_monte_carlo_grad = 10;
   std::stringstream output;
-  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(1);
@@ -149,7 +148,6 @@ TEST(advi_test, univar_no_constraint_meanfield) {
   // Other params
   int n_monte_carlo_grad = 10;
   std::stringstream output;
-  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(1);

--- a/src/test/unit/variational/advi_univar_no_constraint_test.cpp
+++ b/src/test/unit/variational/advi_univar_no_constraint_test.cpp
@@ -23,7 +23,8 @@ TEST(advi_test, univar_no_constraint_fullrank) {
 
   // Other params
   int n_monte_carlo_grad = 10;
-  std::ostream* print_stream = &std::cout;
+  std::stringstream output;
+  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(1);
@@ -37,9 +38,9 @@ TEST(advi_test, univar_no_constraint_fullrank) {
                                                   1e4, // absurdly high!
                                                   100,
                                                   1,
-                                                  print_stream,
-                                                  &std::cout,
-                                                  &std::cout);
+                                                  &output,
+                                                  &output,
+                                                  &output);
 
   // Create some arbitrary variational q() family to calculate the ELBO over
   Eigen::VectorXd mu     = Eigen::VectorXd::Constant(my_model.num_params_r(),
@@ -129,7 +130,7 @@ TEST(advi_test, univar_no_constraint_fullrank) {
           "Dimension of variational q (1) must match in size";
   EXPECT_THROW_MSG(muL.calc_grad(elbo_grad,
                                  my_model, cont_params, n_monte_carlo_grad,
-                                 base_rng, print_stream),
+                                 base_rng, &output),
                    std::invalid_argument, error);
 }
 
@@ -147,7 +148,8 @@ TEST(advi_test, univar_no_constraint_meanfield) {
 
   // Other params
   int n_monte_carlo_grad = 10;
-  std::ostream* print_stream = &std::cout;
+  std::stringstream output;
+  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(1);
@@ -161,9 +163,9 @@ TEST(advi_test, univar_no_constraint_meanfield) {
                                                   1e4, // absurdly high!
                                                   100,
                                                   1,
-                                                  print_stream,
-                                                  &std::cout,
-                                                  &std::cout);
+                                                  &output,
+                                                  &output,
+                                                  &output);
 
   // Create some arbitrary variational q() family to calculate the ELBO over
   Eigen::VectorXd mu  = Eigen::VectorXd::Constant(my_model.num_params_r(),
@@ -245,6 +247,6 @@ TEST(advi_test, univar_no_constraint_meanfield) {
           "Dimension of variational q (1) must match in size";
   EXPECT_THROW_MSG(musigmatilde.calc_grad(elbo_grad,
                                  my_model, cont_params, n_monte_carlo_grad,
-                                 base_rng, print_stream),
+                                 base_rng, &output),
                    std::invalid_argument, error);
 }

--- a/src/test/unit/variational/advi_univar_with_constraint_test.cpp
+++ b/src/test/unit/variational/advi_univar_with_constraint_test.cpp
@@ -23,7 +23,8 @@ TEST(advi_test, univar_with_constraint_fullrank) {
 
   // Other params
   int n_monte_carlo_grad = 10;
-  std::ostream* print_stream = &std::cout;
+  std::stringstream output;
+  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(1);
@@ -37,9 +38,9 @@ TEST(advi_test, univar_with_constraint_fullrank) {
                                                   5e5, // absurdly high!
                                                   100,
                                                   1,
-                                                  print_stream,
-                                                  &std::cout,
-                                                  &std::cout);
+                                                  &output,
+                                                  &output,
+                                                  &output);
 
   // Create some arbitrary variational q() family to calculate the ELBO over
   Eigen::VectorXd mu     = Eigen::VectorXd::Constant(my_model.num_params_r(),
@@ -132,7 +133,7 @@ TEST(advi_test, univar_with_constraint_fullrank) {
           "Dimension of variational q (1) must match in size";
   EXPECT_THROW_MSG(muL.calc_grad(elbo_grad,
                                  my_model, cont_params, n_monte_carlo_grad,
-                                 base_rng, print_stream),
+                                 base_rng, &output),
                    std::invalid_argument, error);
 }
 
@@ -150,7 +151,8 @@ TEST(advi_test, univar_with_constraint_meanfield) {
 
   // Other params
   int n_monte_carlo_grad = 10;
-  std::ostream* print_stream = &std::cout;
+  std::stringstream output;
+  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(1);
@@ -164,9 +166,9 @@ TEST(advi_test, univar_with_constraint_meanfield) {
                                                   5e5, // absurdly high!
                                                   100,
                                                   1,
-                                                  print_stream,
-                                                  &std::cout,
-                                                  &std::cout);
+                                                  &output,
+                                                  &output,
+                                                  &output);
 
   // Create some arbitrary variational q() family to calculate the ELBO over
   Eigen::VectorXd mu  = Eigen::VectorXd::Constant(my_model.num_params_r(),
@@ -252,6 +254,6 @@ TEST(advi_test, univar_with_constraint_meanfield) {
           "Dimension of variational q (1) must match in size";
   EXPECT_THROW_MSG(musigmatilde.calc_grad(elbo_grad,
                                  my_model, cont_params, n_monte_carlo_grad,
-                                 base_rng, print_stream),
+                                 base_rng, &output),
                    std::invalid_argument, error);
 }

--- a/src/test/unit/variational/advi_univar_with_constraint_test.cpp
+++ b/src/test/unit/variational/advi_univar_with_constraint_test.cpp
@@ -24,7 +24,6 @@ TEST(advi_test, univar_with_constraint_fullrank) {
   // Other params
   int n_monte_carlo_grad = 10;
   std::stringstream output;
-  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(1);
@@ -152,7 +151,6 @@ TEST(advi_test, univar_with_constraint_meanfield) {
   // Other params
   int n_monte_carlo_grad = 10;
   std::stringstream output;
-  output.clear();
 
   // Dummy input
   Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(1);

--- a/src/test/unit/variational/hier_logistic_cp_test.cpp
+++ b/src/test/unit/variational/hier_logistic_cp_test.cpp
@@ -17,6 +17,9 @@ TEST(advi_test, hier_logistic_cp_constraint_meanfield) {
   stan::io::dump data_var_context(data_stream);
   data_stream.close();
 
+  std::stringstream output;
+  output.clear();
+
   // Instantiate model
   Model_cp my_model(data_var_context);
 
@@ -34,9 +37,9 @@ TEST(advi_test, hier_logistic_cp_constraint_meanfield) {
                                                      100,
                                                      100,
                                                      1,
-                                                     &std::cout,
-                                                     &std::cout,
-                                                     &std::cout);
+                                                     &output,
+                                                     &output,
+                                                     &output);
 
   test_advi.run(0.01,false,50,1,2e4);
 }


### PR DESCRIPTION
#### Summary:

This suppresses the output in ADVI tests, as well as any test that compiles its own models.

Addresses: https://github.com/stan-dev/stan/issues/1679

#### Intended Effect:

Tests should not require any visual inspection.

#### How to Verify:

Run tests.

#### Documentation:

None.

#### Reviewer Suggestions: 

Anyone.