### PR TITLE
Feature/issue 1800 incr lp stmt

### DIFF
--- a/src/docs/stan-reference/advanced.tex
+++ b/src/docs/stan-reference/advanced.tex
@@ -128,7 +128,7 @@ transformed parameters {
   squared_error = dot_self(y - x * beta);
 }
 model {
-  increment_log_prob(-squared_error);
+  target += -squared_error;
 }
 generated quantities {
   real<lower=0> sigma_squared;
@@ -230,7 +230,7 @@ data {
 // ...
 model {
   // ...
-  increment_log_prob(- lambda * dot_self(beta));
+  target += - lambda * dot_self(beta);
 }
 \end{stancode}
 %
@@ -275,7 +275,7 @@ data {
 model {
   // ...
   for (k in 1:K)
-    increment_log_prob(- lambda * fabs(beta[k]));
+    target += - lambda * fabs(beta[k]);
 }
 \end{stancode}
 
@@ -304,8 +304,8 @@ data {
 model {
   // ...
   for (k in 1:K)
-    increment_log_prob(-lambda1 * fabs(beta[k]));
-  increment_log_prob(-lambda2 * dot_self(beta));
+    target += -lambda1 * fabs(beta[k]);
+  target += -lambda2 * dot_self(beta);
 }
 \end{stancode}
 %

--- a/src/docs/stan-reference/appendices.tex
+++ b/src/docs/stan-reference/appendices.tex
@@ -944,7 +944,7 @@ following form (though not the content; inverting matrices is almost
 always a bad idea).
 %
 \begin{stancode}
-increment_log_prob((y - mu)' * inv(Sigma) * (y - mu));
+target += (y - mu)' * inv(Sigma) * (y - mu);
 \end{stancode}
 %
 Here, the multiplication operator (\code{*}) is aligned to clearly

--- a/src/docs/stan-reference/functions.tex
+++ b/src/docs/stan-reference/functions.tex
@@ -1,23 +1,19 @@
 \part{Built-In Functions}\label{built-in-functions.part}
 
-
-
-
 \chapter{Void Functions}
 
 Stan does not technically support functions that do not return values.
 It does support two types of statements that look like functions, one
 for incrementing log probabilities and one for printing.
 Documentation on these functions is included here for completeness.
+The special keyword \code{void} is used for the return type of void
+functions. 
 
-Although it's not part of Stan's type language, in this chapter,
-\code{void} will be used for the return type.
+\section{Increment Log Probability (deprecated)}
 
-\section{Increment Log Probability}
-
-There is a special function \code{increment\_log\_prob} takes a single
-argument of any expression type \code{T}.
-%
+The increment log density statement, \code{increment\_log\_prob(...)}
+syntactically appears to be a function, but is treated as its own
+special statement.
 \begin{description}
   \fitem{void}{increment\_log\_prob}{T \farg{lp}}{Add \farg{lp} (or
     elements of \farg{lp} if \code{T} is a container type) to the
@@ -25,17 +21,25 @@ argument of any expression type \code{T}.
     function defined by a Stan model.}
 \end{description}
 %
-The expression \code{lp} can be of any expression type.  Specifically,
-it can be an integer or real primitive, a vector, row vector, or
-matrix, or an array of any type, including multidimensional arrays and
-arrays of matrices, vectors, or row vectors.  Vector arguments are
-included for convenience and have no speed advantage over adding
-values in a loop.
+As of Stan 2.10, the \code{increment\_log\_prob()} statement has been
+deprecated in favor of the \code{target~+=} syntax, with exactly the
+same behavior.
+%
+\begin{description}
+  \fitem{void}{target~+=}{T \farg{lp}}{Add \farg{lp} (or
+    elements of \farg{lp} if \code{T} is a container type) to the
+    total log probability accumulator returned by the log probability
+    function defined by a Stan model.}
+\end{description}
+%
 
-The full behavior of the \code{increment\_log\_prob} statement and its
-relation to sampling statements is described in
-\refsection{increment-log-prob}.
-
+In both cases, the expression \code{lp} can be of any expression type.
+Specifically, it can be an integer or real primitive, a vector, row
+vector, or matrix, or an array of any type, including multidimensional
+arrays and arrays of matrices, vectors, or row vectors.  Vector
+arguments are included for convenience and have no speed advantage
+over adding values in a loop.  See \refsection{increment-log-prob} for
+more information on \code{target +=} and \code{increment\_log\_prob}.
 
 \section{Print}
 
@@ -290,24 +294,31 @@ executed on the constrained parmeters, with each sampling statement
 of the model block execution, the value of the log probability
 accumulator is the log probability value returned by the Stan program.
 
-Stan provides a special built-in function \code{get\_lp} that takes no
+Stan provides a special built-in function \code{target()} that takes no
 arguments and returns the current value of the log probability
-accumulator.  This function is primarily useful for debugging
-purposes, where for instance, it may be used with a print statement to
-display the log probability accumulator at various stages of execution
-to see where it becomes ill defined.
+accumulator.%
+%
+\footnote{This function used to be called \code{get\_lp()}, but that
+  name has been deprecated; using it will print a warning.  The
+  function \code{get\_lp()} will be removed in a future release.}
+
+This function is primarily useful for debugging purposes, where for
+instance, it may be used with a print statement to display the log
+probability accumulator at various stages of execution to see where it
+becomes ill defined.
 
 \begin{description}
-  \fitem{real}{get\_lp}{}{
+  \fitem{real}{target}{}{
     Returns the current value of the log probability
     accumulator.}
+  \fitem{real}{get\_lp}{}{
+    Returns the current value of the log probability
+    accumulator; {\bfseries deprecated:} --- use \code{target()} instead).}
 \end{description}
 
-Like user-defined functions that end in \code{\_lp}, the log
-probability get function may only be used in the transformed parameter
-and model blocks, as well as in the bodies of functions with names
-that also end in \code{\_lp}.
-
+Both \code{target} and the deprecated \code{get\_lp} act like other
+functions ending in \code{\_lp}, meaning that they may only may only
+be used in the model block.
 
 \section{Logical Functions}
 

--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -2561,19 +2561,31 @@ assignment statement's execution.
 \section{Log Probability Increment Statement}\label{increment-log-prob.section}
 
 The basis of Stan's execution is the evaluation of a log probability
-function for a given set of parameters.  Data and transformed data are
-fixed before the log density is evaluated.  The total log probability
-is initialized to zero.  Next, any log Jacobian adjustments accrued by
-the variable constraints are added to the log density (the Jacobian
-adjustment may be skipped for optimization).  Sampling and log
-probability increment statements may add to the log density in the
-model block.  A log probability increment statement directly
-increments the log density with the value of an expression, e.g.,
+function for a given set of parameters; this function returns the log
+density of the posterior up to an additive constant.  Data and
+transformed data are fixed before the log density is evaluated.  The
+total log probability is initialized to zero.  Next, any log Jacobian
+adjustments accrued by the variable constraints are added to the log
+density (the Jacobian adjustment may be skipped for optimization).
+Sampling and log probability increment statements may add to the log
+density in the model block.  A log probability increment statement
+directly increments the log density with the value of an expression
+as follows.%
+%
+\footnote{The current notation replaces two previous versions.
+  Originally, a variable \code{lp\_\_} was directly exposed and
+  manipulated;  this is no longer allowed.  The original statement
+  syntax for \code{target += u} was \code{increment\_log\_prob(u)},
+  but this form has been deprecated and will be removed in Stan 3.}
 %
 \begin{stancode}
-increment_log_prob(-0.5 * y * y);
+target += -0.5 * y * y;
 \end{stancode}
 %
+The keyword \code{target} here is actually not a variable, and may not
+be accessed as such (though see below on how to access the value of
+target through a special function).
+
 In this example, the unnormalized log probability of a unit normal
 variable $y$ is added to the total log probability.  In the general
 case, the argument can be any expression.%
@@ -2596,7 +2608,7 @@ parameters {
   real y;
 }
 model {
-  increment_log_prob(-0.5 * y * y);
+  target += -0.5 * y * y;
 }
 \end{stancode}
 %
@@ -2624,38 +2636,36 @@ intractable to evaluate.
 
 \subsubsection{Vectorization}
 
-The \code{increment\_log\_prob} function accepts parameters of any
-expression type, including integers, reals, vectors, row vectors,
-matrices, and arrays of any dimensionality, including arrays of
-vectors and matrices.
+The \code{target += ...} statement accepts an argument in place of
+\code{...} for any expression type, including integers, reals,
+vectors, row vectors, matrices, and arrays of any dimensionality,
+including arrays of vectors and matrices.   For container arguments,
+their sum will be added to the total log density.
 
-\subsection{Log Probability Variable \code{lp\_\_}}
+\subsection{Accessing the Log Density}
 
-Before version 2.0 of Stan, rather than writing
+To increment the log density returned by the model by some value
+\code{u}, use the following statement.%
+%
+\footnote{Originally, Stan provided direct access to the log density
+  through a variable \code{lp\_\_} and then later through the
+  \code{increment\_log\_prob()} statement, but the first has been
+  removed and the latter deprecated.}
 %
 \begin{stancode}
-increment_log_prob(u);
+target += u;
 \end{stancode}
 %
-it was necessary to manipulate a special variable \code{lp\_\_}
-as follows
+In general, \code{u} can be any expression;  if it is a container, the
+log density will be incremented by the sum of the elements in the
+container.
+
+To access accumulated log density up to the current execution point,
+the function \code{get\_lp()} may be used.%
 %
-\begin{stancode}
-lp__ = lp__ + u;
-\end{stancode}
-%
-The special variable \code{lp\_\_} refers to the log probability value
-that will be returned by Stan's log probability function.
-
-\subsubsection{Deprecation of \code{lp\_\_}}
-
-As of Stan version 2.0, the use of \code{lp\_\_} is deprecated.  It
-will be removed altogether in a future release, but until that time,
-programs still work with \code{lp\_\_}.  A deprecation warning is now
-printed every time \code{lp\_\_} is used.
-
-To access the value of \code{lp\_\_} for printing, use the
-\code{get\_lp} function (see \refsection{get-lp}).
+\footnote{The value of \code{lp\_\_} will only hold the Jacobian until
+  the end of the execution because it is not used in either
+  \code{increment\_log\_prob(u)} or \code{target += u}.}
 
 
 \section{Sampling Statements}\label{sampling-statements.section}
@@ -2679,7 +2689,7 @@ sampling statement could be expressed as a direct increment on the
 total log probability as
 %
 \begin{stancode}
-increment_log_prob(normal_log(y,mu,sigma));
+target += normal_log(y,mu,sigma);
 \end{stancode}
 %
 See the subsection of \refsection{sampling-statements} discussing log
@@ -2696,7 +2706,7 @@ case where \code{N} is zero) will be well formed if and only if the
 corresponding assignment statement is well-formed,
 %
 \begin{stancode}
-increment_log_prob(dist_log(ex0,ex1,...,exN));
+target += dist_log(ex0,ex1,...,exN);
 \end{stancode}
 %
 This will be well formed if and only if
@@ -2715,7 +2725,7 @@ y ~ normal(mu,sigma);
 and explicitly incrementing the log probability function, as in
 %
 \begin{stancode}
-increment_log_prob(normal_log(y,mu,sigma));
+target += normal_log(y,mu,sigma);
 \end{stancode}
 %
 The sampling statement drops all the terms in the log probability
@@ -2755,7 +2765,7 @@ account for the log transform.%
   |y|$;  see \refsection{change-of-variables}.}
 %
 \begin{stancode}
-increment_log_prob(- log(fabs(y)));
+target += - log(fabs(y));
 \end{stancode}
 %
 
@@ -2823,9 +2833,8 @@ the accumulated log probability.  For instance, this example has the
 same translation (up to arithmetic precision issues; see below) as
 %
 \begin{stancode}
-increment_log_prob(normal_log(y,0,1));
-increment_log_prob(-(log(normal_cdf(2.1,0,1)
-                         - normal_cdf(-0.5,0,1))));
+target += normal_log(y,0,1);
+target += -(log(normal_cdf(2.1,0,1) - normal_cdf(-0.5,0,1))));
 \end{stancode}
 %
 The function \code{normal\_cdf} represents the cumulative normal
@@ -2844,8 +2853,8 @@ the normal distribution is \code{normal\_cdf\_log} and the ccdf is
 introduced by truncation is equivalent to
 %
 \begin{stancode}
-increment_log_prob(-log_diff_exp(normal_cdf_log(2.1,0,1),
-                                 normal_cdf_log(-0.5,0,1)));
+target += -log_diff_exp(normal_cdf_log(2.1,0,1),
+                        normal_cdf_log(-0.5,0,1));
 \end{stancode}
 %
 
@@ -2870,15 +2879,15 @@ the accumulated log probability (see the subsection of
 and sampling statements for more information).
 %
 \begin{stancode}
-increment_log_prob(normal_log(y, 0, 1));
-increment_log_prob(-(log(1 - normal_cdf(-0.5, 0, 1))));
+target += normal_log(y, 0, 1);
+target += -log(1 - normal_cdf(-0.5, 0, 1));
 \end{stancode}
 %
 The denominator (second line above) is implemented with the more
 efficient and stable version
 %
 \begin{stancode}
-increment_log_prob(-normal_ccdf_log(-0.5, 0, 1));
+target += -normal_ccdf_log(-0.5, 0, 1);
 \end{stancode}
 
 The density $p(x)$ can be truncated above by $b$ to define a density
@@ -2898,8 +2907,8 @@ The truncation has the same effect as the following direct update to
 the accumulated log probability.
 %
 \begin{stancode}
-increment_log_prob(normal_log(y, 0, 1));
-increment_log_prob(-normal_cdf_log(2.1, 0, 1));
+target += normal_log(y, 0, 1);
+target += -normal_cdf_log(2.1, 0, 1);
 \end{stancode}
 
 In all cases, the truncation is only well formed if the
@@ -3625,7 +3634,7 @@ increment statements must have a name that ends in \code{\_lp}.
 Attempts to use sampling statements or increment log probability
 statements in other functions leads to a compile-time error.
 
-Like the \code{increment\_log\_prob} statement and sampling
+Like the target log density increment statement and sampling
 statements, user-defined functions with names that end in \code{\_lp}
 may only be used in blocks where the log probability accumulator is
 accessible, namely the transformed parameters and model blocks.  An
@@ -3656,7 +3665,7 @@ z ~ foo(phi);
 to have the exact same effect as
 %
 \begin{stancode}
-increment_log_prob(foo_log(z,phi));
+target += foo_log(z,phi);
 \end{stancode}
 %
 so that functions that are going to be accessed as distributions
@@ -4664,6 +4673,7 @@ atomic_statement_body
    | expression '~' identifier '(' expressions ')' ?truncation
    | function_literal '(' expressions ')'
    | 'increment_log_prob' '(' expression ')'
+   | 'target' '+=' expression
    | 'print' '(' (expression | string_literal)* ')'
    | 'reject' '(' (expression | string_literal)* ')'
    | 'return' expression

--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -241,7 +241,7 @@ commenting, as in the following example.
 \begin{stancode}
 exp(y) ~ normal(0,1);
 // adjust for change of vars: y = log | d/dy exp(y) |
-increment_log_prob(y);
+target += y;
 \end{stancode}
 %
 It's an art form to empathize with a future code reader and decide
@@ -3825,7 +3825,7 @@ model {
         gamma[t,k] = log_sum_exp(acc);
       }
     }
-    increment_log_prob(log_sum_exp(gamma[T_unsup]));
+    target += log_sum_exp(gamma[T_unsup]);
   }
 \end{stancode}
 %
