### PR TITLE
Manual: Added indexing-based simplification to Multivariate Regression Example

### DIFF
--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -2533,6 +2533,13 @@ non-vectorized alternative:
     y[n] ~ normal(x[n] * beta[jj[n]], sigma);
 \end{stancode}
 %
+For equivalent performance to the vectorized version, but less typing, the entire block can be replaced with:
+%
+\begin{stancode}
+  y ~ normal(beta[jj] .* x,sigma);
+\end{stancode}
+%
+which takes advantage of indexing introduced in Stan version 2.9 (see \refchapter{multi-indexing}).
 
 The code in the Stan program above also builds up an array of vectors
 for the outcomes and for the multivariate normal, which provides a
@@ -2635,14 +2642,10 @@ transformed parameters {
   beta = u * gamma + (diag_pre_multiply(tau,L_Omega) * z)';
 }
 model {
-  vector[N] x_beta_jj;
-  for (n in 1:N)
-    x_beta_jj[n] = x[n] * beta[jj[n]]';
-  y ~ normal(x_beta_jj, sigma);
-
   to_vector(z) ~ normal(0, 1); 
   L_Omega ~ lkj_corr_cholesky(2);
   to_vector(gamma) ~ normal(0, 5);
+  y ~ normal(beta[jj] .* x, sigma);
 }
 \end{stancode}
 

--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -2475,14 +2475,14 @@ data {
   int<lower=1> J;              // num groups
   int<lower=1> L;              // num group predictors
   int<lower=1,upper=J> jj[N];  // group for individual
-  matrix[N, k] x;               // individual predictors
+  matrix[N, K] x;               // individual predictors
   row_vector[L] u[J];          // group predictors
   vector[N] y;                 // outcomes
 }
 parameters {
   corr_matrix[K] Omega;        // prior correlation
   vector<lower=0>[K] tau;      // prior scale
-  matrix[L, k] gamma;           // group coeffs
+  matrix[L, K] gamma;           // group coeffs
   vector[K] beta[J];           // indiv coeffs by group
   real<lower=0> sigma;         // prediction error scale
 }

--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -2496,12 +2496,8 @@ model {
       u_gamma[j] = u[j] * gamma;
     beta ~ multi_normal(u_gamma, quad_form_diag(Omega, tau));
   }
-  {
-    vector[N] x_beta_jj;
-    for (n in 1:N)
-      x_beta_jj[n] = x[n] * beta[jj[n]];
-    y ~ normal(x_beta_jj, sigma);
-  }
+  for (n in 1:N)
+    y[n] ~ normal(x[n] * beta[jj[n]], sigma);
 }
 \end{stancode}
 %
@@ -2521,19 +2517,14 @@ specialized matrix operations.
 
 \subsubsection{Optimization through Vectorization}
 
-The code in the Stan program above builds up a vector with entries
-\code{x\_beta\_jj[n]} of means using the predictor \code{x[n]} and
-group-level coefficient \code{beta[jj[n]]}.  A block is defined with
-brackets around it so that \code{x\_beta\_jj} can be declared as a
-local variable.  The vectorized code is equivalent to the simpler,
-non-vectorized alternative:
+The code in the Stan program above can be sped up dramatically by replacing:
 %
 \begin{stancode}
   for (n in 1:N)
     y[n] ~ normal(x[n] * beta[jj[n]], sigma);
 \end{stancode}
 %
-For equivalent performance to the vectorized version, but less typing, the entire block can be replaced with:
+with:
 %
 \begin{stancode}
   y ~ normal( rows_dot_product(beta[jj] , x),sigma);

--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -659,7 +659,7 @@ With multiple indexing, this can be coded in one line, leading to more
 efficient vectorized code.
 %
 \begin{stancode}
-y ~ normal(alpha[ii] + beta[ii] .* x, sigma);
+y ~ normal( rows_dot_product(alpha[ii] + beta[ii] , x), sigma);
 \end{stancode}
 %
 This latter version is equivalent in speed to the clunky assignment to
@@ -2536,7 +2536,7 @@ non-vectorized alternative:
 For equivalent performance to the vectorized version, but less typing, the entire block can be replaced with:
 %
 \begin{stancode}
-  y ~ normal(beta[jj] .* x,sigma);
+  y ~ normal( rows_dot_product(beta[jj] , x),sigma);
 \end{stancode}
 %
 which takes advantage of indexing introduced in Stan version 2.9 (see \refchapter{multi-indexing}).

--- a/src/docs/stan-reference/programming.tex
+++ b/src/docs/stan-reference/programming.tex
@@ -2631,7 +2631,7 @@ optimized model is as follows.
 parameters {
   matrix[K, J] z;
   cholesky_factor_corr[K] L_Omega;  
-  vector<lower=0;upper=pi()/2>[K] tau_unif;  
+  vector<lower=0,upper=pi()/2>[K] tau_unif;  
   matrix[L, K] gamma;                         // group coeffs
   real<lower=0> sigma;                       // prediction error scale
 }


### PR DESCRIPTION
#### Summary
The Multivariate Regression Example included some optimizations but didn't include the, in my opinion, useful simplification recommended at the beginning of the Multiple Indexing and Range Indexing chapter. My substitution should probably be checked, as the order of variables in the "clunky assignment to a local variable" of the MRE and MIRI sections were different.

#### Reviewer Suggestions

#### Copyright and Licensing
I assert no rights with regards to copyright & licensing.

