### PR TITLE
Updating makefile so dependencies work properly for stanc

### DIFF
--- a/make/libstan
+++ b/make/libstan
@@ -1,5 +1,5 @@
-TEMPLATE_INSTANTIATION := $(shell find src/stan/lang -type f -name '*_inst.cpp') $(shell find src/stan/lang -type f -name '*_def.cpp')
-TEMPLATE_INSTANTIATION := $(TEMPLATE_INSTANTIATION:src/%.cpp=bin/%.o)
+TEMPLATE_INSTANTIATION_CPP := $(shell find src/stan/lang -type f -name '*_inst.cpp') $(shell find src/stan/lang -type f -name '*_def.cpp')
+TEMPLATE_INSTANTIATION := $(TEMPLATE_INSTANTIATION_CPP:src/%.cpp=bin/%.o)
 
 bin/libstanc.a : $(TEMPLATE_INSTANTIATION)
 	@mkdir -p $(dir $@)
@@ -9,9 +9,3 @@ $(TEMPLATE_INSTANTIATION) : bin/%.o : src/%.cpp
 	@mkdir -p $(dir $@)
 	$(COMPILE.c) -O$(O_STANC) $(OUTPUT_OPTION) $<
 
-##
-# Generate dependencies for libraries
-##
-ifneq (,$(filter $(STANC_TESTS),$(MAKECMDGOALS)))
-  -include $(addsuffix .d,$(basename $(TEMPLATE_INSTANTIATION)))
-endif

--- a/make/tests
+++ b/make/tests
@@ -38,10 +38,6 @@ STANC_TESTS_HEADERS := $(shell find src/test/unit/lang -type f -name '*_test.cpp
 STANC_TESTS_O := $(patsubst src/%_test.cpp,%.o,$(STANC_TESTS_HEADERS))
 STANC_TESTS := $(patsubst src/%_test.cpp,%$(EXE),$(STANC_TESTS_HEADERS))
 
-# $(STANC_TESTS) : test/%$(EXE) : test/%.o bin/libstanc.a
-# 	@mkdir -p $(dir $@)
-# 	$(LINK.c) -O$O $(GTEST_MAIN) $< $(CFLAGS_GTEST) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS) $(LDLIBS_STANC)
-
 # add additional dependency to libstanc.a
 ##$(patsubst src/%_test.cpp,%.o,$(STANC_TEST_HEADERS)) : test/%.o : bin/libstanc.a
 $(STANC_TESTS_O) : bin/libstanc.a
@@ -176,3 +172,8 @@ test_name = $(shell echo $(1) | sed 's,_[0-9]\{5\},_test.hpp,g')
 ifneq (,$(filter test/% src/test/test-models/%.hpp,$(MAKECMDGOALS)))
   -include test/test-models/stanc.d
 endif
+
+ifneq (,$(filter $(STANC_TESTS),$(MAKECMDGOALS)))
+  -include $(patsubst src/%.cpp,bin/%.d,$(TEMPLATE_INSTANTIATION_CPP))
+endif
+


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixing the makefile so tests depending on stanc automatically rebuild it when headers change.

#### Intended Effect

Makes testing easier.

#### How to Verify

First build a test. It should build `test/test-models/stanc`. Then run it again and it won't rebuild.
```
./runTests.py src/test/unit/lang/parser/assignment_test.cpp
./runTests.py src/test/unit/lang/parser/assignment_test.cpp
```

Test case 1:
```
touch src/stan/lang/grammars/bare_type_grammar.hpp
./runTests.py src/test/unit/lang/parser/assignment_test.cpp
```

Test case 2:
```
touch src/stan/lang/grammars/bare_type_grammar_def.hpp
./runTests.py src/test/unit/lang/parser/assignment_test.cpp
```

Test case 3:
```
touch src/stan/lang/grammars/bare_type_grammar_inst.cpp
./runTests.py src/test/unit/lang/parser/assignment_test.cpp
```

Prior to this fix, test case 2 would have not rebuilt the parser.

#### Side Effects

None.

#### Documentation

None needed.

#### Reviewer Suggestions

@bob-carpenter 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

