### PR TITLE
Feature/issue 1852 streamline nuts criterion

### DIFF
--- a/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
@@ -7,10 +7,11 @@
 
 namespace stan {
   namespace mcmc {
-
-    // The No-U-Turn Sampler (NUTS) on a
-    // Euclidean manifold with dense metric
-    // and adaptive stepsize
+    /**
+      * The No-U-Turn sampler (NUTS) with multinomial sampling
+      * with a Gaussian-Euclidean disintegration and adaptive
+      * dense metric and adaptive step size
+    */
     template <class Model, class BaseRNG>
     class adapt_dense_e_nuts : public dense_e_nuts<Model, BaseRNG>,
                                public stepsize_covar_adapter {

--- a/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
@@ -7,11 +7,11 @@
 
 namespace stan {
   namespace mcmc {
-
-    // The No-U-Turn Sampler (NUTS) on a
-    // Euclidean manifold with diagonal metric
-    // and adaptive stepsize
-
+    /**
+      * The No-U-Turn sampler (NUTS) with multinomial sampling
+      * with a Gaussian-Euclidean disintegration and adaptive
+      * diagonal metric and adaptive step size
+    */
     template <class Model, class BaseRNG>
     class adapt_diag_e_nuts: public diag_e_nuts<Model, BaseRNG>,
                              public stepsize_var_adapter {

--- a/src/stan/mcmc/hmc/nuts/adapt_unit_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_unit_e_nuts.hpp
@@ -7,11 +7,11 @@
 
 namespace stan {
   namespace mcmc {
-
-    // The No-U-Turn Sampler (NUTS) on a
-    // Euclidean manifold with unit metric
-    // and adaptive stepsize
-
+    /**
+      * The No-U-Turn sampler (NUTS) with multinomial sampling
+      * with a Gaussian-Euclidean disintegration and unit metric
+      * and adaptive step size
+    */
     template <class Model, class BaseRNG>
     class adapt_unit_e_nuts: public unit_e_nuts<Model, BaseRNG>,
                              public stepsize_adapter {

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -20,8 +20,8 @@ namespace stan {
     public:
       base_nuts(Model &model, BaseRNG& rng)
         : base_hmc<Model, Hamiltonian, Integrator, BaseRNG>(model, rng),
-        depth_(0), max_depth_(5), max_deltaH_(1000),
-        n_leapfrog_(0), divergent_(0), energy_(0) {
+          depth_(0), max_depth_(5), max_deltaH_(1000),
+          n_leapfrog_(0), divergent_(0), energy_(0) {
       }
 
       ~base_nuts() {}
@@ -54,6 +54,8 @@ namespace stan {
         ps_point z_sample(z_plus);
         ps_point z_propose(z_plus);
 
+        Eigen::VectorXd p_sharp_plus = this->hamiltonian_.dtau_dp(this->z_);
+        Eigen::VectorXd p_sharp_minus = this->hamiltonian_.dtau_dp(this->z_);
         Eigen::VectorXd rho = this->z_.p;
         double sum_weight = 1;
 
@@ -80,6 +82,7 @@ namespace stan {
                            H0, 1, n_leapfrog,
                            sum_weight_subtree, sum_metro_prob, writer);
             z_plus.ps_point::operator=(this->z_);
+            p_sharp_plus = this->hamiltonian_.dtau_dp(this->z_);
           } else {
             this->z_.ps_point::operator=(z_minus);
             valid_subtree
@@ -87,6 +90,7 @@ namespace stan {
                            H0, -1, n_leapfrog,
                            sum_weight_subtree, sum_metro_prob, writer);
             z_minus.ps_point::operator=(this->z_);
+            p_sharp_minus = this->hamiltonian_.dtau_dp(this->z_);
           }
 
           sum_weight += sum_weight_subtree;
@@ -100,10 +104,8 @@ namespace stan {
             z_sample = z_propose;
 
           // Break when NUTS criterion is not longer satisfied
-          this->z_.ps_point::operator=(z_plus);
-
           rho += rho_subtree;
-          if (!compute_criterion(z_minus, this->z_, rho))
+          if (!compute_criterion(p_sharp_minus, p_sharp_plus, rho))
             break;
         }
 
@@ -135,10 +137,12 @@ namespace stan {
         values.push_back(this->energy_);
       }
 
-      virtual bool compute_criterion(ps_point& start,
-                                     typename Hamiltonian<Model, BaseRNG>
-                                     ::PointType& finish,
-                                     Eigen::VectorXd& rho) = 0;
+      bool compute_criterion(Eigen::VectorXd& p_sharp_minus,
+                             Eigen::VectorXd& p_sharp_plus,
+                             Eigen::VectorXd& rho) {
+        return    p_sharp_plus.dot(rho) > 0
+               && p_sharp_minus.dot(rho) > 0;
+      }
 
       // Returns number of valid points in the completed subtree
       int build_tree(int depth, Eigen::VectorXd& rho, ps_point& z_propose,
@@ -169,7 +173,7 @@ namespace stan {
 
         } else {
           // General recursion
-          ps_point z_init(this->z_);
+          Eigen::VectorXd p_sharp_left = this->hamiltonian_.dtau_dp(this->z_);
 
           Eigen::VectorXd rho_subtree(rho.size());
           rho_subtree.setZero();
@@ -203,7 +207,8 @@ namespace stan {
             z_propose = z_propose_right;
 
           rho += rho_subtree;
-          return compute_criterion(z_init, this->z_, rho_subtree);
+          Eigen::VectorXd p_sharp_right = this->hamiltonian_.dtau_dp(this->z_);
+          return compute_criterion(p_sharp_left, p_sharp_right, rho_subtree);
         }
       }
 

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -13,7 +13,9 @@
 
 namespace stan {
   namespace mcmc {
-    // The No-U-Turn Sampler (NUTS) with multinomial sampling
+    /**
+      * The No-U-Turn sampler (NUTS) with multinomial sampling
+    */
     template <class Model, template<class, class> class Hamiltonian,
               template<class> class Integrator, class BaseRNG>
     class base_nuts : public base_hmc<Model, Hamiltonian, Integrator, BaseRNG> {

--- a/src/stan/mcmc/hmc/nuts/dense_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/dense_e_nuts.hpp
@@ -18,15 +18,6 @@ namespace stan {
       dense_e_nuts(Model &model, BaseRNG& rng)
         : base_nuts<Model, dense_e_metric, expl_leapfrog,
                     BaseRNG>(model, rng) { }
-
-      // Note that the points don't need to be swapped
-      // here since start.mInv = finish.mInv
-      bool compute_criterion(ps_point& start,
-                             dense_e_point& finish,
-                             Eigen::VectorXd& rho) {
-        return finish.p.transpose() * finish.mInv * (rho - finish.p) > 0
-               && start.p.transpose() * finish.mInv * (rho - start.p)  > 0;
-      }
     };
 
   }  // mcmc

--- a/src/stan/mcmc/hmc/nuts/dense_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/dense_e_nuts.hpp
@@ -8,9 +8,10 @@
 
 namespace stan {
   namespace mcmc {
-
-    // The No-U-Turn Sampler (NUTS) on a
-    // Euclidean manifold with dense metric
+    /**
+      * The No-U-Turn sampler (NUTS) with multinomial sampling
+      * with a Gaussian-Euclidean disintegration and dense metric
+    */
     template <class Model, class BaseRNG>
     class dense_e_nuts : public base_nuts<Model, dense_e_metric,
                                           expl_leapfrog, BaseRNG> {

--- a/src/stan/mcmc/hmc/nuts/diag_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/diag_e_nuts.hpp
@@ -18,15 +18,6 @@ namespace stan {
       diag_e_nuts(Model &model, BaseRNG& rng)
         : base_nuts<Model, diag_e_metric, expl_leapfrog,
                     BaseRNG>(model, rng) { }
-
-      // Note that the points don't need to be swapped
-      // here since start.mInv = finish.mInv
-      bool compute_criterion(ps_point& start,
-                             diag_e_point& finish,
-                             Eigen::VectorXd& rho) {
-        return finish.mInv.cwiseProduct(finish.p).dot(rho - finish.p) > 0
-               && finish.mInv.cwiseProduct(start.p).dot(rho - start.p) > 0;
-      }
     };
 
   }  // mcmc

--- a/src/stan/mcmc/hmc/nuts/diag_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/diag_e_nuts.hpp
@@ -8,9 +8,10 @@
 
 namespace stan {
   namespace mcmc {
-
-    // The No-U-Turn Sampler (NUTS) on a
-    // Euclidean manifold with diagonal metric
+    /**
+      * The No-U-Turn sampler (NUTS) with multinomial sampling
+      * with a Gaussian-Euclidean disintegration and diagonal metric
+    */
     template <class Model, class BaseRNG>
     class diag_e_nuts : public base_nuts<Model, diag_e_metric,
                                          expl_leapfrog, BaseRNG> {

--- a/src/stan/mcmc/hmc/nuts/unit_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/unit_e_nuts.hpp
@@ -8,9 +8,10 @@
 
 namespace stan {
   namespace mcmc {
-
-    // The No-U-Turn Sampler (NUTS) on a
-    // Euclidean manifold with unit metric
+    /**
+      * The No-U-Turn sampler (NUTS) with multinomial sampling
+      * with a Gaussian-Euclidean disintegration and unit metric
+    */
     template <class Model, class BaseRNG>
     class unit_e_nuts
       : public base_nuts<Model, unit_e_metric,

--- a/src/stan/mcmc/hmc/nuts/unit_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/unit_e_nuts.hpp
@@ -19,13 +19,6 @@ namespace stan {
       unit_e_nuts(Model &model, BaseRNG& rng)
         : base_nuts<Model, unit_e_metric, expl_leapfrog,
                     BaseRNG>(model, rng) { }
-
-      bool compute_criterion(ps_point& start,
-                             unit_e_point& finish,
-                             Eigen::VectorXd& rho) {
-        return finish.p.dot(rho - finish.p) > 0
-               && start.p.dot(rho - start.p) > 0;
-      }
     };
 
   }  // mcmc

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -108,13 +108,13 @@ TEST_F(performance, values_from_tagged_version) {
     << "last tagged version, 2.9.0, had " << N_values << " elements";
 
   std::vector<double> first_run = last_draws_per_run[0];
-  EXPECT_FLOAT_EQ(-65.943199, first_run[0])
+  EXPECT_FLOAT_EQ(-65.241302, first_run[0])
     << "lp__: index 0";
 
-  EXPECT_FLOAT_EQ(0.73218799, first_run[1])
+  EXPECT_FLOAT_EQ(0.98944098, first_run[1])
     << "accept_stat__: index 1";
 
-  EXPECT_FLOAT_EQ(1.22537, first_run[2])
+  EXPECT_FLOAT_EQ(1.3144701, first_run[2])
     << "stepsize__: index 2";
 
   EXPECT_FLOAT_EQ(1, first_run[3])
@@ -126,13 +126,13 @@ TEST_F(performance, values_from_tagged_version) {
   EXPECT_FLOAT_EQ(0, first_run[5])
     << "divergent__: index 5";
 
-  EXPECT_FLOAT_EQ(67.8694, first_run[6])
+  EXPECT_FLOAT_EQ(65.266701, first_run[6])
     << "energy__: index 6";
 
-  EXPECT_FLOAT_EQ(1.56502, first_run[7])
+  EXPECT_FLOAT_EQ(1.30007, first_run[7])
     << "beta.1: index 7";
 
-  EXPECT_FLOAT_EQ(-0.69909501, first_run[8])
+  EXPECT_FLOAT_EQ(-0.57955098, first_run[8])
     << "beta.2: index 8";
 
   matches_tagged_version = !HasNonfatalFailure();

--- a/src/test/unit/mcmc/hmc/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/base_nuts_test.cpp
@@ -19,13 +19,6 @@ namespace stan {
       mock_nuts(mock_model &m, rng_t& rng)
         : base_nuts<mock_model,mock_hamiltonian,mock_integrator,rng_t>(m, rng)
       { }
-
-    private:
-
-      bool compute_criterion(ps_point& start,
-                             ps_point& finish,
-                             Eigen::VectorXd& rho) { return true; }
-
     };
 
     // Mock Hamiltonian
@@ -77,13 +70,6 @@ namespace stan {
       divergent_nuts(mock_model &m, rng_t& rng)
         : base_nuts<mock_model, divergent_hamiltonian, expl_leapfrog,rng_t>(m, rng)
       { }
-
-    private:
-
-      bool compute_criterion(ps_point& start,
-                             ps_point& finish,
-                             Eigen::VectorXd& rho) { return false; }
-
     };
 
   }

--- a/src/test/unit/mcmc/hmc/derived_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/derived_nuts_test.cpp
@@ -18,8 +18,10 @@ TEST(McmcDerivedNuts, compute_criterion_unit_e) {
 
   int model_size = 1;
 
-  stan::mcmc::ps_point start(model_size);
+  stan::mcmc::unit_e_point start(model_size);
   stan::mcmc::unit_e_point finish(model_size);
+  Eigen::VectorXd p_sharp_start(model_size);
+  Eigen::VectorXd p_sharp_finish(model_size);
   Eigen::VectorXd rho(model_size);
 
   stan::mcmc::mock_model model(model_size);
@@ -31,9 +33,11 @@ TEST(McmcDerivedNuts, compute_criterion_unit_e) {
   finish.q(0) = 2;
   finish.p(0) = 1;
 
+  p_sharp_start = start.p;
+  p_sharp_finish = finish.p;
   rho = start.p + finish.p;
 
-  EXPECT_TRUE(sampler.compute_criterion(start, finish, rho));
+  EXPECT_TRUE(sampler.compute_criterion(p_sharp_start, p_sharp_finish, rho));
 
   start.q(0) = 1;
   start.p(0) = 1;
@@ -41,9 +45,11 @@ TEST(McmcDerivedNuts, compute_criterion_unit_e) {
   finish.q(0) = 2;
   finish.p(0) = -1;
 
+  p_sharp_start = start.p;
+  p_sharp_finish = finish.p;
   rho = start.p + finish.p;
 
-  EXPECT_FALSE(sampler.compute_criterion(start, finish, rho));
+  EXPECT_FALSE(sampler.compute_criterion(p_sharp_start, p_sharp_finish, rho));
 
 }
 
@@ -53,8 +59,10 @@ TEST(McmcDerivedNuts, compute_criterion_diag_e) {
 
   int model_size = 1;
 
-  stan::mcmc::ps_point start(model_size);
+  stan::mcmc::diag_e_point start(model_size);
   stan::mcmc::diag_e_point finish(model_size);
+  Eigen::VectorXd p_sharp_start(model_size);
+  Eigen::VectorXd p_sharp_finish(model_size);
   Eigen::VectorXd rho(model_size);
 
   stan::mcmc::mock_model model(model_size);
@@ -66,9 +74,11 @@ TEST(McmcDerivedNuts, compute_criterion_diag_e) {
   finish.q(0) = 2;
   finish.p(0) = 1;
 
+  p_sharp_start = start.mInv.cwiseProduct(start.p);
+  p_sharp_finish = finish.mInv.cwiseProduct(finish.p);
   rho = start.p + finish.p;
 
-  EXPECT_TRUE(sampler.compute_criterion(start, finish, rho));
+  EXPECT_TRUE(sampler.compute_criterion(p_sharp_start, p_sharp_finish, rho));
 
   start.q(0) = 1;
   start.p(0) = 1;
@@ -76,9 +86,11 @@ TEST(McmcDerivedNuts, compute_criterion_diag_e) {
   finish.q(0) = 2;
   finish.p(0) = -1;
 
+  p_sharp_start = start.mInv.cwiseProduct(start.p);
+  p_sharp_finish = finish.mInv.cwiseProduct(finish.p);
   rho = start.p + finish.p;
 
-  EXPECT_FALSE(sampler.compute_criterion(start, finish, rho));
+  EXPECT_FALSE(sampler.compute_criterion(p_sharp_start, p_sharp_finish, rho));
 }
 
 TEST(McmcDerivedNuts, compute_criterion_dense_e) {
@@ -87,8 +99,10 @@ TEST(McmcDerivedNuts, compute_criterion_dense_e) {
 
   int model_size = 1;
 
-  stan::mcmc::ps_point start(model_size);
+  stan::mcmc::dense_e_point start(model_size);
   stan::mcmc::dense_e_point finish(model_size);
+  Eigen::VectorXd p_sharp_start(model_size);
+  Eigen::VectorXd p_sharp_finish(model_size);
   Eigen::VectorXd rho(model_size);
 
   stan::mcmc::mock_model model(model_size);
@@ -100,18 +114,22 @@ TEST(McmcDerivedNuts, compute_criterion_dense_e) {
   finish.q(0) = 2;
   finish.p(0) = 1;
 
+  p_sharp_start = start.mInv * start.p;
+  p_sharp_finish = finish.mInv * finish.p;
   rho = start.p + finish.p;
 
-  EXPECT_TRUE(sampler.compute_criterion(start, finish, rho));
-  
+  EXPECT_TRUE(sampler.compute_criterion(p_sharp_start, p_sharp_finish, rho));
+
   start.q(0) = 1;
   start.p(0) = 1;
 
   finish.q(0) = 2;
   finish.p(0) = -1;
 
+  p_sharp_start = start.mInv * start.p;
+  p_sharp_finish = finish.mInv * finish.p;
   rho = start.p + finish.p;
 
-  EXPECT_FALSE(sampler.compute_criterion(start, finish, rho));
+  EXPECT_FALSE(sampler.compute_criterion(p_sharp_start, p_sharp_finish, rho));
 
 }

--- a/src/test/unit/mcmc/hmc/mock_hmc.hpp
+++ b/src/test/unit/mcmc/hmc/mock_hmc.hpp
@@ -8,16 +8,12 @@
 #include <stan/mcmc/hmc/integrators/base_integrator.hpp>
 
 namespace stan {
-  
   namespace mcmc {
-    
-
     // Mock Model
     class mock_model: public model::prob_grad {
     public:
-      
       mock_model(size_t num_params_r): model::prob_grad(num_params_r) {};
-      
+
       template <bool propto, bool jacobian_adjust_transforms, typename T>
       T log_prob(Eigen::Matrix<T,Eigen::Dynamic,1>& params_r,
                  std::ostream* output_stream = 0) const {
@@ -28,16 +24,16 @@ namespace stan {
       // double grad_log_prob(std::vector<double>& params_r,
       //                      std::vector<int>& params_i,
       //                      std::vector<double>& gradient,
-      //                      std::ostream* output_stream = 0) { 
-      //   return 0; 
+      //                      std::ostream* output_stream = 0) {
+      //   return 0;
       // }
 
       double log_prob(Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                      std::ostream* output_stream = 0) const { 
+                      std::ostream* output_stream = 0) const {
         return 0;
       }
-      
-      
+
+
     };
 
     // Mock Hamiltonian
@@ -45,49 +41,48 @@ namespace stan {
     class mock_hamiltonian: public base_hamiltonian<Model,
                                                     ps_point,
                                                     BaseRNG> {
-      
+
     public:
       explicit mock_hamiltonian(Model& model)
         : base_hamiltonian<Model, ps_point, BaseRNG>(model) {}
-      
+
       double T(ps_point& z) { return 0; }
-      
+
       double tau(ps_point& z) { return T(z); }
       double phi(ps_point& z) { return this->V(z); }
-      
+
       const Eigen::VectorXd dtau_dq(ps_point& z) {
         return Eigen::VectorXd::Zero(this->model_.num_params_r());
       }
-      
+
+      // Ensures that NUTS non-termination criterion is always true
       const Eigen::VectorXd dtau_dp(ps_point& z) {
-        return Eigen::VectorXd::Zero(this->model_.num_params_r());
+        return Eigen::VectorXd::Ones(this->model_.num_params_r());
       }
-      
+
       const Eigen::VectorXd dphi_dq(ps_point& z) {
         return Eigen::VectorXd::Zero(this->model_.num_params_r());
       }
-      
+
       void sample_p(ps_point& z, BaseRNG& rng) {}
-      
     };
-    
+
     // Mock Integrator
     template <typename Hamiltonian>
     class mock_integrator: public base_integrator<Hamiltonian> {
-    
+
     public:
-      mock_integrator() 
+      mock_integrator()
         : base_integrator<Hamiltonian>() { }
-      
+
       void evolve(typename Hamiltonian::PointType& z,
                   Hamiltonian& hamiltonian,
                   const double epsilon,
                   stan::interface_callbacks::writer::base_writer& writer) {
         z.q += epsilon * z.p;
       };
-      
+
     };
-    
   } // mcmc
 } // stan
 #endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Tweaks the (generalized) No-U-Turn criterion.  Addresses #1852.

#### Intended Effect

The (generalized) No-U-Turn criterion is slightly tweaked which not only allows for an implementation that uses less memory but also makes adding Riemannian NUTS much simpler.  The change is essentially an edge case in the trajectory discretization (include the last point or not?) that is ambiguous in the theoretical definition, so it shouldn't make any appreciable difference in sampler performance.

#### How to Verify

Run unit tests or try running some multivariate models with known expectations.  Everything should fit just as well as before.

#### Side Effects

The tweak in the criterion definition will slightly change the exact sampler output but should not affect the accuracy of any expectations.  For small step sizes any such effects should be negligible.

#### Documentation

No user-facing changes.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Copyright: Michael Betancourt

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)