### PR TITLE
removed std::cout from ast_def.cpp

### DIFF
--- a/src/stan/lang/ast_def.cpp
+++ b/src/stan/lang/ast_def.cpp
@@ -449,7 +449,6 @@ namespace stan {
           match_index = i;
           num_matches = 1;
         } else if (promotions_ui == min_promotions) {
-          std::cout << std::endl;
           ++num_matches;
         }
       }


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Removed use of `std::cout` from `ast_def.cpp`

#### Intended Effect

Can't have `cout` in server code.

#### How to Verify

grep, check diffs

#### Side Effects

No.

#### Documentation

no.

#### Reviewer Suggestions

anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

