### PR TITLE
Feature/issue 1846 multinomial nuts

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -133,6 +133,7 @@ src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp: src/test/test-models
 src/test/unit/mcmc/hmc/hamiltonians/unit_e_metric_test.cpp: src/test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp
 src/test/unit/mcmc/hmc/integrators/expl_leapfrog_test.cpp: src/test/test-models/good/mcmc/hmc/integrators/command.hpp
 src/test/unit/mcmc/hmc/integrators/expl_leapfrog2_test.cpp: src/test/test-models/good/mcmc/hmc/integrators/gauss.hpp
+src/test/unit/mcmc/hmc/unit_e_nuts_test.cpp: src/test/test-models/good/mcmc/hmc/nuts/gauss3D.hpp
 src/test/unit/model/util_test.cpp: src/test/test-models/good/model/valid.hpp src/test/test-models/good/model/domain_fail.hpp
 src/test/unit/optimization/bfgs_linesearch_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp
 src/test/unit/optimization/bfgs_minimizer_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp

--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -54,6 +54,10 @@ namespace stan {
         z_.q = q;
       }
 
+      void init_hamiltonian(interface_callbacks::writer::base_writer& writer) {
+        this->hamiltonian_.init(this->z_, writer);
+      }
+
       void init_stepsize(interface_callbacks::writer::base_writer& writer) {
         ps_point z_init(this->z_);
 

--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -57,6 +57,10 @@ namespace stan {
       void init_stepsize(interface_callbacks::writer::base_writer& writer) {
         ps_point z_init(this->z_);
 
+        // Skip initialization for extreme step sizes
+        if (this->nom_epsilon_ == 0 || this->nom_epsilon_ > 1e7)
+          return;
+
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
         this->hamiltonian_.init(this->z_, writer);
 

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -59,7 +59,7 @@ namespace stan {
 
         double H0 = this->hamiltonian_.H(this->z_);
         int n_leapfrog = 0;
-        double sum_metro_prob = 1; // exp(H0 - H0)
+        double sum_metro_prob = 1;  // exp(H0 - H0)
 
         // Build a trajectory until the NUTS criterion is no longer satisfied
         this->depth_ = 0;

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -13,28 +13,14 @@
 
 namespace stan {
   namespace mcmc {
-
-    struct nuts_util {
-      // Constants through each recursion
-      double log_u;
-      double H0;
-      int sign;
-
-      // Aggregators through each recursion
-      int n_tree;
-      double sum_prob;
-      bool criterion;
-    };
-
-    // The No-U-Turn Sampler (NUTS).
-
+    // The No-U-Turn Sampler (NUTS) with multinomial sampling
     template <class Model, template<class, class> class Hamiltonian,
               template<class> class Integrator, class BaseRNG>
     class base_nuts : public base_hmc<Model, Hamiltonian, Integrator, BaseRNG> {
     public:
       base_nuts(Model &model, BaseRNG& rng)
         : base_hmc<Model, Hamiltonian, Integrator, BaseRNG>(model, rng),
-        depth_(0), max_depth_(5), max_delta_(1000),
+        depth_(0), max_depth_(5), max_deltaH_(1000),
         n_leapfrog_(0), divergent_(0), energy_(0) {
       }
 
@@ -46,18 +32,16 @@ namespace stan {
       }
 
       void set_max_delta(double d) {
-        max_delta_ = d;
+        max_deltaH_ = d;
       }
 
       int get_max_depth() { return this->max_depth_; }
-      double get_max_delta() { return this->max_delta_; }
+      double get_max_delta() { return this->max_deltaH_; }
 
       sample transition(sample& init_sample,
                         interface_callbacks::writer::base_writer& writer) {
         // Initialize the algorithm
         this->sample_stepsize();
-
-        nuts_util util;
 
         this->seed(init_sample.cont_params());
 
@@ -70,83 +54,69 @@ namespace stan {
         ps_point z_sample(z_plus);
         ps_point z_propose(z_plus);
 
-        int n_cont = init_sample.cont_params().size();
+        Eigen::VectorXd rho = this->z_.p;
+        double sum_weight = 1;
 
-        Eigen::VectorXd rho_init = this->z_.p;
-        Eigen::VectorXd rho_plus(n_cont); rho_plus.setZero();
-        Eigen::VectorXd rho_minus(n_cont); rho_minus.setZero();
+        double H0 = this->hamiltonian_.H(this->z_);
+        int n_leapfrog = 0;
+        double sum_metro_prob = 1; // exp(H0 - H0)
 
-        util.H0 = this->hamiltonian_.H(this->z_);
-
-        // Sample the slice variable
-        util.log_u = std::log(this->rand_uniform_());
-
-        // Build a balanced binary tree until the NUTS criterion fails
-        util.criterion = true;
-        int n_valid = 0;
-
+        // Build a trajectory until the NUTS criterion is no longer satisfied
         this->depth_ = 0;
         this->divergent_ = 0;
 
-        util.n_tree = 0;
-        util.sum_prob = 0;
+        while (this->depth_ < this->max_depth_) {
+          // Build a new subtree in a random direction
+          Eigen::VectorXd rho_subtree(rho.size());
+          rho_subtree.setZero();
 
-        while (util.criterion && (this->depth_ <= this->max_depth_)) {
-          // Randomly sample a direction in time
-          ps_point* z = 0;
-          Eigen::VectorXd* rho = 0;
+          bool valid_subtree = false;
+          double sum_weight_subtree = 0;
 
           if (this->rand_uniform_() > 0.5) {
-            z = &z_plus;
-            rho = &rho_plus;
-            util.sign = 1;
+            this->z_.ps_point::operator=(z_plus);
+            valid_subtree
+              = build_tree(this->depth_, rho_subtree, z_propose,
+                           H0, 1, n_leapfrog,
+                           sum_weight_subtree, sum_metro_prob, writer);
+            z_plus.ps_point::operator=(this->z_);
           } else {
-            z = &z_minus;
-            rho = &rho_minus;
-            util.sign = -1;
+            this->z_.ps_point::operator=(z_minus);
+            valid_subtree
+              = build_tree(this->depth_, rho_subtree, z_propose,
+                           H0, -1, n_leapfrog,
+                           sum_weight_subtree, sum_metro_prob, writer);
+            z_minus.ps_point::operator=(this->z_);
           }
 
-          // And build a new subtree in that direction
-          this->z_.ps_point::operator=(*z);
+          sum_weight += sum_weight_subtree;
+          if (!valid_subtree) break;
 
-          int n_valid_subtree = build_tree(depth_, *rho, 0, z_propose, util,
-                                           writer);
+          // Sample from an accepted subtree
           ++(this->depth_);
 
-          *z = this->z_;
-
-          // Metropolis-Hastings sample the fresh subtree
-          if (!util.criterion)
-            break;
-
-          double subtree_prob = 0;
-
-          if (n_valid) {
-            subtree_prob = static_cast<double>(n_valid_subtree) /
-              static_cast<double>(n_valid);
-          } else {
-            subtree_prob = n_valid_subtree ? 1 : 0;
-          }
-
-          if (this->rand_uniform_() < subtree_prob)
+          double accept_prob = sum_weight_subtree / sum_weight;
+          if (this->rand_uniform_() < accept_prob)
             z_sample = z_propose;
 
-          n_valid += n_valid_subtree;
-
-          // Check validity of completed tree
+          // Break when NUTS criterion is not longer satisfied
           this->z_.ps_point::operator=(z_plus);
-          Eigen::VectorXd delta_rho = rho_minus + rho_init + rho_plus;
 
-          util.criterion = compute_criterion(z_minus, this->z_, delta_rho);
+          rho += rho_subtree;
+          if (!compute_criterion(z_minus, this->z_, rho))
+            break;
         }
 
-        this->n_leapfrog_ = util.n_tree;
+        this->n_leapfrog_ = n_leapfrog;
 
-        double accept_prob = util.sum_prob / static_cast<double>(util.n_tree);
+        // Compute average acceptance probabilty across entire trajectory,
+        // even over subtrees that may have been rejected
+        double accept_prob
+          = sum_metro_prob / static_cast<double>(n_leapfrog + 1);
 
         this->z_.ps_point::operator=(z_sample);
         this->energy_ = this->hamiltonian_.H(this->z_);
-        return sample(this->z_.q, - this->z_.V, accept_prob);
+        return sample(this->z_.q, -this->z_.V, accept_prob);
       }
 
       void get_sampler_param_names(std::vector<std::string>& names) {
@@ -171,72 +141,75 @@ namespace stan {
                                      Eigen::VectorXd& rho) = 0;
 
       // Returns number of valid points in the completed subtree
-      int build_tree(int depth, Eigen::VectorXd& rho,
-                     ps_point* z_init_parent, ps_point& z_propose,
-                     nuts_util& util,
+      int build_tree(int depth, Eigen::VectorXd& rho, ps_point& z_propose,
+                     double H0, double sign, int& n_leapfrog,
+                     double& sum_weight, double& sum_metro_prob,
                      interface_callbacks::writer::base_writer& writer) {
         // Base case
         if (depth == 0) {
             this->integrator_.evolve(this->z_, this->hamiltonian_,
-                                     util.sign * this->epsilon_,
+                                     sign * this->epsilon_,
                                      writer);
-            rho += this->z_.p;
-
-            if (z_init_parent) *z_init_parent = this->z_;
-            z_propose = this->z_;
+            ++n_leapfrog;
 
             double h = this->hamiltonian_.H(this->z_);
             if (boost::math::isnan(h))
               h = std::numeric_limits<double>::infinity();
 
-            util.criterion = util.log_u + (h - util.H0) < this->max_delta_;
-            if (!util.criterion) ++(this->divergent_);
+            if ((h - H0) > this->max_deltaH_) this->divergent_ = true;
 
-            util.sum_prob += std::min(1.0, std::exp(util.H0 - h));
-            util.n_tree += 1;
+            double pi = exp(H0 - h);
+            sum_weight += pi;
+            sum_metro_prob += pi > 1 ? 1 : pi;
 
-            return (util.log_u + (h - util.H0) < 0);
+            z_propose = this->z_;
+            rho += this->z_.p;
 
-          } else {
+            return !this->divergent_;
+
+        } else {
           // General recursion
-          Eigen::VectorXd left_subtree_rho(rho.size());
-          left_subtree_rho.setZero();
           ps_point z_init(this->z_);
 
-          int n1 = build_tree(depth - 1, left_subtree_rho, &z_init,
-                              z_propose, util, writer);
+          Eigen::VectorXd rho_subtree(rho.size());
+          rho_subtree.setZero();
 
-          if (z_init_parent) *z_init_parent = z_init;
+          // Build the left subtree
+          double sum_weight_left = 0;
 
-          if (!util.criterion) return 0;
+          bool valid_left
+            = build_tree(depth - 1, rho_subtree, z_propose,
+                         H0, sign, n_leapfrog,
+                         sum_weight_left, sum_metro_prob, writer);
 
-          Eigen::VectorXd right_subtree_rho(rho.size());
-          right_subtree_rho.setZero();
-          ps_point z_propose_right(z_init);
+          sum_weight += sum_weight_left;
+          if (!valid_left) return false;
 
-          int n2 = build_tree(depth - 1, right_subtree_rho, 0,
-                              z_propose_right, util, writer);
+          // Build the right subtree
+          ps_point z_propose_right(this->z_);
+          double sum_weight_right = 0;
 
-          double accept_prob = static_cast<double>(n2) /
-            static_cast<double>(n1 + n2);
+          bool valid_right
+            = build_tree(depth - 1, rho_subtree, z_propose_right,
+                         H0, sign, n_leapfrog,
+                         sum_weight_right, sum_metro_prob, writer);
 
-          if ( util.criterion && (this->rand_uniform_() < accept_prob) )
+          sum_weight += sum_weight_right;
+          if (!valid_right) return false;
+
+          // Multinomial sample from right subtree
+          double accept_prob = sum_weight_right / sum_weight;
+          if (this->rand_uniform_() < accept_prob)
             z_propose = z_propose_right;
 
-          Eigen::VectorXd& subtree_rho = left_subtree_rho;
-          subtree_rho += right_subtree_rho;
-
-          rho += subtree_rho;
-
-          util.criterion &= compute_criterion(z_init, this->z_, subtree_rho);
-
-          return n1 + n2;
+          rho += rho_subtree;
+          return compute_criterion(z_init, this->z_, rho_subtree);
         }
       }
 
       int depth_;
       int max_depth_;
-      double max_delta_;
+      double max_deltaH_;
 
       int n_leapfrog_;
       int divergent_;

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
@@ -1,0 +1,55 @@
+#ifndef STAN_MCMC_HMC_NUTS_ADAPT_DENSE_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_ADAPT_DENSE_E_NUTS_CLASSIC_HPP
+
+#include <stan/interface_callbacks/writer/base_writer.hpp>
+#include <stan/mcmc/stepsize_covar_adapter.hpp>
+#include <stan/mcmc/hmc/nuts_classic/dense_e_nuts_classic.hpp>
+
+namespace stan {
+  namespace mcmc {
+
+    // The No-U-Turn Sampler (NUTS) on a
+    // Euclidean manifold with dense metric
+    // and adaptive stepsize
+    template <class Model, class BaseRNG>
+    class adapt_dense_e_nuts_classic:
+      public dense_e_nuts_classic<Model, BaseRNG>,
+      public stepsize_covar_adapter {
+    public:
+        adapt_dense_e_nuts_classic(Model &model, BaseRNG& rng):
+          dense_e_nuts_classic<Model, BaseRNG>(model, rng),
+          stepsize_covar_adapter(model.num_params_r()) {}
+
+      ~adapt_dense_e_nuts_classic() {}
+
+      sample transition(sample& init_sample,
+                        interface_callbacks::writer::base_writer& writer) {
+        sample s = dense_e_nuts_classic<Model, BaseRNG>::transition(init_sample,
+                                                            writer);
+
+        if (this->adapt_flag_) {
+          this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
+                                                    s.accept_stat());
+
+          bool update = this->covar_adaptation_.learn_covariance(this->z_.mInv,
+                                                                 this->z_.q);
+
+          if (update) {
+            this->init_stepsize(writer);
+
+            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.restart();
+          }
+        }
+        return s;
+      }
+
+      void disengage_adaptation() {
+        base_adapter::disengage_adaptation();
+        this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
+      }
+    };
+
+  }  // mcmc
+}  // stan
+#endif

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
@@ -1,0 +1,56 @@
+#ifndef STAN_MCMC_HMC_NUTS_ADAPT_DIAG_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_ADAPT_DIAG_E_NUTS_CLASSIC_HPP
+
+#include <stan/interface_callbacks/writer/base_writer.hpp>
+#include <stan/mcmc/stepsize_var_adapter.hpp>
+#include <stan/mcmc/hmc/nuts_classic/diag_e_nuts_classic.hpp>
+
+namespace stan {
+  namespace mcmc {
+
+    // The No-U-Turn Sampler (NUTS) on a
+    // Euclidean manifold with diagonal metric
+    // and adaptive stepsize
+
+    template <class Model, class BaseRNG>
+    class adapt_diag_e_nuts_classic:
+      public diag_e_nuts_classic<Model, BaseRNG>,
+      public stepsize_var_adapter {
+    public:
+        adapt_diag_e_nuts_classic(Model &model, BaseRNG& rng):
+          diag_e_nuts_classic<Model, BaseRNG>(model, rng),
+          stepsize_var_adapter(model.num_params_r()) {}
+
+      ~adapt_diag_e_nuts_classic() {}
+
+      sample transition(sample& init_sample,
+                        interface_callbacks::writer::base_writer& writer) {
+        sample s = diag_e_nuts_classic<Model, BaseRNG>::transition(init_sample,
+                                                                   writer);
+
+        if (this->adapt_flag_) {
+          this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
+                                                    s.accept_stat());
+
+          bool update = this->var_adaptation_.learn_variance(this->z_.mInv,
+                                                             this->z_.q);
+
+          if (update) {
+            this->init_stepsize(writer);
+
+            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.restart();
+          }
+        }
+        return s;
+      }
+
+      void disengage_adaptation() {
+        base_adapter::disengage_adaptation();
+        this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
+      }
+    };
+
+  }  // mcmc
+}  // stan
+#endif

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_unit_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_unit_e_nuts_classic.hpp
@@ -1,0 +1,45 @@
+#ifndef STAN_MCMC_HMC_NUTS_ADAPT_UNIT_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_ADAPT_UNIT_E_NUTS_CLASSIC_HPP
+
+#include <stan/interface_callbacks/writer/base_writer.hpp>
+#include <stan/mcmc/hmc/nuts_classic/unit_e_nuts_classic.hpp>
+#include <stan/mcmc/stepsize_adapter.hpp>
+
+namespace stan {
+  namespace mcmc {
+
+    // The No-U-Turn Sampler (NUTS) on a
+    // Euclidean manifold with unit metric
+    // and adaptive stepsize
+
+    template <class Model, class BaseRNG>
+    class adapt_unit_e_nuts_classic:
+      public unit_e_nuts_classic<Model, BaseRNG>,
+      public stepsize_adapter {
+    public:
+      adapt_unit_e_nuts_classic(Model &model, BaseRNG& rng):
+        unit_e_nuts_classic<Model, BaseRNG>(model, rng) {}
+
+      ~adapt_unit_e_nuts_classic() {}
+
+      sample transition(sample& init_sample,
+                        interface_callbacks::writer::base_writer& writer) {
+        sample s = unit_e_nuts_classic<Model, BaseRNG>::transition(init_sample,
+                                                                   writer);
+
+        if (this->adapt_flag_)
+          this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
+                                                    s.accept_stat());
+
+        return s;
+      }
+
+      void disengage_adaptation() {
+        base_adapter::disengage_adaptation();
+        this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
+      }
+    };
+
+  }  // mcmc
+}  // stan
+#endif

--- a/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
@@ -1,0 +1,249 @@
+#ifndef STAN_MCMC_HMC_NUTS_BASE_NUTS_HPP
+#define STAN_MCMC_HMC_NUTS_BASE_NUTS_HPP
+
+#include <stan/interface_callbacks/writer/base_writer.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <stan/mcmc/hmc/base_hmc.hpp>
+#include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace stan {
+  namespace mcmc {
+
+    struct nuts_util {
+      // Constants through each recursion
+      double log_u;
+      double H0;
+      int sign;
+
+      // Aggregators through each recursion
+      int n_tree;
+      double sum_prob;
+      bool criterion;
+    };
+
+    // The No-U-Turn Sampler (NUTS) with the
+    // original slice sampler implementation
+    template <class Model, template<class, class> class Hamiltonian,
+              template<class> class Integrator, class BaseRNG>
+    class base_nuts_classic:
+      public base_hmc<Model, Hamiltonian, Integrator, BaseRNG> {
+    public:
+      base_nuts_classic(Model &model, BaseRNG& rng):
+        base_hmc<Model, Hamiltonian, Integrator, BaseRNG>(model, rng),
+        depth_(0), max_depth_(5), max_delta_(1000),
+        n_leapfrog_(0), divergent_(0), energy_(0) {
+      }
+
+      ~base_nuts_classic() {}
+
+      void set_max_depth(int d) {
+        if (d > 0)
+          max_depth_ = d;
+      }
+
+      void set_max_delta(double d) {
+        max_delta_ = d;
+      }
+
+      int get_max_depth() { return this->max_depth_; }
+      double get_max_delta() { return this->max_delta_; }
+
+      sample transition(sample& init_sample,
+                        interface_callbacks::writer::base_writer& writer) {
+        // Initialize the algorithm
+        this->sample_stepsize();
+
+        nuts_util util;
+
+        this->seed(init_sample.cont_params());
+
+        this->hamiltonian_.sample_p(this->z_, this->rand_int_);
+        this->hamiltonian_.init(this->z_, writer);
+
+        ps_point z_plus(this->z_);
+        ps_point z_minus(z_plus);
+
+        ps_point z_sample(z_plus);
+        ps_point z_propose(z_plus);
+
+        int n_cont = init_sample.cont_params().size();
+
+        Eigen::VectorXd rho_init = this->z_.p;
+        Eigen::VectorXd rho_plus(n_cont); rho_plus.setZero();
+        Eigen::VectorXd rho_minus(n_cont); rho_minus.setZero();
+
+        util.H0 = this->hamiltonian_.H(this->z_);
+
+        // Sample the slice variable
+        util.log_u = std::log(this->rand_uniform_());
+
+        // Build a balanced binary tree until the NUTS criterion fails
+        util.criterion = true;
+        int n_valid = 0;
+
+        this->depth_ = 0;
+        this->divergent_ = 0;
+
+        util.n_tree = 0;
+        util.sum_prob = 0;
+
+        while (util.criterion && (this->depth_ <= this->max_depth_)) {
+          // Randomly sample a direction in time
+          ps_point* z = 0;
+          Eigen::VectorXd* rho = 0;
+
+          if (this->rand_uniform_() > 0.5) {
+            z = &z_plus;
+            rho = &rho_plus;
+            util.sign = 1;
+          } else {
+            z = &z_minus;
+            rho = &rho_minus;
+            util.sign = -1;
+          }
+
+          // And build a new subtree in that direction
+          this->z_.ps_point::operator=(*z);
+
+          int n_valid_subtree = build_tree(depth_, *rho, 0, z_propose, util,
+                                           writer);
+          ++(this->depth_);
+
+          *z = this->z_;
+
+          // Metropolis-Hastings sample the fresh subtree
+          if (!util.criterion)
+            break;
+
+          double subtree_prob = 0;
+
+          if (n_valid) {
+            subtree_prob = static_cast<double>(n_valid_subtree) /
+              static_cast<double>(n_valid);
+          } else {
+            subtree_prob = n_valid_subtree ? 1 : 0;
+          }
+
+          if (this->rand_uniform_() < subtree_prob)
+            z_sample = z_propose;
+
+          n_valid += n_valid_subtree;
+
+          // Check validity of completed tree
+          this->z_.ps_point::operator=(z_plus);
+          Eigen::VectorXd delta_rho = rho_minus + rho_init + rho_plus;
+
+          util.criterion = compute_criterion(z_minus, this->z_, delta_rho);
+        }
+
+        this->n_leapfrog_ = util.n_tree;
+
+        double accept_prob = util.sum_prob / static_cast<double>(util.n_tree);
+
+        this->z_.ps_point::operator=(z_sample);
+        this->energy_ = this->hamiltonian_.H(this->z_);
+        return sample(this->z_.q, - this->z_.V, accept_prob);
+      }
+
+      void get_sampler_param_names(std::vector<std::string>& names) {
+        names.push_back("stepsize__");
+        names.push_back("treedepth__");
+        names.push_back("n_leapfrog__");
+        names.push_back("divergent__");
+        names.push_back("energy__");
+      }
+
+      void get_sampler_params(std::vector<double>& values) {
+        values.push_back(this->epsilon_);
+        values.push_back(this->depth_);
+        values.push_back(this->n_leapfrog_);
+        values.push_back(this->divergent_);
+        values.push_back(this->energy_);
+      }
+
+      virtual bool compute_criterion(ps_point& start,
+                                     typename Hamiltonian<Model, BaseRNG>
+                                     ::PointType& finish,
+                                     Eigen::VectorXd& rho) = 0;
+
+      // Returns number of valid points in the completed subtree
+      int build_tree(int depth, Eigen::VectorXd& rho,
+                     ps_point* z_init_parent, ps_point& z_propose,
+                     nuts_util& util,
+                     interface_callbacks::writer::base_writer& writer) {
+        // Base case
+        if (depth == 0) {
+            this->integrator_.evolve(this->z_, this->hamiltonian_,
+                                     util.sign * this->epsilon_,
+                                     writer);
+            rho += this->z_.p;
+
+            if (z_init_parent) *z_init_parent = this->z_;
+            z_propose = this->z_;
+
+            double h = this->hamiltonian_.H(this->z_);
+            if (boost::math::isnan(h))
+              h = std::numeric_limits<double>::infinity();
+
+            util.criterion = util.log_u + (h - util.H0) < this->max_delta_;
+            if (!util.criterion) ++(this->divergent_);
+
+            util.sum_prob += std::min(1.0, std::exp(util.H0 - h));
+            util.n_tree += 1;
+
+            return (util.log_u + (h - util.H0) < 0);
+
+          } else {
+          // General recursion
+          Eigen::VectorXd left_subtree_rho(rho.size());
+          left_subtree_rho.setZero();
+          ps_point z_init(this->z_);
+
+          int n1 = build_tree(depth - 1, left_subtree_rho, &z_init,
+                              z_propose, util, writer);
+
+          if (z_init_parent) *z_init_parent = z_init;
+
+          if (!util.criterion) return 0;
+
+          Eigen::VectorXd right_subtree_rho(rho.size());
+          right_subtree_rho.setZero();
+          ps_point z_propose_right(z_init);
+
+          int n2 = build_tree(depth - 1, right_subtree_rho, 0,
+                              z_propose_right, util, writer);
+
+          double accept_prob = static_cast<double>(n2) /
+            static_cast<double>(n1 + n2);
+
+          if ( util.criterion && (this->rand_uniform_() < accept_prob) )
+            z_propose = z_propose_right;
+
+          Eigen::VectorXd& subtree_rho = left_subtree_rho;
+          subtree_rho += right_subtree_rho;
+
+          rho += subtree_rho;
+
+          util.criterion &= compute_criterion(z_init, this->z_, subtree_rho);
+
+          return n1 + n2;
+        }
+      }
+
+      int depth_;
+      int max_depth_;
+      double max_delta_;
+
+      int n_leapfrog_;
+      int divergent_;
+      double energy_;
+    };
+
+  }  // mcmc
+}  // stan
+#endif

--- a/src/stan/mcmc/hmc/nuts_classic/dense_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/dense_e_nuts_classic.hpp
@@ -1,0 +1,34 @@
+#ifndef STAN_MCMC_HMC_NUTS_DENSE_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_DENSE_E_NUTS_CLASSIC_HPP
+
+#include <stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp>
+#include <stan/mcmc/hmc/hamiltonians/dense_e_point.hpp>
+#include <stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp>
+#include <stan/mcmc/hmc/integrators/expl_leapfrog.hpp>
+
+namespace stan {
+  namespace mcmc {
+    // The No-U-Turn Sampler (NUTS) on a
+    // Euclidean manifold with dense metric
+    template <class Model, class BaseRNG>
+    class dense_e_nuts_classic:
+      public base_nuts_classic<Model, dense_e_metric,
+                               expl_leapfrog, BaseRNG> {
+    public:
+      dense_e_nuts_classic(Model &model, BaseRNG& rng):
+        base_nuts_classic<Model, dense_e_metric,
+                          expl_leapfrog, BaseRNG>(model, rng) { }
+
+      // Note that the points don't need to be swapped
+      // here since start.mInv = finish.mInv
+      bool compute_criterion(ps_point& start,
+                             dense_e_point& finish,
+                             Eigen::VectorXd& rho) {
+        return finish.p.transpose() * finish.mInv * (rho - finish.p) > 0
+               && start.p.transpose() * finish.mInv * (rho - start.p)  > 0;
+      }
+    };
+
+  }  // mcmc
+}  // stan
+#endif

--- a/src/stan/mcmc/hmc/nuts_classic/diag_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/diag_e_nuts_classic.hpp
@@ -1,0 +1,34 @@
+#ifndef STAN_MCMC_HMC_NUTS_DIAG_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_DIAG_E_NUTS_CLASSIC_HPP
+
+#include <stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp>
+#include <stan/mcmc/hmc/hamiltonians/diag_e_point.hpp>
+#include <stan/mcmc/hmc/hamiltonians/diag_e_metric.hpp>
+#include <stan/mcmc/hmc/integrators/expl_leapfrog.hpp>
+
+namespace stan {
+  namespace mcmc {
+    // The No-U-Turn Sampler (NUTS) on a
+    // Euclidean manifold with diagonal metric
+    template <class Model, class BaseRNG>
+    class diag_e_nuts_classic:
+      public base_nuts_classic<Model, diag_e_metric,
+                               expl_leapfrog, BaseRNG> {
+    public:
+      diag_e_nuts_classic(Model &model, BaseRNG& rng):
+        base_nuts_classic<Model, diag_e_metric,
+                          expl_leapfrog, BaseRNG>(model, rng) { }
+
+      // Note that the points don't need to be swapped
+      // here since start.mInv = finish.mInv
+      bool compute_criterion(ps_point& start,
+                             diag_e_point& finish,
+                             Eigen::VectorXd& rho) {
+        return finish.mInv.cwiseProduct(finish.p).dot(rho - finish.p) > 0
+               && finish.mInv.cwiseProduct(start.p).dot(rho - start.p) > 0;
+      }
+    };
+
+  }  // mcmc
+}  // stan
+#endif

--- a/src/stan/mcmc/hmc/nuts_classic/unit_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/unit_e_nuts_classic.hpp
@@ -1,0 +1,32 @@
+#ifndef STAN_MCMC_HMC_NUTS_UNIT_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_UNIT_E_NUTS_CLASSIC_HPP
+
+#include <stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp>
+#include <stan/mcmc/hmc/hamiltonians/unit_e_point.hpp>
+#include <stan/mcmc/hmc/hamiltonians/unit_e_metric.hpp>
+#include <stan/mcmc/hmc/integrators/expl_leapfrog.hpp>
+
+namespace stan {
+  namespace mcmc {
+    // The No-U-Turn Sampler (NUTS) on a
+    // Euclidean manifold with unit metric
+    template <class Model, class BaseRNG>
+    class unit_e_nuts_classic:
+      public base_nuts_classic<Model, unit_e_metric,
+                               expl_leapfrog, BaseRNG> {
+    public:
+      unit_e_nuts_classic(Model &model, BaseRNG& rng):
+        base_nuts_classic<Model, unit_e_metric,
+                          expl_leapfrog, BaseRNG>(model, rng) { }
+
+      bool compute_criterion(ps_point& start,
+                             unit_e_point& finish,
+                             Eigen::VectorXd& rho) {
+        return finish.p.dot(rho - finish.p) > 0
+               && start.p.dot(rho - start.p) > 0;
+      }
+    };
+
+  }  // mcmc
+}  // stan
+#endif

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -108,31 +108,31 @@ TEST_F(performance, values_from_tagged_version) {
     << "last tagged version, 2.9.0, had " << N_values << " elements";
 
   std::vector<double> first_run = last_draws_per_run[0];
-  EXPECT_FLOAT_EQ(-65.9431, first_run[0])
+  EXPECT_FLOAT_EQ(-65.943199, first_run[0])
     << "lp__: index 0";
 
-  EXPECT_FLOAT_EQ(0.99914801, first_run[1])
+  EXPECT_FLOAT_EQ(0.73218799, first_run[1])
     << "accept_stat__: index 1";
 
-  EXPECT_FLOAT_EQ(0.92122698, first_run[2])
+  EXPECT_FLOAT_EQ(1.22537, first_run[2])
     << "stepsize__: index 2";
 
-  EXPECT_FLOAT_EQ(3, first_run[3])
+  EXPECT_FLOAT_EQ(1, first_run[3])
     << "treedepth__: index 3";
 
-  EXPECT_FLOAT_EQ(7, first_run[4])
+  EXPECT_FLOAT_EQ(3, first_run[4])
     << "n_leapfrog__: index 4";
 
   EXPECT_FLOAT_EQ(0, first_run[5])
     << "divergent__: index 5";
 
-  EXPECT_FLOAT_EQ(66.082497, first_run[6])
+  EXPECT_FLOAT_EQ(67.8694, first_run[6])
     << "energy__: index 6";
 
-  EXPECT_FLOAT_EQ(1.4754699, first_run[7])
+  EXPECT_FLOAT_EQ(1.56502, first_run[7])
     << "beta.1: index 7";
 
-  EXPECT_FLOAT_EQ(-0.79085201, first_run[8])
+  EXPECT_FLOAT_EQ(-0.69909501, first_run[8])
     << "beta.2: index 8";
 
   matches_tagged_version = !HasNonfatalFailure();

--- a/src/test/test-models/good/mcmc/hmc/nuts/gauss3D.stan
+++ b/src/test/test-models/good/mcmc/hmc/nuts/gauss3D.stan
@@ -1,0 +1,7 @@
+parameters {
+  real x[3];
+}
+
+model {
+  x ~ normal(0, 1);
+}

--- a/src/test/unit/mcmc/hmc/base_nuts_classic_test.cpp
+++ b/src/test/unit/mcmc/hmc/base_nuts_classic_test.cpp
@@ -1,0 +1,225 @@
+#include <test/unit/mcmc/hmc/mock_hmc.hpp>
+#include <stan/interface_callbacks/writer/stream_writer.hpp>
+#include <stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp>
+#include <stan/mcmc/hmc/integrators/expl_leapfrog.hpp>
+#include <boost/random/additive_combine.hpp>
+#include <gtest/gtest.h>
+
+typedef boost::ecuyer1988 rng_t;
+
+namespace stan {
+  namespace mcmc {
+
+    class mock_nuts_classic:
+      public base_nuts_classic<mock_model, mock_hamiltonian,
+                               mock_integrator, rng_t> {
+    public:
+      mock_nuts_classic(mock_model &m, rng_t& rng):
+        base_nuts_classic<mock_model, mock_hamiltonian,
+                          mock_integrator, rng_t>(m, rng)
+      { }
+
+    private:
+      bool compute_criterion(ps_point& start,
+                             ps_point& finish,
+                             Eigen::VectorXd& rho) { return true; }
+    };
+
+    // Mock Hamiltonian
+    template <typename M, typename BaseRNG>
+    class divergent_hamiltonian
+      : public base_hamiltonian<M, ps_point, BaseRNG> {
+    public:
+      divergent_hamiltonian(M& m)
+        : base_hamiltonian<M, ps_point, BaseRNG>(m) {}
+
+      double T(ps_point& z) { return 0; }
+
+      double tau(ps_point& z) { return T(z); }
+      double phi(ps_point& z) { return this->V(z); }
+
+      const Eigen::VectorXd dtau_dq(ps_point& z) {
+        return Eigen::VectorXd::Zero(this->model_.num_params_r());
+      }
+
+      const Eigen::VectorXd dtau_dp(ps_point& z) {
+        return Eigen::VectorXd::Zero(this->model_.num_params_r());
+      }
+
+      const Eigen::VectorXd dphi_dq(ps_point& z) {
+        return Eigen::VectorXd::Zero(this->model_.num_params_r());
+      }
+
+      void init(ps_point& z,
+                stan::interface_callbacks::writer::base_writer& writer) {
+        z.V = 0;
+      }
+
+      void sample_p(ps_point& z, BaseRNG& rng) {};
+
+      void update(ps_point& z,
+                  stan::interface_callbacks::writer::base_writer& writer) {
+        z.V += 500;
+      }
+
+    };
+
+    class divergent_nuts_classic:
+      public base_nuts_classic<mock_model, divergent_hamiltonian,
+                               expl_leapfrog, rng_t> {
+    public:
+      divergent_nuts_classic(mock_model &m, rng_t& rng):
+        base_nuts_classic<mock_model, divergent_hamiltonian,
+                          expl_leapfrog, rng_t>(m, rng)
+      { }
+
+    private:
+      bool compute_criterion(ps_point& start,
+                             ps_point& finish,
+                             Eigen::VectorXd& rho) { return false; }
+    };
+
+  }
+}
+
+TEST(McmcBaseNutsClassic, set_max_depth) {
+
+  rng_t base_rng(0);
+
+  Eigen::VectorXd q(2);
+  q(0) = 5;
+  q(1) = 1;
+
+  stan::mcmc::mock_model model(q.size());
+  stan::mcmc::mock_nuts_classic sampler(model, base_rng);
+
+  int old_max_depth = 1;
+  sampler.set_max_depth(old_max_depth);
+  EXPECT_EQ(old_max_depth, sampler.get_max_depth());
+
+  sampler.set_max_depth(-1);
+  EXPECT_EQ(old_max_depth, sampler.get_max_depth());
+}
+
+
+TEST(McmcBaseNuts, set_max_delta) {
+  rng_t base_rng(0);
+
+  Eigen::VectorXd q(2);
+  q(0) = 5;
+  q(1) = 1;
+
+  stan::mcmc::mock_model model(q.size());
+  stan::mcmc::mock_nuts_classic sampler(model, base_rng);
+
+  double old_max_delta = 10;
+  sampler.set_max_delta(old_max_delta);
+  EXPECT_EQ(old_max_delta, sampler.get_max_delta());
+}
+
+TEST(McmcBaseNutsClassic, build_tree) {
+
+  rng_t base_rng(0);
+
+  int model_size = 1;
+  double init_momentum = 1.5;
+
+  Eigen::VectorXd rho = Eigen::VectorXd::Zero(model_size);
+
+  stan::mcmc::ps_point z_init(model_size);
+  z_init.q(0) = 0;
+  z_init.p(0) = init_momentum;
+
+  stan::mcmc::ps_point z_propose(model_size);
+
+  stan::mcmc::nuts_util util;
+  util.log_u = -1;
+  util.H0 = -0.1;
+  util.sign = 1;
+  util.n_tree = 0;
+  util.sum_prob = 0;
+
+  stan::mcmc::mock_model model(model_size);
+  stan::mcmc::mock_nuts_classic sampler(model, base_rng);
+
+  sampler.set_nominal_stepsize(1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+  sampler.z() = z_init;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  int n_valid = sampler.build_tree(3, rho, &z_init, z_propose, util, writer);
+
+  EXPECT_EQ(8, n_valid);
+
+  EXPECT_EQ(8, util.n_tree);
+  EXPECT_FLOAT_EQ(std::exp(util.H0) * util.n_tree, util.sum_prob);
+
+  EXPECT_EQ(init_momentum * util.n_tree, rho(0));
+
+  EXPECT_EQ(init_momentum, z_init.q(0));
+  EXPECT_EQ(init_momentum, z_init.p(0));
+
+  EXPECT_EQ(8 * init_momentum, sampler.z().q(0));
+  EXPECT_EQ(init_momentum, sampler.z().p(0));
+
+  EXPECT_EQ("", output.str());
+}
+
+TEST(McmcBaseNutsClassic, slice_criterion) {
+
+  rng_t base_rng(0);
+
+  int model_size = 1;
+  double init_momentum = 1.5;
+
+  Eigen::VectorXd rho = Eigen::VectorXd::Zero(model_size);
+
+  stan::mcmc::ps_point z_init(model_size);
+  z_init.q(0) = 0;
+  z_init.p(0) = init_momentum;
+
+  stan::mcmc::ps_point z_propose(model_size);
+
+  stan::mcmc::nuts_util util;
+  util.log_u = 0;
+  util.H0 = 0;
+  util.sign = 1;
+  util.n_tree = 0;
+  util.sum_prob = 0;
+
+  stan::mcmc::mock_model model(model_size);
+  stan::mcmc::divergent_nuts_classic sampler(model, base_rng);
+
+  sampler.set_nominal_stepsize(1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+  sampler.z() = z_init;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  int n_valid = 0;
+
+  sampler.z().V = -750;
+  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util, writer);
+
+  EXPECT_EQ(1, n_valid);
+  EXPECT_EQ(0, sampler.divergent_);
+
+  sampler.z().V = -250;
+  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util, writer);
+
+  EXPECT_EQ(0, n_valid);
+  EXPECT_EQ(0, sampler.divergent_);
+
+  sampler.z().V = 750;
+  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util, writer);
+
+  EXPECT_EQ(0, n_valid);
+  EXPECT_EQ(1, sampler.divergent_);
+
+  EXPECT_EQ("", output.str());
+}

--- a/src/test/unit/mcmc/hmc/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/base_nuts_test.cpp
@@ -231,3 +231,35 @@ TEST(McmcBaseNuts, divergence_test) {
 
   EXPECT_EQ("", output.str());
 }
+
+TEST(McmcBaseNuts, transition) {
+
+  rng_t base_rng(0);
+
+  int model_size = 1;
+  double init_momentum = 1.5;
+
+  stan::mcmc::ps_point z_init(model_size);
+  z_init.q(0) = 0;
+  z_init.p(0) = init_momentum;
+
+  stan::mcmc::mock_model model(model_size);
+  stan::mcmc::mock_nuts sampler(model, base_rng);
+
+  sampler.set_nominal_stepsize(1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+  sampler.z() = z_init;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  stan::mcmc::sample init_sample(z_init.q, 0, 0);
+
+  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+
+  EXPECT_EQ(31.5, s.cont_params()(0));
+  EXPECT_EQ(0, s.log_prob());
+  EXPECT_EQ(1, s.accept_stat());
+  EXPECT_EQ("", output.str());
+}

--- a/src/test/unit/mcmc/hmc/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/base_nuts_test.cpp
@@ -9,25 +9,25 @@ typedef boost::ecuyer1988 rng_t;
 
 namespace stan {
   namespace mcmc {
-    
+
     class mock_nuts: public base_nuts<mock_model,
                                       mock_hamiltonian,
                                       mock_integrator,
                                       rng_t> {
-      
+
     public:
       mock_nuts(mock_model &m, rng_t& rng)
         : base_nuts<mock_model,mock_hamiltonian,mock_integrator,rng_t>(m, rng)
       { }
-      
+
     private:
-      
+
       bool compute_criterion(ps_point& start,
                              ps_point& finish,
                              Eigen::VectorXd& rho) { return true; }
-      
+
     };
-    
+
     // Mock Hamiltonian
     template <typename M, typename BaseRNG>
     class divergent_hamiltonian
@@ -35,171 +35,167 @@ namespace stan {
     public:
       divergent_hamiltonian(M& m)
         : base_hamiltonian<M, ps_point, BaseRNG>(m) {}
-      
+
       double T(ps_point& z) { return 0; }
-      
+
       double tau(ps_point& z) { return T(z); }
       double phi(ps_point& z) { return this->V(z); }
-      
+
       const Eigen::VectorXd dtau_dq(ps_point& z) {
         return Eigen::VectorXd::Zero(this->model_.num_params_r());
       }
-      
+
       const Eigen::VectorXd dtau_dp(ps_point& z) {
         return Eigen::VectorXd::Zero(this->model_.num_params_r());
       }
-      
+
       const Eigen::VectorXd dphi_dq(ps_point& z) {
         return Eigen::VectorXd::Zero(this->model_.num_params_r());
       }
-      
+
       void init(ps_point& z,
                 stan::interface_callbacks::writer::base_writer& writer) {
         z.V = 0;
       }
-      
+
       void sample_p(ps_point& z, BaseRNG& rng) {};
-      
+
       void update(ps_point& z,
                   stan::interface_callbacks::writer::base_writer& writer) {
         z.V += 500;
       }
-      
+
     };
-    
+
     class divergent_nuts: public base_nuts<mock_model,
                                            divergent_hamiltonian,
                                            expl_leapfrog,
                                            rng_t> {
-      
+
     public:
-      
+
       divergent_nuts(mock_model &m, rng_t& rng)
         : base_nuts<mock_model, divergent_hamiltonian, expl_leapfrog,rng_t>(m, rng)
       { }
-      
+
     private:
-      
+
       bool compute_criterion(ps_point& start,
                              ps_point& finish,
                              Eigen::VectorXd& rho) { return false; }
-      
+
     };
-    
+
   }
 }
 
 TEST(McmcBaseNuts, set_max_depth) {
-  
+
   rng_t base_rng(0);
 
   Eigen::VectorXd q(2);
   q(0) = 5;
   q(1) = 1;
-  
+
   stan::mcmc::mock_model model(q.size());
   stan::mcmc::mock_nuts sampler(model, base_rng);
-  
+
   int old_max_depth = 1;
   sampler.set_max_depth(old_max_depth);
   EXPECT_EQ(old_max_depth, sampler.get_max_depth());
-  
+
   sampler.set_max_depth(-1);
   EXPECT_EQ(old_max_depth, sampler.get_max_depth());
 }
 
 
-TEST(McmcBaseNuts, set_max_delta) {  
+TEST(McmcBaseNuts, set_max_delta) {
   rng_t base_rng(0);
-  
+
   Eigen::VectorXd q(2);
   q(0) = 5;
   q(1) = 1;
-  
+
   stan::mcmc::mock_model model(q.size());
   stan::mcmc::mock_nuts sampler(model, base_rng);
-  
+
   double old_max_delta = 10;
   sampler.set_max_delta(old_max_delta);
   EXPECT_EQ(old_max_delta, sampler.get_max_delta());
 }
 
 TEST(McmcBaseNuts, build_tree) {
-  
+
   rng_t base_rng(0);
-  
+
   int model_size = 1;
   double init_momentum = 1.5;
-  
-  Eigen::VectorXd rho = Eigen::VectorXd::Zero(model_size);
-  
+
   stan::mcmc::ps_point z_init(model_size);
   z_init.q(0) = 0;
   z_init.p(0) = init_momentum;
-  
+
   stan::mcmc::ps_point z_propose(model_size);
-  
-  stan::mcmc::nuts_util util;
-  util.log_u = -1;
-  util.H0 = -0.1;
-  util.sign = 1;
-  util.n_tree = 0;
-  util.sum_prob = 0;
-  
+
+  Eigen::VectorXd rho = z_init.p;
+  double sum_weight = 0;
+
+  double H0 = -0.1;
+  int n_leapfrog = 0;
+  double sum_metro_prob = 0;
+
   stan::mcmc::mock_model model(model_size);
   stan::mcmc::mock_nuts sampler(model, base_rng);
-  
+
   sampler.set_nominal_stepsize(1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();
   sampler.z() = z_init;
-  
+
   std::stringstream output;
   stan::interface_callbacks::writer::stream_writer writer(output);
 
-  int n_valid = sampler.build_tree(3, rho, &z_init, z_propose, util, writer);
-  
-  EXPECT_EQ(8, n_valid);
-  
-  EXPECT_EQ(8, util.n_tree);
-  EXPECT_FLOAT_EQ(std::exp(util.H0) * util.n_tree, util.sum_prob);
-  
-  EXPECT_EQ(init_momentum * util.n_tree, rho(0));
-  
-  EXPECT_EQ(init_momentum, z_init.q(0));
-  EXPECT_EQ(init_momentum, z_init.p(0));
-  
+  bool valid_subtree = sampler.build_tree(3, rho, z_propose,
+                                          H0, 1, n_leapfrog, sum_weight,
+                                          sum_metro_prob, writer);
+
+  EXPECT_EQ(true, valid_subtree);
+
+  EXPECT_EQ(init_momentum * (n_leapfrog + 1), rho(0));
+
   EXPECT_EQ(8 * init_momentum, sampler.z().q(0));
   EXPECT_EQ(init_momentum, sampler.z().p(0));
+
+  EXPECT_EQ(8, n_leapfrog);
+  EXPECT_FLOAT_EQ(std::exp(H0) * n_leapfrog, sum_weight);
+  EXPECT_FLOAT_EQ(std::exp(H0) * n_leapfrog, sum_metro_prob);
 
   EXPECT_EQ("", output.str());
 }
 
-TEST(McmcBaseNuts, slice_criterion) {
-  
+TEST(McmcBaseNuts, divergence_test) {
+
   rng_t base_rng(0);
-  
+
   int model_size = 1;
   double init_momentum = 1.5;
-  
-  Eigen::VectorXd rho = Eigen::VectorXd::Zero(model_size);
-  
+
   stan::mcmc::ps_point z_init(model_size);
   z_init.q(0) = 0;
   z_init.p(0) = init_momentum;
-  
+
   stan::mcmc::ps_point z_propose(model_size);
-  
-  stan::mcmc::nuts_util util;
-  util.log_u = 0;
-  util.H0 = 0;
-  util.sign = 1;
-  util.n_tree = 0;
-  util.sum_prob = 0;
-  
+
+  Eigen::VectorXd rho = z_init.p;
+  double sum_weight = 0;
+
+  double H0 = -0.1;
+  int n_leapfrog = 0;
+  double sum_metro_prob = 0;
+
   stan::mcmc::mock_model model(model_size);
   stan::mcmc::divergent_nuts sampler(model, base_rng);
-  
+
   sampler.set_nominal_stepsize(1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();
@@ -208,24 +204,29 @@ TEST(McmcBaseNuts, slice_criterion) {
   std::stringstream output;
   stan::interface_callbacks::writer::stream_writer writer(output);
 
-  int n_valid = 0;
-  
+  bool valid_subtree = 0;
+
   sampler.z().V = -750;
-  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util, writer);
-  
-  EXPECT_EQ(1, n_valid);
+  valid_subtree = sampler.build_tree(0, rho, z_propose,
+                                     H0, 1, n_leapfrog, sum_weight,
+                                     sum_metro_prob, writer);
+  EXPECT_EQ(true, valid_subtree);
   EXPECT_EQ(0, sampler.divergent_);
-  
+
   sampler.z().V = -250;
-  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util, writer);
-  
-  EXPECT_EQ(0, n_valid);
+  valid_subtree = sampler.build_tree(0, rho, z_propose,
+                                     H0, 1, n_leapfrog, sum_weight,
+                                     sum_metro_prob, writer);
+
+  EXPECT_EQ(true, valid_subtree);
   EXPECT_EQ(0, sampler.divergent_);
-  
+
   sampler.z().V = 750;
-  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util, writer);
-  
-  EXPECT_EQ(0, n_valid);
+  valid_subtree = sampler.build_tree(0, rho, z_propose,
+                                     H0, 1, n_leapfrog, sum_weight,
+                                     sum_metro_prob, writer);
+
+  EXPECT_EQ(false, valid_subtree);
   EXPECT_EQ(1, sampler.divergent_);
 
   EXPECT_EQ("", output.str());

--- a/src/test/unit/mcmc/hmc/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/base_nuts_test.cpp
@@ -159,7 +159,7 @@ TEST(McmcBaseNuts, build_tree) {
                                           H0, 1, n_leapfrog, sum_weight,
                                           sum_metro_prob, writer);
 
-  EXPECT_EQ(true, valid_subtree);
+  EXPECT_TRUE(valid_subtree);
 
   EXPECT_EQ(init_momentum * (n_leapfrog + 1), rho(0));
 
@@ -210,7 +210,7 @@ TEST(McmcBaseNuts, divergence_test) {
   valid_subtree = sampler.build_tree(0, rho, z_propose,
                                      H0, 1, n_leapfrog, sum_weight,
                                      sum_metro_prob, writer);
-  EXPECT_EQ(true, valid_subtree);
+  EXPECT_TRUE(valid_subtree);
   EXPECT_EQ(0, sampler.divergent_);
 
   sampler.z().V = -250;
@@ -218,7 +218,7 @@ TEST(McmcBaseNuts, divergence_test) {
                                      H0, 1, n_leapfrog, sum_weight,
                                      sum_metro_prob, writer);
 
-  EXPECT_EQ(true, valid_subtree);
+  EXPECT_TRUE(valid_subtree);
   EXPECT_EQ(0, sampler.divergent_);
 
   sampler.z().V = 750;
@@ -226,7 +226,7 @@ TEST(McmcBaseNuts, divergence_test) {
                                      H0, 1, n_leapfrog, sum_weight,
                                      sum_metro_prob, writer);
 
-  EXPECT_EQ(false, valid_subtree);
+  EXPECT_FALSE(valid_subtree);
   EXPECT_EQ(1, sampler.divergent_);
 
   EXPECT_EQ("", output.str());

--- a/src/test/unit/mcmc/hmc/derived_nuts_classic_test.cpp
+++ b/src/test/unit/mcmc/hmc/derived_nuts_classic_test.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+
+#include <stan/interface_callbacks/writer/noop_writer.hpp>
+#include <stan/mcmc/hmc/hamiltonians/unit_e_point.hpp>
+#include <stan/mcmc/hmc/hamiltonians/diag_e_point.hpp>
+#include <stan/mcmc/hmc/hamiltonians/dense_e_point.hpp>
+#include <stan/mcmc/hmc/nuts_classic/unit_e_nuts_classic.hpp>
+#include <stan/mcmc/hmc/nuts_classic/diag_e_nuts_classic.hpp>
+#include <stan/mcmc/hmc/nuts_classic/dense_e_nuts_classic.hpp>
+#include <test/unit/mcmc/hmc/mock_hmc.hpp>
+#include <boost/random/additive_combine.hpp>
+
+typedef boost::ecuyer1988 rng_t;
+
+TEST(McmcDerivedNutsClassic, compute_criterion_unit_e) {
+
+  rng_t base_rng(0);
+
+  int model_size = 1;
+
+  stan::mcmc::ps_point start(model_size);
+  stan::mcmc::unit_e_point finish(model_size);
+  Eigen::VectorXd rho(model_size);
+
+  stan::mcmc::mock_model model(model_size);
+  stan::mcmc::unit_e_nuts_classic<stan::mcmc::mock_model, rng_t>
+    sampler(model, base_rng);
+
+  start.q(0) = 1;
+  start.p(0) = 1;
+
+  finish.q(0) = 2;
+  finish.p(0) = 1;
+
+  rho = start.p + finish.p;
+
+  EXPECT_EQ(true, sampler.compute_criterion(start, finish, rho));
+
+  start.q(0) = 1;
+  start.p(0) = 1;
+
+  finish.q(0) = 2;
+  finish.p(0) = -1;
+
+  rho = start.p + finish.p;
+
+  EXPECT_FALSE(sampler.compute_criterion(start, finish, rho));
+
+}
+
+TEST(McmcDerivedNutsClassic, compute_criterion_diag_e) {
+
+  rng_t base_rng(0);
+
+  int model_size = 1;
+
+  stan::mcmc::ps_point start(model_size);
+  stan::mcmc::diag_e_point finish(model_size);
+  Eigen::VectorXd rho(model_size);
+
+  stan::mcmc::mock_model model(model_size);
+  stan::mcmc::diag_e_nuts_classic<stan::mcmc::mock_model, rng_t>
+    sampler(model, base_rng);
+
+  start.q(0) = 1;
+  start.p(0) = 1;
+
+  finish.q(0) = 2;
+  finish.p(0) = 1;
+
+  rho = start.p + finish.p;
+
+  EXPECT_EQ(true, sampler.compute_criterion(start, finish, rho));
+
+  start.q(0) = 1;
+  start.p(0) = 1;
+
+  finish.q(0) = 2;
+  finish.p(0) = -1;
+
+  rho = start.p + finish.p;
+
+  EXPECT_FALSE(sampler.compute_criterion(start, finish, rho));
+}
+
+TEST(McmcDerivedNutsClassic, compute_criterion_dense_e) {
+
+  rng_t base_rng(0);
+
+  int model_size = 1;
+
+  stan::mcmc::ps_point start(model_size);
+  stan::mcmc::dense_e_point finish(model_size);
+  Eigen::VectorXd rho(model_size);
+
+  stan::mcmc::mock_model model(model_size);
+  stan::mcmc::dense_e_nuts_classic<stan::mcmc::mock_model, rng_t>
+    sampler(model, base_rng);
+
+  start.q(0) = 1;
+  start.p(0) = 1;
+
+  finish.q(0) = 2;
+  finish.p(0) = 1;
+
+  rho = start.p + finish.p;
+
+  EXPECT_EQ(true, sampler.compute_criterion(start, finish, rho));
+
+  start.q(0) = 1;
+  start.p(0) = 1;
+
+  finish.q(0) = 2;
+  finish.p(0) = -1;
+
+  rho = start.p + finish.p;
+
+  EXPECT_FALSE(sampler.compute_criterion(start, finish, rho));
+
+}

--- a/src/test/unit/mcmc/hmc/derived_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/derived_nuts_test.cpp
@@ -13,106 +13,105 @@
 typedef boost::ecuyer1988 rng_t;
 
 TEST(McmcDerivedNuts, compute_criterion_unit_e) {
-  
+
   rng_t base_rng(0);
-  
+
   int model_size = 1;
-  
+
   stan::mcmc::ps_point start(model_size);
   stan::mcmc::unit_e_point finish(model_size);
   Eigen::VectorXd rho(model_size);
 
   stan::mcmc::mock_model model(model_size);
   stan::mcmc::unit_e_nuts<stan::mcmc::mock_model, rng_t> sampler(model, base_rng);
-  
+
   start.q(0) = 1;
   start.p(0) = 1;
-  
+
   finish.q(0) = 2;
   finish.p(0) = 1;
-  
+
   rho = start.p + finish.p;
-  
-  EXPECT_EQ(true, sampler.compute_criterion(start, finish, rho));
-  
+
+  EXPECT_TRUE(sampler.compute_criterion(start, finish, rho));
+
   start.q(0) = 1;
   start.p(0) = 1;
-  
+
   finish.q(0) = 2;
   finish.p(0) = -1;
-  
+
   rho = start.p + finish.p;
-  
+
   EXPECT_FALSE(sampler.compute_criterion(start, finish, rho));
-  
+
 }
 
 TEST(McmcDerivedNuts, compute_criterion_diag_e) {
-  
+
   rng_t base_rng(0);
-  
+
   int model_size = 1;
-  
+
   stan::mcmc::ps_point start(model_size);
   stan::mcmc::diag_e_point finish(model_size);
   Eigen::VectorXd rho(model_size);
-    
+
   stan::mcmc::mock_model model(model_size);
   stan::mcmc::diag_e_nuts<stan::mcmc::mock_model, rng_t> sampler(model, base_rng);
-  
+
   start.q(0) = 1;
   start.p(0) = 1;
-  
+
   finish.q(0) = 2;
   finish.p(0) = 1;
-  
+
   rho = start.p + finish.p;
-  
-  EXPECT_EQ(true, sampler.compute_criterion(start, finish, rho));
-  
+
+  EXPECT_TRUE(sampler.compute_criterion(start, finish, rho));
+
   start.q(0) = 1;
   start.p(0) = 1;
-  
+
   finish.q(0) = 2;
   finish.p(0) = -1;
-  
+
   rho = start.p + finish.p;
-  
+
   EXPECT_FALSE(sampler.compute_criterion(start, finish, rho));
 }
 
 TEST(McmcDerivedNuts, compute_criterion_dense_e) {
-  
+
   rng_t base_rng(0);
-  
+
   int model_size = 1;
-  
+
   stan::mcmc::ps_point start(model_size);
   stan::mcmc::dense_e_point finish(model_size);
   Eigen::VectorXd rho(model_size);
 
   stan::mcmc::mock_model model(model_size);
   stan::mcmc::dense_e_nuts<stan::mcmc::mock_model, rng_t> sampler(model, base_rng);
-  
+
   start.q(0) = 1;
   start.p(0) = 1;
-  
+
   finish.q(0) = 2;
   finish.p(0) = 1;
-  
+
   rho = start.p + finish.p;
-  
-  EXPECT_EQ(true, sampler.compute_criterion(start, finish, rho));
+
+  EXPECT_TRUE(sampler.compute_criterion(start, finish, rho));
   
   start.q(0) = 1;
   start.p(0) = 1;
-  
+
   finish.q(0) = 2;
   finish.p(0) = -1;
-  
-  rho = start.p + finish.p;
-  
-  EXPECT_FALSE(sampler.compute_criterion(start, finish, rho));
-  
-}
 
+  rho = start.p + finish.p;
+
+  EXPECT_FALSE(sampler.compute_criterion(start, finish, rho));
+
+}

--- a/src/test/unit/mcmc/hmc/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/unit_e_nuts_test.cpp
@@ -1,0 +1,112 @@
+#include <stan/interface_callbacks/writer/stream_writer.hpp>
+#include <stan/mcmc/hmc/nuts/unit_e_nuts.hpp>
+#include <boost/random/additive_combine.hpp>
+#include <test/test-models/good/mcmc/hmc/nuts/gauss3D.hpp>
+#include <stan/io/dump.hpp>
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+typedef boost::ecuyer1988 rng_t;
+
+TEST(McmcUnitENuts, build_tree) {
+  rng_t base_rng(4839294);
+
+  stan::mcmc::unit_e_point z_init(3);
+  z_init.q(0) = 1;
+  z_init.q(1) = -1;
+  z_init.q(2) = 1;
+  z_init.p(0) = -1;
+  z_init.p(1) = 1;
+  z_init.p(2) = -1;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+  gauss3D_model_namespace::gauss3D_model model(data_var_context);
+
+  stan::mcmc::unit_e_nuts<gauss3D_model_namespace::gauss3D_model, rng_t>
+    sampler(model, base_rng);
+
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer);
+  sampler.set_nominal_stepsize(0.1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+
+  stan::mcmc::ps_point z_propose = z_init;
+
+  Eigen::VectorXd rho = z_init.p;
+  double sum_weight = 0;
+
+  double H0 = -0.1;
+  int n_leapfrog = 0;
+  double sum_metro_prob = 0;
+
+  bool valid_subtree = sampler.build_tree(3, rho, z_propose,
+                                          H0, 1, n_leapfrog, sum_weight,
+                                          sum_metro_prob, writer);
+
+  EXPECT_EQ(0.1, sampler.get_nominal_stepsize());
+
+  EXPECT_EQ(true, valid_subtree);
+
+  EXPECT_FLOAT_EQ(-11.401228, rho(0));
+  EXPECT_FLOAT_EQ(11.401228, rho(1));
+  EXPECT_FLOAT_EQ(-11.401228, rho(2));
+
+  EXPECT_FLOAT_EQ(-0.022019938, sampler.z().q(0));
+  EXPECT_FLOAT_EQ(0.022019938, sampler.z().q(1));
+  EXPECT_FLOAT_EQ(-0.022019938, sampler.z().q(2));
+
+  EXPECT_FLOAT_EQ(-1.4131583, sampler.z().p(0));
+  EXPECT_FLOAT_EQ(1.4131583, sampler.z().p(1));
+  EXPECT_FLOAT_EQ(-1.4131583, sampler.z().p(2));
+
+  EXPECT_EQ(8, n_leapfrog);
+  EXPECT_FLOAT_EQ(0.36134657, sum_weight);
+  EXPECT_FLOAT_EQ(0.36134657, sum_metro_prob);
+
+  EXPECT_EQ("", output.str());
+}
+
+TEST(McmcUnitENuts, transition) {
+  rng_t base_rng(4839294);
+
+  stan::mcmc::unit_e_point z_init(3);
+  z_init.q(0) = 1;
+  z_init.q(1) = -1;
+  z_init.q(2) = 1;
+  z_init.p(0) = -1;
+  z_init.p(1) = 1;
+  z_init.p(2) = -1;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+  gauss3D_model_namespace::gauss3D_model model(data_var_context);
+
+  stan::mcmc::unit_e_nuts<gauss3D_model_namespace::gauss3D_model, rng_t>
+    sampler(model, base_rng);
+
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer);
+  sampler.set_nominal_stepsize(0.1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+
+  stan::mcmc::sample init_sample(z_init.q, 0, 0);
+
+  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+
+  EXPECT_FLOAT_EQ(1, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-1, s.cont_params()(1));
+  EXPECT_FLOAT_EQ(1, s.cont_params()(2));
+  EXPECT_FLOAT_EQ(-1.5, s.log_prob());
+  EXPECT_FLOAT_EQ(0.99629, s.accept_stat());
+  EXPECT_EQ("", output.str());
+}

--- a/src/test/unit/mcmc/hmc/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/unit_e_nuts_test.cpp
@@ -51,7 +51,7 @@ TEST(McmcUnitENuts, build_tree) {
 
   EXPECT_EQ(0.1, sampler.get_nominal_stepsize());
 
-  EXPECT_EQ(true, valid_subtree);
+  EXPECT_TRUE(valid_subtree);
 
   EXPECT_FLOAT_EQ(-11.401228, rho(0));
   EXPECT_FLOAT_EQ(11.401228, rho(1));


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Change the defaults NUTS sampler to sample from trajectories multinomially instead of with the original slice sampler.  The original implementation has been preserved as "nuts_classic".  Addresses #1846.

#### Intended Effect

Minimal user-facing affects.  Allows for cleaner code and facilitates research.

#### How to Verify

Run tests, try recovering known expectations from analytic models.

#### Side Effects

Small changes to exact sampler output but expectations should be the same with the MCMC standard error.

#### Documentation

None.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Copyright: Michael Betancourt

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)