### PR TITLE
remove dup def for _log funs, fixing #1768

### DIFF
--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -2124,6 +2124,7 @@ namespace stan {
         << EOL;
       generate_comment("Next line prevents compiler griping about no return",
                        indent + 1, o);
+      generate_indent(indent + 1, o);
       o << "throw std::runtime_error"
         << "(\"*** IF YOU SEE THIS, PLEASE REPORT A BUG ***\");"
         << EOL;
@@ -4598,8 +4599,10 @@ namespace stan {
       generate_function_arguments(fun, is_rng, is_lp, is_log, out);
       generate_function_body(fun, scalar_t_name, out);
 
-      // need a second function def for default propto=false for _log funs
-      if (is_log)
+      // need a second function def for default propto=false for _log
+      // funs; but don't want duplicate def, so don't do it for
+      // forward decl when body is no-op
+      if (is_log && !fun.body_.is_no_op_statement())
         generate_propto_default_function(fun, scalar_t_name, out);
       out << EOL;
     }
@@ -4664,7 +4667,7 @@ namespace stan {
 
     void generate_globals(std::ostream& out) {
       out << "static int current_statement_begin__;"
-          << EOL;
+          << EOL2;
     }
 
 

--- a/src/test/test-models/good/fun_log_forward_decl.stan
+++ b/src/test/test-models/good/fun_log_forward_decl.stan
@@ -1,0 +1,20 @@
+/**
+ * this one's for issue #1768, where there was a duplicate fun decl
+ * because of the <false> instantiation of propto
+ */
+functions {
+  real n_log(real y);
+
+  real n_log(real y) {
+    return -0.5 * square(y);
+  }
+}
+parameters {
+  real mu;
+}
+model {
+  mu ~ n();
+  increment_log_prob(n_log(mu));  // check both instantiations
+}
+
+


### PR DESCRIPTION
#### Summary:

Remove duplicate definition of `propto=false` version of `_log` user-defined functions when there is a forward declaration.

#### Intended Effect:

Allow recursive density definitions.

#### How to Verify:

There is a new model test that passes now and didn't pass before.

#### Side Effects:

None.

#### Documentation:

Behavior now matches existing doc.

#### Reviewer Suggestions:

Anyone.