### PR TITLE
Terminate argument parsing when a categorical argument is mistakenly given a value

### DIFF
--- a/src/stan/services/arguments/categorical_argument.hpp
+++ b/src/stan/services/arguments/categorical_argument.hpp
@@ -68,7 +68,7 @@ namespace stan {
         bool good_arg = true;
         bool valid_arg = true;
 
-        while (good_arg) {
+        while (good_arg && valid_arg) {
           if (args.size() == 0)
             return valid_arg;
 
@@ -91,6 +91,9 @@ namespace stan {
           std::string val_name;
           std::string val;
           split_arg(cat_name, val_name, val);
+
+          if (val_name == this->name())
+            return false;
 
           if (_subarguments.size() == 0)
             valid_arg = true;


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Terminate when a categorical argument is mistakenly given a value, avoiding an infinite loop.  Resolves #1949.

#### Intended Effect

Terminate argument parsing appropriately when categorical arguments are misspecified.

#### How to Verify

In Stan run the tests ```./runTests.py -j4 src/test/integration/services/arguments```.

In CmdStan run the test ```./runCmdStanTests.py src/test/interface/services/argument_configuration_test.cpp``` or try to run an example model,

```
make examples/bernoulli/bernoulli
cd examples/bernoulli
./bernoulli sample adapt=0
```

#### Side Effects

None.

#### Documentation

Not user facing.

#### Reviewer Suggestions

@syclik 

#### Copyright and Licensing

Copyright: University of Warwick.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)