### PR TITLE
Fixed numerial instability of transition probabilities

### DIFF
--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -177,28 +177,28 @@ namespace stan {
                      interface_callbacks::writer::base_writer& error_writer) {
         // Base case
         if (depth == 0) {
-            this->integrator_.evolve(this->z_, this->hamiltonian_,
-                                     sign * this->epsilon_,
-                                     info_writer, error_writer);
-            ++n_leapfrog;
+          this->integrator_.evolve(this->z_, this->hamiltonian_,
+                                   sign * this->epsilon_,
+                                   info_writer, error_writer);
+          ++n_leapfrog;
 
-            double h = this->hamiltonian_.H(this->z_);
-            if (boost::math::isnan(h))
-              h = std::numeric_limits<double>::infinity();
+          double h = this->hamiltonian_.H(this->z_);
+          if (boost::math::isnan(h))
+            h = std::numeric_limits<double>::infinity();
 
-            if ((h - H0) > this->max_deltaH_) this->divergent_ = true;
+          if ((h - H0) > this->max_deltaH_) this->divergent_ = true;
 
-            log_sum_weight = math::log_sum_exp(log_sum_weight, H0 - h);
+          log_sum_weight = math::log_sum_exp(log_sum_weight, H0 - h);
 
-            if (H0 - h > 0)
-              sum_metro_prob += 1;
-            else
-              sum_metro_prob += std::exp(H0 - h);
+          if (H0 - h > 0)
+            sum_metro_prob += 1;
+          else
+            sum_metro_prob += std::exp(H0 - h);
 
-            z_propose = this->z_;
-            rho += this->z_.p;
+          z_propose = this->z_;
+          rho += this->z_.p;
 
-            return !this->divergent_;
+          return !this->divergent_;
         }
         // General recursion
         Eigen::VectorXd p_sharp_left = this->hamiltonian_.dtau_dp(this->z_);

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
+#include <stan/math/prim/scal/fun/log_sum_exp.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 #include <algorithm>
@@ -61,7 +62,7 @@ namespace stan {
         Eigen::VectorXd p_sharp_plus = this->hamiltonian_.dtau_dp(this->z_);
         Eigen::VectorXd p_sharp_minus = this->hamiltonian_.dtau_dp(this->z_);
         Eigen::VectorXd rho = this->z_.p;
-        double sum_weight = 1;
+        double log_sum_weight = 0;  // log(exp(H0 - H0))
 
         double H0 = this->hamiltonian_.H(this->z_);
         int n_leapfrog = 0;
@@ -77,14 +78,15 @@ namespace stan {
           rho_subtree.setZero();
 
           bool valid_subtree = false;
-          double sum_weight_subtree = 0;
+          double log_sum_weight_subtree
+            = -std::numeric_limits<double>::infinity();
 
           if (this->rand_uniform_() > 0.5) {
             this->z_.ps_point::operator=(z_plus);
             valid_subtree
               = build_tree(this->depth_, rho_subtree, z_propose,
                            H0, 1, n_leapfrog,
-                           sum_weight_subtree, sum_metro_prob,
+                           log_sum_weight_subtree, sum_metro_prob,
                            info_writer, error_writer);
             z_plus.ps_point::operator=(this->z_);
             p_sharp_plus = this->hamiltonian_.dtau_dp(this->z_);
@@ -93,19 +95,21 @@ namespace stan {
             valid_subtree
               = build_tree(this->depth_, rho_subtree, z_propose,
                            H0, -1, n_leapfrog,
-                           sum_weight_subtree, sum_metro_prob,
+                           log_sum_weight_subtree, sum_metro_prob,
                            info_writer, error_writer);
             z_minus.ps_point::operator=(this->z_);
             p_sharp_minus = this->hamiltonian_.dtau_dp(this->z_);
           }
 
-          sum_weight += sum_weight_subtree;
           if (!valid_subtree) break;
+          log_sum_weight
+            = math::log_sum_exp(log_sum_weight, log_sum_weight_subtree);
 
           // Sample from an accepted subtree
           ++(this->depth_);
 
-          double accept_prob = sum_weight_subtree / sum_weight;
+          double accept_prob
+            = std::exp(log_sum_weight_subtree - log_sum_weight);
           if (this->rand_uniform_() < accept_prob)
             z_sample = z_propose;
 
@@ -153,7 +157,7 @@ namespace stan {
       // Returns number of valid points in the completed subtree
       int build_tree(int depth, Eigen::VectorXd& rho, ps_point& z_propose,
                      double H0, double sign, int& n_leapfrog,
-                     double& sum_weight, double& sum_metro_prob,
+                     double& log_sum_weight, double& sum_metro_prob,
                      interface_callbacks::writer::base_writer& info_writer,
                      interface_callbacks::writer::base_writer& error_writer) {
         // Base case
@@ -169,9 +173,12 @@ namespace stan {
 
             if ((h - H0) > this->max_deltaH_) this->divergent_ = true;
 
-            double pi = exp(H0 - h);
-            sum_weight += pi;
-            sum_metro_prob += pi > 1 ? 1 : pi;
+            log_sum_weight = math::log_sum_exp(log_sum_weight, H0 - h);
+
+            if (H0 - h > 0)
+              sum_metro_prob += 1;
+            else
+              sum_metro_prob += std::exp(H0 - h);
 
             z_propose = this->z_;
             rho += this->z_.p;
@@ -185,32 +192,34 @@ namespace stan {
         rho_subtree.setZero();
 
         // Build the left subtree
-        double sum_weight_left = 0;
+        double log_sum_weight_left = -std::numeric_limits<double>::infinity();
 
         bool valid_left
           = build_tree(depth - 1, rho_subtree, z_propose,
                        H0, sign, n_leapfrog,
-                       sum_weight_left, sum_metro_prob,
+                       log_sum_weight_left, sum_metro_prob,
                        info_writer, error_writer);
 
-        sum_weight += sum_weight_left;
         if (!valid_left) return false;
+        log_sum_weight
+          = math::log_sum_exp(log_sum_weight, log_sum_weight_left);
 
         // Build the right subtree
         ps_point z_propose_right(this->z_);
-        double sum_weight_right = 0;
+        double log_sum_weight_right = -std::numeric_limits<double>::infinity();
 
         bool valid_right
           = build_tree(depth - 1, rho_subtree, z_propose_right,
                        H0, sign, n_leapfrog,
-                       sum_weight_right, sum_metro_prob,
+                       log_sum_weight_right, sum_metro_prob,
                        info_writer, error_writer);
 
-        sum_weight += sum_weight_right;
         if (!valid_right) return false;
+        log_sum_weight
+          = math::log_sum_exp(log_sum_weight, log_sum_weight_right);
 
         // Multinomial sample from right subtree
-        double accept_prob = sum_weight_right / sum_weight;
+        double accept_prob = std::exp(log_sum_weight_right - log_sum_weight);
         if (this->rand_uniform_() < accept_prob)
           z_propose = z_propose_right;
 

--- a/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
@@ -207,33 +207,33 @@ namespace stan {
                      interface_callbacks::writer::base_writer& error_writer) {
         // Base case
         if (depth == 0) {
-            this->integrator_.evolve(this->z_, this->hamiltonian_,
-                                     sign * this->epsilon_,
-                                     info_writer, error_writer);
-            ++n_leapfrog;
+          this->integrator_.evolve(this->z_, this->hamiltonian_,
+                                   sign * this->epsilon_,
+                                   info_writer, error_writer);
+          ++n_leapfrog;
 
-            double h = this->hamiltonian_.H(this->z_);
-            if (boost::math::isnan(h))
-              h = std::numeric_limits<double>::infinity();
+          double h = this->hamiltonian_.H(this->z_);
+          if (boost::math::isnan(h))
+            h = std::numeric_limits<double>::infinity();
 
-            if ((h - H0) > this->max_deltaH_) this->divergent_ = true;
+          if ((h - H0) > this->max_deltaH_) this->divergent_ = true;
 
-            double dG_dt = this->hamiltonian_.dG_dt(this->z_,
-                                                    info_writer,
-                                                    error_writer);
+          double dG_dt = this->hamiltonian_.dG_dt(this->z_,
+                                                  info_writer,
+                                                  error_writer);
 
-            stable_sum(ave, log_sum_weight,
-                       dG_dt, H0 - h,
-                       ave, log_sum_weight);
+          stable_sum(ave, log_sum_weight,
+                     dG_dt, H0 - h,
+                     ave, log_sum_weight);
 
-            if (H0 - h > 0)
-              sum_metro_prob += 1;
-            else
-              sum_metro_prob += std::exp(H0 - h);
+          if (H0 - h > 0)
+            sum_metro_prob += 1;
+          else
+            sum_metro_prob += std::exp(H0 - h);
 
-            z_propose = this->z_;
+          z_propose = this->z_;
 
-            return !this->divergent_;
+          return !this->divergent_;
         }
         // General recursion
 

--- a/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
@@ -16,17 +16,19 @@ namespace stan {
   namespace mcmc {
     /**
      * a1 and a2 are running averages of the form
-     *   a1 = ( \sum_{n \in N1} w_{n} f_{n} ) / ( \sum_{n \in N1}  w_{n} )
-     *   a2 = ( \sum_{n \in N2} w_{n} f_{n} ) / ( \sum_{n \in N2}  w_{n} )
+     *   \f$ a1 =   ( \sum_{n \in N1} w_{n} f_{n} )
+     *            / ( \sum_{n \in N1}  w_{n} ) \f$
+     *   \f$ a2 =   ( \sum_{n \in N2} w_{n} f_{n} )
+     *            / ( \sum_{n \in N2}  w_{n} ) \f$
      * and the weights are the respective normalizing constants
-     *   w1 = \sum_{n \in N1} w_{n}
-     *   w2 = \sum_{n \in N2} w_{n}.
+     *   \f$ w1 = \sum_{n \in N1} w_{n} \f$
+     *   \f$ w2 = \sum_{n \in N2} w_{n}. \f$
      *
      * This function returns the pooled average
-     *   sum_a =   ( \sum_{n \in N1 \cup N2} w_{n} f_{n} )
-     *           / ( \sum_{n \in N1 \cup N2}  w_{n} )
+     *   \f$ sum_a =   ( \sum_{n \in N1 \cup N2} w_{n} f_{n} )
+     *               / ( \sum_{n \in N1 \cup N2}  w_{n} ) \f$
      * and the pooled weights
-     *   log_sum_w = log(w1 + w2).
+     *   \f$ log_sum_w = log(w1 + w2). \f$
      *
      * @param a1 First running average, f1 / w1
      * @param log_w1 Log of first summed weight

--- a/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
@@ -33,7 +33,7 @@ namespace stan {
      * @param a1 First running average, f1 / w1
      * @param log_w1 Log of first summed weight
      * @param a2 Second running average
-     * @param low_w2 Log of second summed weight
+     * @param log_w2 Log of second summed weight
      * @param sum_a Average of input running averages
      * @param log_sum_w Log of summed input weights
     */

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -139,7 +139,7 @@ TEST(McmcNutsBaseNuts, build_tree) {
   stan::mcmc::ps_point z_propose(model_size);
 
   Eigen::VectorXd rho = z_init.p;
-  double sum_weight = 0;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
   int n_leapfrog = 0;
@@ -160,7 +160,7 @@ TEST(McmcNutsBaseNuts, build_tree) {
 
 
   bool valid_subtree = sampler.build_tree(3, rho, z_propose,
-                                          H0, 1, n_leapfrog, sum_weight,
+                                          H0, 1, n_leapfrog, log_sum_weight,
                                           sum_metro_prob, writer, error_writer);
 
   EXPECT_TRUE(valid_subtree);
@@ -171,7 +171,7 @@ TEST(McmcNutsBaseNuts, build_tree) {
   EXPECT_EQ(init_momentum, sampler.z().p(0));
 
   EXPECT_EQ(8, n_leapfrog);
-  EXPECT_FLOAT_EQ(std::exp(H0) * n_leapfrog, sum_weight);
+  EXPECT_FLOAT_EQ(H0 + std::log(n_leapfrog), log_sum_weight);
   EXPECT_FLOAT_EQ(std::exp(H0) * n_leapfrog, sum_metro_prob);
 
   EXPECT_EQ("", output.str());
@@ -192,7 +192,7 @@ TEST(McmcNutsBaseNuts, divergence_test) {
   stan::mcmc::ps_point z_propose(model_size);
 
   Eigen::VectorXd rho = z_init.p;
-  double sum_weight = 0;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
   int n_leapfrog = 0;
@@ -216,7 +216,7 @@ TEST(McmcNutsBaseNuts, divergence_test) {
 
   sampler.z().V = -750;
   valid_subtree = sampler.build_tree(0, rho, z_propose,
-                                     H0, 1, n_leapfrog, sum_weight,
+                                     H0, 1, n_leapfrog, log_sum_weight,
                                      sum_metro_prob,
                                      writer, error_writer);
   EXPECT_TRUE(valid_subtree);
@@ -224,7 +224,7 @@ TEST(McmcNutsBaseNuts, divergence_test) {
 
   sampler.z().V = -250;
   valid_subtree = sampler.build_tree(0, rho, z_propose,
-                                     H0, 1, n_leapfrog, sum_weight,
+                                     H0, 1, n_leapfrog, log_sum_weight,
                                      sum_metro_prob,
                                      writer, error_writer);
 
@@ -233,7 +233,7 @@ TEST(McmcNutsBaseNuts, divergence_test) {
 
   sampler.z().V = 750;
   valid_subtree = sampler.build_tree(0, rho, z_propose,
-                                     H0, 1, n_leapfrog, sum_weight,
+                                     H0, 1, n_leapfrog, log_sum_weight,
                                      sum_metro_prob,
                                      writer, error_writer);
 

--- a/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
@@ -41,14 +41,14 @@ TEST(McmcSoftAbsNuts, build_tree) {
   stan::mcmc::ps_point z_propose = z_init;
 
   Eigen::VectorXd rho = z_init.p;
-  double sum_weight = 0;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
   int n_leapfrog = 0;
   double sum_metro_prob = 0;
 
   bool valid_subtree = sampler.build_tree(3, rho, z_propose,
-                                          H0, 1, n_leapfrog, sum_weight,
+                                          H0, 1, n_leapfrog, log_sum_weight,
                                           sum_metro_prob, writer, error_writer);
 
   EXPECT_EQ(0.1, sampler.get_nominal_stepsize());
@@ -68,7 +68,7 @@ TEST(McmcSoftAbsNuts, build_tree) {
   EXPECT_FLOAT_EQ(-1.5019561, sampler.z().p(2));
 
   EXPECT_EQ(8, n_leapfrog);
-  EXPECT_FLOAT_EQ(0.34310558, sum_weight);
+  EXPECT_FLOAT_EQ(std::log(0.34310558), log_sum_weight);
   EXPECT_FLOAT_EQ(0.34310558, sum_metro_prob);
 
   EXPECT_EQ("", output.str());

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -41,14 +41,14 @@ TEST(McmcUnitENuts, build_tree) {
   stan::mcmc::ps_point z_propose = z_init;
 
   Eigen::VectorXd rho = z_init.p;
-  double sum_weight = 0;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
   int n_leapfrog = 0;
   double sum_metro_prob = 0;
 
   bool valid_subtree = sampler.build_tree(3, rho, z_propose,
-                                          H0, 1, n_leapfrog, sum_weight,
+                                          H0, 1, n_leapfrog, log_sum_weight,
                                           sum_metro_prob,
                                           writer, error_writer);
 
@@ -69,7 +69,7 @@ TEST(McmcUnitENuts, build_tree) {
   EXPECT_FLOAT_EQ(-1.4131583, sampler.z().p(2));
 
   EXPECT_EQ(8, n_leapfrog);
-  EXPECT_FLOAT_EQ(0.36134657, sum_weight);
+  EXPECT_FLOAT_EQ(std::log(0.36134657), log_sum_weight);
   EXPECT_FLOAT_EQ(0.36134657, sum_metro_prob);
 
   EXPECT_EQ("", output.str());

--- a/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
@@ -153,8 +153,8 @@ TEST(McmcXHMCBaseXHMC, build_tree) {
 
   stan::mcmc::ps_point z_propose(model_size);
 
-  double sum_numer = 0;
-  double sum_weight = 0;
+  double ave = 0;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
   int n_leapfrog = 0;
@@ -175,7 +175,7 @@ TEST(McmcXHMCBaseXHMC, build_tree) {
 
 
   bool valid_subtree = sampler.build_tree(3, z_propose,
-                                          sum_numer, sum_weight,
+                                          ave, log_sum_weight,
                                           H0, 1, n_leapfrog,
                                           sum_metro_prob,
                                           writer, error_writer);
@@ -186,8 +186,8 @@ TEST(McmcXHMCBaseXHMC, build_tree) {
   EXPECT_EQ(init_momentum, sampler.z().p(0));
 
   EXPECT_EQ(8, n_leapfrog);
-  EXPECT_FLOAT_EQ(std::exp(H0) * 2 * n_leapfrog, sum_numer);
-  EXPECT_FLOAT_EQ(std::exp(H0) * n_leapfrog, sum_weight);
+  EXPECT_FLOAT_EQ(2, ave);
+  EXPECT_FLOAT_EQ(H0  + std::log(n_leapfrog), log_sum_weight);
   EXPECT_FLOAT_EQ(std::exp(H0) * n_leapfrog, sum_metro_prob);
 
   EXPECT_EQ("", output.str());
@@ -207,8 +207,8 @@ TEST(McmcXHMCBaseXHMC, divergence_test) {
 
   stan::mcmc::ps_point z_propose(model_size);
 
-  double sum_numer = 0;
-  double sum_weight = 0;
+  double ave = 0;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
   int n_leapfrog = 0;
@@ -232,7 +232,7 @@ TEST(McmcXHMCBaseXHMC, divergence_test) {
 
   sampler.z().V = -750;
   valid_subtree = sampler.build_tree(0, z_propose,
-                                     sum_numer, sum_weight,
+                                     ave, log_sum_weight,
                                      H0, 1, n_leapfrog,
                                      sum_metro_prob,
                                      writer, error_writer);
@@ -241,7 +241,7 @@ TEST(McmcXHMCBaseXHMC, divergence_test) {
 
   sampler.z().V = -250;
   valid_subtree = sampler.build_tree(0, z_propose,
-                                     sum_numer, sum_weight,
+                                     ave, log_sum_weight,
                                      H0, 1, n_leapfrog,
                                      sum_metro_prob,
                                      writer, error_writer);
@@ -251,7 +251,7 @@ TEST(McmcXHMCBaseXHMC, divergence_test) {
 
   sampler.z().V = 750;
   valid_subtree = sampler.build_tree(0, z_propose,
-                                     sum_numer, sum_weight,
+                                     ave, log_sum_weight,
                                      H0, 1, n_leapfrog,
                                      sum_metro_prob,
                                      writer, error_writer);

--- a/src/test/unit/mcmc/hmc/xhmc/softabs_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/softabs_xhmc_test.cpp
@@ -40,14 +40,14 @@ TEST(McmcUnitEXHMC, build_tree) {
 
   stan::mcmc::ps_point z_propose = z_init;
 
-  double sum_numer = 0;
-  double sum_weight = 0;
+  double ave = 0;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
   int n_leapfrog = 0;
   double sum_metro_prob = 0;
 
-  bool valid_subtree = sampler.build_tree(3, z_propose, sum_numer, sum_weight,
+  bool valid_subtree = sampler.build_tree(3, z_propose, ave, log_sum_weight,
                                           H0, 1, n_leapfrog,
                                           sum_metro_prob, writer, error_writer);
 
@@ -72,8 +72,8 @@ TEST(McmcUnitEXHMC, build_tree) {
   EXPECT_FLOAT_EQ(-1.1836562, z_propose.p(2));
 
   EXPECT_EQ(8, n_leapfrog);
-  EXPECT_FLOAT_EQ(1.291629, sum_numer);
-  EXPECT_FLOAT_EQ(0.34310558, sum_weight);
+  EXPECT_FLOAT_EQ(3.7645235, ave);
+  EXPECT_FLOAT_EQ(std::log(0.34310558), log_sum_weight);
   EXPECT_FLOAT_EQ(0.34310558, sum_metro_prob);
 
   EXPECT_EQ("", output.str());

--- a/src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp
@@ -40,14 +40,14 @@ TEST(McmcUnitEXHMC, build_tree) {
 
   stan::mcmc::ps_point z_propose = z_init;
 
-  double sum_numer = 0;
-  double sum_weight = 0;
+  double ave = 0;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
   int n_leapfrog = 0;
   double sum_metro_prob = 0;
 
-  bool valid_subtree = sampler.build_tree(3, z_propose, sum_numer, sum_weight,
+  bool valid_subtree = sampler.build_tree(3, z_propose, ave, log_sum_weight,
                                           H0, 1, n_leapfrog,
                                           sum_metro_prob,
                                           writer, error_writer);
@@ -73,8 +73,8 @@ TEST(McmcUnitEXHMC, build_tree) {
   EXPECT_FLOAT_EQ(-1.1785525, z_propose.p(2));
 
   EXPECT_EQ(8, n_leapfrog);
-  EXPECT_FLOAT_EQ(1.5251483, sum_numer);
-  EXPECT_FLOAT_EQ(0.36134657, sum_weight);
+  EXPECT_FLOAT_EQ(4.2207355, ave);
+  EXPECT_FLOAT_EQ(std::log(0.36134657), log_sum_weight);
   EXPECT_FLOAT_EQ(0.36134657, sum_metro_prob);
 
   EXPECT_EQ("", output.str());


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes the numerical instability of NUTS (and XHMC) that could occur out in the tails of a target distribution.

#### Intended Effect

Avoids the transient warmup issues seen in various models.

#### How to Verify

Run on any of the models that were proving problematic.  Make sure to use the same seed.

#### Side Effects

Very small increase in cost due to the extra exps and logs needed for the logarithmic summations, should be negligible.

#### Documentation

Not user facing.

#### Reviewer Suggestions

@bob-carpenter, @syclik, @wds15 

#### Copyright and Licensing

Copyright: University of Warwick.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
