### PR TITLE
add break and continue statements

### DIFF
--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -3273,6 +3273,112 @@ defines its own local block implicitly over the statement following it
 in which the loop variable is defined.  As far as Stan is concerned,
 these two uses of \code{n} are unrelated.
 
+\section{Break and Continue Statements}
+
+The one-token statements \code{continue} and \code{break} may be used
+within loops to alter control flow;  \code{continue} causes the next
+iteration of the loop to run immediately, whereas \code{break}
+terminates the loop and causes execution to resume after the loop.
+Both control structures must appear in loops, and only break or
+continue to the most deeply nested loop in which they are nested.
+
+Although these control statements may seem undesirable because of
+their goto like behavior, judicious use can greatly improve the
+readability of nested code by reducing the level of nesting.
+
+\subsection{Break Statements}
+
+When a \code{break} statement is executed, the loop currently being
+executed is ended and execution picks up with the next statement after
+the loop.  For example, consider the following program:
+%
+\begin{stancode}
+while (1) {
+  if (n < 0) break;
+  foo(n);
+  n = n - 1;
+}
+\end{stancode}
+%
+The \code{while~(1)} loop is a ``forever'' loop, because \code{1} is
+the true value, so the test always succeeds.  Within the loop, if the
+value of \code{n} is less than 0, the loop terminates, otherwise it
+executes \code{foo(n)} and then decrements \code{n}.  The statement
+above does exactly the same thing as
+%
+\begin{stancode}
+while (n >= 0) {
+  foo(n);
+  n = n - 1;
+}
+\end{stancode}
+
+\subsection{Continue Statements}
+
+The \code{continue} statement ends the current operation of the loop
+and returns to the condition at the top of the loop.  Such loops are
+typically used to exclude some values from calculations.  For example,
+we could use the following loop to sum the positive values in the
+array \code{x},
+%
+\begin{stancode}
+real sum;
+sum <- 0;
+for (n in 1:size(x)) {
+  if (x[n] <= 0) continue;
+  sum <- sum + x[n];
+}
+\end{stancode}
+%
+When the continue statement is executed, control jumps back to the
+conditional part of the loop.  With while and for loops, this causes
+control to return to the conditional of the loop.  With for loops,
+this advances the loop variable, so the the above program will not go
+into an infinite loop when faced with an \code{x[n]} less than zero.
+
+The loop example with \code{continue} above has the same behavior as
+%
+\begin{stancode}
+for (n in 1:size(x)) {
+  if (x[n] > 0) {
+    sum <- sum + x[n];
+  }
+}
+%
+While the latter form may seem more readable in this simple case, the
+former has the main line of execution nested one level less deep.
+Instead, the conditional at the top finds cases to exclude and doesn't
+require the same level of nesting for code that's not excluded.
+
+\subsection{Breaking and Continuing Nested Loops}
+
+If there is a loop nested within a loop, a \code{break} or
+\code{continue} statement only breaks out of the inner loop. So
+%
+\begin{stancode}
+while (cond1) {
+  ...
+  while (cond2) {
+    ...
+    if (cond3) break;
+    ...
+  }
+  // execution continues here after break
+  ...
+}
+\end{stancode}
+%
+If the break is triggered by \code{cond3} being true, execution will
+continue after the nested loop, as indicated.
+
+As with break statements, continue statements go back to the top of
+the most deeply nested loop in which the \code{continue} appears.  
+
+Although break and continue must appear within loops, they may appear
+in nested statements within loops, such as within the conditionals
+shown above.  The break and continue statements jump past any control
+structure other than while and for loops.
+
 \section{Print Statements}\label{print-statements.section}
 
 Stan provides print statements that can print literal strings and the
@@ -4673,6 +4779,8 @@ atomic_statement_body
    | function_literal '(' expressions ')'
    | 'increment_log_prob' '(' expression ')'
    | 'target' '+=' expression
+   | 'break'
+   | 'continue'
    | 'print' '(' (expression | string_literal)* ')'
    | 'reject' '(' (expression | string_literal)* ')'
    | 'return' expression
@@ -4726,6 +4834,11 @@ literals cannot consist of only a period or only an exponent.
 Both the conditional if-then-else statement and while-loop statement
 require the expression denoting the condition to be a primitive type,
 integer or real.
+
+\subsection{Only Break and Continue in Loops}
+
+The \code{break} and \code{continue} statements may only be used in
+loops (i.e., for loops or while loops).
 
 \subsection{Probability Function Naming}
 

--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -3279,18 +3279,21 @@ The one-token statements \code{continue} and \code{break} may be used
 within loops to alter control flow;  \code{continue} causes the next
 iteration of the loop to run immediately, whereas \code{break}
 terminates the loop and causes execution to resume after the loop.
