### PR TITLE
Make stan_csv_reader insensitive to whitespace around rhs of .csv fil…

### DIFF
--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -101,7 +101,8 @@ namespace stan {
           if (equal != std::string::npos) {
             name = lhs.substr(0, equal);
             boost::trim(name);
-            value = lhs.substr(equal + 2, lhs.size());
+            value = lhs.substr(equal + 1, lhs.size());
+            boost::trim(value);
             boost::replace_first(value, " (Default)", "");
           } else {
             if (lhs.compare(" data") == 0) {

--- a/src/test/unit/io/stan_csv_reader_test.cpp
+++ b/src/test/unit/io/stan_csv_reader_test.cpp
@@ -10,6 +10,7 @@ public:
   void SetUp () {
     blocker0_stream.open("src/test/unit/io/test_csv_files/blocker.0.csv");
     metadata1_stream.open("src/test/unit/io/test_csv_files/metadata1.csv");
+    metadata3_stream.open("src/test/unit/io/test_csv_files/metadata3.csv");
     header1_stream.open("src/test/unit/io/test_csv_files/header1.csv");
     adaptation1_stream.open("src/test/unit/io/test_csv_files/adaptation1.csv");
     samples1_stream.open("src/test/unit/io/test_csv_files/samples1.csv");
@@ -26,6 +27,7 @@ public:
   void TearDown() {
     blocker0_stream.close();
     metadata1_stream.close();
+    metadata3_stream.close();
     header1_stream.close();
     adaptation1_stream.close();
     samples1_stream.close();
@@ -42,12 +44,36 @@ public:
   std::ifstream blocker0_stream, epil0_stream;
   std::ifstream blocker_nondiag0_stream;
   std::ifstream metadata1_stream, header1_stream, adaptation1_stream, samples1_stream;
+  std::ifstream metadata3_stream;
   std::ifstream metadata2_stream, header2_stream, adaptation2_stream, samples2_stream;
+
 };
 
 TEST_F(StanIoStanCsvReader,read_metadata1) {
   stan::io::stan_csv_metadata metadata;
   EXPECT_TRUE(stan::io::stan_csv_reader::read_metadata(metadata1_stream, metadata, 0));
+  
+  EXPECT_EQ(2, metadata.stan_version_major);
+  EXPECT_EQ(9, metadata.stan_version_minor);
+  EXPECT_EQ(0, metadata.stan_version_patch);
+  
+  EXPECT_EQ("blocker_model", metadata.model);
+  EXPECT_EQ("../example-models/bugs_examples/vol1/blocker/blocker.data.R", metadata.data);
+  EXPECT_EQ("../example-models/bugs_examples/vol1/blocker/blocker.init.R", metadata.init);
+  EXPECT_FALSE(metadata.append_samples);
+  EXPECT_FALSE(metadata.save_warmup);
+  EXPECT_EQ(4085885484U, metadata.seed);
+  EXPECT_FALSE(metadata.random_seed);
+  EXPECT_EQ(1U, metadata.chain_id);
+  EXPECT_EQ(2000U, metadata.num_samples);
+  EXPECT_EQ(2000U, metadata.num_warmup);
+  EXPECT_EQ(2U, metadata.thin);
+  EXPECT_EQ("hmc", metadata.algorithm);
+  EXPECT_EQ("nuts", metadata.engine);
+}
+TEST_F(StanIoStanCsvReader,read_metadata3) {
+  stan::io::stan_csv_metadata metadata;
+  EXPECT_TRUE(stan::io::stan_csv_reader::read_metadata(metadata3_stream, metadata, 0));
   
   EXPECT_EQ(2, metadata.stan_version_major);
   EXPECT_EQ(9, metadata.stan_version_minor);

--- a/src/test/unit/io/test_csv_files/metadata3.csv
+++ b/src/test/unit/io/test_csv_files/metadata3.csv
@@ -1,0 +1,37 @@
+# stan_version_major =2
+# stan_version_minor = 9
+# stan_version_patch =  0
+# model= blocker_model
+# method= sample (Default)
+#   sample
+#     num_samples = 2000
+#     num_warmup = 2000
+#     save_warmup = 0 (Default)
+#     thin = 2
+#     adapt
+#       engaged = 1 (Default)
+#       gamma = 0.050000000000000003 (Default)
+#       delta = 0.80000000000000004 (Default)
+#       kappa = 0.75 (Default)
+#       t0 = 10 (Default)
+#       init_buffer = 75 (Default)
+#       term_buffer = 50 (Default)
+#       window = 25 (Default)
+#     algorithm = hmc (Default)
+#       hmc
+#         engine = nuts (Default)
+#           nuts
+#             max_depth = 10 (Default)
+#         metric = diag_e (Default)
+#         stepsize = 1 (Default)
+#         stepsize_jitter = 0 (Default)
+# id = 0 (Default)
+# data
+#   file = ../example-models/bugs_examples/vol1/blocker/blocker.data.R
+# init = ../example-models/bugs_examples/vol1/blocker/blocker.init.R
+# random
+#   seed = 4085885484
+# output
+#   file = blocker.0.csv
+#   diagnostic_file =  (Default)
+#   refresh = 100 (Default)


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run unit tests: `./runTests.py src/test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary
There is a two-line change to stan_csv_reader that trims whitespace before using rhs.

#### Intended Effect
Read .csv files produced by rstan/pystan which do no follow the cmdstan convention of including whitespace around the "=" in metadata.

#### How to Verify
There is a new test file and test, it fails with the old stan_csv_reader and passes with the new one.  It has three lines modified with different whitespace patterns. It probably is possible to make the test smaller but the test should pass regardless of any stray whitespace so I'd rather keep the large file.

#### Side Effects
None.

#### Documentation


#### Reviewer Suggestions

#### Copyright and Licensing

Krzysztof Sakrejda

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

…e metadata.

Previously running stansummary on a .csv file produced by either rstan or pystan
would fail on a metadata line with no space after the "=" sign.  Editing the
files to say "= " would fix the problem.  With this change any amount of spacing
before or after the value works as it gets trimmed before the lexical_cast.