### PR TITLE
add pstream to cdfs for truncation, fixing #1628

### DIFF
--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -1875,14 +1875,14 @@ namespace stan {
           o_ << ", ";
           generate_expression(x.dist_.args_[i], o_);
         }
-        if (is_user_defined_prob_function(x.dist_.family_ + "_log",
-                                          x.expr_,
-                                          x.dist_.args_)) {
+        bool is_user_defined
+          = is_user_defined_prob_function(x.dist_.family_ + "_log",
+                                          x.expr_, x.dist_.args_);
+        if (is_user_defined)
           o_ << ", pstream__";
-        }
         o_ << "));" << EOL;
         // rest of impl is for truncation
-        // generate bounds test
+        // test variable is within truncation interval
         if (x.truncation_.has_low()) {
           generate_indent(indent_, o_);
           o_ << "if (";
@@ -1907,6 +1907,7 @@ namespace stan {
           generate_indent(indent_, o_);
           o_ << "else ";
         }
+        // rest of code for three cases: T[L,H], T[L,], T[,H]
         if (x.truncation_.has_low() && x.truncation_.has_high()) {
           // T[L,U]: -log_diff_exp(Dist_cdf_log(U|params),
           //                       Dist_cdf_log(L|Params))
@@ -1917,12 +1918,16 @@ namespace stan {
             o_ << ", ";
             generate_expression(x.dist_.args_[i], o_);
           }
+          if (is_user_defined)
+            o_ << ", pstream__";
           o_ << "), " << x.dist_.family_ << "_cdf_log(";
           generate_expression(x.truncation_.low_.expr_, o_);
           for (size_t i = 0; i < x.dist_.args_.size(); ++i) {
             o_ << ", ";
             generate_expression(x.dist_.args_[i], o_);
           }
+          if (is_user_defined)
+            o_ << ", pstream__";
           o_ << ")));" << EOL;
         } else if (!x.truncation_.has_low() && x.truncation_.has_high()) {
           // T[,U];  -Dist_cdf_log(U)
@@ -1933,6 +1938,8 @@ namespace stan {
             o_ << ", ";
             generate_expression(x.dist_.args_[i], o_);
           }
+          if (is_user_defined)
+            o_ << ", pstream__";
           o_ << "));" << EOL;
         } else if (x.truncation_.has_low() && !x.truncation_.has_high()) {
           // T[L,]: -Dist_ccdf_log(L)
@@ -1943,6 +1950,8 @@ namespace stan {
             o_ << ", ";
             generate_expression(x.dist_.args_[i], o_);
           }
+          if (is_user_defined)
+            o_ << ", pstream__";
           o_ << "));" << EOL;
         }
       }

--- a/src/test/test-models/good/truncation-user-defined.stan
+++ b/src/test/test-models/good/truncation-user-defined.stan
@@ -1,0 +1,18 @@
+functions {
+  real foo_log(real y, real theta) { return 1; }
+  real foo_cdf_log(real y, real theta) { return 1; }
+  real foo_ccdf_log(real y, real theta) { return 1; }
+}
+data {
+  real y;
+}
+parameters {
+  real theta;
+  real L;
+  real U;
+}
+model {
+  y ~ foo(theta) T[L, ];
+  y ~ foo(theta) T[ , U];
+  y ~ foo(theta) T[L, U];
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add `pstream__` argument to user-defined CDFs and CCDFs.

#### Intended Effect

Allow truncation to be used for user-defined densities.

#### How to Verify

New good model test that'll get picked up on integration tests; wouldn't compile before, compiles now.

#### Side Effects

None.

#### Documentation

Code was fixed to match doc.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

