### PR TITLE
Adding one more use of error_writer to #1836

### DIFF
--- a/src/stan/services/sample/init_windowed_adapt.hpp
+++ b/src/stan/services/sample/init_windowed_adapt.hpp
@@ -19,8 +19,9 @@ namespace stan {
                           unsigned int num_warmup,
                           const Eigen::VectorXd& cont_params,
                           interface_callbacks::writer::base_writer& info_writer,
-                          interface_callbacks::writer::base_writer& error_writer) {
-        init_adapt<Sampler>(sampler, adapt, cont_params, info_writer, error_writer);
+                      interface_callbacks::writer::base_writer& error_writer) {
+        init_adapt<Sampler>(sampler, adapt, cont_params,
+                            info_writer, error_writer);
 
         unsigned int init_buffer
           = dynamic_cast<u_int_argument*>(adapt->arg("init_buffer"))->value();

--- a/src/stan/services/sample/init_windowed_adapt.hpp
+++ b/src/stan/services/sample/init_windowed_adapt.hpp
@@ -18,8 +18,9 @@ namespace stan {
                           stan::services::categorical_argument* adapt,
                           unsigned int num_warmup,
                           const Eigen::VectorXd& cont_params,
-                          interface_callbacks::writer::base_writer& writer) {
-        init_adapt<Sampler>(sampler, adapt, cont_params, writer);
+                          interface_callbacks::writer::base_writer& info_writer,
+                          interface_callbacks::writer::base_writer& error_writer) {
+        init_adapt<Sampler>(sampler, adapt, cont_params, info_writer, error_writer);
 
         unsigned int init_buffer
           = dynamic_cast<u_int_argument*>(adapt->arg("init_buffer"))->value();
@@ -30,7 +31,7 @@ namespace stan {
 
         dynamic_cast<Sampler*>(sampler)
           ->set_window_params(num_warmup, init_buffer, term_buffer,
-                              window, writer);
+                              window, info_writer);
 
         return true;
       }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Finishes up #1836. Missed one use.

#### Side Effects
Needs updates to CmdStan and RStan.

#### Documentation
None.

#### Reviewer Suggestions
Ben reviewed the last one... this is just an extension of it.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