-Both control structures must appear in loops, and only break or
-continue to the most deeply nested loop in which they are nested.
+Both control structures must appear in loops.  Both \code{break} and
+\code{continue} scope to the most deeply nested loop, but pass through
+non-loop statements.
 
 Although these control statements may seem undesirable because of
-their goto like behavior, judicious use can greatly improve the
-readability of nested code by reducing the level of nesting.
+their goto-like behavior, their judicious use can greatly improve
+readability by reducing the level of nesting or eliminating bookeeping
+inside loops.
 
 \subsection{Break Statements}
 
-When a \code{break} statement is executed, the loop currently being
-executed is ended and execution picks up with the next statement after
-the loop.  For example, consider the following program:
+When a \code{break} statement is executed, the most deeply nested loop
+currently being executed is ended and execution picks up with the next
+statement after the loop.  For example, consider the following
+program:
 %
 \begin{stancode}
 while (1) {
@@ -3312,6 +3315,9 @@ while (n >= 0) {
   n = n - 1;
 }
 \end{stancode}
+%
+This case is simply illustrative of the behavior; it is not a case
+where a \code{break} simplifies the loop.
 
 \subsection{Continue Statements}
 
@@ -3323,10 +3329,10 @@ array \code{x},
 %
 \begin{stancode}
 real sum;
-sum <- 0;
+sum = 0;
 for (n in 1:size(x)) {
   if (x[n] <= 0) continue;
-  sum <- sum + x[n];
+  sum = sum + x[n];
 }
 \end{stancode}
 %
@@ -3335,20 +3341,24 @@ conditional part of the loop.  With while and for loops, this causes
 control to return to the conditional of the loop.  With for loops,
 this advances the loop variable, so the the above program will not go
 into an infinite loop when faced with an \code{x[n]} less than zero.
-
-The loop example with \code{continue} above has the same behavior as
+Thus the above program could be rewritten with deeper nesting by
+reversing the conditional,
 %
 \begin{stancode}
+real sum;
+sum = 0;
 for (n in 1:size(x)) {
-  if (x[n] > 0) {
-    sum <- sum + x[n];
-  }
+  if (x[n] > 0)
+    sum = sum + x[n];
 }
+\end{stancode}
 %
 While the latter form may seem more readable in this simple case, the
 former has the main line of execution nested one level less deep.
 Instead, the conditional at the top finds cases to exclude and doesn't
-require the same level of nesting for code that's not excluded.
+require the same level of nesting for code that's not excluded.  When
+there are several such exclusion conditions, the break or continue
+versions tend to be much easier to read.
 
 \subsection{Breaking and Continuing Nested Loops}
 
@@ -3369,15 +3379,16 @@ while (cond1) {
 \end{stancode}
 %
 If the break is triggered by \code{cond3} being true, execution will
-continue after the nested loop, as indicated.
+continue after the nested loop.
 
 As with break statements, continue statements go back to the top of
 the most deeply nested loop in which the \code{continue} appears.  
 
 Although break and continue must appear within loops, they may appear
 in nested statements within loops, such as within the conditionals
-shown above.  The break and continue statements jump past any control
-structure other than while and for loops.
+shown above or within nested statements.  The break and continue
+statements jump past any control structure other than while-loops and
+for-loops.
 
 \section{Print Statements}\label{print-statements.section}
 
@@ -4837,8 +4848,8 @@ integer or real.
 
 \subsection{Only Break and Continue in Loops}
 
-The \code{break} and \code{continue} statements may only be used in
-loops (i.e., for loops or while loops).
+The \code{break} and \code{continue} statements may only be used
+within the body of a for-loop or while-loop.
 
 \subsection{Probability Function Naming}
 

--- a/src/stan/lang/ast.hpp
+++ b/src/stan/lang/ast.hpp
@@ -22,6 +22,7 @@ namespace stan {
     struct assignment;
     struct assgn;
     struct binary_op;
+    struct break_continue_statement;
     struct conditional_op;
     struct conditional_statement;
     struct distribution;
@@ -793,12 +794,12 @@ namespace stan {
                      boost::recursive_wrapper<for_statement>,
                      boost::recursive_wrapper<conditional_statement>,
                      boost::recursive_wrapper<while_statement>,
+                     boost::recursive_wrapper<break_continue_statement>,
                      boost::recursive_wrapper<print_statement>,
                      boost::recursive_wrapper<reject_statement>,
                      boost::recursive_wrapper<return_statement>,
                      boost::recursive_wrapper<no_op_statement> >
       statement_t;
-
       statement_t statement_;
       size_t begin_line_;
       size_t end_line_;
@@ -815,6 +816,7 @@ namespace stan {
       statement(const for_statement& st);  // NOLINT(runtime/explicit)
       statement(const conditional_statement& st);  // NOLINT(runtime/explicit)
       statement(const while_statement& st);  // NOLINT(runtime/explicit)
+      statement(const break_continue_statement& st);  // NOLINT
       statement(const print_statement& st);  // NOLINT(runtime/explicit)
       statement(const reject_statement& st);  // NOLINT(runtime/explicit)
       statement(const no_op_statement& st);  // NOLINT(runtime/explicit)
@@ -834,6 +836,7 @@ namespace stan {
       bool operator()(const for_statement& st) const;  // NOLINT
       bool operator()(const conditional_statement& st) const;  // NOLINT
       bool operator()(const while_statement& st) const;  // NOLINT
+      bool operator()(const break_continue_statement& st) const;  // NOLINT
       bool operator()(const print_statement& st) const;  // NOLINT
       bool operator()(const reject_statement& st) const;  // NOLINT
       bool operator()(const no_op_statement& st) const;  // NOLINT
@@ -856,6 +859,7 @@ namespace stan {
       bool operator()(const for_statement& st) const;  // NOLINT
       bool operator()(const conditional_statement& st) const;  // NOLINT
       bool operator()(const while_statement& st) const;  // NOLINT
+      bool operator()(const break_continue_statement& st) const;  // NOLINT
       bool operator()(const print_statement& st) const;  // NOLINT
       bool operator()(const reject_statement& st) const;  // NOLINT
       bool operator()(const no_op_statement& st) const;  // NOLINT
@@ -897,6 +901,12 @@ namespace stan {
       while_statement();
       while_statement(const expression& condition,
                       const statement& body);
+    };
+
+    struct break_continue_statement {
+      std::string generate_;
+      break_continue_statement();
+      break_continue_statement(const std::string& generate);
     };
 
     struct print_statement {

--- a/src/stan/lang/ast.hpp
+++ b/src/stan/lang/ast.hpp
@@ -906,7 +906,7 @@ namespace stan {
     struct break_continue_statement {
       std::string generate_;
       break_continue_statement();
-      break_continue_statement(const std::string& generate);
+      explicit break_continue_statement(const std::string& generate);
     };
 
     struct print_statement {

--- a/src/stan/lang/ast_def.cpp
+++ b/src/stan/lang/ast_def.cpp
@@ -617,6 +617,15 @@ namespace stan {
       // body must end in appropriate return
       return returns_type(return_type_, st.body_, error_msgs_);
     }
+    bool returns_type_vis::operator()(const break_continue_statement& st)
+      const  {
+      // break/continue OK only as end of nested loop in void return
+      bool pass = (return_type_ == VOID_T);
+      if (!pass)
+        error_msgs_ << "statement " << st.generate_
+                    << " does not match return type";
+      return pass;
+    }
     bool returns_type_vis::operator()(const
                                       conditional_statement& st) const  {
       // all condition bodies must end in appropriate return
@@ -1582,6 +1591,8 @@ namespace stan {
     statement::statement(const expression& st) : statement_(st) { }
     statement::statement(const for_statement& st) : statement_(st) { }
     statement::statement(const while_statement& st) : statement_(st) { }
+    statement::statement(const break_continue_statement& st)
+      : statement_(st) { }
     statement::statement(const conditional_statement& st) : statement_(st) { }
     statement::statement(const print_statement& st) : statement_(st) { }
     statement::statement(const reject_statement& st) : statement_(st) { }
@@ -1621,6 +1632,11 @@ namespace stan {
     bool is_no_op_statement_vis::operator()(const while_statement& st) const {
       return false;
     }
+    bool
+    is_no_op_statement_vis::operator()(const break_continue_statement& st)
+      const {
+      return false;
+    }
     bool is_no_op_statement_vis::operator()(const print_statement& st) const {
       return false;
     }
@@ -1656,13 +1672,16 @@ namespace stan {
         statement_(stmt) {
     }
 
-    while_statement::while_statement() {
-    }
+    while_statement::while_statement() { }
     while_statement::while_statement(const expression& condition,
                                      const statement& body)
       : condition_(condition),
         body_(body) {
     }
+
+    break_continue_statement::break_continue_statement() { }
+    break_continue_statement::break_continue_statement(const std::string& s)
+      : generate_(s) { }
 
     conditional_statement::conditional_statement() {
     }

--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -2176,8 +2176,6 @@ namespace stan {
     };
 
 
-
-
     void generate_statement(const statement& s,
                             int indent,
                             std::ostream& o,

--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -2123,7 +2123,7 @@ namespace stan {
       }
       void operator()(const break_continue_statement& st) const {
         generate_indent(indent_, o_);
-        o_ << st.generate_ << EOL;
+        o_ << st.generate_ << ";" << EOL;
       }
       void operator()(const conditional_statement& x) const {
         for (size_t i = 0; i < x.conditions_.size(); ++i) {

--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -2121,6 +2121,10 @@ namespace stan {
         generate_indent(indent_, o_);
         o_ << "}" << EOL;
       }
+      void operator()(const break_continue_statement& st) const {
+        generate_indent(indent_, o_);
+        o_ << st.generate_ << EOL;
+      }
       void operator()(const conditional_statement& x) const {
         for (size_t i = 0; i < x.conditions_.size(); ++i) {
           if (i == 0)
@@ -2162,6 +2166,9 @@ namespace stan {
       bool operator()(const for_statement& st) const  { return true; }
       bool operator()(const conditional_statement& st) const { return true; }
       bool operator()(const while_statement& st) const { return true; }
+      bool operator()(const break_continue_statement& st) const {
+        return true;
+      }
       bool operator()(const print_statement& st) const { return true; }
       bool operator()(const reject_statement& st) const { return true; }
       bool operator()(const no_op_statement& st) const { return true; }

--- a/src/stan/lang/grammars/functions_grammar_def.hpp
+++ b/src/stan/lang/grammars/functions_grammar_def.hpp
@@ -70,7 +70,7 @@ namespace stan {
           [validate_pmf_pdf_variate_f(_val, _pass,
                                       boost::phoenix::ref(error_msgs_))]
         > eps[scope_lp_f(boost::phoenix::ref(var_map_))]
-        > statement_g(_a, _b, true)
+        > statement_g(_a, _b, true, false)
         > eps[unscope_variables_f(_val, boost::phoenix::ref(var_map_))]
         > eps[validate_return_type_f(_val, _pass,
                                      boost::phoenix::ref(error_msgs_))]

--- a/src/stan/lang/grammars/program_grammar_def.hpp
+++ b/src/stan/lang/grammars/program_grammar_def.hpp
@@ -75,7 +75,7 @@ namespace stan {
         model_r.name("model declaration (or perhaps an earlier block)");
         model_r
           %= lit("model")
-          > statement_g(true, local_origin, false);
+          > statement_g(true, local_origin, false, false);
 
         end_var_decls_r.name(
             "one of the following:\n"
@@ -115,10 +115,10 @@ namespace stan {
                >> lit("data"))
               > lit('{'))
           > var_decls_g(true, transformed_data_origin)  // -constraints
-          > ((statement_g(false, transformed_data_origin, false)
-              > *statement_g(false, transformed_data_origin, false)
+          > ((statement_g(false, transformed_data_origin, false, false)
+              > *statement_g(false, transformed_data_origin, false, false)
               > end_var_definitions_r)
-             | (*statement_g(false, transformed_data_origin, false)
+             | (*statement_g(false, transformed_data_origin, false, false)
                 > end_var_decls_statements_r));
 
         param_var_decls_r.name("parameter variable declarations");
@@ -134,7 +134,7 @@ namespace stan {
               > lit("parameters")
               > lit('{'))
           > var_decls_g(true, transformed_parameter_origin)
-          > *statement_g(false, transformed_parameter_origin, false)
+          > *statement_g(false, transformed_parameter_origin, false, false)
           > end_var_decls_statements_r;
 
         generated_var_decls_r.name("generated variable declarations");
@@ -143,7 +143,7 @@ namespace stan {
               > lit("quantities")
               > lit('{'))
           > var_decls_g(true, derived_origin)
-          > *statement_g(false, derived_origin, false)
+          > *statement_g(false, derived_origin, false, false)
           > end_var_decls_statements_r;
 
         on_error<rethrow>(program_r,

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -784,7 +784,7 @@ namespace stan {
     extern boost::phoenix::function<add_var> add_var_f;
 
     struct validate_in_loop : public phoenix_functor_ternary {
-      void operator()(bool in_loop, bool pass, std::ostream& error_msgs) const;
+      void operator()(bool in_loop, bool& pass, std::ostream& error_msgs) const;
     };
     extern boost::phoenix::function<validate_in_loop> validate_in_loop_f;
 

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -783,6 +783,11 @@ namespace stan {
     };
     extern boost::phoenix::function<add_var> add_var_f;
 
+    struct validate_in_loop : public phoenix_functor_ternary {
+      void operator()(bool in_loop, bool pass, std::ostream& error_msgs) const;
+    };
+    extern boost::phoenix::function<validate_in_loop> validate_in_loop_f;
+
   }
 }
 #endif

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -2458,6 +2458,15 @@ namespace stan {
                                       variable_map&, bool&, const var_origin&,
                                       std::ostream&) const;
 
+    void validate_in_loop::operator()(bool in_loop, bool pass,
+                                        std::ostream& error_msgs) const {
+      pass = in_loop;
+      if (!pass)
+        error_msgs << "break or continue statements are only allowed"
+                   << " in the body of for loops or while loops."
+                   << std::endl;
+    }
+    boost::phoenix::function<validate_in_loop> validate_in_loop_f;
 
   }
 }

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -2465,12 +2465,12 @@ namespace stan {
                                       variable_map&, bool&, const var_origin&,
                                       std::ostream&) const;
 
-    void validate_in_loop::operator()(bool in_loop, bool pass,
-                                        std::ostream& error_msgs) const {
+    void validate_in_loop::operator()(bool in_loop, bool& pass,
+                                      std::ostream& error_msgs) const {
       pass = in_loop;
       if (!pass)
-        error_msgs << "break or continue statements are only allowed"
-                   << " in the body of for loops or while loops."
+        error_msgs << "ERROR: break and continue statements are only allowed"
+                   << " in the body of a for-loop or while-loop."
                    << std::endl;
     }
     boost::phoenix::function<validate_in_loop> validate_in_loop_f;

--- a/src/stan/lang/grammars/statement_2_grammar.hpp
+++ b/src/stan/lang/grammars/statement_2_grammar.hpp
@@ -15,10 +15,11 @@ namespace stan {
     template <typename Iterator>
     struct statement_grammar;
 
+    // for _r1, _r2, _r3, _r4 doc, see statement_grammar_def.hpp
     template <typename Iterator>
     struct statement_2_grammar
       : boost::spirit::qi::grammar<Iterator,
-                                   statement(bool, var_origin, bool),
+                                   statement(bool, var_origin, bool, bool),
                                    whitespace_grammar<Iterator> > {
       variable_map& var_map_;
       std::stringstream& error_msgs_;
@@ -30,12 +31,13 @@ namespace stan {
                           statement_grammar<Iterator>& sg);
 
       boost::spirit::qi::rule<Iterator,
-                              conditional_statement(bool, var_origin, bool),
+                              conditional_statement(bool, var_origin, bool,
+                                                    bool),
                               whitespace_grammar<Iterator> >
       conditional_statement_r;
 
       boost::spirit::qi::rule<Iterator,
-                              statement(bool, var_origin, bool),
+                              statement(bool, var_origin, bool, bool),
                               whitespace_grammar<Iterator> >
       statement_2_r;
     };

--- a/src/stan/lang/grammars/statement_2_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_2_grammar_def.hpp
@@ -32,12 +32,13 @@ namespace stan {
       using boost::spirit::qi::labels::_r1;
       using boost::spirit::qi::labels::_r2;
       using boost::spirit::qi::labels::_r3;
+      using boost::spirit::qi::labels::_r4;
 
       // _r1 true if sample_r allowed (inherited)
       // _r2 source of variables allowed for assignments
       // set to true if sample_r are allowed
       statement_2_r.name("statement");
-      statement_2_r %= conditional_statement_r(_r1, _r2, _r3);
+      statement_2_r %= conditional_statement_r(_r1, _r2, _r3, _r4);
 
       conditional_statement_r.name("if-else statement");
       conditional_statement_r
@@ -47,7 +48,7 @@ namespace stan {
           [add_conditional_condition_f(_val, _1, _pass,
                                        boost::phoenix::ref(error_msgs_))]
         > lit(')')
-        > statement_g(_r1, _r2, _r3)
+        > statement_g(_r1, _r2, _r3, _r4)
           [add_conditional_body_f(_val, _1)]
         > * (((lit("else") >> no_skip[!char_("a-zA-Z0-9_")])
               >> (lit("if")  >> no_skip[!char_("a-zA-Z0-9_")]))
@@ -56,10 +57,10 @@ namespace stan {
                [add_conditional_condition_f(_val, _1, _pass,
                                             boost::phoenix::ref(error_msgs_))]
              > lit(')')
-             > statement_g(_r1, _r2, _r3)
+             > statement_g(_r1, _r2, _r3, _r4)
                [add_conditional_body_f(_val, _1)])
         > -((lit("else") >> no_skip[!char_("a-zA-Z0-9_")])
-            > statement_g(_r1, _r2, _r3)
+            > statement_g(_r1, _r2, _r3, _r4)
               [add_conditional_body_f(_val, _1)]);
     }
 

--- a/src/stan/lang/grammars/statement_grammar.hpp
+++ b/src/stan/lang/grammars/statement_grammar.hpp
@@ -20,7 +20,7 @@ namespace stan {
     template <typename Iterator>
     struct statement_grammar
       : boost::spirit::qi::grammar<Iterator,
-                                   statement(bool, var_origin, bool),
+                                   statement(bool, var_origin, bool, bool),
                                    whitespace_grammar<Iterator> > {
       statement_grammar(variable_map& var_map,
                         std::stringstream& error_msgs);
@@ -93,6 +93,10 @@ namespace stan {
                               whitespace_grammar<Iterator> >
       while_statement_r;
 
+      boost::spirit::qi::rule<Iterator,
+                              break_continue_statement(bool),
+                              whitespace_grammar<Iterator> >
+      break_continue_statement_r;
 
       boost::spirit::qi::rule<Iterator,
                               print_statement(var_origin),
@@ -157,18 +161,18 @@ namespace stan {
       sample_r;
 
       boost::spirit::qi::rule<Iterator,
-                              statement(bool, var_origin, bool),
+                              statement(bool, var_origin, bool, bool),
                               whitespace_grammar<Iterator> >
       statement_r;
 
       boost::spirit::qi::rule<Iterator,
-                              statement(bool, var_origin, bool),
+                              statement(bool, var_origin, bool, bool),
                               whitespace_grammar<Iterator> >
       statement_sub_r;
 
       boost::spirit::qi::rule<Iterator,
                               boost::spirit::qi::locals<std::vector<var_decl> >,
-                              statements(bool, var_origin, bool),
+                              statements(bool, var_origin, bool, bool),
                               whitespace_grammar<Iterator> >
       statement_seq_r;
 

--- a/src/stan/lang/grammars/statement_grammar.hpp
+++ b/src/stan/lang/grammars/statement_grammar.hpp
@@ -94,7 +94,7 @@ namespace stan {
       while_statement_r;
 
       boost::spirit::qi::rule<Iterator,
-                              break_continue_statement(bool),
+                              break_continue_statement(bool),  // NOLINT
                               whitespace_grammar<Iterator> >
       break_continue_statement_r;
 

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -177,13 +177,13 @@ namespace stan {
         > statement_r(_r1, _r2, _r3, true)
           [add_while_body_f(_val, _1)];
 
-      // _r1 == _r4 from statement_r
+      // _r1 here == _r4 from statement_r
       break_continue_statement_r.name("break or continue statement");
       break_continue_statement_r
         %= (string("break") | string("continue"))
         > eps[validate_in_loop_f(_r1, _pass, boost::phoenix::ref(error_msgs_))]
         > lit(';');
-      
+
       // _r1, _r2, _r3 same as statement_r
       for_statement_r.name("for statement");
       for_statement_r

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -40,6 +40,9 @@ BOOST_FUSION_ADAPT_STRUCT(stan::lang::for_statement,
 BOOST_FUSION_ADAPT_STRUCT(stan::lang::return_statement,
                           (stan::lang::expression, return_value_) )
 
+BOOST_FUSION_ADAPT_STRUCT(stan::lang::break_continue_statement,
+                          (std::string, generate_) )
+
 BOOST_FUSION_ADAPT_STRUCT(stan::lang::print_statement,
                           (std::vector<stan::lang::printable>, printables_) )
 
@@ -78,6 +81,7 @@ namespace stan {
       using boost::spirit::qi::lexeme;
       using boost::spirit::qi::lit;
       using boost::spirit::qi::no_skip;
+      using boost::spirit::qi::string;
       using boost::spirit::qi::_pass;
       using boost::spirit::qi::_val;
       using boost::spirit::qi::raw;
@@ -86,6 +90,7 @@ namespace stan {
       using boost::spirit::qi::labels::_r1;
       using boost::spirit::qi::labels::_r2;
       using boost::spirit::qi::labels::_r3;
+      using boost::spirit::qi::labels::_r4;
 
       using boost::phoenix::begin;
       using boost::phoenix::end;
@@ -94,22 +99,24 @@ namespace stan {
       //   _r1 true if sample_r allowed
       //   _r2 source of variables allowed for assignments
       //   _r3 true if return_r allowed
+      //   _r4 true if in loop (allowing break/continue)
 
       // raw[ ] just to wrap to get line numbers
       statement_r.name("statement");
       statement_r
-        = raw[statement_sub_r(_r1, _r2, _r3)[assign_lhs_f(_val, _1)]]
+        = raw[statement_sub_r(_r1, _r2, _r3, _r4)[assign_lhs_f(_val, _1)]]
         [add_line_number_f(_val, begin(_1), end(_1))];
 
       statement_sub_r.name("statement");
       statement_sub_r
         %= no_op_statement_r                        // key ";"
-        | statement_seq_r(_r1, _r2, _r3)            // key "{"
+        | statement_seq_r(_r1, _r2, _r3, _r4)       // key "{"
         | increment_log_prob_statement_r(_r1, _r2)  // key "increment_log_prob"
         | increment_target_statement_r(_r1, _r2)    // key "target"
         | for_statement_r(_r1, _r2, _r3)            // key "for"
         | while_statement_r(_r1, _r2, _r3)          // key "while"
-        | statement_2_g(_r1, _r2, _r3)              // key "if"
+        | break_continue_statement_r(_r4)           // key "break", "continue"
+        | statement_2_g(_r1, _r2, _r3, _r4)         // key "if"
         | print_statement_r(_r2)                    // key "print"
         | reject_statement_r(_r2)                   // key "reject"
         | return_statement_r(_r2)                   // key "return"
@@ -121,12 +128,12 @@ namespace stan {
         [expression_as_statement_f(_pass, _1,
                                    boost::phoenix::ref(error_msgs_))];
 
-      // _r1, _r2, _r3 same as statement_r
+      // _r1, _r2, _r3, _r4 same as statement_r
       statement_seq_r.name("sequence of statements");
       statement_seq_r
         %= lit('{')
         > local_var_decls_r[assign_lhs_f(_a, _1)]
-        > *statement_r(_r1, _r2, _r3)
+        > *statement_r(_r1, _r2, _r3, _r4)
         > lit('}')
         > eps[unscope_locals_f(_a, boost::phoenix::ref(var_map_))];
 
@@ -158,7 +165,7 @@ namespace stan {
                                           boost::phoenix::ref(error_msgs_))]
         > lit(';');
 
-      // _r1, _r2, _r3 same as statement_r
+      // _r1, _r2, _r3, same as statement_r
       while_statement_r.name("while statement");
       while_statement_r
         = (lit("while") >> no_skip[!char_("a-zA-Z0-9_")])
@@ -167,10 +174,16 @@ namespace stan {
           [add_while_condition_f(_val, _1, _pass,
                                  boost::phoenix::ref(error_msgs_))]
         > lit(')')
-        > statement_r(_r1, _r2, _r3)
+        > statement_r(_r1, _r2, _r3, true)
           [add_while_body_f(_val, _1)];
 
-
+      // _r1 == _r4 from statement_r
+      break_continue_statement_r.name("break or continue statement");
+      break_continue_statement_r
+        %= (string("break") | string("continue"))
+        > eps[validate_in_loop_f(_r1, _pass, boost::phoenix::ref(error_msgs_))]
+        > lit(';');
+      
       // _r1, _r2, _r3 same as statement_r
       for_statement_r.name("for statement");
       for_statement_r
@@ -182,7 +195,7 @@ namespace stan {
         > lit("in")
         > range_r(_r2)
         > lit(')')
-        > statement_r(_r1, _r2, _r3)
+        > statement_r(_r1, _r2, _r3, true)
         > eps
         [remove_loop_identifier_f(_a, boost::phoenix::ref(var_map_))];
 

--- a/src/test/test-models/bad/break1.stan
+++ b/src/test/test-models/bad/break1.stan
@@ -1,0 +1,7 @@
+// tests correct value passed from transformed data
+transformed data {
+  int n;
+  break;
+}
+model {
+}

--- a/src/test/test-models/bad/break2.stan
+++ b/src/test/test-models/bad/break2.stan
@@ -1,0 +1,7 @@
+// tests correct value passed from transformed parameters
+transformed parameters {
+  real y;
+  break;
+}
+model {
+}

--- a/src/test/test-models/bad/break3.stan
+++ b/src/test/test-models/bad/break3.stan
@@ -1,0 +1,7 @@
+// tests correct value passed from model
+transformed data {
+}
+model {
+  int n;
+  break;
+}

--- a/src/test/test-models/bad/break4.stan
+++ b/src/test/test-models/bad/break4.stan
@@ -1,0 +1,7 @@
+// tests correct value passed from generated quantities
+model {
+}
+generated quantities {
+  int n;
+  break;
+}

--- a/src/test/test-models/bad/break5.stan
+++ b/src/test/test-models/bad/break5.stan
@@ -1,0 +1,9 @@
+// tests correct value passed from functions
+functions {
+  int foo(int n) {
+    break;
+  }
+}
+model {
+}
+

--- a/src/test/test-models/bad/break6.stan
+++ b/src/test/test-models/bad/break6.stan
@@ -1,0 +1,8 @@
+// tests right value passed through conditionals
+parameters {
+  real y;
+}
+model {
+  if (1)
+    break;
+}

--- a/src/test/test-models/bad/break7.stan
+++ b/src/test/test-models/bad/break7.stan
@@ -1,0 +1,11 @@
+// tests right value passed through else if in conditional
+parameters {
+  real y;
+}
+model {
+  int z;
+  if (1)
+    z = 10;
+  else if (0)
+    break;
+}

--- a/src/test/test-models/bad/break8.stan
+++ b/src/test/test-models/bad/break8.stan
@@ -1,0 +1,13 @@
+// tests right value passed through else in conditional
+parameters {
+  real y;
+}
+model {
+  int z;
+  if (1)
+    z = 10;
+  else if (0)
+    z = 5;
+  else
+    break;
+}

--- a/src/test/test-models/bad/continue1.stan
+++ b/src/test/test-models/bad/continue1.stan
@@ -1,0 +1,7 @@
+// tests correct value passed from transformed data
+transformed data {
+  int n;
+  continue;
+}
+model {
+}

--- a/src/test/test-models/bad/continue2.stan
+++ b/src/test/test-models/bad/continue2.stan
@@ -1,0 +1,7 @@
+// tests correct value passed from transformed parameters
+transformed parameters {
+  real y;
+  continue;
+}
+model {
+}

--- a/src/test/test-models/bad/continue3.stan
+++ b/src/test/test-models/bad/continue3.stan
@@ -1,0 +1,7 @@
+// tests correct value passed from model
+transformed data {
+}
+model {
+  int n;
+  continue;
+}

--- a/src/test/test-models/bad/continue4.stan
+++ b/src/test/test-models/bad/continue4.stan
@@ -1,0 +1,7 @@
+// tests correct value passed from generated quantities
+model {
+}
+generated quantities {
+  int n;
+  continue;
+}

--- a/src/test/test-models/bad/continue5.stan
+++ b/src/test/test-models/bad/continue5.stan
@@ -1,0 +1,9 @@
+// tests correct value passed from functions
+functions {
+  int foo(int n) {
+    continue;
+  }
+}
+model {
+}
+

--- a/src/test/test-models/good/break-continue.stan
+++ b/src/test/test-models/good/break-continue.stan
@@ -1,0 +1,68 @@
+// test right value passed through for, while and embedded
+functions {
+  int foo(int a) {
+    // direct while
+    while (1) break;
+    while (0) continue;
+
+    // direct for
+    for (i in 1:10) break;
+    for (i in 1:10) continue;
+
+    // in statement seq
+    while (1) {
+      int b;
+      b = 5;
+      break;
+    }
+    
+    // if, else if, else body
+    while (1) {
+      if (0) break;
+      else if (1) break;
+      else break;
+    }
+
+    // nested while
+    while (1) while (0) break;
+
+    // nested for
+    while (1) for (i in 1:10) break;
+
+    // nested block
+    while (1) {
+      int b;
+      b = 5;
+      {
+        int c;
+        c = 6;
+        break;
+      }
+    }
+
+    return 0;
+  }
+}
+transformed data {
+  int x;
+  x = 0;
+  while (0) break;
+  while (1) continue;
+}
+parameters {
+  real y;
+}
+transformed parameters {
+  real z;
+  z = 1;
+  while (0) break;
+  while (1) continue;
+}
+model {
+}
+generated quantities {
+   real u;
+   u = 1;
+   while (1) break;
+   while (0) continue;
+}

--- a/src/test/unit/lang/parser/break_continue_test.cpp
+++ b/src/test/unit/lang/parser/break_continue_test.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+#include <test/unit/lang/utility.hpp>
+#include <exception>
+
+TEST(lang_parser, break_continue_parsable) {
+  test_parsable("break-continue");
+}
+
+void test_bad_break(const std::string& model_name) {
+  test_throws(model_name,
+              "ERROR: break and continue statements are only allowed"
+              " in the body of a for-loop or while-loop.");
+}
+
+TEST(lang_parser, break_continue_bad_break1) {
+  test_bad_break("break1");
+  test_bad_break("continue1");
+  test_bad_break("break2");
+  test_bad_break("continue2");
+  test_bad_break("break3");
+  test_bad_break("continue3");
+  test_bad_break("break4");
+  test_bad_break("continue4");
+  test_bad_break("break5");
+  test_bad_break("continue5");
+  test_bad_break("break6");
+  test_bad_break("break7");
+  test_bad_break("break8");
+}
+


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add break and continue statements to Stan language.

#### Intended Effect

More flexible control structures.

#### How to Verify

Unit tests for uses and illegal uses not in loops.  

#### Side Effects

No.

#### Documentation

Language reference in the manual updated with behavior, examples, and BNF with side conditions.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
