### PR TITLE
Bugfix/1815 advi buffered message

### DIFF
--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -28,24 +28,32 @@ namespace stan {
     /**
      * Automatic Differentiation Variational Inference
      *
-     * Runs "black box" variational inference by applying stochastic gradient
-     * ascent in order to maximize the Evidence Lower Bound for a given model
+     * Implements "black box" variational inference using stochastic gradient
+     * ascent to maximize the Evidence Lower Bound for a given model
      * and variational family.
      *
      * @tparam Model                 class of model
      * @tparam Q                     class of variational distribution
      * @tparam BaseRNG               class of random number generator
-     * @param  m                     stan model
-     * @param  cont_params           initialization of continuous parameters
-     * @param  rng                   random number generator
-     * @param  n_monte_carlo_grad    number of samples for gradient computation
-     * @param  n_monte_carlo_elbo    number of samples for ELBO computation
-     * @param  eval_elbo             evaluate ELBO at every "eval_elbo" iters
-     * @param  n_posterior_samples   number of samples to draw from posterior
      */
     template <class Model, class Q, class BaseRNG>
     class advi {
     public:
+      /**
+       * Constructor
+       * 
+       * @param  m                    stan model
+       * @param  cont_params          initialization of continuous parameters
+       * @param  rng                  random number generator
+       * @param  n_monte_carlo_grad   number of samples for gradient computation
+       * @param  n_monte_carlo_elbo   number of samples for ELBO computation
+       * @param  eval_elbo            evaluate ELBO at every "eval_elbo" iters
+       * @param  n_posterior_samples  number of samples to draw from posterior
+       * @throw  std::runtime_error   if n_monte_carlo_grad is not positive
+       * @throw  std::runtime_error   if n_monte_carlo_elbo is not positive
+       * @throw  std::runtime_error   if eval_elbo is not positive
+       * @throw  std::runtime_error   if n_posterior_samples is not positive
+       */
       advi(Model& m,
            Eigen::VectorXd& cont_params,
            BaseRNG& rng,
@@ -65,11 +73,11 @@ namespace stan {
                              "Number of Monte Carlo samples for gradients",
                              n_monte_carlo_grad_);
         math::check_positive(function,
+                             "Number of Monte Carlo samples for ELBO",
+                             n_monte_carlo_elbo_);
+        math::check_positive(function,
                              "Evaluate ELBO at every eval_elbo iteration",
                              eval_elbo_);
-        math::check_positive(function,
-                             "Number of posterior samples for output",
-                             n_posterior_samples_);
         math::check_positive(function,
                              "Number of posterior samples for output",
                              n_posterior_samples_);
@@ -133,8 +141,8 @@ namespace stan {
        * @param[in] variational variational approximation at which to evaluate
        * the ELBO.
        * @param[out] elbo_grad gradient of ELBO with respect to variational
-       * @param message_writer writer for messages
        * approximation.
+       * @param message_writer writer for messages
        */
       void calc_ELBO_grad(const Q& variational, Q& elbo_grad,
                           interface_callbacks::writer::base_writer&

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -521,9 +521,9 @@ namespace stan {
         // Draw more samples from posterior and write on subsequent lines
         message_writer();
         std::stringstream ss;
-        ss << "Drawing "
+        ss << "Drawing a sample of size "
            << n_posterior_samples_
-           << " samples from the approximate posterior... ";
+           << " from the approximate posterior... ";
         message_writer(ss.str());
 
         for (int n = 0; n < n_posterior_samples_; ++n) {

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -524,7 +524,7 @@ namespace stan {
         ss << "Drawing "
            << n_posterior_samples_
            << " samples from the approximate posterior... ";
-        message_writer(ss.str());           
+        message_writer(ss.str());
 
         for (int n = 0; n < n_posterior_samples_; ++n) {
           variational.sample(rng_, cont_params_);

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -524,6 +524,7 @@ namespace stan {
         ss << "Drawing "
            << n_posterior_samples_
            << " samples from the approximate posterior... ";
+        message_writer(ss.str());           
 
         for (int n = 0; n < n_posterior_samples_; ++n) {
           variational.sample(rng_, cont_params_);
@@ -535,8 +536,7 @@ namespace stan {
                                         message_writer,
                                         parameter_writer);
         }
-        ss << "COMPLETED.";
-        message_writer(ss.str());
+        message_writer("COMPLETED.");
 
         return stan::services::error_codes::OK;
       }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Addresses issue https://github.com/stan-dev/stan/issues/1815 by

- fixing the buffered message issue
- cleaning up some comments
- changing the terminology of the output message

#### Intended Effect

To fix https://github.com/stan-dev/stan/issues/1815

#### How to Verify

Tests and visual inspection.

#### Side Effects

None.

#### Documentation

None.

#### Reviewer Suggestions

@syclik and/or @bob-carpenter 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): @akucukelbir

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
