### PR TITLE
Add uniform static HMC sampler

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -133,6 +133,7 @@ src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp: src/test/test-models
 src/test/unit/mcmc/hmc/hamiltonians/unit_e_metric_test.cpp: src/test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp
 src/test/unit/mcmc/hmc/integrators/expl_leapfrog_test.cpp: src/test/test-models/good/mcmc/hmc/integrators/command.hpp
 src/test/unit/mcmc/hmc/integrators/expl_leapfrog2_test.cpp: src/test/test-models/good/mcmc/hmc/integrators/gauss.hpp
+src/test/unit/mcmc/hmc/derived_static_uniform_test.cpp: src/test/test-models/good/mcmc/hmc/static_uniform/gauss.hpp
 src/test/unit/model/util_test.cpp: src/test/test-models/good/model/valid.hpp src/test/test-models/good/model/domain_fail.hpp
 src/test/unit/optimization/bfgs_linesearch_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp
 src/test/unit/optimization/bfgs_minimizer_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp

--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -54,6 +54,10 @@ namespace stan {
         z_.q = q;
       }
 
+      void init_hamiltonian(interface_callbacks::writer::base_writer& writer) {
+        this->hamiltonian_.init(this->z_, writer);
+      }
+
       void init_stepsize(interface_callbacks::writer::base_writer& writer) {
         ps_point z_init(this->z_);
 

--- a/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
@@ -1,0 +1,53 @@
+#ifndef STAN_MCMC_HMC_STATIC_UNIFORM_ADAPT_DENSE_E_STATIC_UNIFORM_HPP
+#define STAN_MCMC_HMC_STATIC_UNIFORM_ADAPT_DENSE_E_STATIC_UNIFORM_HPP
+
+#include <stan/mcmc/stepsize_covar_adapter.hpp>
+#include <stan/mcmc/hmc/static_uniform/dense_e_static_uniform.hpp>
+
+namespace stan {
+  namespace mcmc {
+    // Hamiltonian Monte Carlo on a
+    // Euclidean manifold with dense metric,
+    // static integration time,
+    // and adaptive stepsize
+    template <typename M, class BaseRNG>
+    class adapt_dense_e_static_uniform:
+      public dense_e_static_uniform<M, BaseRNG>,
+      public stepsize_covar_adapter {
+    public:
+      adapt_dense_e_static_uniform(M &m, BaseRNG& rng):
+        dense_e_static_uniform<M, BaseRNG>(m, rng),
+        stepsize_covar_adapter(m.num_params_r()) { }
+
+      ~adapt_dense_e_static_uniform() { }
+
+      sample transition(sample& init_sample,
+                        interface_callbacks::writer::base_writer& writer) {
+        sample s = dense_e_static_uniform<M, BaseRNG>::transition(init_sample,
+                                                                  writer);
+
+        if (this->adapt_flag_) {
+          this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
+                                                    s.accept_stat());
+
+          bool update = this->covar_adaptation_.learn_covariance
+            (this->z_.mInv, this->z_.q);
+
+          if (update) {
+            this->init_stepsize(writer);
+            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.restart();
+          }
+        }
+        return s;
+      }
+
+      void disengage_adaptation() {
+        base_adapter::disengage_adaptation();
+        this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
+      }
+    };
+  }  // mcmc
+}  // stan
+
+#endif

