### PR TITLE
Remove unused 'filename' param in stan::lang::parse

### DIFF
--- a/src/stan/command/stanc_helper.hpp
+++ b/src/stan/command/stanc_helper.hpp
@@ -149,7 +149,7 @@ int stanc_helper(int argc, const char* argv[],
     }
 
     bool valid_model
-      = stan::lang::compile(err_stream, in, out, model_name, in_file_name);
+      = stan::lang::compile(err_stream, in, out, model_name);
 
     out.close();
     if (!valid_model) {

--- a/src/stan/lang/compiler.hpp
+++ b/src/stan/lang/compiler.hpp
@@ -20,8 +20,6 @@ namespace stan {
      * @param stan_lang_in Stan model specification
      * @param cpp_out C++ code output stream
      * @param model_name Name of model class
-     * @param in_file_name Name of input file to use in error
-     * messages; defaults to <code>input</code>.
      *
      * @return <code>false</code> if code could not be generated
      *    due to syntax error in the Stan model;
@@ -30,10 +28,9 @@ namespace stan {
     bool compile(std::ostream* msgs,
                  std::istream& stan_lang_in,
                  std::ostream& cpp_out,
-                 const std::string& model_name,
-                 const std::string& in_file_name = "input") {
+                 const std::string& model_name) {
       program prog;
-      bool parsed_ok = parse(msgs, stan_lang_in, in_file_name,
+      bool parsed_ok = parse(msgs, stan_lang_in,
                              model_name, prog);
       if (!parsed_ok)
         return false;  // syntax error in program

--- a/src/stan/lang/parser.hpp
+++ b/src/stan/lang/parser.hpp
@@ -58,7 +58,6 @@ namespace stan {
 
     inline bool parse(std::ostream* output_stream,
                       std::istream& input,
-                      const std::string& filename,
                       const std::string& model_name,
                       program& result) {
       using boost::spirit::multi_pass;

--- a/src/test/unit/lang/compiler_test.cpp
+++ b/src/test/unit/lang/compiler_test.cpp
@@ -5,12 +5,11 @@
 TEST(LangCompiler, compile) {
   std::stringstream msgs, stan_lang_in, cpp_out;
   std::string model_name = "m";
-  std::string in_file_name = "input";
   
 
   stan_lang_in << "model { }";
   
-  stan::lang::compile(&msgs, stan_lang_in, cpp_out, model_name, in_file_name);
+  stan::lang::compile(&msgs, stan_lang_in, cpp_out, model_name);
   
   EXPECT_EQ("", msgs.str());
   EXPECT_EQ(std::string::npos, cpp_out.str().find("int main("));
@@ -21,14 +20,13 @@ TEST(LangCompiler, streams) {
 
   std::stringstream msgs, stan_lang_in, cpp_out;
   std::string model_name = "m";
-  std::string in_file_name = "input";
 
   stan_lang_in.str("model { }");
-  EXPECT_NO_THROW(stan::lang::compile(0, stan_lang_in, cpp_out, model_name, in_file_name));
+  EXPECT_NO_THROW(stan::lang::compile(0, stan_lang_in, cpp_out, model_name));
 
   stan_lang_in.str("model { }");
   std::stringstream out;
-  EXPECT_NO_THROW(stan::lang::compile(&out, stan_lang_in, cpp_out, model_name, in_file_name));
+  EXPECT_NO_THROW(stan::lang::compile(&out, stan_lang_in, cpp_out, model_name));
   
   // TODO(carpenter): wrong place to test basic test util behavior
   // TODO(carpenter): functions failing have no doc

--- a/src/test/unit/lang/utility.hpp
+++ b/src/test/unit/lang/utility.hpp
@@ -53,7 +53,7 @@ bool is_parsable(const std::string& file_name,
   std::ifstream fs(file_name.c_str());
   std::string model_name = file_name_to_model_name(file_name);
   bool parsable
-    = stan::lang::parse(msgs, fs, file_name, model_name, prog);             
+    = stan::lang::parse(msgs, fs, model_name, prog);
   return parsable;
 }
 
@@ -160,11 +160,10 @@ void test_warning(const std::string& model_name,
 
 std::string model_to_cpp(const std::string& model_text) {
   std::string model_name = "foo";
-  std::string file_name = "dummy";
   std::stringstream ss(model_text);
   std::stringstream msgs;
   stan::lang::program prog;
-  bool parsable = stan::lang::parse(&msgs, ss, file_name, model_name, prog);
+  bool parsable = stan::lang::parse(&msgs, ss, model_name, prog);
   EXPECT_TRUE(parsable);
 
   std::stringstream output;


### PR DESCRIPTION
#### Summary:

This pull request removes the unused `filename` parameter for the function `parse` (in stan/lang/parser.hpp) and updates all locations where the function is called.

#### How to Verify:

Unit tests pass. Check (previous versions of) stan/lang/parser.hpp to verify that `filename` was unused.

#### Side Effects:

None. No interface uses the parameter.

#### Documentation:

NA

#### Reviewer Suggestions: 

Anyone.