### PR TITLE
aligned makefile, fixed #1870

### DIFF
--- a/makefile
+++ b/makefile
@@ -25,7 +25,7 @@ C++11 = false
 ##
 # Set default compiler options.
 ## 
-CFLAGS = -I src -isystem $(EIGEN) -isystem $(BOOST) -isystem $(CVODES)/include -isystem $(MATH) -Wall -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -pipe 
+CFLAGS = -I src -isystem $(EIGEN) -isystem $(BOOST) -isystem $(CVODES)/include -isystem $(MATH) -Wall -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DNO_FPRINTF_OUTPUT -pipe 
 CFLAGS_GTEST = -DGTEST_USE_OWN_TR1_TUPLE
 LDLIBS = 
 LDLIBS_STANC = -Lbin -lstanc


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run unit tests: `./runTests.py src/test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary
added -DNO_FPRINTF_OUTPUT to CFLAGS

#### Intended Effect
align CFLAGS with math

#### How to Verify
build something

#### Side Effects
None.

#### Documentation
None.

#### Reviewer Suggestions
Anyone.
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

