### PR TITLE
Use delayed rejection transition in multinomial NUTS

### DIFF
--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -102,8 +102,6 @@ namespace stan {
           }
 
           if (!valid_subtree) break;
-          log_sum_weight
-            = math::log_sum_exp(log_sum_weight, log_sum_weight_subtree);
 
           // Sample from an accepted subtree
           ++(this->depth_);
@@ -112,6 +110,18 @@ namespace stan {
             = std::exp(log_sum_weight_subtree - log_sum_weight);
           if (this->rand_uniform_() < accept_prob)
             z_sample = z_propose;
+
+          if (log_sum_weight_subtree > log_sum_weight) {
+            z_sample = z_propose;
+          } else {
+            double accept_prob
+              = std::exp(log_sum_weight_subtree - log_sum_weight);
+            if (this->rand_uniform_() < accept_prob)
+              z_sample = z_propose;
+          }
+
+          log_sum_weight
+            = math::log_sum_exp(log_sum_weight, log_sum_weight_subtree);
 
           // Break when NUTS criterion is not longer satisfied
           rho += rho_subtree;

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -108,13 +108,13 @@ TEST_F(performance, values_from_tagged_version) {
     << "last tagged version, 2.9.0, had " << N_values << " elements";
 
   std::vector<double> first_run = last_draws_per_run[0];
-  EXPECT_FLOAT_EQ(-65.241302, first_run[0])
+  EXPECT_FLOAT_EQ(-67.4618, first_run[0])
     << "lp__: index 0";
 
-  EXPECT_FLOAT_EQ(0.98944098, first_run[1])
+  EXPECT_FLOAT_EQ(0.96871901, first_run[1])
     << "accept_stat__: index 1";
 
-  EXPECT_FLOAT_EQ(1.3144701, first_run[2])
+  EXPECT_FLOAT_EQ(1.21214, first_run[2])
     << "stepsize__: index 2";
 
   EXPECT_FLOAT_EQ(1, first_run[3])
@@ -126,13 +126,13 @@ TEST_F(performance, values_from_tagged_version) {
   EXPECT_FLOAT_EQ(0, first_run[5])
     << "divergent__: index 5";
 
-  EXPECT_FLOAT_EQ(65.266701, first_run[6])
+  EXPECT_FLOAT_EQ(68.961502, first_run[6])
     << "energy__: index 6";
 
-  EXPECT_FLOAT_EQ(1.30007, first_run[7])
+  EXPECT_FLOAT_EQ(1.79573, first_run[7])
     << "beta.1: index 7";
 
-  EXPECT_FLOAT_EQ(-0.57955098, first_run[8])
+  EXPECT_FLOAT_EQ(-0.77275401, first_run[8])
     << "beta.2: index 8";
 
   matches_tagged_version = !HasNonfatalFailure();

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -272,7 +272,7 @@ TEST(McmcNutsBaseNuts, transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
-  EXPECT_EQ(31.5, s.cont_params()(0));
+  EXPECT_EQ(-42, s.cont_params()(0));
   EXPECT_EQ(0, s.log_prob());
   EXPECT_EQ(1, s.accept_stat());
   EXPECT_EQ("", output_stream.str());

--- a/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
@@ -109,11 +109,11 @@ TEST(McmcSoftAbsNuts, transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
-  EXPECT_FLOAT_EQ(1, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-1, s.cont_params()(1));
-  EXPECT_FLOAT_EQ(1, s.cont_params()(2));
-  EXPECT_FLOAT_EQ(-1.5, s.log_prob());
-  EXPECT_FLOAT_EQ(0.99709648, s.accept_stat());
+  EXPECT_FLOAT_EQ(-0.13615179, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-0.53625083, s.cont_params()(1));
+  EXPECT_FLOAT_EQ(0.073073119, s.cont_params()(2));
+  EXPECT_FLOAT_EQ(-0.15572098, s.log_prob());
+  EXPECT_FLOAT_EQ(0.99829924, s.accept_stat());
   EXPECT_EQ("", output.str());
   EXPECT_EQ("", error_stream.str());
 }

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -109,11 +109,11 @@ TEST(McmcUnitENuts, transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
-  EXPECT_FLOAT_EQ(1, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-1, s.cont_params()(1));
-  EXPECT_FLOAT_EQ(1, s.cont_params()(2));
-  EXPECT_FLOAT_EQ(-1.5, s.log_prob());
-  EXPECT_FLOAT_EQ(0.99629, s.accept_stat());
+  EXPECT_FLOAT_EQ(-0.30853021, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-0.44694126, s.cont_params()(1));
+  EXPECT_FLOAT_EQ(-0.073457584, s.cont_params()(2));
+  EXPECT_FLOAT_EQ(-0.1501717, s.log_prob());
+  EXPECT_FLOAT_EQ(0.99752671, s.accept_stat());
   EXPECT_EQ("", output_stream.str());
   EXPECT_EQ("", error_stream.str());
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Changes the trajectory -> state transition in NUTS from the naive uniform transition to the "delayed rejection" transition used in the original NUTS implementation.  Addresses #1906.

#### Intended Effect

Should give higher performance for most models.

#### How to Verify

Spot check the ESS for various models.  The effect is evident in a 100-dimensional IID gaussian target, but other models should be compared.

#### Side Effects

None.

#### Documentation

None user facing.

#### Reviewer Suggestions

@syclik, @bob-carpenter 

#### Copyright and Licensing

Copyright: University of Warwick.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
