### PR TITLE
Fix minor typo in reference manual.

### DIFF
--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -3471,7 +3471,7 @@ reject statements to raise errors or help with debugging.
 \noindent
 Stan allows users to define their own functions.  The basic syntax is
 a simplified version of that used in C and \Cpp.  This chapter
-specifies how functions are declare, defined, and used in Stan; see
+specifies how functions are declared, defined, and used in Stan; see
 \refchapter{functions-programming} for a more programming-oriented
 perspective.
 


### PR DESCRIPTION
This corrects a minor typo in the introduction to chapter 27.