### PR TITLE
Bugfix/issue 1713 unit vector

### DIFF
--- a/src/docs/bibtex/all.bib
+++ b/src/docs/bibtex/all.bib
@@ -1,6 +1,16 @@
 % a do-nothing command that serves a purpose
 @preamble{ " \newcommand{\noop}[1]{} " }
 
+@article{Marsaglia:1972,
+  title={Choosing a point from the surface of a sphere},
+  author={Marsaglia, George},
+  journal={The Annals of Mathematical Statistics},
+  volume={43},
+  number={2},
+  pages={645--646},
+  year={1972}
+}
+
 @book{HopcroftMotwani:2006,
   title={Introduction to Automata Theory, Languages, and Computation},
   author={Hopcroft, John E. and Rajeev Motwani},

--- a/src/docs/stan-reference/advanced.tex
+++ b/src/docs/stan-reference/advanced.tex
@@ -1846,7 +1846,7 @@ if it has unit Euclidean length, so that
 \[
 \Vert x \Vert 
 \ = \ \sqrt{x^{\top}\,x}
-}\ = \ \sqrt{x_1^2 + x_2^2 + \cdots + x_n^2}
+\ = \ \sqrt{x_1^2 + x_2^2 + \cdots + x_n^2}
 \ = \ 1\ .
 \]
 %

--- a/src/docs/stan-reference/advanced.tex
+++ b/src/docs/stan-reference/advanced.tex
@@ -1839,39 +1839,78 @@ z_k
 \]
 
 \section{Unit Vector}
-Unit vectors show up in directional statistics.
 
-The $n$-sphere is the set of points $x \in \reals^n$ such that
+An $n$-dimensional vector $x \in \reals^n$ is said to be a unit vector
+if it has unit Euclidean length, so that
+%
 \[
-\Vert x \Vert^2 = \sum_{i=1}^n x_i^2 = 1\ .
+\Vert x \Vert 
+\ = \ \sqrt{x^{\top}\,x}
+\ = \ \sqrt{x_1^2 + x_2^2 + \cdots + x_n^2}
+\ = \ 1\ .
 \]
+%
+Unit vectors are convenient for directional statistics, because they
+determine directions, or equivalently, rotations around the origin.
+
+The $n-1$ sphere $S^{n-1}$ is defined as the set of $n$-dimensional
+unit vectors, 
+\[
+S^{n-1} = \{ x \in \reals^n \, : \, \Vert x \Vert = 1 \}.
+\]
+%
+Even though the $S^{n-1}$ sphere is made up of $n$-dimensional
+vectors, it is only an $(n-1)$-dimensional manifold.  For example, $S^2$
+is a simple model of the surface of the Earth, which despite being
+embedded in three dimensions, has a set of points definable by two
+dimensions, latitude and longitude. behaves locally as a plane in the
+sense. Unlike a plane, though, when you head off along a great circle
+on the surface of a sphere, you wind up back where you started.
+
+Even though $S^{n-1}$ behaves locally like $\reals^{n-1}$, there is no
+way to smoothly map between them. For example, because
+latitude and longitude work on a modular basis (wrapping at $2\pi$
+radians in natural units), they do not produce a smooth map. To
+finesse this problem, Stan generates points at random in $\reals^n$
+with independent unit normal distributions, which are then
+standardized by dividing by their Euclidean length.
+\cite{Marsaglia:1972} showed this generates points uniformly at random
+on $S^{n-1}$.  That is, if we draw $y_n \sim \distro{Normal}(0, 1)$,
+then $x = \frac{y}{\Vert y \Vert}$ has a uniform distribution over
+$S^{n-1}$, which allows an $n$-dimensional basis for $S^n$.
+
 
 \subsection{Unit Vector Inverse Transform}
 
-To parameterize unit length vectors, Stan formerly utilized unrestricted
-hyperspherical angles. Currently, Stan divides an unconstrained vector
-$y \in \reals^{n}$ by its norm, $\sqrt{y^\top y}$ to obtain a unit vector
-$x$.
-\begin{eqnarray*}
-x & = & \frac{y}{\sqrt{y^\top y}}.
-\end{eqnarray*}
-This approach has a slight inconvenience that it is undefined if $y$ is
-a zero vector, which cannot occur during sampling but the unconstrained
-parameters that yield $x$ can be initialized to zero, in which case the
-sampling algorithm will be unable to start. To work around this problem,
-you can initialize each unconstrained parameter randomly from a very small
-interval centered at zero.
+Stan divides an unconstrained vector $y \in \reals^{n}$ by its norm,
+$\Vert y \Vert = \sqrt{y^\top y}$, to obtain a unit vector $x$,
+%
+\[
+x = \frac{y}{\Vert y \Vert}.
+\]
+%
 
