### PR TITLE
Feature/issue 1936 print

### DIFF
--- a/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
@@ -112,16 +112,15 @@ namespace stan {
 
       void write_error_msg_(const std::exception& e,
                             interface_callbacks::writer::base_writer& writer) {
-        writer();
         writer("Informational Message: The current Metropolis proposal "
                "is about to be rejected because of the following issue:");
         writer(e.what());
         writer("If this warning occurs sporadically, such as for highly "
                "constrained variable types like covariance matrices, then "
                "the sampler is fine,");
-        writer();
         writer("but if this warning occurs often then your model may be "
                "either severely ill-conditioned or misspecified.");
+        writer();
       }
     };
 

--- a/src/stan/model/util.hpp
+++ b/src/stan/model/util.hpp
@@ -437,17 +437,12 @@ namespace stan {
       try {
         stan::math::gradient(model_functional<M>(model, &ss), x, f, grad_f);
       } catch (std::exception& e) {
-        std::string msg = ss.str();
-        if (msg.length() > 1)
-          writer(msg.substr(0, msg.length() - 1));
+        if (ss.str().length() > 0)
+          writer(ss.str());
         throw;
       }
-      // FIXME(DL): remove blank line at the end of the gradient call
-      //            this assumes the last character is a newline
-      //            this matches the v2.8.0 behavior
-      std::string msg = ss.str();
-      if (msg.length() > 1)
-        writer(msg.substr(0, msg.length() - 1));
+        if (ss.str().length() > 0)
+          writer(ss.str());
     }
 
     template <class M>

--- a/src/stan/model/util.hpp
+++ b/src/stan/model/util.hpp
@@ -441,8 +441,8 @@ namespace stan {
           writer(ss.str());
         throw;
       }
-        if (ss.str().length() > 0)
-          writer(ss.str());
+      if (ss.str().length() > 0)
+        writer(ss.str());
     }
 
     template <class M>

