### PR TITLE
Index type for Eigen ctors, fixes #1909

### DIFF
--- a/src/test/test-models/good/vector-zero.stan
+++ b/src/test/test-models/good/vector-zero.stan
@@ -1,0 +1,69 @@
+data {
+  vector[0] d_v;
+  row_vector[0] d_rv;
+  matrix[0, 2] d_m1;
+  matrix[3, 0] d_m2;
+  matrix[0, 0] d_m12;
+  real d_r1[0];
+  real d_r2a[0, 4];
+  real d_r2b[2, 0];
+  real d_r2c[0, 0];
+  int d_i1[0];
+  int d_i2a[4, 0];
+  int d_i2b[0, 3];
+  int d_i2c[0, 0];
+}
+transformed data {
+  vector[0] td_v;
+  row_vector[0] td_rv;
+  matrix[0, 2] td_m1;
+  matrix[3, 0] td_m2;
+  matrix[0, 0] td_m12;
+  real td_r1[0];
+  real td_r2a[0, 4];
+  real td_r2b[2, 0];
+  real td_r2c[0, 0];
+  int td_i1[0];
+  int td_i2a[4, 0];
+  int td_i2b[0, 3];
+  int td_i2c[0, 0];
+}
+parameters {
+  vector[0] p_v;
+  row_vector[0] p_rv;
+  matrix[0, 2] p_m1;
+  matrix[3, 0] p_m2;
+  matrix[0, 0] p_m12;
+  real p_r1[0];
+  real p_r2a[0, 4];
+  real p_r2b[2, 0];
+  real p_r2c[0, 0];
+}
+transformed parameters {
+  vector[0] tp_v;
+  row_vector[0] tp_rv;
+  matrix[0, 2] tp_m1;
+  matrix[3, 0] tp_m2;
+  matrix[0, 0] tp_m12;
+  real tp_r1[0];
+  real tp_r2a[0, 4];
+  real tp_r2b[2, 0];
+  real tp_r2c[0, 0];
+}
+model {
+}
+generated quantities {
+  vector[0] gq_v;
+  row_vector[0] gq_rv;
+  matrix[0, 2] gq_m1;
+  matrix[3, 0] gq_m2;
+  matrix[0, 0] gq_m12;
+  real gq_r1[0];
+  real gq_r2a[0, 4];
+  real gq_r2b[2, 0];
+  real gq_r2c[0, 0];
+  int gq_i1[0];
+  int gq_i2a[4, 0];
+  int gq_i2b[0, 3];
+  int gq_i2c[0, 0];
+}

--- a/src/test/unit/lang/parser/var_decls_grammar_test.cpp
+++ b/src/test/unit/lang/parser/var_decls_grammar_test.cpp
@@ -67,3 +67,6 @@ TEST(langParserVarDeclsGrammarDef, constraintsInLocals) {
   test_throws("local_var_constraint3",
               "require unconstrained. found range constraint.");
 }
+TEST (langParserVarDeclsGrammarDef, zeroVecs) {
+  test_parsable("vector-zero");
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

I couldn't run cpplint because insalling Anaconda and Python 3.x broke my build.

#### Summary

Generate explicit static cast to `VectorXd::Index` type for constructors of Eigen types to deal with ambiguity of `VectorXd(0)` call.

#### Intended Effect

Allow zero sizes for row vectors, vectors, and matrices in Stan.

#### How to Verify

New model test compiles.

#### Side Effects

No.

#### Documentation

Behavior now matches doc.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

