### PR TITLE
add incomplete beta as inc_beta

### DIFF
--- a/src/docs/stan-reference/appendices.tex
+++ b/src/docs/stan-reference/appendices.tex
@@ -1073,8 +1073,31 @@ constant for the beta distribution, and is defined for $a > 0$ and $b
 \ = \
 \int_0^1 u^{a - 1} (1 - u)^{b - 1} \, du
 \ = \
-\frac{\Gamma(a) \, \Gamma(b)}{\Gamma(a+b)}.
+\frac{\Gamma(a) \, \Gamma(b)}{\Gamma(a+b)} \, .
 \]
+
+\section{Incomplete Beta}\label{inc-beta-appendix.section}
+
+The incomplete beta function, $\mathrm{B}(x; a, b)$, is defined for 
+$x \in [0, 1]$ and $a, b \geq 0$ such that $a + b \neq 0$ by
+\[
+\mathrm{B}(x; \, a, b) 
+\ = \
+\int_0^x u^{a -  1} \, (1 - u)^{b - 1} \, du,
+\]
+%
+where $\mathrm{B}(a, b)$ is the beta function defined in
+\refsection{beta-appendix}.  If $x = 1$, the incomplete beta function
+reduces to the beta function, $\mathrm{B}(1; a, b) = \mathrm{B}(a,
+b)$.
+
+The regularized incomplete beta function divides the incomplete beta
+function by the beta function,
+\[
+I_x(a, b) \ = \ \frac{\mathrm{B}(x; \, a, b)}{B(a, b)} \, .
+\]
+
+
 
 
 \section{Gamma}\label{gamma-appendix.section}

--- a/src/docs/stan-reference/functions.tex
+++ b/src/docs/stan-reference/functions.tex
@@ -1115,6 +1115,11 @@ distribution function (and its complement).
 
 \begin{description}
   %
+  \fitem{real}{inc\_beta}{real \farg{alpha}, real \farg{beta}, real
+    \farg{x}}{ Returns the incomplete beta function up to \farg{x}
+    applied to \farg{alpha} and \farg{beta}.  See
+    \refsection{inc-beta-appendix} for a definition.  }
+  %
   \fitem{real}{lbeta}{real \farg{alpha}, real \farg{beta}}{ 
     Returns the natural logarithm of the beta function applied to 
     \farg{alpha} and \farg{beta}.  The beta function, $\mbox{B}(\alpha,\beta)$,

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -364,6 +364,7 @@ add("hypergeometric_log", DOUBLE_T, INT_T, INT_T, INT_T, INT_T);
 add("hypergeometric_rng", INT_T, INT_T, INT_T, INT_T);
 add_binary("hypot");
 add("if_else", DOUBLE_T, INT_T, DOUBLE_T, DOUBLE_T);
+add("inc_beta", DOUBLE_T, DOUBLE_T, DOUBLE_T, DOUBLE_T);
 add("int_step", INT_T, DOUBLE_T);
 add("int_step", INT_T, INT_T);
 add_unary("inv");

--- a/src/test/test-models/good/function-signatures/math/functions/inc_beta.stan
+++ b/src/test/test-models/good/function-signatures/math/functions/inc_beta.stan
@@ -1,0 +1,28 @@
+transformed data {
+  real a;
+  a <- inc_beta(1, 1, 1);
+  a <- inc_beta(1, 1, 2.7);
+  a <- inc_beta(1, 2.7, 1);
+  a <- inc_beta(1, 2.7, 2.7);
+  a <- inc_beta(2.7, 1, 1);
+  a <- inc_beta(2.7, 1, 2.7);
+  a <- inc_beta(2.7, 2.7, 1);
+  a <- inc_beta(2.7, 2.7, 2.7);
+}  
+parameters {
+  real b;
+}
+transformed parameters {
+  real c;
+  c <- inc_beta(b, b, b);
+  c <- inc_beta(b, b, 2.7);
+  c <- inc_beta(b, 2.7, b);
+  c <- inc_beta(b, 2.7, 2.7);
+  c <- inc_beta(2.7, b, b);
+  c <- inc_beta(2.7, b, 2.7);
+  c <- inc_beta(2.7, 2.7, b);
+}
+model {
+  b ~ normal(0, 1);
+}
+  

--- a/src/test/unit/lang/parser/math_functions_test.cpp
+++ b/src/test/unit/lang/parser/math_functions_test.cpp
@@ -141,6 +141,10 @@ TEST(lang_parser, if_else_math_function_signatures) {
   test_parsable("function-signatures/math/functions/if_else");
 }
 
+TEST(lang_parser, inc_beta_math_function_signatures) {
+  test_parsable("function-signatures/math/functions/inc_beta");
+}
+
 TEST(lang_parser, int_step_math_function_signatures) {
   test_parsable("function-signatures/math/functions/int_step");
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Expose the incomplete beta function `B(x; a, b)` as `inc_beta(a, b, x)`.  

I copied the argument order from the math library. Mathematical notation is `B(x; a, b)`, Boost uses `ibeta(a, b, x)`, and and Matlab uses `beta_inc(x, a, b)`.

#### Intended Effect

Allow users to call incomplete beta in Stan progams.

#### How to Verify

Unit tests for language.  Build and view doc.

#### Side Effects

No.

#### Documentation

Yes, in function list and in appendix for mathematical definition.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

