### PR TITLE
qualify nullary fun names to avoid clash, finishes #1459

### DIFF
--- a/src/test/test-models/good/nullary-unconflicted.stan
+++ b/src/test/test-models/good/nullary-unconflicted.stan
@@ -1,0 +1,18 @@
+parameters {
+  real e;
+  real pi;
+  real log2;
+  real log10;
+  real sqrt2;
+  real not_a_number;
+  real positive_infinity;
+  real negative_infinity;
+  real machine_precision;
+}
+transformed parameters {
+  real mu;
+  mu = e() + pi() + log2() + log10() + sqrt2() + not_a_number()
+    + positive_infinity() + negative_infinity() + machine_precision();
+}
+model {
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Qualify namespace with `stan::math::` for built-in nullary functions.

#### Intended Effect

Avoid name conflicts that currently arise if a variable in Stan is declared with the same name as a built-in and both are used.

#### How to Verify

New model test exercising everything.

#### Side Effects

No.

#### Documentation

No, now the code matches the doc.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