-\subsection{Absolute Jacobian Determinant of the Unit Vector
-  Inverse Transform}
-The Jacobian matrix relating the input vector $y$ to the output vector $x$
-is singular because $x^\top x = 1$ for any non-zero input vector $y$. Thus,
-there technically is no unique transformation from $x$ to $y$. To 
-circumvent this issue let $r = \sqrt{y^\top y}$ so that $y = r x$. The
-transformation from $\left(r, x_{-n}\right)$ to $y$ is well-defined but $r$
-is arbitrary, so we set $r = 1$. In this case, the determinant of the 
-Jacobian is proportional to $-0.5 y^\top y$, which is the kernel of a 
-standard multivariate normal distribution with $n$ independent dimensions.
+\subsubsection{Warning: undefined at zero!}
+
+The above mapping from $\reals^n$ to $S^n$ is not defined at zero.
+While this point outcome has measure zero during sampling, and may
+thus be ignored, it is the default initialization point and thus unit
+vector parameters cannot be initialized at zero.  A simple workaround
+is to initialize from a very small interval around zero, which is an
+option built into all of the Stan interfaces.
+
+\subsection{Absolute Jacobian Determinant of the Unit Vector Inverse
+  Transform}
+
+The Jacobian matrix relating the input vector $y$ to the output vector
+$x$ is singular because $x^\top x = 1$ for any non-zero input vector
+$y$. Thus, there technically is no unique transformation from $x$ to
+$y$. To circumvent this issue, let $r = \sqrt{y^\top y}$ so that $y = r
+x$. The transformation from $\left(r, x_{-n}\right)$ to $y$ is
+well-defined but $r$ is arbitrary, so we set $r = 1$. In this case,
+the determinant of the Jacobian is proportional to $-\frac{1}{2} y^\top y$,
+which is the kernel of a standard multivariate normal distribution
+with $n$ independent dimensions.
 
 \section{Correlation Matrices}\label{correlation-matrix-transform.section}
 

--- a/src/docs/stan-reference/advanced.tex
+++ b/src/docs/stan-reference/advanced.tex
@@ -1838,7 +1838,7 @@ z_k
 .
 \]
 
-\section{Unit Vector}
+\section{Unit Vector}\label{unit-vector.section}
 
 An $n$-dimensional vector $x \in \reals^n$ is said to be a unit vector
 if it has unit Euclidean length, so that
@@ -1846,38 +1846,10 @@ if it has unit Euclidean length, so that
 \[
 \Vert x \Vert 
 \ = \ \sqrt{x^{\top}\,x}
-\ = \ \sqrt{x_1^2 + x_2^2 + \cdots + x_n^2}
+}\ = \ \sqrt{x_1^2 + x_2^2 + \cdots + x_n^2}
 \ = \ 1\ .
 \]
 %
-Unit vectors are convenient for directional statistics, because they
-determine directions, or equivalently, rotations around the origin.
-
-The $n-1$ sphere $S^{n-1}$ is defined as the set of $n$-dimensional
-unit vectors, 
-\[
-S^{n-1} = \{ x \in \reals^n \, : \, \Vert x \Vert = 1 \}.
-\]
-%
-Even though the $S^{n-1}$ sphere is made up of $n$-dimensional
-vectors, it is only an $(n-1)$-dimensional manifold.  For example, $S^2$
-is a simple model of the surface of the Earth, which despite being
-embedded in three dimensions, has a set of points definable by two
-dimensions, latitude and longitude. behaves locally as a plane in the
-sense. Unlike a plane, though, when you head off along a great circle
-on the surface of a sphere, you wind up back where you started.
-
-Even though $S^{n-1}$ behaves locally like $\reals^{n-1}$, there is no
-way to smoothly map between them. For example, because
-latitude and longitude work on a modular basis (wrapping at $2\pi$
-radians in natural units), they do not produce a smooth map. To
-finesse this problem, Stan generates points at random in $\reals^n$
-with independent unit normal distributions, which are then
-standardized by dividing by their Euclidean length.
-\cite{Marsaglia:1972} showed this generates points uniformly at random
-on $S^{n-1}$.  That is, if we draw $y_n \sim \distro{Normal}(0, 1)$,
-then $x = \frac{y}{\Vert y \Vert}$ has a uniform distribution over
-$S^{n-1}$, which allows an $n$-dimensional basis for $S^n$.
 
 
 \subsection{Unit Vector Inverse Transform}
@@ -1889,6 +1861,20 @@ $\Vert y \Vert = \sqrt{y^\top y}$, to obtain a unit vector $x$,
 x = \frac{y}{\Vert y \Vert}.
 \]
 %
