### PR TITLE
Feature/issue 1836 streams

### DIFF
--- a/src/stan/mcmc/base_mcmc.hpp
+++ b/src/stan/mcmc/base_mcmc.hpp
@@ -18,7 +18,8 @@ namespace stan {
 
       virtual sample
       transition(sample& init_sample,
-                 interface_callbacks::writer::base_writer& writer) = 0;
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) = 0;
 
       virtual void get_sampler_param_names(std::vector<std::string>& names) {}
 

--- a/src/stan/mcmc/fixed_param_sampler.hpp
+++ b/src/stan/mcmc/fixed_param_sampler.hpp
@@ -12,8 +12,10 @@ namespace stan {
     public:
       fixed_param_sampler() { }
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         return init_sample;
       }
     };

--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -54,11 +54,15 @@ namespace stan {
         z_.q = q;
       }
 
-      void init_hamiltonian(interface_callbacks::writer::base_writer& writer) {
-        this->hamiltonian_.init(this->z_, writer);
+      void
+      init_hamiltonian(interface_callbacks::writer::base_writer& info_writer,
+                       interface_callbacks::writer::base_writer& error_writer) {
+        this->hamiltonian_.init(this->z_, info_writer, error_writer);
       }
 
-      void init_stepsize(interface_callbacks::writer::base_writer& writer) {
+      void
+      init_stepsize(interface_callbacks::writer::base_writer& info_writer,
+                    interface_callbacks::writer::base_writer& error_writer) {
         ps_point z_init(this->z_);
 
         // Skip initialization for extreme step sizes
@@ -66,13 +70,14 @@ namespace stan {
           return;
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, writer);
+        this->hamiltonian_.init(this->z_, info_writer, error_writer);
 
         // Guaranteed to be finite if randomly initialized
         double H0 = this->hamiltonian_.H(this->z_);
 
         this->integrator_.evolve(this->z_, this->hamiltonian_,
-                                 this->nom_epsilon_, writer);
+                                 this->nom_epsilon_,
+                                 info_writer, error_writer);
 
         double h = this->hamiltonian_.H(this->z_);
         if (boost::math::isnan(h))
@@ -86,12 +91,13 @@ namespace stan {
           this->z_.ps_point::operator=(z_init);
 
           this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-          this->hamiltonian_.init(this->z_, writer);
+          this->hamiltonian_.init(this->z_, info_writer, error_writer);
 
           double H0 = this->hamiltonian_.H(this->z_);
 
           this->integrator_.evolve(this->z_, this->hamiltonian_,
-                                   this->nom_epsilon_, writer);
+                                   this->nom_epsilon_,
+                                   info_writer, error_writer);
 
           double h = this->hamiltonian_.H(this->z_);
           if (boost::math::isnan(h))

--- a/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
@@ -49,18 +49,22 @@ namespace stan {
 
       virtual void sample_p(Point& z, BaseRNG& rng) = 0;
 
-      virtual void init(Point& z,
-                        interface_callbacks::writer::base_writer& writer) {
-        this->update(z, writer);
+      virtual void
+      init(Point& z,
+           interface_callbacks::writer::base_writer& info_writer,
+           interface_callbacks::writer::base_writer& error_writer) {
+        this->update(z, info_writer, error_writer);
       }
 
-      virtual void update(Point& z,
-                          interface_callbacks::writer::base_writer& writer) {
+      virtual void
+      update(Point& z,
+             interface_callbacks::writer::base_writer& info_writer,
+             interface_callbacks::writer::base_writer& error_writer) {
         try {
-          stan::model::gradient(model_, z.q, z.V, z.g, writer);
+          stan::model::gradient(model_, z.q, z.V, z.g, info_writer);
           z.V *= -1;
         } catch (const std::exception& e) {
-          this->write_error_msg_(e, writer);
+          this->write_error_msg_(e, error_writer);
           z.V = std::numeric_limits<double>::infinity();
         }
         z.g *= -1;

--- a/src/stan/mcmc/hmc/integrators/base_integrator.hpp
+++ b/src/stan/mcmc/hmc/integrators/base_integrator.hpp
@@ -11,10 +11,12 @@ namespace stan {
     public:
       base_integrator() {}
 
-      virtual void evolve(typename Hamiltonian::PointType& z,
-                          Hamiltonian& hamiltonian,
-                          const double epsilon,
-                          interface_callbacks::writer::base_writer& writer) = 0;
+      virtual void
+      evolve(typename Hamiltonian::PointType& z,
+             Hamiltonian& hamiltonian,
+             const double epsilon,
+             interface_callbacks::writer::base_writer& info_writer,
+             interface_callbacks::writer::base_writer& error_writer) = 0;
     };
 
   }  // mcmc

--- a/src/stan/mcmc/hmc/integrators/base_leapfrog.hpp
+++ b/src/stan/mcmc/hmc/integrators/base_leapfrog.hpp
@@ -18,19 +18,22 @@ namespace stan {
       void evolve(typename Hamiltonian::PointType& z,
                   Hamiltonian& hamiltonian,
                   const double epsilon,
-                  interface_callbacks::writer::base_writer& writer) {
+                  interface_callbacks::writer::base_writer& info_writer,
+                  interface_callbacks::writer::base_writer& error_writer) {
         begin_update_p(z, hamiltonian, 0.5 * epsilon);
 
         update_q(z, hamiltonian, epsilon);
-        hamiltonian.update(z, writer);
+        hamiltonian.update(z, info_writer, error_writer);
 
         end_update_p(z, hamiltonian, 0.5 * epsilon);
       }
 
-      void verbose_evolve(typename Hamiltonian::PointType& z,
-                          Hamiltonian& hamiltonian,
-                          const double epsilon,
-                          interface_callbacks::writer::base_writer& writer) {
+      void
+      verbose_evolve(typename Hamiltonian::PointType& z,
+                     Hamiltonian& hamiltonian,
+                     const double epsilon,
+                     interface_callbacks::writer::base_writer& info_writer,
+                     interface_callbacks::writer::base_writer& error_writer) {
         std::stringstream msg;
         msg.precision(6);
 
@@ -38,13 +41,13 @@ namespace stan {
         int nColumn = 4;
 
         msg << "Verbose Hamiltonian Evolution, Step Size = " << epsilon << ":";
-        writer(msg.str());
+        info_writer(msg.str());
 
         msg.str("");
         msg << "    " << std::setw(nColumn * width)
             << std::setfill('-')
             << "" << std::setfill(' ');
-        writer(msg.str());
+        info_writer(msg.str());
 
         msg.str("");
         msg << "    "
@@ -52,7 +55,7 @@ namespace stan {
             << std::setw(width) << std::left << "Initial"
             << std::setw(width) << std::left << "Current"
             << std::setw(width) << std::left << "DeltaH";
-        writer(msg.str());
+        info_writer(msg.str());
 
         msg.str("");
         msg << "    "
@@ -60,13 +63,13 @@ namespace stan {
             << std::setw(width) << std::left << "Hamiltonian"
             << std::setw(width) << std::left << "Hamiltonian"
             << std::setw(width) << std::left << "/ Stepsize^{2}";
-        writer(msg.str());
+        info_writer(msg.str());
 
         msg.str("");
         msg << "    " << std::setw(nColumn * width)
             << std::setfill('-')
             << "" << std::setfill(' ');
-        writer(msg.str());
+        info_writer(msg.str());
 
         double H0 = hamiltonian.H(z);
 
@@ -80,10 +83,10 @@ namespace stan {
             << std::setw(width) << std::left << H0
             << std::setw(width) << std::left << H1
             << std::setw(width) << std::left << (H1 - H0) / (epsilon * epsilon);
-        writer(msg.str());
+        info_writer(msg.str());
 
         update_q(z, hamiltonian, epsilon);
-        hamiltonian.update(z, writer);
+        hamiltonian.update(z, info_writer, error_writer);
 
         double H2 = hamiltonian.H(z);
 
@@ -93,7 +96,7 @@ namespace stan {
             << std::setw(width) << std::left << H0
             << std::setw(width) << std::left << H2
             << std::setw(width) << std::left << (H2 - H0) / (epsilon * epsilon);
-        writer(msg.str());
+        info_writer(msg.str());
 
         end_update_p(z, hamiltonian, 0.5 * epsilon);
 
@@ -105,7 +108,7 @@ namespace stan {
             << std::setw(width) << std::left << H0
             << std::setw(width) << std::left << H3
             << std::setw(width) << std::left << (H3 - H0) / (epsilon * epsilon);
-        writer(msg.str());
+        info_writer(msg.str());
 
         msg.str("");
         msg << "    "
@@ -113,7 +116,7 @@ namespace stan {
             << std::setfill('-')
             << ""
             << std::setfill(' ');
-        writer(msg.str());
+        info_writer(msg.str());
       }
 
       virtual void begin_update_p(typename Hamiltonian::PointType& z,

--- a/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
@@ -22,10 +22,13 @@ namespace stan {
 
       ~adapt_dense_e_nuts() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         sample s = dense_e_nuts<Model, BaseRNG>::transition(init_sample,
-                                                            writer);
+                                                            info_writer,
+                                                            error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -35,7 +38,7 @@ namespace stan {
                                                                  this->z_.q);
 
           if (update) {
-            this->init_stepsize(writer);
+            this->init_stepsize(info_writer);
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();

--- a/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
@@ -22,10 +22,13 @@ namespace stan {
 
       ~adapt_diag_e_nuts() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         sample s = diag_e_nuts<Model, BaseRNG>::transition(init_sample,
-                                                           writer);
+                                                           info_writer,
+                                                           error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -35,7 +38,7 @@ namespace stan {
                                                              this->z_.q);
 
           if (update) {
-            this->init_stepsize(writer);
+            this->init_stepsize(info_writer);
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();

--- a/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
@@ -38,7 +38,7 @@ namespace stan {
                                                              this->z_.q);
 
           if (update) {
-            this->init_stepsize(info_writer);
+            this->init_stepsize(info_writer, error_writer);
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();

--- a/src/stan/mcmc/hmc/nuts/adapt_unit_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_unit_e_nuts.hpp
@@ -21,9 +21,13 @@ namespace stan {
 
       ~adapt_unit_e_nuts() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
-        sample s = unit_e_nuts<Model, BaseRNG>::transition(init_sample, writer);
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
+        sample s = unit_e_nuts<Model, BaseRNG>::transition(init_sample,
+                                                           info_writer,
+                                                           error_writer);
 
         if (this->adapt_flag_)
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -50,7 +50,7 @@ namespace stan {
         this->seed(init_sample.cont_params());
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, info_writer);
+        this->hamiltonian_.init(this->z_, info_writer, error_writer);
 
         ps_point z_plus(this->z_);
         ps_point z_minus(z_plus);
@@ -84,7 +84,8 @@ namespace stan {
             valid_subtree
               = build_tree(this->depth_, rho_subtree, z_propose,
                            H0, 1, n_leapfrog,
-                           sum_weight_subtree, sum_metro_prob, info_writer);
+                           sum_weight_subtree, sum_metro_prob,
+                           info_writer, error_writer);
             z_plus.ps_point::operator=(this->z_);
             p_sharp_plus = this->hamiltonian_.dtau_dp(this->z_);
           } else {
@@ -92,7 +93,8 @@ namespace stan {
             valid_subtree
               = build_tree(this->depth_, rho_subtree, z_propose,
                            H0, -1, n_leapfrog,
-                           sum_weight_subtree, sum_metro_prob, info_writer);
+                           sum_weight_subtree, sum_metro_prob,
+                           info_writer, error_writer);
             z_minus.ps_point::operator=(this->z_);
             p_sharp_minus = this->hamiltonian_.dtau_dp(this->z_);
           }
@@ -152,12 +154,13 @@ namespace stan {
       int build_tree(int depth, Eigen::VectorXd& rho, ps_point& z_propose,
                      double H0, double sign, int& n_leapfrog,
                      double& sum_weight, double& sum_metro_prob,
-                     interface_callbacks::writer::base_writer& writer) {
+                     interface_callbacks::writer::base_writer& info_writer,
+                     interface_callbacks::writer::base_writer& error_writer) {
         // Base case
         if (depth == 0) {
             this->integrator_.evolve(this->z_, this->hamiltonian_,
                                      sign * this->epsilon_,
-                                     writer);
+                                     info_writer, error_writer);
             ++n_leapfrog;
 
             double h = this->hamiltonian_.H(this->z_);
@@ -187,7 +190,8 @@ namespace stan {
         bool valid_left
           = build_tree(depth - 1, rho_subtree, z_propose,
                        H0, sign, n_leapfrog,
-                       sum_weight_left, sum_metro_prob, writer);
+                       sum_weight_left, sum_metro_prob,
+                       info_writer, error_writer);
 
         sum_weight += sum_weight_left;
         if (!valid_left) return false;
@@ -199,7 +203,8 @@ namespace stan {
         bool valid_right
           = build_tree(depth - 1, rho_subtree, z_propose_right,
                        H0, sign, n_leapfrog,
-                       sum_weight_right, sum_metro_prob, writer);
+                       sum_weight_right, sum_metro_prob,
+                       info_writer, error_writer);
 
         sum_weight += sum_weight_right;
         if (!valid_right) return false;

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -40,15 +40,17 @@ namespace stan {
       int get_max_depth() { return this->max_depth_; }
       double get_max_delta() { return this->max_deltaH_; }
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         // Initialize the algorithm
         this->sample_stepsize();
 
         this->seed(init_sample.cont_params());
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, writer);
+        this->hamiltonian_.init(this->z_, info_writer);
 
         ps_point z_plus(this->z_);
         ps_point z_minus(z_plus);
@@ -82,7 +84,7 @@ namespace stan {
             valid_subtree
               = build_tree(this->depth_, rho_subtree, z_propose,
                            H0, 1, n_leapfrog,
-                           sum_weight_subtree, sum_metro_prob, writer);
+                           sum_weight_subtree, sum_metro_prob, info_writer);
             z_plus.ps_point::operator=(this->z_);
             p_sharp_plus = this->hamiltonian_.dtau_dp(this->z_);
           } else {
@@ -90,7 +92,7 @@ namespace stan {
             valid_subtree
               = build_tree(this->depth_, rho_subtree, z_propose,
                            H0, -1, n_leapfrog,
-                           sum_weight_subtree, sum_metro_prob, writer);
+                           sum_weight_subtree, sum_metro_prob, info_writer);
             z_minus.ps_point::operator=(this->z_);
             p_sharp_minus = this->hamiltonian_.dtau_dp(this->z_);
           }

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
@@ -22,10 +22,13 @@ namespace stan {
 
       ~adapt_dense_e_nuts_classic() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
-        sample s = dense_e_nuts_classic<Model, BaseRNG>::transition(init_sample,
-                                                            writer);
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
+        sample s
+          = dense_e_nuts_classic<Model, BaseRNG>::transition(init_sample,
+                                                             info_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -35,7 +38,7 @@ namespace stan {
                                                                  this->z_.q);
 
           if (update) {
-            this->init_stepsize(writer);
+            this->init_stepsize(info_writer);
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
@@ -23,10 +23,14 @@ namespace stan {
 
       ~adapt_diag_e_nuts_classic() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
-        sample s = diag_e_nuts_classic<Model, BaseRNG>::transition(init_sample,
-                                                                   writer);
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
+        sample s
+          = diag_e_nuts_classic<Model, BaseRNG>::transition(init_sample,
+                                                            info_writer,
+                                                            error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -36,7 +40,7 @@ namespace stan {
                                                              this->z_.q);
 
           if (update) {
-            this->init_stepsize(writer);
+            this->init_stepsize(info_writer);
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_unit_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_unit_e_nuts_classic.hpp
@@ -22,10 +22,14 @@ namespace stan {
 
       ~adapt_unit_e_nuts_classic() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
-        sample s = unit_e_nuts_classic<Model, BaseRNG>::transition(init_sample,
-                                                                   writer);
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
+        sample s
+          = unit_e_nuts_classic<Model, BaseRNG>::transition(init_sample,
+                                                            info_writer,
+                                                            error_writer);
 
         if (this->adapt_flag_)
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,

--- a/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
@@ -65,7 +65,7 @@ namespace stan {
         this->seed(init_sample.cont_params());
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, info_writer);
+        this->hamiltonian_.init(this->z_, info_writer, error_writer);
 
         ps_point z_plus(this->z_);
         ps_point z_minus(z_plus);
@@ -113,7 +113,7 @@ namespace stan {
           this->z_.ps_point::operator=(*z);
 
           int n_valid_subtree = build_tree(depth_, *rho, 0, z_propose, util,
-                                           info_writer);
+                                           info_writer, error_writer);
           ++(this->depth_);
 
           *z = this->z_;
@@ -177,12 +177,13 @@ namespace stan {
       int build_tree(int depth, Eigen::VectorXd& rho,
                      ps_point* z_init_parent, ps_point& z_propose,
                      nuts_util& util,
-                     interface_callbacks::writer::base_writer& writer) {
+                     interface_callbacks::writer::base_writer& info_writer,
+                     interface_callbacks::writer::base_writer& error_writer) {
         // Base case
         if (depth == 0) {
             this->integrator_.evolve(this->z_, this->hamiltonian_,
                                      util.sign * this->epsilon_,
-                                     writer);
+                                     info_writer, error_writer);
             rho += this->z_.p;
 
             if (z_init_parent) *z_init_parent = this->z_;
@@ -207,7 +208,8 @@ namespace stan {
           ps_point z_init(this->z_);
 
           int n1 = build_tree(depth - 1, left_subtree_rho, &z_init,
-                              z_propose, util, writer);
+                              z_propose, util,
+                              info_writer, error_writer);
 
           if (z_init_parent) *z_init_parent = z_init;
 
@@ -218,7 +220,8 @@ namespace stan {
           ps_point z_propose_right(z_init);
 
           int n2 = build_tree(depth - 1, right_subtree_rho, 0,
-                              z_propose_right, util, writer);
+                              z_propose_right, util,
+                              info_writer, error_writer);
 
           double accept_prob = static_cast<double>(n2) /
             static_cast<double>(n1 + n2);

--- a/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
@@ -53,8 +53,10 @@ namespace stan {
       int get_max_depth() { return this->max_depth_; }
       double get_max_delta() { return this->max_delta_; }
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         // Initialize the algorithm
         this->sample_stepsize();
 
@@ -63,7 +65,7 @@ namespace stan {
         this->seed(init_sample.cont_params());
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, writer);
+        this->hamiltonian_.init(this->z_, info_writer);
 
         ps_point z_plus(this->z_);
         ps_point z_minus(z_plus);
@@ -111,7 +113,7 @@ namespace stan {
           this->z_.ps_point::operator=(*z);
 
           int n_valid_subtree = build_tree(depth_, *rho, 0, z_propose, util,
-                                           writer);
+                                           info_writer);
           ++(this->depth_);
 
           *z = this->z_;

--- a/src/stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp
@@ -23,10 +23,14 @@ namespace stan {
 
       ~adapt_dense_e_static_hmc() { }
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
-        sample s = dense_e_static_hmc<Model, BaseRNG>::transition(init_sample,
-                                                                  writer);
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
+        sample s
+          = dense_e_static_hmc<Model, BaseRNG>::transition(init_sample,
+                                                           info_writer,
+                                                           error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -37,7 +41,7 @@ namespace stan {
             (this->z_.mInv, this->z_.q);
 
           if (update) {
-            this->init_stepsize(writer);
+            this->init_stepsize(info_writer);
             this->update_L_();
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));

--- a/src/stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp
@@ -23,10 +23,14 @@ namespace stan {
 
       ~adapt_diag_e_static_hmc() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
-        sample s = diag_e_static_hmc<Model, BaseRNG>::transition(init_sample,
-                                                                 writer);
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
+        sample s
+          = diag_e_static_hmc<Model, BaseRNG>::transition(init_sample,
+                                                          info_writer,
+                                                          error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -37,7 +41,7 @@ namespace stan {
                                                              this->z_.q);
 
           if (update) {
-            this->init_stepsize(writer);
+            this->init_stepsize(info_writer);
             this->update_L_();
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));

--- a/src/stan/mcmc/hmc/static/adapt_unit_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_unit_e_static_hmc.hpp
@@ -22,10 +22,14 @@ namespace stan {
 
       ~adapt_unit_e_static_hmc() { }
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
-        sample s = unit_e_static_hmc<Model, BaseRNG>::transition(init_sample,
-                                                                 writer);
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
+        sample s
+          = unit_e_static_hmc<Model, BaseRNG>::transition(init_sample,
+                                                          info_writer,
+                                                          error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,

--- a/src/stan/mcmc/hmc/static/base_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/base_static_hmc.hpp
@@ -40,7 +40,7 @@ namespace stan {
         this->seed(init_sample.cont_params());
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, info_writer);
+        this->hamiltonian_.init(this->z_, info_writer, error_writer);
 
         ps_point z_init(this->z_);
 
@@ -49,7 +49,7 @@ namespace stan {
         for (int i = 0; i < L_; ++i)
           this->integrator_.evolve(this->z_, this->hamiltonian_,
                                    this->epsilon_,
-                                   info_writer);
+                                   info_writer, error_writer);
 
         double h = this->hamiltonian_.H(this->z_);
         if (boost::math::isnan(h)) h = std::numeric_limits<double>::infinity();

--- a/src/stan/mcmc/hmc/static/base_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/base_static_hmc.hpp
@@ -31,14 +31,16 @@ namespace stan {
 
       ~base_static_hmc() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         this->sample_stepsize();
 
         this->seed(init_sample.cont_params());
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, writer);
+        this->hamiltonian_.init(this->z_, info_writer);
 
         ps_point z_init(this->z_);
 
@@ -47,7 +49,7 @@ namespace stan {
         for (int i = 0; i < L_; ++i)
           this->integrator_.evolve(this->z_, this->hamiltonian_,
                                    this->epsilon_,
-                                   writer);
+                                   info_writer);
 
         double h = this->hamiltonian_.H(this->z_);
         if (boost::math::isnan(h)) h = std::numeric_limits<double>::infinity();

--- a/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
@@ -23,11 +23,14 @@ namespace stan {
 
       ~adapt_dense_e_static_uniform() { }
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         sample s
           = dense_e_static_uniform<Model, BaseRNG>::transition(init_sample,
-                                                               writer);
+                                                               info_writer,
+                                                               error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -37,7 +40,7 @@ namespace stan {
             (this->z_.mInv, this->z_.q);
 
           if (update) {
-            this->init_stepsize(writer);
+            this->init_stepsize(info_writer);
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
@@ -40,7 +40,7 @@ namespace stan {
             (this->z_.mInv, this->z_.q);
 
           if (update) {
-            this->init_stepsize(info_writer);
+            this->init_stepsize(info_writer, error_writer);
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
@@ -39,7 +39,7 @@ namespace stan {
           bool update = this->var_adaptation_.learn_variance(this->z_.mInv,
                                                              this->z_.q);
           if (update) {
-            this->init_stepsize(info_writer);
+            this->init_stepsize(info_writer, error_writer);
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
@@ -23,11 +23,14 @@ namespace stan {
 
       ~adapt_diag_e_static_uniform() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         sample s
           = diag_e_static_uniform<Model, BaseRNG>::transition(init_sample,
-                                                              writer);
+                                                              info_writer,
+                                                              error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -36,7 +39,7 @@ namespace stan {
           bool update = this->var_adaptation_.learn_variance(this->z_.mInv,
                                                              this->z_.q);
           if (update) {
-            this->init_stepsize(writer);
+            this->init_stepsize(info_writer);
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp
@@ -23,11 +23,14 @@ namespace stan {
 
       ~adapt_unit_e_static_uniform() { }
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         sample s
           = unit_e_static_uniform<Model, BaseRNG>::transition(init_sample,
-                                                              writer);
+                                                              info_writer,
+                                                              error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,

--- a/src/stan/mcmc/hmc/static_uniform/base_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/base_static_uniform.hpp
@@ -42,7 +42,7 @@ namespace stan {
         this->seed(init_sample.cont_params());
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, info_writer);
+        this->hamiltonian_.init(this->z_, info_writer, error_writer);
 
         ps_point z_init(this->z_);
         double H0 = this->hamiltonian_.H(this->z_);
@@ -56,7 +56,8 @@ namespace stan {
 
         for (int l = 0; l < Lp; ++l) {
           this->integrator_.evolve(this->z_, this->hamiltonian_,
-                                   -this->epsilon_, info_writer);
+                                   -this->epsilon_,
+                                   info_writer, error_writer);
 
           double h = this->hamiltonian_.H(this->z_);
           if (boost::math::isnan(h))
@@ -74,7 +75,8 @@ namespace stan {
 
         for (int l = 0; l < L_ - 1 - Lp; ++l) {
           this->integrator_.evolve(this->z_, this->hamiltonian_,
-                                   this->epsilon_, info_writer);
+                                   this->epsilon_,
+                                   info_writer, error_writer);
 
           double h = this->hamiltonian_.H(this->z_);
           if (boost::math::isnan(h))

--- a/src/stan/mcmc/hmc/static_uniform/base_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/base_static_uniform.hpp
@@ -33,14 +33,16 @@ namespace stan {
 
       ~base_static_uniform() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         this->sample_stepsize();
 
         this->seed(init_sample.cont_params());
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, writer);
+        this->hamiltonian_.init(this->z_, info_writer);
 
         ps_point z_init(this->z_);
         double H0 = this->hamiltonian_.H(this->z_);
@@ -54,7 +56,7 @@ namespace stan {
 
         for (int l = 0; l < Lp; ++l) {
           this->integrator_.evolve(this->z_, this->hamiltonian_,
-                                   -this->epsilon_, writer);
+                                   -this->epsilon_, info_writer);
 
           double h = this->hamiltonian_.H(this->z_);
           if (boost::math::isnan(h))
@@ -72,7 +74,7 @@ namespace stan {
 
         for (int l = 0; l < L_ - 1 - Lp; ++l) {
           this->integrator_.evolve(this->z_, this->hamiltonian_,
-                                   this->epsilon_, writer);
+                                   this->epsilon_, info_writer);
 
           double h = this->hamiltonian_.H(this->z_);
           if (boost::math::isnan(h))

--- a/src/stan/mcmc/hmc/xhmc/adapt_dense_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_dense_e_xhmc.hpp
@@ -22,10 +22,13 @@ namespace stan {
 
       ~adapt_dense_e_xhmc() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         sample s = dense_e_xhmc<Model, BaseRNG>::transition(init_sample,
-                                                            writer);
+                                                            info_writer,
+                                                            error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -35,7 +38,7 @@ namespace stan {
                                                                  this->z_.q);
 
           if (update) {
-            this->init_stepsize(writer);
+            this->init_stepsize(info_writer);
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();

--- a/src/stan/mcmc/hmc/xhmc/adapt_diag_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_diag_e_xhmc.hpp
@@ -22,10 +22,13 @@ namespace stan {
 
       ~adapt_diag_e_xhmc() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         sample s = diag_e_xhmc<Model, BaseRNG>::transition(init_sample,
-                                                           writer);
+                                                           info_writer,
+                                                           error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -35,7 +38,7 @@ namespace stan {
                                                              this->z_.q);
 
           if (update) {
-            this->init_stepsize(writer);
+            this->init_stepsize(info_writer);
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();

--- a/src/stan/mcmc/hmc/xhmc/adapt_unit_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_unit_e_xhmc.hpp
@@ -21,9 +21,14 @@ namespace stan {
 
       ~adapt_unit_e_xhmc() {}
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
-        sample s = unit_e_xhmc<Model, BaseRNG>::transition(init_sample, writer);
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
+        sample s
+          = unit_e_xhmc<Model, BaseRNG>::transition(init_sample,
+                                                    info_writer,
+                                                    error_writer);
 
         if (this->adapt_flag_)
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,

--- a/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
@@ -47,15 +47,17 @@ namespace stan {
       double get_max_deltaH() { return this->max_deltaH_; }
       double get_x_delta() { return this->x_delta_; }
 
-      sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+      sample
+      transition(sample& init_sample,
+                 interface_callbacks::writer::base_writer& info_writer,
+                 interface_callbacks::writer::base_writer& error_writer) {
         // Initialize the algorithm
         this->sample_stepsize();
 
         this->seed(init_sample.cont_params());
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, writer);
+        this->hamiltonian_.init(this->z_, info_writer);
 
         ps_point z_plus(this->z_);
         ps_point z_minus(z_plus);
@@ -85,14 +87,14 @@ namespace stan {
             valid_subtree
               = build_tree(this->depth_, z_propose,
                            sum_numer_subtree, sum_weight_subtree,
-                           H0, 1, n_leapfrog, sum_metro_prob, writer);
+                           H0, 1, n_leapfrog, sum_metro_prob, info_writer);
             z_plus.ps_point::operator=(this->z_);
           } else {
             this->z_.ps_point::operator=(z_minus);
             valid_subtree
               = build_tree(this->depth_, z_propose,
                            sum_numer_subtree, sum_weight_subtree,
-                           H0, -1, n_leapfrog, sum_metro_prob, writer);
+                           H0, -1, n_leapfrog, sum_metro_prob, info_writer);
             z_minus.ps_point::operator=(this->z_);
           }
 

--- a/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
@@ -57,7 +57,7 @@ namespace stan {
         this->seed(init_sample.cont_params());
 
         this->hamiltonian_.sample_p(this->z_, this->rand_int_);
-        this->hamiltonian_.init(this->z_, info_writer);
+        this->hamiltonian_.init(this->z_, info_writer, error_writer);
 
         ps_point z_plus(this->z_);
         ps_point z_minus(z_plus);
@@ -87,14 +87,16 @@ namespace stan {
             valid_subtree
               = build_tree(this->depth_, z_propose,
                            sum_numer_subtree, sum_weight_subtree,
-                           H0, 1, n_leapfrog, sum_metro_prob, info_writer);
+                           H0, 1, n_leapfrog, sum_metro_prob,
+                           info_writer, error_writer);
             z_plus.ps_point::operator=(this->z_);
           } else {
             this->z_.ps_point::operator=(z_minus);
             valid_subtree
               = build_tree(this->depth_, z_propose,
                            sum_numer_subtree, sum_weight_subtree,
-                           H0, -1, n_leapfrog, sum_metro_prob, info_writer);
+                           H0, -1, n_leapfrog, sum_metro_prob,
+                           info_writer, error_writer);
             z_minus.ps_point::operator=(this->z_);
           }
 
@@ -147,12 +149,13 @@ namespace stan {
                      double& sum_numer, double& sum_weight,
                      double H0, double sign, int& n_leapfrog,
                      double& sum_metro_prob,
-                     interface_callbacks::writer::base_writer& writer) {
+                     interface_callbacks::writer::base_writer& info_writer,
+                     interface_callbacks::writer::base_writer& error_writer) {
         // Base case
         if (depth == 0) {
             this->integrator_.evolve(this->z_, this->hamiltonian_,
                                      sign * this->epsilon_,
-                                     writer);
+                                     info_writer, error_writer);
             ++n_leapfrog;
 
             double h = this->hamiltonian_.H(this->z_);
@@ -179,7 +182,8 @@ namespace stan {
         bool valid_left
           = build_tree(depth - 1, z_propose,
                        sum_numer_left, sum_weight_left,
-                       H0, sign, n_leapfrog, sum_metro_prob, writer);
+                       H0, sign, n_leapfrog, sum_metro_prob,
+                       info_writer, error_writer);
 
         sum_numer += sum_numer_left;
         sum_weight += sum_weight_left;
@@ -193,7 +197,8 @@ namespace stan {
         bool valid_right
           = build_tree(depth - 1, z_propose_right,
                        sum_numer_right, sum_weight_right,
-                       H0, sign, n_leapfrog, sum_metro_prob, writer);
+                       H0, sign, n_leapfrog, sum_metro_prob,
+                       info_writer, error_writer);
 
         sum_numer += sum_numer_right;
         sum_weight += sum_weight_right;

--- a/src/stan/services/mcmc/sample.hpp
+++ b/src/stan/services/mcmc/sample.hpp
@@ -30,7 +30,8 @@ namespace stan {
                   const std::string& suffix,
                   std::ostream& o,
                   StartTransitionCallback& callback,
-                  interface_callbacks::writer::base_writer& writer) {
+                  interface_callbacks::writer::base_writer& info_writer,
+                  interface_callbacks::writer::base_writer& error_writer) {
         stan::services::sample::generate_transitions<Model, RNG,
                                                      StartTransitionCallback,
                                                      SampleRecorder,
@@ -41,7 +42,7 @@ namespace stan {
            mcmc_writer,
            init_s, model, base_rng,
            prefix, suffix, o,
-           callback, writer);
+           callback, info_writer, error_writer);
       }
 
     }

--- a/src/stan/services/mcmc/warmup.hpp
+++ b/src/stan/services/mcmc/warmup.hpp
@@ -29,7 +29,8 @@ namespace stan {
                   const std::string& suffix,
                   std::ostream& o,
                   StartTransitionCallback& callback,
-                  interface_callbacks::writer::base_writer& writer) {
+                  interface_callbacks::writer::base_writer& info_writer,
+                  interface_callbacks::writer::base_writer& error_writer) {
         sample::generate_transitions<Model, RNG, StartTransitionCallback,
                                      SampleRecorder, DiagnosticRecorder,
                                      MessageRecorder>
@@ -38,7 +39,7 @@ namespace stan {
            mcmc_writer,
            init_s, model, base_rng,
            prefix, suffix, o,
-           callback, writer);
+           callback, info_writer, error_writer);
       }
 
     }

--- a/src/stan/services/sample/generate_transitions.hpp
+++ b/src/stan/services/sample/generate_transitions.hpp
@@ -34,13 +34,15 @@ namespace stan {
                                 std::ostream& o,
                                 StartTransitionCallback& callback,
                                 interface_callbacks::writer::base_writer&
-                                writer) {
+                                info_writer,
+                                interface_callbacks::writer::base_writer&
+                                error_writer) {
         for (int m = 0; m < num_iterations; ++m) {
           callback();
 
           progress(m, start, finish, refresh, warmup, prefix, suffix, o);
 
-          init_s = sampler->transition(init_s, writer);
+          init_s = sampler->transition(init_s, info_writer, error_writer);
 
           if ( save && ( (m % num_thin) == 0) ) {
             mcmc_writer.write_sample_params(base_rng, init_s, *sampler, model);

--- a/src/stan/services/sample/init_adapt.hpp
+++ b/src/stan/services/sample/init_adapt.hpp
@@ -19,7 +19,8 @@ namespace stan {
                       const double kappa,
                       const double t0,
                       const Eigen::VectorXd& cont_params,
-                      interface_callbacks::writer::base_writer& writer) {
+                      interface_callbacks::writer::base_writer& info_writer,
+                      interface_callbacks::writer::base_writer& error_writer) {
         const double epsilon = sampler->get_nominal_stepsize();
 
         sampler->get_stepsize_adaptation().set_mu(log(10 * epsilon));
@@ -32,10 +33,10 @@ namespace stan {
 
         try {
           sampler->z().q = cont_params;
-          sampler->init_stepsize(writer);
+          sampler->init_stepsize(info_writer, error_writer);
         } catch (const std::exception& e) {
-          writer("Exception initializing step size.");
-          writer(e.what());
+          error_writer("Exception initializing step size.");
+          error_writer(e.what());
           return false;
         }
         return true;
@@ -45,7 +46,8 @@ namespace stan {
       bool init_adapt(stan::mcmc::base_mcmc* sampler,
                       categorical_argument* adapt,
                       const Eigen::VectorXd& cont_params,
-                      interface_callbacks::writer::base_writer& writer) {
+                      interface_callbacks::writer::base_writer& info_writer,
+                      interface_callbacks::writer::base_writer& error_writer) {
         double delta
           = dynamic_cast<real_argument*>(adapt->arg("delta"))->value();
         double gamma
@@ -57,7 +59,7 @@ namespace stan {
 
         return init_adapt<Sampler>(dynamic_cast<Sampler*>(sampler),
                                    delta, gamma, kappa, t0, cont_params,
-                                   writer);
+                                   info_writer, error_writer);
       }
 
     }

--- a/src/test/performance/utility.hpp
+++ b/src/test/performance/utility.hpp
@@ -456,7 +456,8 @@ namespace stan {
                                              s, model, base_rng,
                                              prefix, suffix, std::cout,
                                              startTransitionCallback,
-                                             info_writer);
+                                             info_writer,
+                                             err_writer);
 
         clock_t end = clock();
         warmDeltaT = static_cast<double>(end - start) / CLOCKS_PER_SEC;
@@ -476,7 +477,8 @@ namespace stan {
            s, model, base_rng,
            prefix, suffix, std::cout,
            startTransitionCallback,
-           info_writer);
+           info_writer,
+           err_writer);
           
         end = clock();
         sampleDeltaT = static_cast<double>(end - start) / CLOCKS_PER_SEC;

--- a/src/test/performance/utility.hpp
+++ b/src/test/performance/utility.hpp
@@ -436,7 +436,7 @@ namespace stan {
 
         stan::services::sample::init_adapt(sampler_ptr, 0.8, 0.05, 0.75, 10,
                                            cont_params,
-                                           info_writer);
+                                           info_writer, err_writer);
         sampler_ptr->set_window_params(num_warmup, 75, 50, 25, info_writer);
           
         // Headers

--- a/src/test/unit/mcmc/hmc/base_hmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/base_hmc_test.cpp
@@ -23,7 +23,8 @@ namespace stan {
       { }
 
       sample transition(sample& init_sample,
-                        interface_callbacks::writer::base_writer& writer) {
+                        interface_callbacks::writer::base_writer& info_writer,
+                        interface_callbacks::writer::base_writer& error_writer) {
         this->seed(init_sample.cont_params());
         return sample(this->z_.q, - this->hamiltonian_.V(this->z_), 0);
       }

--- a/src/test/unit/mcmc/hmc/hamiltonians/base_hamiltonian_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/base_hamiltonian_test.cpp
@@ -21,8 +21,10 @@ TEST(BaseHamiltonian, update) {
   stan::mcmc::ps_point z(11);
   z.q.setOnes();
   stan::interface_callbacks::writer::stream_writer writer(metric_output);
-  
-  metric.update(z, writer);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
+  metric.update(z, writer, error_writer);
 
   EXPECT_FLOAT_EQ(10.73223197, z.V);
 
@@ -33,6 +35,7 @@ TEST(BaseHamiltonian, update) {
 
   EXPECT_EQ("", model_output.str());
   EXPECT_EQ("", metric_output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(BaseHamiltonian, streams) {

--- a/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
@@ -61,13 +61,17 @@ TEST(McmcDenseEMetric, gradients) {
 
   std::stringstream model_output, metric_output;
   stan::interface_callbacks::writer::stream_writer writer(metric_output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
+
   funnel_model_namespace::funnel_model model(data_var_context, &model_output);
 
   stan::mcmc::dense_e_metric<funnel_model_namespace::funnel_model, rng_t> metric(model);
   
   double epsilon = 1e-6;
   
-  metric.update(z, writer);
+  metric.update(z, writer, error_writer);
   
   Eigen::VectorXd g1 = metric.dtau_dq(z);
   
@@ -76,15 +80,15 @@ TEST(McmcDenseEMetric, gradients) {
     double delta = 0;
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta += metric.tau(z);
     
     z.q(i) -= 2 * epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta -= metric.tau(z);
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     
     delta /= 2 * epsilon;
     
@@ -119,15 +123,15 @@ TEST(McmcDenseEMetric, gradients) {
     double delta = 0;
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta += metric.phi(z);
     
     z.q(i) -= 2 * epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta -= metric.phi(z);
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     
     delta /= 2 * epsilon;
     
@@ -137,6 +141,7 @@ TEST(McmcDenseEMetric, gradients) {
 
   EXPECT_EQ("", model_output.str());
   EXPECT_EQ("", metric_output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcDenseEMetric, streams) {

--- a/src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp
@@ -62,11 +62,14 @@ TEST(McmcDiagEMetric, gradients) {
   funnel_model_namespace::funnel_model model(data_var_context, &model_output);
 
   stan::interface_callbacks::writer::stream_writer writer(metric_output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
   stan::mcmc::diag_e_metric<funnel_model_namespace::funnel_model, rng_t> metric(model);
   
   double epsilon = 1e-6;
   
-  metric.update(z, writer);
+  metric.update(z, writer, error_writer);
   
   Eigen::VectorXd g1 = metric.dtau_dq(z);
   
@@ -75,15 +78,15 @@ TEST(McmcDiagEMetric, gradients) {
     double delta = 0;
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta += metric.tau(z);
     
     z.q(i) -= 2 * epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta -= metric.tau(z);
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     
     delta /= 2 * epsilon;
     
@@ -118,15 +121,15 @@ TEST(McmcDiagEMetric, gradients) {
     double delta = 0;
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta += metric.phi(z);
     
     z.q(i) -= 2 * epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta -= metric.phi(z);
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     
     delta /= 2 * epsilon;
     
@@ -135,6 +138,7 @@ TEST(McmcDiagEMetric, gradients) {
   }
   EXPECT_EQ("", model_output.str());
   EXPECT_EQ("", metric_output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcDiagEMetric, streams) {

--- a/src/test/unit/mcmc/hmc/hamiltonians/unit_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/unit_e_metric_test.cpp
@@ -60,6 +60,8 @@ TEST(McmcUnitEMetric, gradients) {
   
   std::stringstream model_output, metric_output;
   stan::interface_callbacks::writer::stream_writer writer(metric_output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
   
   funnel_model_namespace::funnel_model model(data_var_context, &model_output);
   
@@ -67,7 +69,7 @@ TEST(McmcUnitEMetric, gradients) {
   
   double epsilon = 1e-6;
 
-  metric.update(z, writer);
+  metric.update(z, writer, error_writer);
   
   Eigen::VectorXd g1 = metric.dtau_dq(z);
   
@@ -76,15 +78,15 @@ TEST(McmcUnitEMetric, gradients) {
     double delta = 0;
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta += metric.tau(z);
     
     z.q(i) -= 2 * epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta -= metric.tau(z);
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     
     delta /= 2 * epsilon;
     
@@ -119,15 +121,15 @@ TEST(McmcUnitEMetric, gradients) {
     double delta = 0;
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta += metric.phi(z);
     
     z.q(i) -= 2 * epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     delta -= metric.phi(z);
     
     z.q(i) += epsilon;
-    metric.update(z, writer);
+    metric.update(z, writer, error_writer);
     
     delta /= 2 * epsilon;
     
@@ -138,6 +140,7 @@ TEST(McmcUnitEMetric, gradients) {
 
   EXPECT_EQ("", model_output.str());
   EXPECT_EQ("", metric_output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcUnitEMetric, streams) {

--- a/src/test/unit/mcmc/hmc/integrators/expl_leapfrog2_test.cpp
+++ b/src/test/unit/mcmc/hmc/integrators/expl_leapfrog2_test.cpp
@@ -23,6 +23,9 @@ TEST(McmcHmcIntegratorsExplLeapfrog, energy_conservation) {
   std::stringstream model_output;
   std::stringstream metric_output;
   stan::interface_callbacks::writer::stream_writer writer(metric_output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
   gauss_model_namespace::gauss_model model(data_var_context, &model_output);
   
   stan::mcmc::expl_leapfrog<
@@ -35,7 +38,7 @@ TEST(McmcHmcIntegratorsExplLeapfrog, energy_conservation) {
   z.q(0) = 1;
   z.p(0) = 1;
   
-  metric.update(z, writer);
+  metric.update(z, writer, error_writer);
   double H0 = metric.H(z);
   double aveDeltaH = 0;
   
@@ -45,7 +48,7 @@ TEST(McmcHmcIntegratorsExplLeapfrog, energy_conservation) {
   
   for (size_t n = 0; n < L; ++n) {
     
-    integrator.evolve(z, metric, epsilon, writer);
+    integrator.evolve(z, metric, epsilon, writer, error_writer);
     
     double deltaH = metric.H(z) - H0;
     aveDeltaH += (deltaH - aveDeltaH) / double(n + 1);
@@ -58,6 +61,7 @@ TEST(McmcHmcIntegratorsExplLeapfrog, energy_conservation) {
   
   EXPECT_EQ("", model_output.str());
   EXPECT_EQ("", metric_output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcHmcIntegratorsExplLeapfrog, symplecticness) {  
@@ -70,6 +74,9 @@ TEST(McmcHmcIntegratorsExplLeapfrog, symplecticness) {
   std::stringstream model_output;
   std::stringstream metric_output;
   stan::interface_callbacks::writer::stream_writer writer(metric_output);  
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
   
   gauss_model_namespace::gauss_model model(data_var_context, &model_output);
   
@@ -102,11 +109,11 @@ TEST(McmcHmcIntegratorsExplLeapfrog, symplecticness) {
   size_t L = pi / epsilon;
   
   for (int i = 0; i < n_points; ++i)
-    metric.init(z.at(i), writer);
+    metric.init(z.at(i), writer, error_writer);
   
   for (size_t n = 0; n < L; ++n)
     for (int i = 0; i < n_points; ++i)
-      integrator.evolve(z.at(i), metric, epsilon, writer);
+      integrator.evolve(z.at(i), metric, epsilon, writer, error_writer);
   
   // Compute area of evolved shape using divergence theorem in 2D
   double area = 0;
@@ -145,5 +152,6 @@ TEST(McmcHmcIntegratorsExplLeapfrog, symplecticness) {
 
   EXPECT_EQ("", model_output.str());
   EXPECT_EQ("", metric_output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 

--- a/src/test/unit/mcmc/hmc/integrators/expl_leapfrog_test.cpp
+++ b/src/test/unit/mcmc/hmc/integrators/expl_leapfrog_test.cpp
@@ -21,6 +21,7 @@ class McmcHmcIntegratorsExplLeapfrogF : public testing::Test {
 public:
   McmcHmcIntegratorsExplLeapfrogF()
     : writer_(output),
+      error_writer_(error_output),
       unit_e_integrator(),
       diag_e_integrator() {}
   
@@ -32,7 +33,7 @@ public:
 
     model = new command_model_namespace::command_model(data_var_context);
     output.str("");
-    output.clear();
+    error_output.str("");
   }
   
   void TearDown() {
@@ -40,6 +41,7 @@ public:
   }
 
   stan::interface_callbacks::writer::stream_writer writer_;
+  stan::interface_callbacks::writer::stream_writer error_writer_;
   
   // integrator under test
   stan::mcmc::expl_leapfrog<
@@ -55,6 +57,7 @@ public:
 
   // output
   std::stringstream output;
+  std::stringstream error_output;
 };
 
 
@@ -85,6 +88,7 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, begin_update_p) {
   EXPECT_NEAR(z.g(0),  1.99987371079118, 5e-14);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, update_q) {
@@ -113,6 +117,7 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, update_q) {
   EXPECT_NEAR(z.g(0),  1.99987371079118, 5e-14);
   
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, end_update_p) {
@@ -141,6 +146,7 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, end_update_p) {
   EXPECT_NEAR(z.g(0),  1.67264975797776, 5e-14);
   
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_1) {
@@ -162,13 +168,14 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_1) {
   // setup epsilon
   double epsilon = 0.1;
 
-  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_);
+  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_, error_writer_);
   EXPECT_NEAR(z.V,     1.67676034808195, 5e-14);
   EXPECT_NEAR(z.q(0),  1.83126205010749, 5e-14);
   EXPECT_NEAR(z.p(0), -1.77767970934226, 5e-14);
   EXPECT_NEAR(z.g(0),  1.83126205010749, 5e-14);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_2) {
@@ -190,13 +197,14 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_2) {
   // setup epsilon
   double epsilon = 0.2;
 
-  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_);
+  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_, error_writer_);
   EXPECT_NEAR(z.V,     2.13439496506688, 5e-14);
   EXPECT_NEAR(z.q(0),  2.06610501430439, 5e-14);
   EXPECT_NEAR(z.p(0),  0.124546016135635, 5e-14);
   EXPECT_NEAR(z.g(0),  2.06610501430439, 5e-14);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_3) {
@@ -218,13 +226,14 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_3) {
   // setup epsilon
   double epsilon = 0.2;
 
-  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_);
+  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_, error_writer_);
   EXPECT_NEAR(z.V,     2.13439496506688, 5e-14);
   EXPECT_NEAR(z.q(0),  2.06610501430439, 5e-14);
   EXPECT_NEAR(z.p(0),  0.124546016135635, 5e-14);
   EXPECT_NEAR(z.g(0),  2.06610501430439, 5e-14);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_4) {
@@ -246,13 +255,14 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_4) {
   // setup epsilon
   double epsilon = 0.4;
 
-  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_);
+  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_, error_writer_);
   EXPECT_NEAR(z.V,     1.03001529319458, 5e-14);
   EXPECT_NEAR(z.q(0),  1.43528066467474, 5e-14);
   EXPECT_NEAR(z.p(0), -1.69853874822605, 5e-14);
   EXPECT_NEAR(z.g(0),  1.43528066467474, 5e-14);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_5) {
@@ -274,13 +284,14 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_5) {
   // setup epsilon
   double epsilon = 0.8;
 
-  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_);
+  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_, error_writer_);
   EXPECT_NEAR(z.V,     0.777009958583946, 5e-14);
   EXPECT_NEAR(z.q(0),  1.24660335198005, 5e-14);
   EXPECT_NEAR(z.p(0), -1.44022928930593, 5e-14);
   EXPECT_NEAR(z.g(0),  1.24660335198005, 5e-14);
   
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_6) {
   // setup z
@@ -301,13 +312,14 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_6) {
   // setup epsilon
   double epsilon = 1.6;
 
-  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_);
+  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_, error_writer_);
   EXPECT_NEAR(z.V,     0.0837242558054816, 5e-14);
   EXPECT_NEAR(z.q(0), -0.409204730680088, 5e-14);
   EXPECT_NEAR(z.p(0), -1.17831024137547, 5e-14);
   EXPECT_NEAR(z.g(0), -0.409204730680088, 5e-14);
   
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_7) {
@@ -329,13 +341,14 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_7) {
   // setup epsilon
   double epsilon = 3.2;
 
-  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_);
+  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_, error_writer_);
   EXPECT_NEAR(z.V,     12.3878614837537, 5e-13);
   EXPECT_NEAR(z.q(0),  -4.97752176966686, 5e-14);
   EXPECT_NEAR(z.p(0),  5.78359874382383, 5e-14);
   EXPECT_NEAR(z.g(0),  -4.97752176966686, 5e-14);
   
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_8) {
@@ -357,13 +370,14 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_8) {
   // setup epsilon
   double epsilon = -1;
 
-  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_);
+  unit_e_integrator.evolve(z, hamiltonian, epsilon, writer_, error_writer_);
   EXPECT_NEAR(z.V,     6.96111198693627, 5e-14);
   EXPECT_NEAR(z.q(0),  3.73124965311523, 5e-14);
   EXPECT_NEAR(z.p(0),  0.134248884233563, 5e-14);
   EXPECT_NEAR(z.g(0),  3.73124965311523, 5e-14);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_9) {
@@ -386,13 +400,14 @@ TEST_F(McmcHmcIntegratorsExplLeapfrogF, evolve_9) {
   // setup epsilon
   double epsilon = 2.40769920051673;
 
-  diag_e_integrator.evolve(z, hamiltonian, epsilon, writer_);
+  diag_e_integrator.evolve(z, hamiltonian, epsilon, writer_, error_writer_);
   EXPECT_NEAR(z.V,     1.46626604258356, 5e-14);
   EXPECT_NEAR(z.q(0), -1.71246374711032, 5e-14);
   EXPECT_NEAR(z.p(0),  0.371492925378682, 5e-14);
   EXPECT_NEAR(z.g(0), -1.71246374711032, 5e-14);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_output.str());
 }
 
 TEST_F(McmcHmcIntegratorsExplLeapfrogF, streams) {

--- a/src/test/unit/mcmc/hmc/mock_hmc.hpp
+++ b/src/test/unit/mcmc/hmc/mock_hmc.hpp
@@ -80,7 +80,8 @@ namespace stan {
       void evolve(typename Hamiltonian::PointType& z,
                   Hamiltonian& hamiltonian,
                   const double epsilon,
-                  stan::interface_callbacks::writer::base_writer& writer) {
+                  interface_callbacks::writer::base_writer& info_writer,
+                  interface_callbacks::writer::base_writer& error_writer) {
         z.q += epsilon * z.p;
       };
 

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -239,15 +239,18 @@ TEST(McmcNutsBaseNuts, transition) {
   sampler.sample_stepsize();
   sampler.z() = z_init;
 
-  std::stringstream output;
-  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream output_stream;
+  stan::interface_callbacks::writer::stream_writer writer(output_stream);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
-  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+  stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
   EXPECT_EQ(31.5, s.cont_params()(0));
   EXPECT_EQ(0, s.log_prob());
   EXPECT_EQ(1, s.accept_stat());
-  EXPECT_EQ("", output.str());
+  EXPECT_EQ("", output_stream.str());
+  EXPECT_EQ("", error_stream.str());
 }

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -83,8 +83,10 @@ TEST(McmcUnitENuts, transition) {
   z_init.p(1) = 1;
   z_init.p(2) = -1;
 
-  std::stringstream output;
-  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream output_stream;
+  stan::interface_callbacks::writer::stream_writer writer(output_stream);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -101,12 +103,13 @@ TEST(McmcUnitENuts, transition) {
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
-  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+  stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
   EXPECT_FLOAT_EQ(1, s.cont_params()(0));
   EXPECT_FLOAT_EQ(-1, s.cont_params()(1));
   EXPECT_FLOAT_EQ(1, s.cont_params()(2));
   EXPECT_FLOAT_EQ(-1.5, s.log_prob());
   EXPECT_FLOAT_EQ(0.99629, s.accept_stat());
-  EXPECT_EQ("", output.str());
+  EXPECT_EQ("", output_stream.str());
+  EXPECT_EQ("", error_stream.str());
 }

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -22,6 +22,8 @@ TEST(McmcUnitENuts, build_tree) {
 
   std::stringstream output;
   stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -31,7 +33,7 @@ TEST(McmcUnitENuts, build_tree) {
     sampler(model, base_rng);
 
   sampler.z() = z_init;
-  sampler.init_hamiltonian(writer);
+  sampler.init_hamiltonian(writer, error_writer);
   sampler.set_nominal_stepsize(0.1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();
@@ -47,7 +49,8 @@ TEST(McmcUnitENuts, build_tree) {
 
   bool valid_subtree = sampler.build_tree(3, rho, z_propose,
                                           H0, 1, n_leapfrog, sum_weight,
-                                          sum_metro_prob, writer);
+                                          sum_metro_prob,
+                                          writer, error_writer);
 
   EXPECT_EQ(0.1, sampler.get_nominal_stepsize());
 
@@ -70,6 +73,7 @@ TEST(McmcUnitENuts, build_tree) {
   EXPECT_FLOAT_EQ(0.36134657, sum_metro_prob);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcUnitENuts, transition) {
@@ -96,7 +100,7 @@ TEST(McmcUnitENuts, transition) {
     sampler(model, base_rng);
 
   sampler.z() = z_init;
-  sampler.init_hamiltonian(writer);
+  sampler.init_hamiltonian(writer, error_writer);
   sampler.set_nominal_stepsize(0.1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();

--- a/src/test/unit/mcmc/hmc/nuts_classic/base_nuts_classic_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts_classic/base_nuts_classic_test.cpp
@@ -53,14 +53,16 @@ namespace stan {
       }
 
       void init(ps_point& z,
-                stan::interface_callbacks::writer::base_writer& writer) {
+                interface_callbacks::writer::base_writer& info_writer,
+                interface_callbacks::writer::base_writer& error_writer) {
         z.V = 0;
       }
 
       void sample_p(ps_point& z, BaseRNG& rng) {};
 
       void update(ps_point& z,
-                  stan::interface_callbacks::writer::base_writer& writer) {
+                  interface_callbacks::writer::base_writer& info_writer,
+                  interface_callbacks::writer::base_writer& error_writer) {
         z.V += 500;
       }
 
@@ -151,8 +153,12 @@ TEST(McmcNutsBaseNutsClassic, build_tree) {
 
   std::stringstream output;
   stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
-  int n_valid = sampler.build_tree(3, rho, &z_init, z_propose, util, writer);
+
+  int n_valid = sampler.build_tree(3, rho, &z_init, z_propose, util,
+                                   writer, error_writer);
 
   EXPECT_EQ(8, n_valid);
 
@@ -168,6 +174,7 @@ TEST(McmcNutsBaseNutsClassic, build_tree) {
   EXPECT_EQ(init_momentum, sampler.z().p(0));
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcNutsBaseNutsClassic, slice_criterion) {
@@ -202,26 +209,33 @@ TEST(McmcNutsBaseNutsClassic, slice_criterion) {
 
   std::stringstream output;
   stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
 
   int n_valid = 0;
 
   sampler.z().V = -750;
-  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util, writer);
+  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util,
+                               writer, error_writer);
 
   EXPECT_EQ(1, n_valid);
   EXPECT_EQ(0, sampler.divergent_);
 
   sampler.z().V = -250;
-  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util, writer);
+  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util,
+                               writer, error_writer);
 
   EXPECT_EQ(0, n_valid);
   EXPECT_EQ(0, sampler.divergent_);
 
   sampler.z().V = 750;
-  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util, writer);
+  n_valid = sampler.build_tree(0, rho, &z_init, z_propose, util,
+                               writer, error_writer);
 
   EXPECT_EQ(0, n_valid);
   EXPECT_EQ(1, sampler.divergent_);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_stream.str());
 }

--- a/src/test/unit/mcmc/hmc/static_uniform/derived_static_uniform_test.cpp
+++ b/src/test/unit/mcmc/hmc/static_uniform/derived_static_uniform_test.cpp
@@ -19,8 +19,10 @@ TEST(McmcStaticUniformUnitE, transition) {
   z_init.q(0) = 1;
   z_init.p(0) = -1;
 
-  std::stringstream output;
-  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream output_stream;
+  stan::interface_callbacks::writer::stream_writer writer(output_stream);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -37,12 +39,13 @@ TEST(McmcStaticUniformUnitE, transition) {
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
-  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+  stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
   EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
   EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
   EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
-  EXPECT_EQ("", output.str());
+  EXPECT_EQ("", output_stream.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcStaticUniformDiagE, transition) {
@@ -52,8 +55,10 @@ TEST(McmcStaticUniformDiagE, transition) {
   z_init.q(0) = 1;
   z_init.p(0) = -1;
 
-  std::stringstream output;
-  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream output_stream;
+  stan::interface_callbacks::writer::stream_writer writer(output_stream);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -70,12 +75,13 @@ TEST(McmcStaticUniformDiagE, transition) {
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
-  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+  stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
   EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
   EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
   EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
-  EXPECT_EQ("", output.str());
+  EXPECT_EQ("", output_stream.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcStaticUniformDenseE, transition) {
@@ -85,8 +91,10 @@ TEST(McmcStaticUniformDenseE, transition) {
   z_init.q(0) = 1;
   z_init.p(0) = -1;
 
-  std::stringstream output;
-  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream output_stream;
+  stan::interface_callbacks::writer::stream_writer writer(output_stream);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -103,12 +111,13 @@ TEST(McmcStaticUniformDenseE, transition) {
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
-  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+  stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
   EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
   EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
   EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
-  EXPECT_EQ("", output.str());
+  EXPECT_EQ("", output_stream.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcAdaptStaticUniformUnitE, transition) {
@@ -118,8 +127,10 @@ TEST(McmcAdaptStaticUniformUnitE, transition) {
   z_init.q(0) = 1;
   z_init.p(0) = -1;
 
-  std::stringstream output;
-  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream output_stream;
+  stan::interface_callbacks::writer::stream_writer writer(output_stream);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -136,12 +147,13 @@ TEST(McmcAdaptStaticUniformUnitE, transition) {
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
-  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+  stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
   EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
   EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
   EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
-  EXPECT_EQ("", output.str());
+  EXPECT_EQ("", output_stream.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcAdaptStaticUniformDiagE, transition) {
@@ -151,8 +163,10 @@ TEST(McmcAdaptStaticUniformDiagE, transition) {
   z_init.q(0) = 1;
   z_init.p(0) = -1;
 
-  std::stringstream output;
-  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream output_stream;
+  stan::interface_callbacks::writer::stream_writer writer(output_stream);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -169,12 +183,13 @@ TEST(McmcAdaptStaticUniformDiagE, transition) {
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
-  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+  stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
   EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
   EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
   EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
-  EXPECT_EQ("", output.str());
+  EXPECT_EQ("", output_stream.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcAdaptStaticUniformDenseE, transition) {
@@ -184,8 +199,10 @@ TEST(McmcAdaptStaticUniformDenseE, transition) {
   z_init.q(0) = 1;
   z_init.p(0) = -1;
 
-  std::stringstream output;
-  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream output_stream;
+  stan::interface_callbacks::writer::stream_writer writer(output_stream);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -202,10 +219,11 @@ TEST(McmcAdaptStaticUniformDenseE, transition) {
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
-  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+  stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
   EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
   EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
   EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
-  EXPECT_EQ("", output.str());
+  EXPECT_EQ("", output_stream.str());
+  EXPECT_EQ("", error_stream.str());
 }

--- a/src/test/unit/mcmc/hmc/static_uniform/derived_static_uniform_test.cpp
+++ b/src/test/unit/mcmc/hmc/static_uniform/derived_static_uniform_test.cpp
@@ -32,7 +32,7 @@ TEST(McmcStaticUniformUnitE, transition) {
     sampler(model, base_rng);
 
   sampler.z() = z_init;
-  sampler.init_hamiltonian(writer);
+  sampler.init_hamiltonian(writer, error_writer);
   sampler.set_nominal_stepsize(0.1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();
@@ -68,7 +68,7 @@ TEST(McmcStaticUniformDiagE, transition) {
     sampler(model, base_rng);
 
   sampler.z() = z_init;
-  sampler.init_hamiltonian(writer);
+  sampler.init_hamiltonian(writer, error_writer);
   sampler.set_nominal_stepsize(0.1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();
@@ -104,7 +104,7 @@ TEST(McmcStaticUniformDenseE, transition) {
     sampler(model, base_rng);
 
   sampler.z() = z_init;
-  sampler.init_hamiltonian(writer);
+  sampler.init_hamiltonian(writer, error_writer);
   sampler.set_nominal_stepsize(0.1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();
@@ -140,7 +140,7 @@ TEST(McmcAdaptStaticUniformUnitE, transition) {
     sampler(model, base_rng);
 
   sampler.z() = z_init;
-  sampler.init_hamiltonian(writer);
+  sampler.init_hamiltonian(writer, error_writer);
   sampler.set_nominal_stepsize(0.1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();
@@ -176,7 +176,7 @@ TEST(McmcAdaptStaticUniformDiagE, transition) {
     sampler(model, base_rng);
 
   sampler.z() = z_init;
-  sampler.init_hamiltonian(writer);
+  sampler.init_hamiltonian(writer, error_writer);
   sampler.set_nominal_stepsize(0.1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();
@@ -212,7 +212,7 @@ TEST(McmcAdaptStaticUniformDenseE, transition) {
     sampler(model, base_rng);
 
   sampler.z() = z_init;
-  sampler.init_hamiltonian(writer);
+  sampler.init_hamiltonian(writer, error_writer);
   sampler.set_nominal_stepsize(0.1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();

--- a/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
@@ -49,14 +49,16 @@ namespace stan {
       }
 
       void init(ps_point& z,
-                stan::interface_callbacks::writer::base_writer& writer) {
+                interface_callbacks::writer::base_writer& info_writer,
+                interface_callbacks::writer::base_writer& error_writer) {                
         z.V = 0;
       }
 
       void sample_p(ps_point& z, BaseRNG& rng) {};
 
       void update(ps_point& z,
-                  stan::interface_callbacks::writer::base_writer& writer) {
+                  interface_callbacks::writer::base_writer& info_writer,
+                  interface_callbacks::writer::base_writer& error_writer) {                
         z.V += 500;
       }
 
@@ -156,11 +158,15 @@ TEST(McmcXHMCBaseXHMC, build_tree) {
 
   std::stringstream output;
   stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
 
   bool valid_subtree = sampler.build_tree(3, z_propose,
                                           sum_numer, sum_weight,
                                           H0, 1, n_leapfrog,
-                                          sum_metro_prob, writer);
+                                          sum_metro_prob,
+                                          writer, error_writer);
 
   EXPECT_TRUE(valid_subtree);
 
@@ -173,6 +179,7 @@ TEST(McmcXHMCBaseXHMC, build_tree) {
   EXPECT_FLOAT_EQ(std::exp(H0) * n_leapfrog, sum_metro_prob);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcXHMCBaseXHMC, divergence_test) {
@@ -205,6 +212,9 @@ TEST(McmcXHMCBaseXHMC, divergence_test) {
 
   std::stringstream output;
   stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
 
   bool valid_subtree = 0;
 
@@ -212,7 +222,8 @@ TEST(McmcXHMCBaseXHMC, divergence_test) {
   valid_subtree = sampler.build_tree(0, z_propose,
                                      sum_numer, sum_weight,
                                      H0, 1, n_leapfrog,
-                                     sum_metro_prob, writer);
+                                     sum_metro_prob,
+                                     writer, error_writer);
   EXPECT_TRUE(valid_subtree);
   EXPECT_EQ(0, sampler.divergent_);
 
@@ -220,7 +231,8 @@ TEST(McmcXHMCBaseXHMC, divergence_test) {
   valid_subtree = sampler.build_tree(0, z_propose,
                                      sum_numer, sum_weight,
                                      H0, 1, n_leapfrog,
-                                     sum_metro_prob, writer);
+                                     sum_metro_prob,
+                                     writer, error_writer);
 
   EXPECT_TRUE(valid_subtree);
   EXPECT_EQ(0, sampler.divergent_);
@@ -229,12 +241,14 @@ TEST(McmcXHMCBaseXHMC, divergence_test) {
   valid_subtree = sampler.build_tree(0, z_propose,
                                      sum_numer, sum_weight,
                                      H0, 1, n_leapfrog,
-                                     sum_metro_prob, writer);
+                                     sum_metro_prob,
+                                     writer, error_writer);
 
   EXPECT_FALSE(valid_subtree);
   EXPECT_EQ(1, sampler.divergent_);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcXHMCBaseXHMC, transition) {

--- a/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
@@ -256,15 +256,18 @@ TEST(McmcXHMCBaseXHMC, transition) {
   sampler.sample_stepsize();
   sampler.z() = z_init;
 
-  std::stringstream output;
-  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream output_stream;
+  stan::interface_callbacks::writer::stream_writer writer(output_stream);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
-  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+  stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
   EXPECT_EQ(31.5, s.cont_params()(0));
   EXPECT_EQ(0, s.log_prob());
   EXPECT_EQ(1, s.accept_stat());
-  EXPECT_EQ("", output.str());
+  EXPECT_EQ("", output_stream.str());
+  EXPECT_EQ("", error_stream.str());
 }

--- a/src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp
@@ -88,8 +88,10 @@ TEST(McmcUnitEXHMC, transition) {
   z_init.p(1) = 1;
   z_init.p(2) = -1;
 
-  std::stringstream output;
-  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream output_stream;
+  stan::interface_callbacks::writer::stream_writer writer(output_stream);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -106,12 +108,13 @@ TEST(McmcUnitEXHMC, transition) {
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
-  stan::mcmc::sample s = sampler.transition(init_sample, writer);
+  stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
   EXPECT_FLOAT_EQ(1, s.cont_params()(0));
   EXPECT_FLOAT_EQ(-1, s.cont_params()(1));
   EXPECT_FLOAT_EQ(1, s.cont_params()(2));
   EXPECT_FLOAT_EQ(-1.5, s.log_prob());
   EXPECT_FLOAT_EQ(0.99805242, s.accept_stat());
-  EXPECT_EQ("", output.str());
+  EXPECT_EQ("", output_stream.str());
+  EXPECT_EQ("", error_stream.str());
 }

--- a/src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp
@@ -22,6 +22,9 @@ TEST(McmcUnitEXHMC, build_tree) {
 
   std::stringstream output;
   stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -31,7 +34,7 @@ TEST(McmcUnitEXHMC, build_tree) {
     sampler(model, base_rng);
 
   sampler.z() = z_init;
-  sampler.init_hamiltonian(writer);
+  sampler.init_hamiltonian(writer, error_writer);
   sampler.set_nominal_stepsize(0.1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();
@@ -47,7 +50,8 @@ TEST(McmcUnitEXHMC, build_tree) {
 
   bool valid_subtree = sampler.build_tree(3, z_propose, sum_numer, sum_weight,
                                           H0, 1, n_leapfrog,
-                                          sum_metro_prob, writer);
+                                          sum_metro_prob,
+                                          writer, error_writer);
 
   EXPECT_EQ(0.1, sampler.get_nominal_stepsize());
 
@@ -75,6 +79,7 @@ TEST(McmcUnitEXHMC, build_tree) {
   EXPECT_FLOAT_EQ(0.36134657, sum_metro_prob);
 
   EXPECT_EQ("", output.str());
+  EXPECT_EQ("", error_stream.str());
 }
 
 TEST(McmcUnitEXHMC, transition) {
@@ -101,7 +106,7 @@ TEST(McmcUnitEXHMC, transition) {
     sampler(model, base_rng);
 
   sampler.z() = z_init;
-  sampler.init_hamiltonian(writer);
+  sampler.init_hamiltonian(writer, error_writer);
   sampler.set_nominal_stepsize(0.1);
   sampler.set_stepsize_jitter(0);
   sampler.sample_stepsize();

--- a/src/test/unit/services/init/command_init_test.cpp
+++ b/src/test/unit/services/init/command_init_test.cpp
@@ -12,7 +12,8 @@ typedef stan::mcmc::adapt_unit_e_nuts<Model, rng_t> sampler;
 class UiCommand : public testing::Test {
 public:
   UiCommand()
-    : writer(output) {}
+    : writer(output),
+      error_writer(error) {}
   
   void SetUp() {
     std::fstream empty_data_stream(std::string("").c_str());
@@ -55,12 +56,13 @@ public:
 
   std::stringstream model_output, output, error;
   stan::interface_callbacks::writer::stream_writer writer;
+  stan::interface_callbacks::writer::stream_writer error_writer;
 };
 
 TEST_F(UiCommand, init_adapt_z_0) {
   EXPECT_TRUE(stan::services::sample::init_adapt(sampler_ptr,
                                                  delta, gamma, kappa, t0,
-                                                 z_0, writer));
+                                                 z_0, writer, error_writer));
   EXPECT_FLOAT_EQ(0.125, sampler_ptr->get_nominal_stepsize());
 
   for (size_t n = 0; n < model->num_params_r(); n++) {
@@ -76,7 +78,7 @@ TEST_F(UiCommand, init_adapt_z_0) {
 TEST_F(UiCommand, init_adapt_z_init) {
   EXPECT_TRUE(stan::services::sample::init_adapt(sampler_ptr,
                                                  delta, gamma, kappa, t0,
-                                                 z_init, writer));
+                                                 z_init, writer, error_writer));
   EXPECT_FLOAT_EQ(0.25, sampler_ptr->get_nominal_stepsize());
   for (size_t n = 0; n < model->num_params_r(); n++) {
     EXPECT_FLOAT_EQ(z_init[n], sampler_ptr->z().q[n]);

--- a/src/test/unit/services/mcmc/warmup_test.cpp
+++ b/src/test/unit/services/mcmc/warmup_test.cpp
@@ -15,7 +15,8 @@ public:
     : base_mcmc(), n_transition_called(0) { }
 
   stan::mcmc::sample transition(stan::mcmc::sample& init_sample,
-                                stan::interface_callbacks::writer::base_writer& writer) {
+                                stan::interface_callbacks::writer::base_writer& info_writer,
+                                stan::interface_callbacks::writer::base_writer& error_writer) {
     n_transition_called++;
     return init_sample;
   }
@@ -35,13 +36,15 @@ struct mock_callback {
 class StanServices : public testing::Test {
 public:
   StanServices()
-    : message_writer(message_output, "# ") { }
+    : message_writer(message_output, "# "),
+      error_writer(error_output) { }
   
   void SetUp() {
     model_output.str("");
     sample_output.str("");
     diagnostic_output.str("");
     message_output.str("");
+    error_output.str("");
 
     sampler = new mock_sampler();
 
@@ -84,9 +87,13 @@ public:
   double log_prob;
   double stat;
 
-  std::stringstream model_output,
-    sample_output, diagnostic_output, message_output;
+  std::stringstream model_output;
+  std::stringstream sample_output;
+  std::stringstream diagnostic_output;
+  std::stringstream message_output;
+  std::stringstream error_output;
   stan::interface_callbacks::writer::stream_writer message_writer;
+  stan::interface_callbacks::writer::stream_writer error_writer;
 };
 
 
@@ -110,7 +117,8 @@ TEST_F(StanServices, warmup) {
                                *writer, s, *model, base_rng,
                                prefix, suffix, ss,
                                callback,
-                               message_writer);
+                               message_writer,
+                               error_writer);
   
   EXPECT_EQ(num_warmup, sampler->n_transition_called);
   EXPECT_EQ(num_warmup, callback.n);

--- a/src/test/unit/services/sample/generate_transitions_test.cpp
+++ b/src/test/unit/services/sample/generate_transitions_test.cpp
@@ -15,7 +15,9 @@ public:
     : base_mcmc(), n_transition_called(0) { }
 
   stan::mcmc::sample transition(stan::mcmc::sample& init_sample,
-                                stan::interface_callbacks::writer::base_writer& writer) {
+                                stan::interface_callbacks::writer::base_writer& info_writer,
+                                stan::interface_callbacks::writer::base_writer& error_writer) {
+    
     n_transition_called++;
     return init_sample;
   }
@@ -35,13 +37,15 @@ struct mock_callback {
 class StanServices : public testing::Test {
 public:
   StanServices()
-    : message_writer(message_output, "# ") { }
+    : message_writer(message_output, "# "),
+      error_writer(error_output, "# ") { }
   
   void SetUp() {
     model_output.str("");
     sample_output.str("");
     diagnostic_output.str("");
     message_output.str("");
+    error_output.str("");
 
     sampler = new mock_sampler();
 
@@ -84,10 +88,13 @@ public:
   double log_prob;
   double stat;
 
-  std::stringstream model_output,
-    sample_output, diagnostic_output, message_output;
-
+  std::stringstream model_output;
+  std::stringstream sample_output;
+  std::stringstream diagnostic_output;
+  std::stringstream message_output;
+  std::stringstream error_output;
   stan::interface_callbacks::writer::stream_writer message_writer;
+  stan::interface_callbacks::writer::stream_writer error_writer;
 };
 
 
@@ -113,7 +120,8 @@ TEST_F(StanServices, generate_transitions) {
                                                *writer, s, *model, base_rng,
                                                prefix, suffix, ss,
                                                callback,
-                                               message_writer);
+                                               message_writer,
+                                               error_writer);
   
   EXPECT_EQ(num_iterations, sampler->n_transition_called);
   EXPECT_EQ(num_iterations, callback.n);
@@ -124,5 +132,6 @@ TEST_F(StanServices, generate_transitions) {
   EXPECT_EQ("", sample_output.str());
   EXPECT_EQ("", diagnostic_output.str());
   EXPECT_EQ("", message_output.str());
+  EXPECT_EQ("", error_output.str());
 }
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Between 2.9.0 and now, I merged the error stream and standard output stream. This pull request adds a second writer for errors that should be pumped to std::cerr or the equivalent.

#### Intended Effect

Allows us to separate standard output and error output for the time being. I'll be fixing everything generally in the next few weeks.

#### How to Verify

Run tests.

#### Side Effects

The upstream CmdStan test will fail. This isn't a problem. It only affects CmdStan, RStan, and PyStan in a few lines.

And... @betanalpha's new pull requests with algorithms will have conflicts, but hopefully it's not too onerous.

#### Documentation

None.

#### Reviewer Suggestions

@bgoodri or @bob-carpenter 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
