### PR TITLE
Fix header guard

### DIFF
--- a/src/stan/mcmc/hmc/xhmc/diag_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/diag_e_xhmc.hpp
@@ -1,5 +1,5 @@
 #ifndef STAN_MCMC_HMC_NUTS_DIAG_E_XHMC_HPP
-#define STAN_MCMC_HMC_NUTS_DIAG_E_NUTS_HPP_E_XHMC_HPP
+#define STAN_MCMC_HMC_NUTS_DIAG_E_XHMC_HPP
 
 #include <stan/mcmc/hmc/xhmc/base_xhmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/diag_e_point.hpp>


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixed typo on header guard.

#### Intended Effect

Proper header guarding.

#### How to Verify

In develop including src/stan/mcmc/hmc/xhmc/diag_e_xhmc.hpp twice should cause problems.  Now it will not.

#### Side Effects

None.

#### Documentation

Not user facing.

#### Reviewer Suggestions

@syclik @bob-carpenter 

#### Copyright and Licensing

Copyright: University of Warwick

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)