### PR TITLE
Fixes #1912. Adds PYTHON2 variable for use in cpplint

### DIFF
--- a/make/cpplint
+++ b/make/cpplint
@@ -1,5 +1,5 @@
-RUN_CPPLINT ?= python $(CPPLINT)/cpplint.py
+PYTHON2 ?= python
 
 .PHONY: cpplint
 cpplint:
-	@$(RUN_CPPLINT) --output=vs7 --counting=detailed --root=src --extension=hpp,cpp --filter=-runtime/indentation_namespace,-readability/namespace,-legal/copyright,-whitespace/indent,-runtime/reference $(shell find src/stan -name '*.hpp' -o -name '*.cpp')
+        @$(PYTHON2) $(CPPLINT)/cpplint.py --output=vs7 --counting=detailed --root=src --extension=hpp,cpp --filter=-runtime/indentation_namespace,-readability/namespace,-legal/copyright,-whitespace/indent,-runtime/reference $(shell find src/stan -name '*.hpp' -o -name '*.cpp')

--- a/make/cpplint
+++ b/make/cpplint
@@ -2,4 +2,4 @@ PYTHON2 ?= python
 
 .PHONY: cpplint
 cpplint:
-        @$(PYTHON2) $(CPPLINT)/cpplint.py --output=vs7 --counting=detailed --root=src --extension=hpp,cpp --filter=-runtime/indentation_namespace,-readability/namespace,-legal/copyright,-whitespace/indent,-runtime/reference $(shell find src/stan -name '*.hpp' -o -name '*.cpp')
+	@$(PYTHON2) $(CPPLINT)/cpplint.py --output=vs7 --counting=detailed --root=src --extension=hpp,cpp --filter=-runtime/indentation_namespace,-readability/namespace,-legal/copyright,-whitespace/indent,-runtime/reference $(shell find src/stan -name '*.hpp' -o -name '*.cpp')

--- a/makefile
+++ b/makefile
@@ -143,6 +143,8 @@ endif
 	@echo '  - cpplint       : runs cpplint.py on source files. requires python 2.7.'
 	@echo '                    cpplint is called using the CPPLINT variable:'
 	@echo '                      CPPLINT = $(CPPLINT)'
+	@echo '                    To set the version of python 2, set the PYTHON2 variable:'
+	@echo '                      PYTHON2 = $(PYTHON2)'
 	@echo ''
 	@echo 'Clean:'
 	@echo '  - clean         : Basic clean. Leaves doc and compiled libraries intact.'


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Adds a PYTHON2 make variable to control cpplint behavior.

#### How to Verify
Run `make cpplint PYTHON2=<some other python version>`

#### Side Effects
Removing the `RUN_CPPLINT` make variable.

#### Documentation
Updated in the top level make help.

#### Reviewer Suggestions
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

