### PR TITLE
More fixes for streams. This should really fix #1836.

### DIFF
--- a/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
@@ -38,7 +38,7 @@ namespace stan {
                                                                  this->z_.q);
 
           if (update) {
-            this->init_stepsize(info_writer);
+            this->init_stepsize(info_writer, error_writer);
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();

--- a/src/stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp
@@ -41,7 +41,7 @@ namespace stan {
             (this->z_.mInv, this->z_.q);
 
           if (update) {
-            this->init_stepsize(info_writer);
+            this->init_stepsize(info_writer, error_writer);
             this->update_L_();
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));

--- a/src/stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp
@@ -41,7 +41,7 @@ namespace stan {
                                                              this->z_.q);
 
           if (update) {
-            this->init_stepsize(info_writer);
+            this->init_stepsize(info_writer, error_writer);
             this->update_L_();
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Fixes the info vs error stream issue. This is necessary for downstream interfaces being able to separate apart the info from the errors.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

