### PR TITLE
make clean-all now removes built CVODES binaries

### DIFF
--- a/makefile
+++ b/makefile
@@ -151,6 +151,7 @@ endif
 	@echo '  - clean-manual  : Cleans temporary files from building the manual.'
 	@echo '  - clean-deps    : Removes dependency files for tests. If tests stop building,'
 	@echo '                    run this target.'
+	@echo '  - clean-cvodes  : Removes binaries built for CVODES'
 	@echo '  - clean-all     : Cleans up all of Stan.'
 	@echo ''
 	@echo 'Higher level targets:'
@@ -170,7 +171,7 @@ docs: manual doxygen
 # Clean up.
 ##
 MODEL_SPECS := $(shell find src/test -type f -name '*.stan')
-.PHONY: clean clean-demo clean-dox clean-manual clean-models clean-all clean-deps
+.PHONY: clean clean-demo clean-dox clean-manual clean-models clean-all clean-deps clean-cvodes
 clean:
 	$(RM) $(shell find src -type f -name '*.dSYM') $(shell find src -type f -name '*.d.*')
 	$(RM) $(wildcard $(MODEL_SPECS:%.stan=%.hpp))
@@ -189,7 +190,11 @@ clean-deps:
 	@echo '  removing dependency files'
 	$(shell find . -type f -name '*.d' -exec rm {} +)
 
-clean-all: clean clean-manual clean-deps
+clean-cvodes:
+	$(RM) $(wildcard $(CVODES)/lib/*)
+	$(RM) $(wildcard $(CVODES)/src/*/*.o)
+
+clean-all: clean clean-manual clean-deps clean-cvodes
 	$(RM) -r test bin
 	@echo '  removing .o files'
 	$(shell find src -type f -name '*.o' -exec rm {} +)

--- a/makefile
+++ b/makefile
@@ -151,7 +151,6 @@ endif
 	@echo '  - clean-manual  : Cleans temporary files from building the manual.'
 	@echo '  - clean-deps    : Removes dependency files for tests. If tests stop building,'
 	@echo '                    run this target.'
-	@echo '  - clean-cvodes  : Removes binaries built for CVODES'
 	@echo '  - clean-all     : Cleans up all of Stan.'
 	@echo ''
 	@echo 'Higher level targets:'
@@ -171,7 +170,7 @@ docs: manual doxygen
 # Clean up.
 ##
 MODEL_SPECS := $(shell find src/test -type f -name '*.stan')
-.PHONY: clean clean-demo clean-dox clean-manual clean-models clean-all clean-deps clean-cvodes
+.PHONY: clean clean-demo clean-dox clean-manual clean-models clean-all clean-deps
 clean:
 	$(RM) $(shell find src -type f -name '*.dSYM') $(shell find src -type f -name '*.d.*')
 	$(RM) $(wildcard $(MODEL_SPECS:%.stan=%.hpp))
@@ -190,11 +189,7 @@ clean-deps:
 	@echo '  removing dependency files'
 	$(shell find . -type f -name '*.d' -exec rm {} +)
 
-clean-cvodes:
-	$(RM) $(wildcard $(CVODES)/lib/*)
-	$(RM) $(wildcard $(CVODES)/src/*/*.o)
-
-clean-all: clean clean-manual clean-deps clean-cvodes
+clean-all: clean clean-manual clean-deps clean-libraries
 	$(RM) -r test bin
 	@echo '  removing .o files'
 	$(shell find src -type f -name '*.o' -exec rm {} +)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
`make clean-all` now removes all of the CVODES binaries.

#### Side Effects
None.

#### Documentation
Updated in the default `make` target.

#### Reviewer Suggestions
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