@@ -4341,7 +4341,7 @@ parameters {
 }
 model {
   y_obs ~ normal(mu,sigma); 
-  increment_log_prob(N_cens * normal_ccdf_log(U,mu,sigma));
+  target += N_cens * normal_ccdf_log(U,mu,sigma);
 }
 \end{stancode}
 %
@@ -4369,7 +4369,7 @@ parameters {
 model {
   L ~ normal(mu,sigma);
   y_obs ~ normal(mu,sigma);
-  increment_log_prob(N_cens * normal_cdf_log(L,mu,sigma));
+  target += N_cens * normal_cdf_log(L,mu,sigma);
 }
 \end{stancode}
 %
@@ -4458,10 +4458,8 @@ parameters {
   real y;
 }
 model {
-  increment_log_prob(log_sum_exp(log(0.3) 
-                                   + normal_log(y,-1,2),
-                                 log(0.7) 
-                                   + normal_log(y,3,1)));
+  target += log_sum_exp(log(0.3) + normal_log(y,-1,2),
+                        log(0.7) + normal_log(y,3,1));
 }
 \end{stancode}
 %
@@ -4512,7 +4510,7 @@ model {
       ps[k] = log(theta[k]) 
                + normal_log(y[n],mu[k],sigma[k]);
     }
-    increment_log_prob(log_sum_exp(ps));
+    target += log_sum_exp(ps);
   }
 }
 \end{stancode}
