### PR TITLE
Bugfix/issue 1736 initialization

### DIFF
--- a/src/stan/services/init/initialize_state.hpp
+++ b/src/stan/services/init/initialize_state.hpp
@@ -218,7 +218,7 @@ namespace stan {
 
         if (num_init_tries > MAX_INIT_TRIES) {
           std::stringstream R_ss, MAX_INIT_TRIES_ss;
-          R_ss << -R;
+          R_ss << R;
           MAX_INIT_TRIES_ss << MAX_INIT_TRIES;
 
           writer();
@@ -300,7 +300,7 @@ namespace stan {
 
           if (num_init_tries > MAX_INIT_TRIES) {
             std::stringstream R_ss, MAX_INIT_TRIES_ss;
-            R_ss << -R;
+            R_ss << R;
             MAX_INIT_TRIES_ss << MAX_INIT_TRIES;
 
             writer();

--- a/src/test/unit/services/init/initialize_state_test.cpp
+++ b/src/test/unit/services/init/initialize_state_test.cpp
@@ -495,6 +495,9 @@ TEST_F(StanServices, initialize_state_random_reject_all) {
   EXPECT_TRUE(output.str()
               .find("Log probability evaluates to log(0)")
               != std::string::npos);
+  EXPECT_TRUE(output.str()
+              .find("Initialization between (-1.5, 1.5) failed after 100 attempts.")
+              != std::string::npos);
 }
 
 


### PR DESCRIPTION
#### Summary:

When initialization fails, the error messages is incorrect. Instead of:
```
Initialization between (-2, 2) failed after 100 attempts.
```
the current code outputs:
```
Initialization between (--2, -2) failed after 100 attempts.
```

#### Intended Effect:
Fixes error message printed to screen.

#### How to Verify:
Run the new test.

#### Side Effects:
None.

#### Documentation:
None.

#### Reviewer Suggestions: 
Anyone.