### PR TITLE
update error msg for , instead of | in prob funs, fixes #1940

### DIFF
--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -659,6 +659,11 @@ namespace stan {
     };
     extern boost::phoenix::function<set_var_type> set_var_type_f;
 
+    struct require_vbar : public phoenix_functor_binary {
+      void operator()(bool& pass, std::ostream& error_msgs) const;
+    };
+    extern boost::phoenix::function<require_vbar> require_vbar_f;
+
     struct validate_no_constraints_vis : public boost::static_visitor<bool> {
       std::stringstream& error_msgs_;
       explicit validate_no_constraints_vis(std::stringstream& error_msgs);

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1912,6 +1912,17 @@ namespace stan {
     }
     boost::phoenix::function<set_var_type> set_var_type_f;
 
+    void require_vbar::operator()(bool& pass, std::ostream& error_msgs) const {
+      pass = false;
+      error_msgs << "Probabilty functions with suffixes _lpdf, _lpmf,"
+                 << " _lcdf, and _lccdf," << std::endl
+                 << "require a vertical bar (|) between the first two"
+                 << " arguments." << std::endl;
+    }
+    boost::phoenix::function<require_vbar> require_vbar_f;
+
+
+
     validate_no_constraints_vis::validate_no_constraints_vis(
                                                std::stringstream& error_msgs)
       : error_msgs_(error_msgs) { }

--- a/src/stan/lang/grammars/term_grammar_def.hpp
+++ b/src/stan/lang/grammars/term_grammar_def.hpp
@@ -231,7 +231,7 @@ namespace stan {
         %= lexeme[char_("a-zA-Z")
                   >> *char_("a-zA-Z0-9_.")];
 
-      prob_args_r.name("probability function arguments");
+      prob_args_r.name("probability function argument");
       prob_args_r
         %= (lit('(') >> lit(')'))
         | hold[lit('(')
@@ -239,7 +239,9 @@ namespace stan {
                >> lit(')')]
         | (lit('(')
            >> expression_g(_r1)
-           >> lit('|')
+           >> (lit(',')
+               [require_vbar_f(_pass, boost::phoenix::ref(error_msgs_))]
+               | (eps > lit('|')))
            >> (expression_g(_r1) % ',')
            >> lit(')'));
 

--- a/src/test/test-models/bad/prob-fun-args-no-bar.stan
+++ b/src/test/test-models/bad/prob-fun-args-no-bar.stan
@@ -1,0 +1,6 @@
+parameters {
+  real y;
+}
+model {
+  target += normal_lpdf(y, 0, 1);
+}

--- a/src/test/unit/lang/parser/redefine_prob_functions_test.cpp
+++ b/src/test/unit/lang/parser/redefine_prob_functions_test.cpp
@@ -35,4 +35,10 @@ TEST(langParser, lpdfReal) {
               "Parse Error.  Probability density functions require"
               " real variates (first argument). Found type = int");
 }
-
+TEST(langParser, badArgs) {
+  test_throws("prob-fun-args-no-bar",
+              "Probabilty functions with suffixes _lpdf, _lpmf,"
+                  " _lcdf, and _lccdf,",
+              "require a vertical bar (|) between the first two"
+                  " arguments.");
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run (parser) unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Clarify error messages for probability functions.

#### Intended Effect

Make it easier for users to understand error messages.

#### How to Verify

New model unit tests for new message.

#### Side Effects

No.

#### Documentation

Not necessary.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