--- a/src/stan/model/util.hpp
+++ b/src/stan/model/util.hpp
@@ -434,7 +434,14 @@ namespace stan {
                   Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_f,
                   stan::interface_callbacks::writer::base_writer& writer) {
       std::stringstream ss;
-      stan::math::gradient(model_functional<M>(model, &ss), x, f, grad_f);
+      try {
+        stan::math::gradient(model_functional<M>(model, &ss), x, f, grad_f);
+      } catch (std::exception& e) {
+        std::string msg = ss.str();
+        if (msg.length() > 1)
+          writer(msg.substr(0, msg.length() - 1));
+        throw;
+      }
       // FIXME(DL): remove blank line at the end of the gradient call
       //            this assumes the last character is a newline
       //            this matches the v2.8.0 behavior

--- a/src/stan/services/init/initialize_state.hpp
+++ b/src/stan/services/init/initialize_state.hpp
@@ -134,7 +134,6 @@ namespace stan {
                                 init_grad, writer);
         } catch (const std::exception& e) {
           io::write_error_msg(writer, e);
-          writer();
           writer("Rejecting initial value:");
           writer("  Error evaluating the log probability "
                  "at the initial value.");

--- a/src/stan/services/init/initialize_state.hpp
+++ b/src/stan/services/init/initialize_state.hpp
@@ -124,6 +124,7 @@ namespace stan {
           validate_unconstrained_initialization(cont_params, model);
         } catch (const std::exception& e) {
           writer(e.what());
+          writer();          
           return false;
         }
         double init_log_prob;
@@ -137,6 +138,7 @@ namespace stan {
           writer("Rejecting initial value:");
           writer("  Error evaluating the log probability "
                  "at the initial value.");
+          writer();          
           return false;
         }
         if (!boost::math::isfinite(init_log_prob)) {
@@ -144,6 +146,7 @@ namespace stan {
           writer("  Log probability evaluates to log(0), "
                  "i.e. negative infinity.");
           writer("  Stan can't start sampling from this initial value.");
+          writer();          
           return false;
         }
         for (int i = 0; i < init_grad.size(); ++i) {
@@ -152,6 +155,7 @@ namespace stan {
             writer("  Gradient evaluated at the initial value "
                    "is not finite.");
             writer("  Stan can't start sampling from this initial value.");
+            writer();            
             return false;
           }
         }

--- a/src/stan/services/init/initialize_state.hpp
+++ b/src/stan/services/init/initialize_state.hpp
@@ -124,7 +124,7 @@ namespace stan {
           validate_unconstrained_initialization(cont_params, model);
         } catch (const std::exception& e) {
           writer(e.what());
-          writer();          
+          writer();
           return false;
         }
         double init_log_prob;
@@ -138,7 +138,7 @@ namespace stan {
           writer("Rejecting initial value:");
           writer("  Error evaluating the log probability "
                  "at the initial value.");
-          writer();          
+          writer();
           return false;
         }
         if (!boost::math::isfinite(init_log_prob)) {
@@ -146,7 +146,7 @@ namespace stan {
           writer("  Log probability evaluates to log(0), "
                  "i.e. negative infinity.");
           writer("  Stan can't start sampling from this initial value.");
-          writer();          
+          writer();
           return false;
         }
         for (int i = 0; i < init_grad.size(); ++i) {
@@ -155,7 +155,7 @@ namespace stan {
             writer("  Gradient evaluated at the initial value "
                    "is not finite.");
             writer("  Stan can't start sampling from this initial value.");
-            writer();            
+            writer();
             return false;
           }
         }

--- a/src/stan/services/init/initialize_state.hpp
+++ b/src/stan/services/init/initialize_state.hpp
@@ -130,7 +130,7 @@ namespace stan {
         Eigen::VectorXd init_grad = Eigen::VectorXd::Zero(model.num_params_r());
         try {
           stan::model::gradient(model, cont_params, init_log_prob,
-                                init_grad);
+                                init_grad, writer);
         } catch (const std::exception& e) {
           io::write_error_msg(writer, e);
           writer();

--- a/src/stan/services/io/write_error_msg.hpp
+++ b/src/stan/services/io/write_error_msg.hpp
@@ -17,7 +17,6 @@ namespace stan {
        */
       void write_error_msg(interface_callbacks::writer::base_writer& writer,
                            const std::exception& e) {
-        writer();
         writer("Informational Message: The current Metropolis"
                " proposal is about to be rejected because of"
                " the following issue:");
@@ -28,6 +27,7 @@ namespace stan {
         writer("but if this warning occurs often then your model"
                " may be either severely ill-conditioned or"
                " misspecified.");
+        writer();
       }
 
     }

--- a/src/test/unit/services/init/initialize_state_test.cpp
+++ b/src/test/unit/services/init/initialize_state_test.cpp
@@ -764,7 +764,7 @@ TEST_F(StanServices, initialize_state_source_inf) {
   EXPECT_EQ(0, rng.calls);
   std::stringstream expected_msg;
   expected_msg << "param_0 initialized to invalid value (" 
-               << std::numeric_limits<double>::infinity() << ")\n";
+               << std::numeric_limits<double>::infinity() << ")\n\n";
   EXPECT_EQ(expected_msg.str(), output.str());
   EXPECT_EQ(1, context_factory.calls);
   EXPECT_EQ("abcd", context_factory.last_call);

--- a/src/test/unit/services/init/initialize_state_test.cpp
+++ b/src/test/unit/services/init/initialize_state_test.cpp
@@ -5,6 +5,7 @@
 #include <stan/interface_callbacks/writer/stream_writer.hpp>
 #include <stan/services/init/initialize_state.hpp>
 #include <stan/model/prob_grad.hpp>
+#include <stan/math/prim/mat/fun/stan_print.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
@@ -195,6 +196,7 @@ public:
   template <bool propto, bool jacobian_adjust_transforms, typename T>
   T log_prob(Eigen::Matrix<T,Eigen::Dynamic,1>& params_r,
              std::ostream* output_stream = 0) const {
+    
     templated_log_prob_calls++;
     throw std::domain_error("throwing within log_prob");
     return log_prob_return_value;
@@ -260,6 +262,24 @@ public:
   double log_prob_return_value;
 };
 
+
+// Mock Throwing Model throws exception with a print statement
+class mock_throwing_model_with_print: public mock_throwing_model {
+public:
+  mock_throwing_model_with_print(size_t num_params_r)
+    : mock_throwing_model(num_params_r) { }
+  
+  template <bool propto, bool jacobian_adjust_transforms, typename T>
+  T log_prob(Eigen::Matrix<T,Eigen::Dynamic,1>& params_r,
+             std::ostream* output_stream = 0) const {
+    if (output_stream)
+      stan::math::stan_print(output_stream, "foo");    
+    templated_log_prob_calls++;
+    throw std::domain_error("throwing within log_prob");
+    return log_prob_return_value;
+  }
+};
+
 class mock_rng {
 public:
   typedef double result_type;
@@ -318,6 +338,7 @@ public:
     model(3),
     inf_model(3),
     throwing_model(3),
+    throwing_model_with_print(3),
     writer(output) {}
 
   void SetUp() {
@@ -334,6 +355,7 @@ public:
   mock_model model;
   mock_inf_model inf_model;
   mock_throwing_model throwing_model;
+  mock_throwing_model_with_print throwing_model_with_print;
   mock_rng rng;
   std::stringstream output;
   mock_context_factory context_factory;
@@ -974,4 +996,37 @@ TEST_F(StanServices2, streams) {
   stan::test::reset_std_streams();
   EXPECT_EQ("", stan::test::cout_ss.str());
   EXPECT_EQ("", stan::test::cerr_ss.str());
+}
+
+
+TEST_F(StanServices, initialize_state_values_with_print) {
+  using stan::services::init::initialize_state_values;
+  throwing_model_with_print.log_prob_return_value =
+    -std::numeric_limits<double>::infinity();
+  EXPECT_FALSE(initialize_state_values(cont_params,
+                                       throwing_model_with_print,
+                                       writer));
+  ASSERT_EQ(3, cont_params.size());
+  EXPECT_FLOAT_EQ(0, cont_params[0]);
+  EXPECT_FLOAT_EQ(0, cont_params[1]);
+  EXPECT_FLOAT_EQ(0, cont_params[2]);
+  EXPECT_EQ(1, throwing_model_with_print.templated_log_prob_calls);
+  EXPECT_EQ(0, model.transform_inits_calls);
+  EXPECT_NE("", output.str()) << "expecting error message";
+  EXPECT_TRUE(output.str()
+              .find("foo\n")
+              != std::string::npos)
+    << "Expecting to find the output from the stan print call.";
+  EXPECT_TRUE(output.str()
+              .find("Rejecting initial value")
+              != std::string::npos);
+  EXPECT_TRUE(output.str()
+              .find("throwing within log_prob")
+              != std::string::npos)
+    << output.str();
+  EXPECT_TRUE(output.str()
+              .find("Error evaluating the log probability "
+                    "at the initial value.")
+              != std::string::npos)
+    << output.str();
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
`print()` within a Stan program currently does not print if there's an exception in the model block. With this fix, Stan programs will print the message as expected.

#### Intended Effect

Fixes #1936. 

#### How to Verify

Run the new unit test in `src/test/unit/services/init/initialize_state_test.cpp`.
You can also verify using the Stan program in #1936.

#### Side Effects

None.

#### Documentation

None.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