@@ -4545,20 +4543,20 @@ attempting to vectorize naively, as it results in a different model.
 A proper mixture at the observation level is defined as
 %
 \begin{stancode}
-for (n in 1:N)
-  increment_log_prob(log(lambda) 
-                       + normal_log(y[n], mu[1], sigma[1]),
-                     log1m(lambda) 
-                       + normal_log(y[n], mu[2], sigma[2]));
+for (n in 1:N) {
+  target += log_sum_exp(log(lambda) 
+                          + normal_log(y[n], mu[1], sigma[1]),
+                        log1m(lambda)
+                          + normal_log(y[n], mu[2], sigma[2]));
 \end{stancode}
 %
 or equivalently
 %
 \begin{stancode}
 for (n in 1:N)
-  increment_log_prob(log_mix(lambda, 
-                             normal_log(y[n], mu[1], sigma[1]),
-                             normal_log(y[n], mu[2], sigma[2])));
+  target += log_mix(lambda, 
+                    normal_log(y[n], mu[1], sigma[1]),
+                    normal_log(y[n], mu[2], sigma[2])));
 \end{stancode}
 %
 This definition assumes that each observation $y_n$ may have arisen
@@ -4573,18 +4571,18 @@ Contrast the previous model with the following (erroneous) attempt to
 vectorize the model.
 %
 \begin{stancode}
