### PR TITLE
Remove duplicate acceptance procedure, update tests

### DIFF
--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -106,11 +106,6 @@ namespace stan {
           // Sample from an accepted subtree
           ++(this->depth_);
 
-          double accept_prob
-            = std::exp(log_sum_weight_subtree - log_sum_weight);
-          if (this->rand_uniform_() < accept_prob)
-            z_sample = z_propose;
-
           if (log_sum_weight_subtree > log_sum_weight) {
             z_sample = z_propose;
           } else {

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -108,13 +108,13 @@ TEST_F(performance, values_from_tagged_version) {
     << "last tagged version, 2.9.0, had " << N_values << " elements";
 
   std::vector<double> first_run = last_draws_per_run[0];
-  EXPECT_FLOAT_EQ(-67.4618, first_run[0])
+  EXPECT_FLOAT_EQ(-65.742996, first_run[0])
     << "lp__: index 0";
 
-  EXPECT_FLOAT_EQ(0.96871901, first_run[1])
+  EXPECT_FLOAT_EQ(0.622922, first_run[1])
     << "accept_stat__: index 1";
 
-  EXPECT_FLOAT_EQ(1.21214, first_run[2])
+  EXPECT_FLOAT_EQ(1.15558, first_run[2])
     << "stepsize__: index 2";
 
   EXPECT_FLOAT_EQ(1, first_run[3])
@@ -126,13 +126,13 @@ TEST_F(performance, values_from_tagged_version) {
   EXPECT_FLOAT_EQ(0, first_run[5])
     << "divergent__: index 5";
 
-  EXPECT_FLOAT_EQ(68.961502, first_run[6])
+  EXPECT_FLOAT_EQ(67.453796, first_run[6])
     << "energy__: index 6";
 
-  EXPECT_FLOAT_EQ(1.79573, first_run[7])
+  EXPECT_FLOAT_EQ(1.40756, first_run[7])
     << "beta.1: index 7";
 
-  EXPECT_FLOAT_EQ(-0.77275401, first_run[8])
+  EXPECT_FLOAT_EQ(-0.763035, first_run[8])
     << "beta.2: index 8";
 
   matches_tagged_version = !HasNonfatalFailure();

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -272,7 +272,7 @@ TEST(McmcNutsBaseNuts, transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
-  EXPECT_EQ(-42, s.cont_params()(0));
+  EXPECT_EQ(31.5, s.cont_params()(0));
   EXPECT_EQ(0, s.log_prob());
   EXPECT_EQ(1, s.accept_stat());
   EXPECT_EQ("", output_stream.str());

--- a/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
@@ -109,11 +109,11 @@ TEST(McmcSoftAbsNuts, transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
-  EXPECT_FLOAT_EQ(-0.13615179, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.53625083, s.cont_params()(1));
-  EXPECT_FLOAT_EQ(0.073073119, s.cont_params()(2));
-  EXPECT_FLOAT_EQ(-0.15572098, s.log_prob());
-  EXPECT_FLOAT_EQ(0.99829924, s.accept_stat());
+  EXPECT_FLOAT_EQ(1.9313564, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-0.86902142, s.cont_params()(1));
+  EXPECT_FLOAT_EQ(1.6008, s.cont_params()(2));
+  EXPECT_FLOAT_EQ(-3.5239484, s.log_prob());
+  EXPECT_FLOAT_EQ(0.99709648, s.accept_stat());
   EXPECT_EQ("", output.str());
   EXPECT_EQ("", error_stream.str());
 }

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -109,11 +109,11 @@ TEST(McmcUnitENuts, transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
-  EXPECT_FLOAT_EQ(-0.30853021, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.44694126, s.cont_params()(1));
-  EXPECT_FLOAT_EQ(-0.073457584, s.cont_params()(2));
-  EXPECT_FLOAT_EQ(-0.1501717, s.log_prob());
-  EXPECT_FLOAT_EQ(0.99752671, s.accept_stat());
+  EXPECT_FLOAT_EQ(1.6761723, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-1.1139321, s.cont_params()(1));
+  EXPECT_FLOAT_EQ(1.5012255, s.cont_params()(2));
+  EXPECT_FLOAT_EQ(-3.1520379, s.log_prob());
+  EXPECT_FLOAT_EQ(0.99629009, s.accept_stat());
   EXPECT_EQ("", output_stream.str());
   EXPECT_EQ("", error_stream.str());
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Removes duplicate acceptance procedure in the default NUTS algorithm that was causing chains to push too far out into the tails.

#### Intended Effect

Restores correctness of default NUTS algorithm.

#### How to Verify

The following model,

    parameters {
      real<lower=0, upper=1> x;
    }
    model {
      x ~ uniform(0, 1);
    }

should now return an actually uniform distribution.

#### Side Effects

Small changes to all default sampler output.

#### Documentation

None.

#### Reviewer Suggestions

@syclik, @bob-carpenter, @bgoodri 

#### Copyright and Licensing

Copyright: University of Warwick.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
