### PR TITLE
deprecation of <- clarified to indicate Stan, fixing #1819

### DIFF
--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -500,7 +500,8 @@ namespace stan {
 
     void deprecate_old_assignment_op::operator()(std::ostream& error_msgs)
       const {
-      error_msgs << "Warning (non-fatal): assignment operator <- deprecated;"
+      error_msgs << "Warning (non-fatal): assignment operator <- deprecated"
+                 << " in the Stan language;"
                  << " use = instead."
                  << std::endl;
     }
@@ -1372,7 +1373,8 @@ namespace stan {
       if (fun.name_ == "abs"
           && fun.args_.size() > 0
           && fun.args_[0].expression_type().is_primitive_double()) {
-        error_msgs << "Warning: Function abs(real) is deprecated."
+        error_msgs << "Warning: Function abs(real) is deprecated"
+                   << " in the Stan language."
                    << std::endl
                    << "         It will be removed in a future release."
                    << std::endl

--- a/src/test/test-models/good/abs-deprecate.stan
+++ b/src/test/test-models/good/abs-deprecate.stan
@@ -1,0 +1,10 @@
+transformed data {
+  real mu;
+  mu = abs(-1.2);
+}
+parameters {
+  real y;
+}
+model {
+  y ~ normal(mu, 1);
+}

--- a/src/test/unit/lang/parser/assignment_test.cpp
+++ b/src/test/unit/lang/parser/assignment_test.cpp
@@ -26,7 +26,8 @@ TEST(lang_parser, mat_assign_funciton_signatures) {
 TEST(lang_parser, new_assign) {
   test_parsable("assignment-new");
   test_warning("assignment-old",
-               "Warning (non-fatal): assignment operator <- deprecated;"
+               "Warning (non-fatal): assignment operator <- deprecated"
+               " in the Stan language;"
                " use = instead.");
 
 }

--- a/src/test/unit/lang/parser/expression_grammar_test.cpp
+++ b/src/test/unit/lang/parser/expression_grammar_test.cpp
@@ -6,3 +6,7 @@ TEST(langParserStatementGrammarDef, intDivUserFacing) {
                "a[1] / b[2]");
 }
 
+TEST(langParserStatementGrammarDef, absDeprecate) {
+  test_warning("abs-deprecate",
+               "Warning: Function abs(real) is deprecated in the Stan language.");
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`  (cheated and only ran changed ones)
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Uses Ben's wording for new message indicating that deprecation of <- is in Stan only.  Also applied to abs(real), the only other confusible deprecation warning.

#### Intended Effect

Not confuse users.

#### How to Verify

New unit tests.

#### Side Effects

No.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