+
+To generate a unit vector, Stan generates points at random in
+$\reals^n$ with independent unit normal distributions, which are then
+standardized by dividing by their Euclidean length.
+\cite{Marsaglia:1972} showed this generates points uniformly at random
+on $S^{n-1}$.  That is, if we draw $y_n \sim \distro{Normal}(0, 1)$
+for $n \in 1{:}n$, then $x = \frac{y}{\Vert y \Vert}$ has a uniform
+distribution over $S^{n-1}$.  This allows us to use an $n$-dimensional
+basis for $S^{n-1}$ that preserves local neighborhoods in that points
+that are close to each other in $\reals^n$ map to points near each
+other in $S^{n-1}$.  The mapping is not perfectly distance preserving,
+because there are points arbitrarily far away from each other in
+$\reals^n$ that map to identical points in $S^{n-1}$.
+
 
 \subsubsection{Warning: undefined at zero!}
 

--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -7964,6 +7964,19 @@ R_{\theta}
 Given a two-dimensional vector $x$, $R_{\theta} \, x$ is the rotation
 of $x$ (around the origin) by $\theta$ degrees.
 
+\section{Circular Representations of Days and Years}
+
+A 24-hour clock naturally represents the progression of time through
+the day, moving from midnight to noon and back again in one rotation.
+A point on a circle divided into 24 hours is thus a natural
+representation for the time of day.  Similarly, years cycle through
+the seasons and return to the season from which they started.
+
+In human affairs, temporal effects often arise by convention.  These
+can be modeled directly with ad-hoc predictors for holidays and
+weekends, or with data normalization back to natural scales for
+daylight savings time.
+
 
 \chapter{Reparameterization \& Change of Variables}\label{change-of-variables.chapter}
 

--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -7842,6 +7842,127 @@ defining the covariance matrix in the model block as a local variable.
 
 
 