-increment_log_prob(log(lambda) 
-                     + normal_log(y, mu[1], sigma[1]),
-                   log1m(lambda)
-                     + normal_log(y, mu[2], sigma[2]));
+target += log_sum_exp(log(lambda) 
+                        + normal_log(y, mu[1], sigma[1]),
+                      log1m(lambda)
+                        + normal_log(y, mu[2], sigma[2]));
 \end{stancode}
 %
 or equivalently,
 %
 \begin{stancode}
-increment_log_prob(log_mix(lambda,
-                           normal_log(y, mu[1], sigma[1]),
-                           normal_log(y, mu[2], sigma[2])));
+target += log_mix(lambda,
+                  normal_log(y, mu[1], sigma[1]),
+                  normal_log(y, mu[2], sigma[2]));
 \end{stancode}
 %
 This second definition implies that the entire sequence $y_1, \ldots, y_n$ of
@@ -4649,12 +4647,12 @@ parameters {
 model {
   for (n in 1:N) {
     if (y[n] == 0)
-      increment_log_prob(log_sum_exp(bernoulli_log(1,theta),
-                                     bernoulli_log(0,theta) 
-                                     + poisson_log(y[n],lambda)));
+      target += log_sum_exp(bernoulli_log(1,theta),
+                            bernoulli_log(0,theta) 
+                              + poisson_log(y[n],lambda));
     else
-      increment_log_prob(bernoulli_log(0,theta)
-                         + poisson_log(y[n],lambda));
+      target += bernoulli_log(0,theta)
+                  + poisson_log(y[n],lambda);
   }
 }
 \end{stancode}
@@ -4664,9 +4662,10 @@ on the linear scale; it is defined to be equal to \code{log(exp(lp1) +
   exp(lp2))}, but is more arithmetically stable and faster.
 
 Although it might be tempting to try to use the \code{if\_else} syntax
-within the \code{increment\_log\_prob} function, it is not recommended
+within the \code{target += ...} function, it is not recommended
 because \code{if\_else(c,e1,e2)} evaluates both \code{e1} and
-\code{e2} no matter what the value of \code{c} is.
+\code{e2} no matter what the value of \code{c} is, which leads to
+inefficiencies due to derivative calculations that are not needed.
 
 \subsection{Hurdle Models}
 
@@ -4713,7 +4712,7 @@ This allows the truncated Poisson distribution to be coded as
 \begin{stancode}
 if (y[n] > 0) {
   y[n] ~ poisson(lambda);
-  increment_log_prob(-log1m_exp(-lambda));
+  target += -log1m_exp(-lambda);
 }
 \end{stancode}
 %
@@ -4947,10 +4946,10 @@ transformed parameters {
   sigma = sqrt(sigma_sq);
 }
 model {
-  increment_log_prob(-2 * log(sigma));
+  target += -2 * log(sigma);
   for (n in 1:N)
-    increment_log_prob(log(Phi((y[n] + 0.5 - mu) / sigma)
-                           - Phi((y[n] - 0.5 - mu) / sigma)));
+    target += log(Phi((y[n] + 0.5 - mu) / sigma)
+                  - Phi((y[n] - 0.5 - mu) / sigma));
 }
 \end{stancode}
 
@@ -4979,7 +4978,7 @@ transformed parameters {
   z = y + y_err;
 }
 model {
-  increment_log_prob(-2 * log(sigma));
+  target += -2 * log(sigma);
   z ~ normal(mu, sigma);
 }
 \end{stancode}
@@ -5342,7 +5341,7 @@ transformed parameters {
 model {
   e ~ exponential(r_e);
   l ~ exponential(r_l);
-  increment_log_prob(log_sum_exp(lp));
+  target += log_sum_exp(lp);
 }    
 \end{stancode}
 \vspace*{-6pt}
@@ -5728,18 +5727,15 @@ transformed parameters {
   chi[1] = (1 - phi[1]) + phi[1] * (1 - p[2]) * chi[2];
 }
 model {
-  increment_log_prob(history[2] * log(chi[2]));
-  increment_log_prob(history[3] * (log(phi[2]) + log(p[3])));
-  increment_log_prob(history[4] * (log(chi[1])));
-  increment_log_prob(history[5] 
-                     * (log(phi[1]) + log1m(p[2])
-                        + log(phi[2]) + log(p[3])));
-  increment_log_prob(history[6] 
-                     * (log(phi[1]) + log(p[2]) 
-                        + log(chi[2])));
-  increment_log_prob(history[7] 
-                     * (log(phi[1]) + log(p[2]) 
-                        + log(phi[2]) + log(p[3])));
+  target += history[2] * log(chi[2]);
+  target += history[3] * (log(phi[2]) + log(p[3]));
+  target += history[4] * (log(chi[1]));
+  target += history[5] * (log(phi[1]) + log1m(p[2])
+                            + log(phi[2]) + log(p[3]));
+  target += history[6] * (log(phi[1]) + log(p[2]) 
+                            + log(chi[2]));
+  target += history[7] * (log(phi[1]) + log(p[2]) 
+                            + log(phi[2]) + log(p[3]));
 }
 generated quantities {
   real<lower=0,upper=1> beta3;
@@ -6215,7 +6211,7 @@ model {
       theta[j,k] ~ dirichlet(beta[k]);
 
   for (i in 1:I)
-    increment_log_prob(log_sum_exp(log_q_z[i]));
+    target += log_sum_exp(log_q_z[i]);
 }
 \end{stancode}
 \vspace*{-12pt}
@@ -6566,7 +6562,7 @@ model {
 
   // likelihood
   for (n in 1:N)
-    increment_log_prob(log_sum_exp(soft_z[n])); 
+    target += log_sum_exp(soft_z[n]));
 }
 \end{stancode}
 %
@@ -6818,7 +6814,7 @@ model {
       gamma[doc[n],k] = gamma[doc[n],k] 
                          + categorical_log(w[n],phi[k]);
   for (m in 1:M)
-    increment_log_prob(log_sum_exp(gamma[m]));
+    target += log_sum_exp(gamma[m]);
 }
 \end{stancode}
 %
@@ -7003,7 +6999,7 @@ model {
     real gamma[K];
     for (k in 1:K) 
       gamma[k] = log(theta[doc[n],k]) + log(phi[k,w[n]]);
-    increment_log_prob(log_sum_exp(gamma));  // likelihood
+    target += log_sum_exp(gamma));  // likeliho;
   }
 }
 \end{stancode}