--- a/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
@@ -6,10 +6,12 @@
 
 namespace stan {
   namespace mcmc {
-    // Hamiltonian Monte Carlo on a
-    // Euclidean manifold with dense metric,
-    // static integration time,
-    // and adaptive stepsize
+    /**
+      * Hamiltonian Monte Carlo implemetnation that uniformly samples
+      * from trajectories with a static integration time with a
+      * Gaussian-Euclidean disintegration and dense metric and
+      * adaptive step size
+    */
     template <typename M, class BaseRNG>
     class adapt_dense_e_static_uniform:
       public dense_e_static_uniform<M, BaseRNG>,

--- a/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
@@ -1,0 +1,52 @@
+#ifndef STAN_MCMC_HMC_STATIC_UNIFORM_ADAPT_DIAG_E_STATIC_UNIFORM_HPP
+#define STAN_MCMC_HMC_STATIC_UNIFORM_ADAPT_DIAG_E_STATIC_UNIFORM_HPP
+
+#include <stan/mcmc/stepsize_var_adapter.hpp>
+#include <stan/mcmc/hmc/static_uniform/diag_e_static_uniform.hpp>
+
+namespace stan {
+  namespace mcmc {
+    // Hamiltonian Monte Carlo on a
+    // Euclidean manifold with diagonal metric,
+    // static integration time,
+    // and adaptive stepsize
+    template <typename M, class BaseRNG>
+    class adapt_diag_e_static_uniform:
+      public diag_e_static_uniform<M, BaseRNG>,
+      public stepsize_var_adapter {
+    public:
+        adapt_diag_e_static_uniform(M &m, BaseRNG& rng):
+          diag_e_static_uniform<M, BaseRNG>(m, rng),
+          stepsize_var_adapter(m.num_params_r()) {}
+
+      ~adapt_diag_e_static_uniform() {}
+
+      sample transition(sample& init_sample,
+                        interface_callbacks::writer::base_writer& writer) {
+        sample s = diag_e_static_uniform<M, BaseRNG>::transition(init_sample,
+                                                                 writer);
+
+        if (this->adapt_flag_) {
+          this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
+                                                    s.accept_stat());
+
+          bool update = this->var_adaptation_.learn_variance(this->z_.mInv,
+                                                             this->z_.q);
+          if (update) {
+            this->init_stepsize(writer);
+            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.restart();
+          }
+        }
+        return s;
+      }
+
+      void disengage_adaptation() {
+        base_adapter::disengage_adaptation();
+        this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
+      }
+    };
+  }  // mcmc
+}  // stan
+
+#endif

--- a/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
@@ -6,10 +6,12 @@
 
 namespace stan {
   namespace mcmc {
-    // Hamiltonian Monte Carlo on a
-    // Euclidean manifold with diagonal metric,
-    // static integration time,
-    // and adaptive stepsize
+    /**
+      * Hamiltonian Monte Carlo implemetnation that uniformly samples
+      * from trajectories with a static integration time with a
+      * Gaussian-Euclidean disintegration and diagonal metric and
+      * adaptive step size
+    */
     template <typename M, class BaseRNG>
     class adapt_diag_e_static_uniform:
       public diag_e_static_uniform<M, BaseRNG>,

--- a/src/stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp
@@ -7,10 +7,12 @@
 
 namespace stan {
   namespace mcmc {
-    // Hamiltonian Monte Carlo on a
-    // Euclidean manifold with unit metric,
-    // static integration time,
-    // and adaptive stepsize
+    /**
+      * Hamiltonian Monte Carlo implemetnation that uniformly samples
+      * from trajectories with a static integration time with a
+      * Gaussian-Euclidean disintegration and unit metric and
+      * adaptive step size
+    */
     template <class Model, class BaseRNG>
     class adapt_unit_e_static_uniform:
       public unit_e_static_uniform<Model, BaseRNG>,

--- a/src/stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp
@@ -1,0 +1,46 @@
+#ifndef STAN_MCMC_HMC_STATIC_ADAPT_UNIT_E_STATIC_HMC_HPP
+#define STAN_MCMC_HMC_STATIC_ADAPT_UNIT_E_STATIC_HMC_HPP
+
+#include <stan/interface_callbacks/writer/base_writer.hpp>
+#include <stan/mcmc/hmc/static/unit_e_static_hmc.hpp>
+#include <stan/mcmc/stepsize_adapter.hpp>
+
+namespace stan {
+  namespace mcmc {
+    // Hamiltonian Monte Carlo on a
+    // Euclidean manifold with unit metric,
+    // static integration time,
+    // and adaptive stepsize
+    template <class Model, class BaseRNG>
+    class adapt_unit_e_static_uniform:
+      public unit_e_static_uniform<Model, BaseRNG>,
+      public stepsize_adapter {
+    public:
+      adapt_unit_e_static_uniform(Model &model, BaseRNG& rng):
+        unit_e_static_uniform<Model, BaseRNG>(model, rng) { }
+
+      ~adapt_unit_e_static_uniform() { }
+
+      sample transition(sample& init_sample,
+                        interface_callbacks::writer::base_writer& writer) {
+        sample s
+          = unit_e_static_uniform<Model, BaseRNG>::transition(init_sample,
+                                                              writer);
+
+        if (this->adapt_flag_) {
+          this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
+                                                    s.accept_stat());
+          this->update_L_();
+        }
+
+        return s;
+      }
+
+      void disengage_adaptation() {
+        base_adapter::disengage_adaptation();
+        this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
+      }
+    };
+  }  // mcmc
+}  // stan
+#endif

--- a/src/stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp
@@ -2,7 +2,7 @@
 #define STAN_MCMC_HMC_STATIC_ADAPT_UNIT_E_STATIC_HMC_HPP
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
-#include <stan/mcmc/hmc/static/unit_e_static_hmc.hpp>
+#include <stan/mcmc/hmc/static_uniform/unit_e_static_uniform.hpp>
 #include <stan/mcmc/stepsize_adapter.hpp>
 
 namespace stan {

--- a/src/stan/mcmc/hmc/static_uniform/base_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/base_static_uniform.hpp
@@ -1,0 +1,158 @@
+#ifndef STAN_MCMC_HMC_UNIFORM_BASE_STATIC_UNIFORM_HPP
+#define STAN_MCMC_HMC_UNIFORM_BASE_STATIC_UNIFORM_HPP
+
+#include <stan/interface_callbacks/writer/base_writer.hpp>
+#include <stan/mcmc/hmc/base_hmc.hpp>
+#include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace stan {
+
+  namespace mcmc {
+
+    // Hamiltonian Monte Carlo
+    // with static integration time
+    template <class Model,
+              template<class, class> class Hamiltonian,
+              template<class> class Integrator,
+              class BaseRNG>
+    class base_static_uniform:
+      public base_hmc<Model, Hamiltonian, Integrator, BaseRNG> {
+    public:
+      base_static_uniform(Model &m, BaseRNG& rng)
+        : base_hmc<Model, Hamiltonian, Integrator, BaseRNG>(m, rng),
+          T_(1), energy_(0) {
+        update_L_();
+      }
+
+      ~base_static_uniform() {}
+
+      sample transition(sample& init_sample,
+                        interface_callbacks::writer::base_writer& writer) {
+        this->sample_stepsize();
+
+        this->seed(init_sample.cont_params());
+
+        this->hamiltonian_.sample_p(this->z_, this->rand_int_);
+        this->hamiltonian_.init(this->z_, writer);
+
+        ps_point z_init(this->z_);
+        double H0 = this->hamiltonian_.H(this->z_);
+
+        ps_point z_sample(this->z_);
+        double sum_prob = 1;
+        double sum_metro_prob = 1;
+
+        boost::random::uniform_int_distribution<> uniform(0, L_ - 1);
+        int Lp = uniform(this->rand_int_);
+
+        for (int l = 0; l < Lp; ++l) {
+          this->integrator_.evolve(this->z_, this->hamiltonian_,
+                                   -this->epsilon_, writer);
+
+          double h = this->hamiltonian_.H(this->z_);
+          if (boost::math::isnan(h))
+            h = std::numeric_limits<double>::infinity();
+
+          double prob = std::exp(H0 - h);
+          sum_prob += prob;
+          sum_metro_prob += prob > 1 ? 1 : prob;
+
+          if (this->rand_uniform_() < prob / sum_prob)
+            z_sample = this->z_;
+        }
+
+        this->z_.ps_point::operator=(z_init);
+
+        for (int l = 0; l < L_ - 1 - Lp; ++l) {
+          this->integrator_.evolve(this->z_, this->hamiltonian_,
+                                   this->epsilon_, writer);
+
+          double h = this->hamiltonian_.H(this->z_);
+          if (boost::math::isnan(h))
+            h = std::numeric_limits<double>::infinity();
+
+          double prob = std::exp(H0 - h);
+          sum_prob += prob;
+          sum_metro_prob += prob > 1 ? 1 : prob;
+
+          if (this->rand_uniform_() < prob / sum_prob)
+            z_sample = this->z_;
+        }
+
+        double accept_prob = sum_metro_prob / static_cast<double>(L_);
+
+        this->z_.ps_point::operator=(z_sample);
+        this->energy_ = this->hamiltonian_.H(this->z_);
+        return sample(this->z_.q,
+                      - this->hamiltonian_.V(this->z_),
+                      accept_prob);
+      }
+
+      void get_sampler_param_names(std::vector<std::string>& names) {
+        names.push_back("stepsize__");
+        names.push_back("int_time__");
+        names.push_back("energy__");
+      }
+
+      void get_sampler_params(std::vector<double>& values) {
+        values.push_back(this->epsilon_);
+        values.push_back(this->T_);
+        values.push_back(this->energy_);
+      }
+
+      void set_nominal_stepsize_and_T(const double e, const double t) {
+        if (e > 0 && t > 0) {
+          this->nom_epsilon_ = e;
+          T_ = t;
+          update_L_();
+        }
+      }
+
+      void set_nominal_stepsize_and_L(const double e, const int l) {
+        if (e > 0 && l > 0) {
+          this->nom_epsilon_ = e;
+          L_ = l;
+          T_ = this->nom_epsilon_ * L_; }
+      }
+
+      void set_T(const double t) {
+        if (t > 0) {
+          T_ = t;
+          update_L_();
+        }
+      }
+
+      void set_nominal_stepsize(const double e) {
+        if (e > 0) {
+          this->nom_epsilon_ = e;
+          update_L_();
+        }
+      }
+
+      double get_T() {
+        return this->T_;
+      }
+
+      int get_L() {
+        return this->L_;
+      }
+
+    protected:
+      double T_;
+      int L_;
+      double energy_;
+
+      void update_L_() {
+        L_ = static_cast<int>(T_ / this->nom_epsilon_);
+        L_ = L_ < 1 ? 1 : L_;
+      }
+    };
+  }  // mcmc
+}  // stan
+#endif

--- a/src/stan/mcmc/hmc/static_uniform/base_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/base_static_uniform.hpp
@@ -14,9 +14,10 @@
 namespace stan {
 
   namespace mcmc {
-
-    // Hamiltonian Monte Carlo
-    // with static integration time
+    /**
+      * Hamiltonian Monte Carlo implemetnation that uniformly samples
+      * from trajectories with a static integration time
+    */
     template <class Model,
               template<class, class> class Hamiltonian,
               template<class> class Integrator,

--- a/src/stan/mcmc/hmc/static_uniform/dense_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/dense_e_static_uniform.hpp
@@ -1,0 +1,25 @@
+#ifndef STAN_MCMC_HMC_STATIC_UNIFORM_DENSE_E_STATIC_UNIFORM_HPP
+#define STAN_MCMC_HMC_STATIC_UNIFORM_DENSE_E_STATIC_UNIFORM_HPP
+
+#include <stan/mcmc/hmc/static_uniform/base_static_uniform.hpp>
+#include <stan/mcmc/hmc/hamiltonians/dense_e_point.hpp>
+#include <stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp>
+#include <stan/mcmc/hmc/integrators/expl_leapfrog.hpp>
+
+namespace stan {
+  namespace mcmc {
+    // Hamiltonian Monte Carlo on a
+    // Euclidean manifold with dense metric
+    // and static integration time
+    template <typename M, class BaseRNG>
+    class dense_e_static_uniform
+      : public base_static_uniform<M, dense_e_metric, expl_leapfrog, BaseRNG> {
+    public:
+      dense_e_static_uniform(M &m, BaseRNG& rng):
+        base_static_uniform<M, dense_e_metric, expl_leapfrog, BaseRNG>(m, rng) {
+      }
+    };
+  }  // mcmc
+}  // stan
+
+#endif

--- a/src/stan/mcmc/hmc/static_uniform/dense_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/dense_e_static_uniform.hpp
@@ -8,9 +8,11 @@
 
 namespace stan {
   namespace mcmc {
-    // Hamiltonian Monte Carlo on a
-    // Euclidean manifold with dense metric
-    // and static integration time
+    /**
+      * Hamiltonian Monte Carlo implemetnation that uniformly samples
+      * from trajectories with a static integration time with a
+      * Gaussian-Euclidean disintegration and dense metric
+    */
     template <typename M, class BaseRNG>
     class dense_e_static_uniform
       : public base_static_uniform<M, dense_e_metric, expl_leapfrog, BaseRNG> {

--- a/src/stan/mcmc/hmc/static_uniform/diag_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/diag_e_static_uniform.hpp
@@ -1,0 +1,25 @@
+#ifndef STAN_MCMC_HMC_STATIC_UNIFORM_DIAG_E_STATIC_UNIFORM_HPP
+#define STAN_MCMC_HMC_STATIC_UNIFORM_DIAG_E_STATIC_UNIFORM_HPP
+
+#include <stan/mcmc/hmc/static_uniform/base_static_uniform.hpp>
+#include <stan/mcmc/hmc/hamiltonians/diag_e_point.hpp>
+#include <stan/mcmc/hmc/hamiltonians/diag_e_metric.hpp>
+#include <stan/mcmc/hmc/integrators/expl_leapfrog.hpp>
+
+namespace stan {
+  namespace mcmc {
+    // Hamiltonian Monte Carlo on a
+    // Euclidean manifold with diagonal metric
+    // and static integration time
+    template <typename M, class BaseRNG>
+    class diag_e_static_uniform
+      : public base_static_uniform<M, diag_e_metric, expl_leapfrog, BaseRNG> {
+    public:
+      diag_e_static_uniform(M &m, BaseRNG& rng):
+        base_static_uniform<M, diag_e_metric, expl_leapfrog, BaseRNG>(m, rng) {
+      }
+    };
+  }  // mcmc
+}  // stan
+
+#endif

--- a/src/stan/mcmc/hmc/static_uniform/diag_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/diag_e_static_uniform.hpp
@@ -8,9 +8,11 @@
 
 namespace stan {
   namespace mcmc {
-    // Hamiltonian Monte Carlo on a
-    // Euclidean manifold with diagonal metric
-    // and static integration time
+    /**
+      * Hamiltonian Monte Carlo implemetnation that uniformly samples
+      * from trajectories with a static integration time with a
+      * Gaussian-Euclidean disintegration and diagonal metric
+    */
     template <typename M, class BaseRNG>
     class diag_e_static_uniform
       : public base_static_uniform<M, diag_e_metric, expl_leapfrog, BaseRNG> {

--- a/src/stan/mcmc/hmc/static_uniform/unit_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/unit_e_static_uniform.hpp
@@ -1,0 +1,26 @@
+#ifndef STAN_MCMC_HMC_STATIC_UNIFORM_UNIT_E_STATIC_UNIFORM_HPP
+#define STAN_MCMC_HMC_STATIC_UNIFORM_UNIT_E_STATIC_UNIFORM_HPP
+
+#include <stan/mcmc/hmc/static_uniform/base_static_uniform.hpp>
+#include <stan/mcmc/hmc/hamiltonians/unit_e_point.hpp>
+#include <stan/mcmc/hmc/hamiltonians/unit_e_metric.hpp>
+#include <stan/mcmc/hmc/integrators/expl_leapfrog.hpp>
+
+namespace stan {
+  namespace mcmc {
+    // Hamiltonian Monte Carlo on a
+    // Euclidean manifold with unit metric
+    // and static integration time
+
+    template <typename M, class BaseRNG>
+    class unit_e_static_uniform
+      : public base_static_uniform<M, unit_e_metric, expl_leapfrog, BaseRNG> {
+    public:
+      unit_e_static_uniform(M &m, BaseRNG& rng):
+        base_static_uniform<M, unit_e_metric, expl_leapfrog, BaseRNG>(m, rng) {
+      }
+    };
+  }  // mcmc
+}  // stan
+
+#endif

--- a/src/stan/mcmc/hmc/static_uniform/unit_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/unit_e_static_uniform.hpp
@@ -8,10 +8,11 @@
 
 namespace stan {
   namespace mcmc {
-    // Hamiltonian Monte Carlo on a
-    // Euclidean manifold with unit metric
-    // and static integration time
-
+    /**
+      * Hamiltonian Monte Carlo implemetnation that uniformly samples
+      * from trajectories with a static integration time with a
+      * Gaussian-Euclidean disintegration and unit metric
+    */
     template <typename M, class BaseRNG>
     class unit_e_static_uniform
       : public base_static_uniform<M, unit_e_metric, expl_leapfrog, BaseRNG> {

--- a/src/test/test-models/good/mcmc/hmc/static_uniform/gauss.stan
+++ b/src/test/test-models/good/mcmc/hmc/static_uniform/gauss.stan
@@ -1,0 +1,7 @@
+parameters {
+  real x;
+}
+
+model {
+  x ~ normal(0, 1);
+}

--- a/src/test/unit/mcmc/hmc/base_static_uniform_test.cpp
+++ b/src/test/unit/mcmc/hmc/base_static_uniform_test.cpp
@@ -1,0 +1,119 @@
+#include <test/unit/mcmc/hmc/mock_hmc.hpp>
+#include <stan/mcmc/hmc/static_uniform/base_static_uniform.hpp>
+#include <stan/interface_callbacks/writer/base_writer.hpp>
+#include <stan/interface_callbacks/writer/stream_writer.hpp>
+#include <boost/random/additive_combine.hpp>
+#include <gtest/gtest.h>
+
+typedef boost::ecuyer1988 rng_t;
+
+namespace stan {
+  namespace mcmc {
+    // Mock Static HMC
+    class mock_static_uniform:
+      public base_static_uniform<mock_model, mock_hamiltonian,
+                                 mock_integrator, rng_t> {
+    public:
+      mock_static_uniform(mock_model &m, rng_t& rng):
+        base_static_uniform<mock_model, mock_hamiltonian,
+                            mock_integrator, rng_t>(m, rng) { }
+    };
+  }
+}
+
+TEST(McmcBaseStaticUniform, set_nominal_stepsize) {
+  rng_t base_rng(0);
+
+  std::vector<double> q(5, 1.0);
+  std::vector<int> r(2, 2);
+
+  stan::mcmc::mock_model model(q.size());
+
+  stan::mcmc::mock_static_uniform sampler(model, base_rng);
+
+  double old_epsilon = 1.0;
+
+  sampler.set_nominal_stepsize(old_epsilon);
+  EXPECT_EQ(old_epsilon, sampler.get_nominal_stepsize());
+  EXPECT_EQ(true, sampler.get_L() > 0);
+
+  sampler.set_nominal_stepsize(-0.1);
+  EXPECT_EQ(old_epsilon, sampler.get_nominal_stepsize());
+}
+
+TEST(McmcBaseStaticUniform, set_T) {
+
+  rng_t base_rng(0);
+
+  std::vector<double> q(5, 1.0);
+  std::vector<int> r(2, 2);
+
+  stan::mcmc::mock_model model(q.size());
+
+  stan::mcmc::mock_static_uniform sampler(model, base_rng);
+
+  double old_T = 3.0;
+
+  sampler.set_T(old_T);
+  EXPECT_EQ(old_T, sampler.get_T());
+  EXPECT_EQ(true, sampler.get_L() > 0);
+
+  sampler.set_T(-0.1);
+  EXPECT_EQ(old_T, sampler.get_T());
+}
+
+TEST(McmcBaseStaticUniform, set_nominal_stepsize_and_T) {
+
+  rng_t base_rng(0);
+
+  std::vector<double> q(5, 1.0);
+  std::vector<int> r(2, 2);
+
+  stan::mcmc::mock_model model(q.size());
+
+  stan::mcmc::mock_static_uniform sampler(model, base_rng);
+
+  double old_epsilon = 1.0;
+  double old_T = 3.0;
+
+  sampler.set_nominal_stepsize_and_T(old_epsilon, old_T);
+  EXPECT_EQ(old_epsilon, sampler.get_nominal_stepsize());
+  EXPECT_EQ(old_T, sampler.get_T());
+  EXPECT_EQ(true, sampler.get_L() > 0);
+
+  sampler.set_nominal_stepsize_and_T(-0.1, 5.0);
+  EXPECT_EQ(old_epsilon, sampler.get_nominal_stepsize());
+  EXPECT_EQ(old_T, sampler.get_T());
+
+  sampler.set_nominal_stepsize_and_T(5.0, -0.1);
+  EXPECT_EQ(old_epsilon, sampler.get_nominal_stepsize());
+  EXPECT_EQ(old_T, sampler.get_T());
+}
+
+TEST(McmcBaseStaticUniform, set_nominal_stepsize_and_L) {
+
+  rng_t base_rng(0);
+
+  std::vector<double> q(5, 1.0);
+  std::vector<int> r(2, 2);
+
+  stan::mcmc::mock_model model(q.size());
+
+  stan::mcmc::mock_static_uniform sampler(model, base_rng);
+
+  double old_epsilon = 1.0;
+  int old_L = 10;
+
+  sampler.set_nominal_stepsize_and_L(old_epsilon, old_L);
+  EXPECT_EQ(old_epsilon, sampler.get_nominal_stepsize());
+  EXPECT_EQ(old_L, sampler.get_L());
+  EXPECT_EQ(true, sampler.get_T() > 0);
+
+  sampler.set_nominal_stepsize_and_L(-0.1, 5);
+  EXPECT_EQ(old_epsilon, sampler.get_nominal_stepsize());
+  EXPECT_EQ(old_L, sampler.get_L());
+
+  sampler.set_nominal_stepsize_and_T(5.0, -1);
+  EXPECT_EQ(old_epsilon, sampler.get_nominal_stepsize());
+  EXPECT_EQ(old_L, sampler.get_L());
+}

--- a/src/test/unit/mcmc/hmc/derived_static_uniform_test.cpp
+++ b/src/test/unit/mcmc/hmc/derived_static_uniform_test.cpp
@@ -1,0 +1,211 @@
+#include <stan/mcmc/hmc/static_uniform/unit_e_static_uniform.hpp>
+#include <stan/mcmc/hmc/static_uniform/diag_e_static_uniform.hpp>
+#include <stan/mcmc/hmc/static_uniform/dense_e_static_uniform.hpp>
+#include <stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp>
+#include <stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp>
+#include <stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp>
+#include <stan/interface_callbacks/writer/base_writer.hpp>
+#include <stan/interface_callbacks/writer/stream_writer.hpp>
+#include <test/test-models/good/mcmc/hmc/static_uniform/gauss.hpp>
+#include <boost/random/additive_combine.hpp>
+#include <gtest/gtest.h>
+
+typedef boost::ecuyer1988 rng_t;
+
+TEST(McmcStaticUniformUnitE, transition) {
+  rng_t base_rng(4839294);
+
+  stan::mcmc::unit_e_point z_init(1);
+  z_init.q(0) = 1;
+  z_init.p(0) = -1;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+  gauss_model_namespace::gauss_model model(data_var_context);
+
+  stan::mcmc::unit_e_static_uniform<gauss_model_namespace::gauss_model, rng_t>
+    sampler(model, base_rng);
+
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer);
+  sampler.set_nominal_stepsize(0.1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+
+  stan::mcmc::sample init_sample(z_init.q, 0, 0);
+
+  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+
+  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_EQ("", output.str());
+}
+
+TEST(McmcStaticUniformDiagE, transition) {
+  rng_t base_rng(4839294);
+
+  stan::mcmc::diag_e_point z_init(1);
+  z_init.q(0) = 1;
+  z_init.p(0) = -1;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+  gauss_model_namespace::gauss_model model(data_var_context);
+
+  stan::mcmc::diag_e_static_uniform<gauss_model_namespace::gauss_model, rng_t>
+    sampler(model, base_rng);
+
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer);
+  sampler.set_nominal_stepsize(0.1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+
+  stan::mcmc::sample init_sample(z_init.q, 0, 0);
+
+  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+
+  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_EQ("", output.str());
+}
+
+TEST(McmcStaticUniformDenseE, transition) {
+  rng_t base_rng(4839294);
+
+  stan::mcmc::dense_e_point z_init(1);
+  z_init.q(0) = 1;
+  z_init.p(0) = -1;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+  gauss_model_namespace::gauss_model model(data_var_context);
+
+  stan::mcmc::dense_e_static_uniform<gauss_model_namespace::gauss_model, rng_t>
+    sampler(model, base_rng);
+
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer);
+  sampler.set_nominal_stepsize(0.1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+
+  stan::mcmc::sample init_sample(z_init.q, 0, 0);
+
+  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+
+  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_EQ("", output.str());
+}
+
+TEST(McmcAdaptStaticUniformUnitE, transition) {
+  rng_t base_rng(4839294);
+
+  stan::mcmc::unit_e_point z_init(1);
+  z_init.q(0) = 1;
+  z_init.p(0) = -1;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+  gauss_model_namespace::gauss_model model(data_var_context);
+
+  stan::mcmc::adapt_unit_e_static_uniform<gauss_model_namespace::gauss_model, rng_t>
+    sampler(model, base_rng);
+
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer);
+  sampler.set_nominal_stepsize(0.1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+
+  stan::mcmc::sample init_sample(z_init.q, 0, 0);
+
+  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+
+  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_EQ("", output.str());
+}
+
+TEST(McmcAdaptStaticUniformDiagE, transition) {
+  rng_t base_rng(4839294);
+
+  stan::mcmc::diag_e_point z_init(1);
+  z_init.q(0) = 1;
+  z_init.p(0) = -1;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+  gauss_model_namespace::gauss_model model(data_var_context);
+
+  stan::mcmc::adapt_diag_e_static_uniform<gauss_model_namespace::gauss_model, rng_t>
+    sampler(model, base_rng);
+
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer);
+  sampler.set_nominal_stepsize(0.1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+
+  stan::mcmc::sample init_sample(z_init.q, 0, 0);
+
+  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+
+  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_EQ("", output.str());
+}
+
+TEST(McmcAdaptStaticUniformDenseE, transition) {
+  rng_t base_rng(4839294);
+
+  stan::mcmc::dense_e_point z_init(1);
+  z_init.q(0) = 1;
+  z_init.p(0) = -1;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+  gauss_model_namespace::gauss_model model(data_var_context);
+
+  stan::mcmc::adapt_dense_e_static_uniform<gauss_model_namespace::gauss_model, rng_t>
+    sampler(model, base_rng);
+
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer);
+  sampler.set_nominal_stepsize(0.1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+
+  stan::mcmc::sample init_sample(z_init.q, 0, 0);
+
+  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+
+  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_EQ("", output.str());
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds a static HMC sampler that samples trajectories of fixed sized uniformly around the initial point instead of deterministically forward in time.  Addresses #1849.

#### Intended Effect

Adds a new HMC sampler.

#### How to Verify

Run tests.

#### Side Effects

None.

#### Documentation

None.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Copyright: Michael Betancourt

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
