### PR TITLE
user-defined lpdf fixed, finishes #1944

### DIFF
--- a/src/stan/lang/ast.hpp
+++ b/src/stan/lang/ast.hpp
@@ -198,6 +198,7 @@ namespace stan {
                                 function_signature_t& signature);
       bool is_defined(const std::string& name,
                       const function_signature_t& sig);
+      bool has_user_defined_key(const std::string& name) const;
       std::set<std::string> key_set() const;
       bool has_key(const std::string& key) const;
 

--- a/src/stan/lang/ast_def.cpp
+++ b/src/stan/lang/ast_def.cpp
@@ -166,9 +166,8 @@ namespace stan {
                                               name_sig) {
       return user_defined_set_.find(name_sig) != user_defined_set_.end();
     }
-    bool
-    function_signatures::is_defined(const std::string& name,
-                                    const function_signature_t& sig) {
+    bool function_signatures::is_defined(const std::string& name,
+                                         const function_signature_t& sig) {
       if (sigs_map_.find(name) == sigs_map_.end())
         return false;
       const std::vector<function_signature_t> sigs = sigs_map_[name];
@@ -177,6 +176,7 @@ namespace stan {
           return true;
       return false;
     }
+
     void function_signatures::add(const std::string& name,
                                    const expr_type& result_type,
                                    const std::vector<expr_type>& arg_types) {
@@ -487,7 +487,6 @@ namespace stan {
         }
         error_msgs << std::endl;
       }
-
       return expr_type();  // ill-formed dummy
     }
 
@@ -495,13 +494,27 @@ namespace stan {
 #include <stan/lang/function_signatures.h>  // NOLINT
     }
 
-    std::set<std::string>
-    function_signatures::key_set() const {
+    bool function_signatures::has_user_defined_key(const std::string& key)
+      const {
+      using std::pair;
+      using std::set;
+      using std::string;
+      for (set<pair<string, function_signature_t> >::const_iterator
+             it = user_defined_set_.begin();
+           it != user_defined_set_.end();
+           ++it) {
+        if (it->first == key)
+          return true;
+      }
+      return false;
+    }
+
+    std::set<std::string> function_signatures::key_set() const {
       using std::map;
       using std::set;
       using std::string;
       using std::vector;
-      set<std::string> result;
+      set<string> result;
       for (map<string, vector<function_signature_t> >::const_iterator
              it = sigs_map_.begin();
            it != sigs_map_.end();

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -829,13 +829,13 @@ for (size_t i = 0; i < int_vector_types.size(); ++i) {
     add("poisson_log", DOUBLE_T, int_vector_types[i],
 	vector_types[j]);
     add("poisson_lccdf", DOUBLE_T, int_vector_types[i],
-	vector_types[j]);
+    	vector_types[j]);
     add("poisson_lcdf", DOUBLE_T, int_vector_types[i],
-	vector_types[j]);
+    	vector_types[j]);
     add("poisson_lpmf", DOUBLE_T, int_vector_types[i],
-	vector_types[j]);
+    	vector_types[j]);
   }
- }
+}
 add("poisson_rng", INT_T, DOUBLE_T);
 for (size_t i = 0; i < int_vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1505,11 +1505,14 @@ namespace stan {
               "'_lpdf' for density functions or '_lpmf' for mass functions",
               fun, error_msgs);
 
-      // need old function names (_log) until math gets updated to new ones
-      replace_suffix("_lpdf", "_log", fun);
-      replace_suffix("_lpmf", "_log", fun);
-      replace_suffix("_lcdf", "_cdf_log", fun);
-      replace_suffix("_lccdf", "_ccdf_log", fun);
+      // use old function names for built-in prob funs
+      if (!function_signatures::instance().has_user_defined_key(fun.name_)) {
+        replace_suffix("_lpdf", "_log", fun);
+        replace_suffix("_lpmf", "_log", fun);
+        replace_suffix("_lcdf", "_cdf_log", fun);
+        replace_suffix("_lccdf", "_ccdf_log", fun);
+      }
+      // know these are not user-defined`x
       replace_suffix("lmultiply", "multiply_log", fun);
       replace_suffix("lchoose", "binomial_coefficient_log", fun);
 

--- a/src/test/test-models/good/user-defined-lpdf-fun.stan
+++ b/src/test/test-models/good/user-defined-lpdf-fun.stan
@@ -1,0 +1,42 @@
+functions {
+  real bar_lpmf(int y, real z) {
+    return 1.0;
+  }
+  real bar_lcdf(int y, real z) {
+    return 1.0;
+  }
+  real bar_lccdf(int y, real z) {
+    return 1.0;
+  }
+
+  real foo_lpdf(real y, real sigma) {
+    return 1.0;
+  }
+  real foo_lcdf(real y, real sigma) {
+    return 1.0;
+  }
+  real foo_lccdf(real y, real sigma) {
+    return 1.0;
+  }
+}
+parameters {
+  real y;
+}
+model {
+  target += foo_lpdf(y | 7.0);
+  target += foo_lcdf(y | 7.0);
+  target += foo_lccdf(y | 7.0);
+
+  target += normal_lpdf(y | 7.0, 1.0);
+  target += normal_lcdf(y | 7.0, 1.0);
+  target += normal_lccdf(y | 7.0, 1.0);
+
+  target += bar_lpmf(2 | 7.0);
+  target += bar_lcdf(2 | 7.0);
+  target += bar_lccdf(2 | 7.0);
+
+  target += poisson_lpmf(2 | 7.0);
+  target += poisson_lcdf(2 | 7.0);
+  target += poisson_lccdf(2 | 7.0);
+
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Allow user defined `_lpdf` and `_lpmf` functions with sampling notation.

#### Intended Effect

Fixes bug.

#### How to Verify

Model and integration test.

#### Side Effects

No.

#### Documentation

Fixes code to match existing doc.

#### Reviewer Suggestions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