@@ -8041,7 +8037,7 @@ parameters {
   ...
 model {
   log(y) ~ normal(mu,sigma);
-  increment_log_prob(-log(y));
+  target += -log(y);
   ...
 \end{stancode}
 %
@@ -8056,7 +8052,7 @@ model {
   real log_y;
   log_y = log(y);
   log_y ~ normal(mu,sigma);
-  increment_log_prob(-log_y);
+  target += -log_y;
   ...
 \end{stancode}
 %
@@ -8083,7 +8079,7 @@ log(y) ~ normal(mu,sigma);
 or as an increment to the log probability function, as in
 %
 \begin{stancode}
-increment_log_prob(normal_log(log(y), mu, sigma));
+target += normal_log(log(y), mu, sigma);
 \end{stancode}
 
 \subsubsection{Gamma and Inverse Gamma Distribution}\label{jacobian-adjustment.section}
@@ -8119,7 +8115,7 @@ parameters {
 transformed parameters {
   real<lower=0> y;
   y = 1 / y_inv;                         // change
-  increment_log_prob( -2 * log(y_inv) );  // adjustment
+  target +=  -2 * log(y_inv) );  // adjustme;
 }
 model {
   y ~ gamma(2,4);
@@ -8158,7 +8154,7 @@ transformed parameters {
   matrix[K,K] J;   // Jacobian matrix of transform
   ... compute v as a function of u ...
   ... compute J[m,n] = d.v[m] / d.u[n] ...
-  increment_log_prob(log(fabs(determinant(J))));
+  target += log(fabs(determinant(J)));
   ...
 model {
   v ~ ...;
@@ -8184,7 +8180,7 @@ transformed parameters {
   vector[K] J_diag;  // diagonals of Jacobian matrix
   ... 
   ... compute J[k,k] = d.v[k] / d.u[k] ...
-  increment_log_prob(sum(log(J_diag)));
+  target += sum(log(J_diag));
   ...
 \end{stancode}
 
@@ -8237,7 +8233,7 @@ parameters {
   real<lower=-1,upper=1> y;
 }
 model {
-  increment_log_prob(log1m(fabs(y)));
+  target += log1m(fabs(y));
 }
 \end{stancode}
 %
@@ -8261,7 +8257,7 @@ $\reals$ as follows by defining the probability to be \code{log(0.0)},
 i.e., $-\infty$, for values outside of $(-1,1)$.
 %
 \begin{stancode}
-increment_log_prob(log(fmax(0.0,1 - fabs(y))));
+target += log(fmax(0.0,1 - fabs(y)));
 \end{stancode}
 %
 With the constraint on \code{y} in place, this is just a less
@@ -8288,7 +8284,7 @@ where \code{lambda} is the inverse scale and \code{y} the sampled
 variate.
 %
 \begin{stancode}
-increment_log_prob(log(lambda) - y * lambda);
+target += log(lambda) - y * lambda;
 \end{stancode}
 %
 This encoding will work for any \code{lambda} and \code{y}; they can
@@ -8733,7 +8729,7 @@ y ~ foo(theta1,...,thetaN);
 can be used as shorthand for 
 %
 \begin{stancode}
-increment_log_prob(foo_log(y,theta1,...,thetaN));
+target += foo_log(y,theta1,...,thetaN);
 \end{stancode}
 %
 As with the built-in functions, the suffix \code{\_log} is dropped and

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -334,7 +334,7 @@ add("gaussian_dlm_obs_log", DOUBLE_T, MATRIX_T, MATRIX_T, MATRIX_T,
     MATRIX_T, MATRIX_T, VECTOR_T, MATRIX_T);
 add("gaussian_dlm_obs_log", DOUBLE_T, MATRIX_T, MATRIX_T, MATRIX_T,
     VECTOR_T, MATRIX_T, VECTOR_T, MATRIX_T);
-add_nullary("get_lp");  // special handling in term_grammar_def
+add_nullary("get_lp");  // because of get
 for (size_t i = 0; i < vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {
     for (size_t k = 0; k < vector_types.size(); ++k) {
@@ -873,6 +873,7 @@ for (size_t i = 0; i < base_types.size(); ++i) {
 }
 add_unary("tan");
 add_unary("tanh");
+add_nullary("target");  // converted to "get_lp" in term_grammar semantics
 add("tcrossprod", MATRIX_T, MATRIX_T);
 add_unary("tgamma");
 add("to_array_1d", expr_type(DOUBLE_T, 1), MATRIX_T);

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -462,6 +462,12 @@ namespace stan {
     extern boost::phoenix::function<validate_int_expr_warn>
     validate_int_expr_warn_f;
 
+    // called from: statement_grammar
+    struct deprecate_increment_log_prob : public phoenix_functor_unary<void> {
+      void operator()(std::stringstream& error_msgs) const;
+    };
+    extern boost::phoenix::function<deprecate_increment_log_prob>
+    deprecate_increment_log_prob_f;
 
     // called from: statement_grammar
     struct validate_allow_sample : public phoenix_functor_ternary<void> {

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1011,6 +1011,17 @@ namespace stan {
     }
     boost::phoenix::function<validate_int_expr_warn> validate_int_expr_warn_f;
 
+    void deprecate_increment_log_prob::operator()(
+                                    std::stringstream& error_msgs) const {
+      error_msgs << "Warning (non-fatal): increment_log_prob(...);"
+                 << " is deprecated and will be removed in the future."
+                 << std::endl
+                 << "  Use target += ...; instead."
+                 << std::endl;
+    }
+    boost::phoenix::function<deprecate_increment_log_prob>
+    deprecate_increment_log_prob_f;
+
     void validate_allow_sample::operator()(const bool& allow_sample,
                                            bool& pass,
                                            std::stringstream& error_msgs)
@@ -1291,6 +1302,16 @@ namespace stan {
                                         const var_origin& var_origin,
                                         bool& pass,
                                         std::ostream& error_msgs) const {
+      if (fun.name_ == "get_lp")
+        error_msgs << "Warning (non-fatal): get_lp() function deprecated."
+                   << std::endl
+                   << "  It will be removed in a future release."
+                   << std::endl
+                   << "  Use target() instead."
+                   << std::endl;
+      if (fun.name_ == "target")
+        fun.name_ = "get_lp";  // for code gen and context validation
+
       std::vector<expr_type> arg_types;
       for (size_t i = 0; i < fun.args_.size(); ++i)
         arg_types.push_back(fun.args_[i].expression_type());
@@ -1301,7 +1322,6 @@ namespace stan {
         pass = false;
         return;
       }
-
 
       if (has_rng_suffix(fun.name_)) {
         if (!( var_origin == derived_origin
@@ -1318,19 +1338,21 @@ namespace stan {
         }
       }
 
-      if (has_lp_suffix(fun.name_)) {
+      if (has_lp_suffix(fun.name_) || fun.name_ == "target") {
         // modified function_argument_origin to add _lp because
         // that's only viable context
         if (!(var_origin == transformed_parameter_origin
               || var_origin == function_argument_origin_lp
               || var_origin == void_function_argument_origin_lp
               || var_origin == local_origin)) {
-          error_msgs << "Functions suffixed with _lp only allowed in"
-                     << " transformed parameter block, model block"
+          error_msgs << "Function target() or functions suffixed with _lp only"
+                     << " allowed in transformed parameter block, model block"
                      << std::endl
                      << "or the body of a function with suffix _lp."
                      << std::endl
-                     << "Found function = " << fun.name_ << " in block = ";
+                     << "Found function = "
+                     << (fun.name_ == "get_lp" ? "target or get_lp" : fun.name_)
+                     << " in block = ";
           print_var_origin(error_msgs, var_origin);
           error_msgs << std::endl;
           pass = false;
@@ -1648,14 +1670,14 @@ namespace stan {
       std::string name = var_expr.name_;
       if (name == std::string("lp__")) {
         error_msgs << std::endl
-                   << "WARNING:"
+                   << "ERROR (fatal):  Use of lp__ is no longer supported."
                    << std::endl
-                   << "  Direct use of variable lp__ is deprecated"
-                   << " and will be removed in a future release."
+                   << "  Use target += ... statement to increment log density."
                    << std::endl
-                   << "  Please use increment_log_prob(u)"
-                   << " in place of of lp__ <- lp__ + u."
+                   << "  Use target() function to get log density."
                    << std::endl;
+        pass = false;
+        return;
       } else if (name == std::string("params_r__")) {
         error_msgs << std::endl << "WARNING:" << std::endl
                    << "  Direct access to params_r__ yields an inconsistent"
@@ -1923,6 +1945,7 @@ namespace stan {
       reserve("cov_matrix");
       reserve("corr_matrix");
 
+      reserve("target");
 
       reserve("model");
       reserve("data");

--- a/src/stan/lang/grammars/statement_grammar.hpp
+++ b/src/stan/lang/grammars/statement_grammar.hpp
@@ -77,6 +77,11 @@ namespace stan {
       increment_log_prob_statement_r;
 
       boost::spirit::qi::rule<Iterator,
+                              increment_log_prob_statement(bool, var_origin),
+                              whitespace_grammar<Iterator> >
+      increment_target_statement_r;
+
+      boost::spirit::qi::rule<Iterator,
                               boost::spirit::qi::locals<std::string>,
                               for_statement(bool, var_origin, bool),
                               whitespace_grammar<Iterator> >

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -106,6 +106,7 @@ namespace stan {
         %= no_op_statement_r                        // key ";"
         | statement_seq_r(_r1, _r2, _r3)            // key "{"
         | increment_log_prob_statement_r(_r1, _r2)  // key "increment_log_prob"
+        | increment_target_statement_r(_r1, _r2)    // key "target"
         | for_statement_r(_r1, _r2, _r3)            // key "for"
         | while_statement_r(_r1, _r2, _r3)          // key "while"
         | statement_2_g(_r1, _r2, _r3)              // key "if"
@@ -136,13 +137,25 @@ namespace stan {
       increment_log_prob_statement_r.name("increment log prob statement");
       increment_log_prob_statement_r
         %= (lit("increment_log_prob") >> no_skip[!char_("a-zA-Z0-9_")])
-        > eps[ validate_allow_sample_f(_r1, _pass,
-                                       boost::phoenix::ref(error_msgs_)) ]
+        > eps[deprecate_increment_log_prob_f(boost::phoenix::ref(error_msgs_))]
+        > eps[validate_allow_sample_f(_r1, _pass,
+                                      boost::phoenix::ref(error_msgs_))]
         > lit('(')
         > expression_g(_r2)
           [validate_non_void_expression_f(_1, _pass,
                                           boost::phoenix::ref(error_msgs_))]
         > lit(')')
+        > lit(';');
+
+      // just variant syntax for increment_log_prob_r (see above)
+      increment_target_statement_r.name("increment target statement");
+      increment_target_statement_r
+        %= (lit("target") >> lit("+="))
+        > eps[validate_allow_sample_f(_r1, _pass,
+                                      boost::phoenix::ref(error_msgs_))]
+        > expression_g(_r2)
+          [validate_non_void_expression_f(_1, _pass,
+                                          boost::phoenix::ref(error_msgs_))]
         > lit(';');
 
       // _r1, _r2, _r3 same as statement_r

--- a/src/test/test-models/bad/get-lp-target-data.stan
+++ b/src/test/test-models/bad/get-lp-target-data.stan
@@ -1,0 +1,9 @@
+transformed data {
+  print("target=", target());
+}
+parameters {
+  real<lower=0> y;
+}
+model {
+  y ~ normal(0, 1);
+}

--- a/src/test/test-models/bad/lang/good_trunc.stan
+++ b/src/test/test-models/bad/lang/good_trunc.stan
@@ -7,8 +7,4 @@ model {
     y ~ normal(0,1) T[0, ];
     y ~ normal(0,1) T[ ,0];
     y ~ normal(0,1);
-
-    for (n in 1:5) ;
-
-    lp__ <- lp__ + 1.0; // lp__ is type real
 }

--- a/src/test/test-models/bad/lp-error.stan
+++ b/src/test/test-models/bad/lp-error.stan
@@ -1,0 +1,6 @@
+parameters {
+  real<lower=0> y;
+}
+model {
+  lp__ = lp__ - y^2 / 2;
+}

--- a/src/test/test-models/bad/target-reserved.stan
+++ b/src/test/test-models/bad/target-reserved.stan
@@ -1,0 +1,9 @@
+data {
+  real target;
+}
+parameters {
+  real y;
+}
+model {
+  y ~ normal(0, 1);
+}

--- a/src/test/test-models/good/deprecate-increment-log-prob.stan
+++ b/src/test/test-models/good/deprecate-increment-log-prob.stan
@@ -1,0 +1,24 @@
+data {
+  real a;
+  vector[3] b;
+  real c[7];
+  real d[8, 9];
+}
+parameters {
+  real e;
+  vector[3] f;
+  real g[7];
+  real h[8, 9];
+}
+model {
+  //  increment_log_prob(-e^2 / 2);
+  increment_log_prob(a);
+  increment_log_prob(b);
+  increment_log_prob(b);
+  increment_log_prob(c);
+  increment_log_prob(d);
+  increment_log_prob(e);
+  increment_log_prob(f);
+  increment_log_prob(g);
+  increment_log_prob(h);
+}

--- a/src/test/test-models/good/get-lp-deprecate.stan
+++ b/src/test/test-models/good/get-lp-deprecate.stan
@@ -1,0 +1,7 @@
+parameters {
+  real<lower=0> y;
+}
+model {
+  print("target=", get_lp());
+  y ~ normal(0, 1);
+}

--- a/src/test/test-models/good/get-lp-target.stan
+++ b/src/test/test-models/good/get-lp-target.stan
@@ -1,0 +1,12 @@
+parameters {
+  real<lower=0> y;
+}
+transformed parameters {
+  print("target = ", target());
+  print("get_lp = ", get_lp());
+}
+model {
+  print("target = ", target());
+  print("get_lp = ", get_lp());
+  y ~ normal(0, 1);
+}

--- a/src/test/test-models/good/increment-target.stan
+++ b/src/test/test-models/good/increment-target.stan
@@ -1,0 +1,24 @@
+data {
+  real a;
+  vector[3] b;
+  real c[7];
+  real d[8, 9];
+}
+parameters {
+  real e;
+  vector[3] f;
+  real g[7];
+  real h[8, 9];
+}
+model {
+  target += -e^2 / 2;
+  target += a;
+  target += b;
+  target += b;
+  target += c;
+  target += d;
+  target += e;
+  target += f;
+  target += g;
+  target += h;
+}

--- a/src/test/unit/lang/parser/get_lp_test.cpp
+++ b/src/test/unit/lang/parser/get_lp_test.cpp
@@ -3,9 +3,11 @@
 
 TEST(langParser, illegalScope) { 
   test_throws("get_lp_bad_scope1",
-              "Functions suffixed with _lp only allowed in");
+              "Function target() or functions suffixed with _lp only"
+              " allowed in transformed parameter block, model block");
   test_throws("get_lp_bad_scope2",
-              "Functions suffixed with _lp only allowed in");
+              "Function target() or functions suffixed with _lp only"
+              " allowed in transformed parameter block, model block");
 }
 TEST(langParser, legal) {
   test_parsable("get_lp_good");

--- a/src/test/unit/lang/parser/statement_grammar_test.cpp
+++ b/src/test/unit/lang/parser/statement_grammar_test.cpp
@@ -31,6 +31,25 @@ TEST(langParserStatementGrammar, validateAllowSample) {
               "Sampling statements (~) and increment_log_prob() are");
 }
 
+TEST(langParserStatementGrammar, targetIncrement) {
+  test_parsable("increment-target");
+}
+
+TEST(langParserStatementGrammar, targetReserved) {
+  test_throws("target-reserved",
+              "variable identifier (name) may not be reserved word");
+  test_throws("target-reserved",
+              "found identifier=target");
+}
+
+TEST(langParserStatementGrammar, deprecateIncrementLogProb) {
+  test_warning("deprecate-increment-log-prob",
+               "Warning (non-fatal): increment_log_prob(...);"
+               " is deprecated and will be removed in the future.");
+  test_warning("deprecate-increment-log-prob",
+               "  Use target += ...; instead.");
+}
+
 TEST(langParserStatementGrammarDef, jacobianAdjustmentWarning) {
   test_parsable("validate_jacobian_warning_good");
   test_warning("validate_jacobian_warning1",
@@ -81,5 +100,30 @@ TEST(langParserStatementGrammar, useCdfWithSamplingNotation) {
               "Only distribution names can be used with sampling (~) notation");
   test_throws("binomial_coefficient_sample",
               "Only distribution names can be used with sampling (~) notation");
+}
+
+TEST(langParserStatementGrammar, targetFunGetLpDeprecated) {
+  test_warning("get-lp-deprecate", 
+               "Warning (non-fatal): get_lp() function deprecated.");
+  test_warning("get-lp-deprecate", 
+  "  It will be removed in a future release.");
+  test_warning("get-lp-deprecate", 
+               "  Use target() instead.");
+  test_throws("get-lp-target-data",
+              "Function target() or functions suffixed with _lp only"
+              " allowed in transformed parameter block");
+  test_throws("get-lp-target-data",
+              "Found function = target or get_lp"
+              " in block = transformed data");
+  test_parsable("get-lp-target");
+}
+
+TEST(langParserStatementGrammar, removeLpDoubleUnderscore) {
+  test_throws("lp-error",
+              "ERROR (fatal):  Use of lp__ is no longer supported.");
+  test_throws("lp-error",
+              "  Use target += ... statement to increment log density.");
+  test_throws("lp-error",
+              "  Use target() function to get log density.");
 }
 

--- a/src/test/unit/lang/parser/user_defined_functions_test.cpp
+++ b/src/test/unit/lang/parser/user_defined_functions_test.cpp
@@ -55,12 +55,14 @@ TEST(parserFunctions,funsBad5) {
 
 TEST(parserFunctions,funsBad6) {
   test_throws("functions-bad6",
-              "Functions suffixed with _lp only allowed");
+              "Function target() or functions suffixed with _lp only"
+              " allowed in transformed parameter block, model block");
 }
 
 TEST(parserFunctions,funsBad7) {
   test_throws("functions-bad7",
-              "Functions suffixed with _lp only allowed");
+              "Function target() or functions suffixed with _lp only"
+              " allowed in transformed parameter block, model block");
 }
 
 TEST(parserFunctions,funsBad8) {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add `target += ...` to replace `incement_log_prob()` and `target()` to replace `get_lp()`; finally remove `lp__`.

#### Intended Effect

Bring Stan in line with future language changes, while remaining backward compatibility with non-deprecated functionality:

* introduce `target += ...` statement
* introduce `target()` function
* deprecate `get_lp()` with message suggesting replacement
* deprecate `increment_log_prob()` with message suggesting replacement
* remove direct acess `lp__`; print warnings and suggest replacement
* add `target` to list of reserved words

The last two are not strictly backward compatible, but `lp__` was deprecated in Stan 2.0, so I think it's safe to remove it.


#### How to Verify

There are new tests for everything and old tests have been updated.

#### Side Effects

Programs with variables named `target` or that access variable `lp__` will no longer compile.

#### Documentation

All user-facing doc was updated.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