+\chapter{Directions, Rotations, and Hyperspheres}
+
+Directional statistics involve data and/or parameters that are
+constrained to be directions.  The set of directions forms a sphere,
+the geometry of which is not smoothly mappable to that of a Euclidean
+space because you can move around a sphere and come back to where you
+started.  This is why it is impossible to make a map of the globe on a
+flat piece of paper where all points that are close to each other on
+the globe are close to each other on the flat map.  The fundamental
+problem is easy to visualize in two dimensions, because as you move
+around a circle, you wind up back where you started.  In other words,
+0 degrees and 360 degrees (equivalently, 0 and $2 \pi$ radians) pick
+out the same point, and the distance between 359 degrees and 2 degrees
+is the same as the distance between 137 and 140 degrees.
+
+Stan supports directional statistics by providing a unit-vector data
+type, the values of which determine points on a hypersphere (circle in
+two dimensions, sphere in three dimensions).
+
+\section{Unit Vectors}  
+
+The length of a vector $x \in \reals^K$ is given by
+\[
+\Vert x \Vert
+\ = \ \sqrt{x^{\top}\,x}
+\ = \ \sqrt{x_1^2 + x_2^2 + \cdots + x_K^2}.
+\]
+Unit vectors are defined to be vectors of unit length (i.e., length
+one).
+
+With a variable declaration such as
+%
+\begin{stancode}
+unit_vector[K] x;
+\end{stancode}
+%
+the value of \code{x} will be constrained to be a vector of size
+\code{K} with unit length.  \refsection{unit-vector} provides details
+on how a parameter constrained to be a unit-vector is transformed to
+unconstrained space for use in Stan's algorithms.
+
+\section{Circles, Spheres, and Hyperspheres}
+
+An $n$-sphere, written $S^{n}$, is defined as the set of $(n +
+1)$-dimensional unit vectors,
+\[
+S^{n} = \{ x \in \reals^{n+1} \, : \, \Vert x \Vert = 1 \}.
+\]
+%
+Even though $S^n$ is made up of points in $(n+1)$ dimensions, it is
+only an $n$-dimensional manifold.  For example, $S^2$ is defined as a
+set of points in $\reals^3$, but each such point may be described
+uniquely by a latitude and longitude.  Geometrically, the surface
+defined by $S^2$ in $\reals^3$ behaves locally like a plane, i.e.,
+$\reals^2$.  However, the overall shape of $S^2$ is not like a plane
+in that is compact (i.e., there is a maximum distance between points).
+If you set off around the globe in a ``straight line'' (i.e., a
+geodesic), you wind up back where you started eventually; that is why
+the geodesics on the sphere ($S^2$) are called ``great circles,'' and
+why we need to use some clever representations to do circular or
+spherical statistics.
+
+Even though $S^{n-1}$ behaves locally like $\reals^{n-1}$, there is no
+way to smoothly map between them. For example, because
+latitude and longitude work on a modular basis (wrapping at $2\pi$
+radians in natural units), they do not produce a smooth map. 
+
+Like a bounded interval $(a,b)$, in geometric terms, a sphere is
+compact in that the distance between any two points is bounded.
+
+
+\section{Transforming to Unconstrained Parameters}
+
+Stan (inverse) transforms arbitrary points in $\reals^{K+1}$ to points
+in $S^K$ using the auxiliary variable approach of
+\cite{Marsaglia:1972}.  A point $y \in \reals^K$ is transformed to a
+point $x \in S^{K-1}$ by
+%
+\[
+x = \frac{y}{\sqrt{y^{\top} y}}.
+\]
+%
+The problem with this mapping is that it's many to one; any point
+lying on a vector out of the origin is projected to the same point on
+the surface of the sphere.  \cite{Marsaglia:1972} introduced an
+auxiliary variable interpretation of this mapping that provides the
+desired properties of uniformity; see \refsection{unit-vector} for
+details. 
+
+
+\subsubsection{Warning: undefined at zero!}
+
+The above mapping from $\reals^n$ to $S^n$ is not defined at zero.
+While this point outcome has measure zero during sampling, and may
+thus be ignored, it is the default initialization point and thus unit
+vector parameters cannot be initialized at zero.  A simple workaround
+is to initialize from a very small interval around zero, which is an
+option built into all of the Stan interfaces.
+
+
+
+\section{Unit Vectors and Rotations}
+
+Unit vectors correspond directly to angles and thus to rotations.
+This is easy to see in two dimensions, where a point on a circle
+determines a compass direction, or equivalently, an angle $\theta$).
+Given an angle $\theta$, a matrix can be defined, the
+pre-multiplication by which rotates a point by an angle of $\theta$.
+For angle $\theta$ (in two dimensions), the $2 \times 2$ rotation
+matrix is defined by
+\[
+R_{\theta}
+=
+\begin{bmatrix}
+\cos \theta & - \sin \theta 
+\\
+\sin \theta & \cos \theta
+\end{bmatrix}.
+\]
+Given a two-dimensional vector $x$, $R_{\theta} \, x$ is the rotation
+of $x$ (around the origin) by $\theta$ degrees.
 
 
 \chapter{Reparameterization \& Change of Variables}\label{change-of-variables.chapter}

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -813,11 +813,11 @@ namespace stan {
        * <p>See <code>stan::math::unit_vector_constrain(Eigen::Matrix)</code>.
        *
        * @param k Number of dimensions in resulting unit_vector.
-       * @return unit_vector derived from next <code>k-1</code> scalars.
+       * @return unit_vector derived from next <code>k</code> scalars.
        */
       inline
       Eigen::Matrix<T, Eigen::Dynamic, 1> unit_vector_constrain(size_t k) {
-        return stan::math::unit_vector_constrain(vector(k-1));
+        return stan::math::unit_vector_constrain(vector(k));
       }
 
       /**
@@ -833,7 +833,7 @@ namespace stan {
        * @return The next unit_vector of the specified size.
        */
       inline vector_t unit_vector_constrain(size_t k, T& lp) {
-        return stan::math::unit_vector_constrain(vector(k-1), lp);
+        return stan::math::unit_vector_constrain(vector(k), lp);
       }
 
       /**

--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -2836,10 +2836,9 @@ namespace stan {
         generate_increment(x.M_, x.N_, x.dims_);
       }
       void operator()(const unit_vector_var_decl& x) const {
-        // only K-1 vals
         o_ << INDENT2 << "num_params_r__ += (";
         generate_expression(x.K_, o_);
-        o_ << " - 1)";
+        o_ << ")";
         for (size_t i = 0; i < x.dims_.size(); ++i) {
           o_ << " * ";
           generate_expression(x.dims_[i], o_);
@@ -3712,7 +3711,7 @@ namespace stan {
       }
       void operator()(const unit_vector_var_decl& x) const {
         std::vector<expression> matrix_args;
-        matrix_args.push_back(binary_op(x.K_, "-", int_literal(1)));
+        matrix_args.push_back(x.K_);
         generate_param_names_array(matrix_args, x.name_, x.dims_);
       }
       void operator()(const simplex_var_decl& x) const {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fix dimensionality bug in `unit_vector` constrained variable type.

#### Intended Effect

Allow unit vectors to be used.

#### How to Verify

Build and run the model in issue #1713 and check the output is unit vectors.

#### Side Effects

No, given that nothing worked before.

#### Documentation

The transform was already documented, but I added a new chapter about spheres and the mapping in the user's guide section of the manual.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
