### PR TITLE
Bugfix/1946 double warnings

### DIFF
--- a/src/stan/lang/grammars/expression_grammar_def.hpp
+++ b/src/stan/lang/grammars/expression_grammar_def.hpp
@@ -25,17 +25,43 @@ namespace stan {
         var_map_(var_map),
         error_msgs_(error_msgs),
         expression07_g(var_map, error_msgs, *this) {
-      using boost::spirit::qi::_1;
+      using boost::spirit::qi::char_;
+      using boost::spirit::qi::eps;
       using boost::spirit::qi::lit;
+      using boost::spirit::qi::no_skip;
+      using boost::spirit::qi::_1;
       using boost::spirit::qi::_pass;
       using boost::spirit::qi::_val;
       using boost::spirit::qi::labels::_r1;
 
+      // expression_r.name("expression");
+      // expression_r
+      //   %= conditional_op_r(_r1)
+      //   | expression15_r(_r1);
+
+
+      // conditional_op_r.name("conditional op expression, cond ? t_val : f_val ");
+      // conditional_op_r
+      //   %= expression15_r(_r1)
+      //   >> lit("?")
+      //   >> expression_r(_r1)
+      //   >> lit(":")
+      //   >> expression_r(_r1)[validate_conditional_op_f(_val, _pass,
+      //                                boost::phoenix::ref(error_msgs))];
+
+      // expression_r
+      //   %= expression15_r(_r1)
+      //   >> -(lit('?')
+      //        >> expression_r(_r1)
+      //        >> lit("'")
+      //        >> expression_r(_r1)
+      //           [validate_conditional_op_f(_val, _pass,
+      //                                      boost::phoenix::ref(error_msgs))]);
+
       expression_r.name("expression");
       expression_r
-        %= conditional_op_r(_r1)
-        | expression15_r(_r1);
-
+        %= (expression15_r(_r1) >> no_skip[!char_('?')] > eps)
+        | conditional_op_r(_r1);
 
       conditional_op_r.name("conditional op expression, cond ? t_val : f_val ");
       conditional_op_r

--- a/src/stan/lang/grammars/expression_grammar_def.hpp
+++ b/src/stan/lang/grammars/expression_grammar_def.hpp
@@ -34,30 +34,6 @@ namespace stan {
       using boost::spirit::qi::_val;
       using boost::spirit::qi::labels::_r1;
 
-      // expression_r.name("expression");
-      // expression_r
-      //   %= conditional_op_r(_r1)
-      //   | expression15_r(_r1);
-
-
-      // conditional_op_r.name("conditional op expression, cond ? t_val : f_val ");
-      // conditional_op_r
-      //   %= expression15_r(_r1)
-      //   >> lit("?")
-      //   >> expression_r(_r1)
-      //   >> lit(":")
-      //   >> expression_r(_r1)[validate_conditional_op_f(_val, _pass,
-      //                                boost::phoenix::ref(error_msgs))];
-
-      // expression_r
-      //   %= expression15_r(_r1)
-      //   >> -(lit('?')
-      //        >> expression_r(_r1)
-      //        >> lit("'")
-      //        >> expression_r(_r1)
-      //           [validate_conditional_op_f(_val, _pass,
-      //                                      boost::phoenix::ref(error_msgs))]);
-
       expression_r.name("expression");
       expression_r
         %= (expression15_r(_r1) >> no_skip[!char_('?')] > eps)

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -659,6 +659,11 @@ namespace stan {
     };
     extern boost::phoenix::function<set_var_type> set_var_type_f;
 
+    struct require_vbar : public phoenix_functor_binary {
+      void operator()(bool& pass, std::ostream& error_msgs) const;
+    };
+    extern boost::phoenix::function<require_vbar> require_vbar_f;
+
     struct validate_no_constraints_vis : public boost::static_visitor<bool> {
       std::stringstream& error_msgs_;
       explicit validate_no_constraints_vis(std::stringstream& error_msgs);

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1912,6 +1912,17 @@ namespace stan {
     }
     boost::phoenix::function<set_var_type> set_var_type_f;
 
+    void require_vbar::operator()(bool& pass, std::ostream& error_msgs) const {
+      pass = false;
+      error_msgs << "Probabilty functions with suffixes _lpdf, _lpmf,"
+                 << " _lcdf, and _lccdf," << std::endl
+                 << "require a vertical bar (|) between the first two"
+                 << " arguments." << std::endl;
+    }
+    boost::phoenix::function<require_vbar> require_vbar_f;
+
+
+
     validate_no_constraints_vis::validate_no_constraints_vis(
                                                std::stringstream& error_msgs)
       : error_msgs_(error_msgs) { }

--- a/src/stan/lang/grammars/term_grammar_def.hpp
+++ b/src/stan/lang/grammars/term_grammar_def.hpp
@@ -231,7 +231,7 @@ namespace stan {
         %= lexeme[char_("a-zA-Z")
                   >> *char_("a-zA-Z0-9_.")];
 
-      prob_args_r.name("probability function arguments");
+      prob_args_r.name("probability function argument");
       prob_args_r
         %= (lit('(') >> lit(')'))
         | hold[lit('(')
@@ -239,7 +239,9 @@ namespace stan {
                >> lit(')')]
         | (lit('(')
            >> expression_g(_r1)
-           >> lit('|')
+           >> (lit(',')
+               [require_vbar_f(_pass, boost::phoenix::ref(error_msgs_))]
+               | (eps > lit('|')))
            >> (expression_g(_r1) % ',')
            >> lit(')'));
 

--- a/src/test/test-models/bad/prob-fun-args-no-bar.stan
+++ b/src/test/test-models/bad/prob-fun-args-no-bar.stan
@@ -1,0 +1,6 @@
+parameters {
+  real y;
+}
+model {
+  target += normal_lpdf(y, 0, 1);
+}

--- a/src/test/test-models/good/duplicate-warns.stan
+++ b/src/test/test-models/good/duplicate-warns.stan
@@ -1,0 +1,12 @@
+model {
+  real foo;
+  foo <- 1;
+  increment_log_prob(0);
+  foo = get_lp();
+  foo = multiply_log(1, 1);
+  foo = binomial_coefficient_log(1, 1);
+  // deprecated distribution functions versions
+  foo = normal_log(0.5, 0, 1);
+  foo = normal_cdf_log(0.5, 0, 1);
+  foo = normal_ccdf_log(0.5, 0, 1);
+}

--- a/src/test/unit/lang/parser/duplicate_warnings_test.cpp
+++ b/src/test/unit/lang/parser/duplicate_warnings_test.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include <test/unit/lang/utility.hpp>
+
+TEST(langParser, duplicateWarnings) {
+  test_num_warnings("duplicate-warns",
+                    "assignment operator <- deprecated", 1);
+  test_num_warnings("duplicate-warns",
+                    "increment_log_prob(...); is deprecated", 1);
+  test_num_warnings("duplicate-warns",
+                    "get_lp() function deprecated", 1);
+  test_num_warnings("duplicate-warns",
+                    "'multiply_log' is deprecated", 1);
+  test_num_warnings("duplicate-warns",
+                    "'binomial_coefficient_log' is deprecated", 1);
+  test_num_warnings("duplicate-warns",
+                    "Deprecated function 'normal_log'", 1);
+  test_num_warnings("duplicate-warns",
+                    "Deprecated function 'normal_cdf_log'", 1);
+  test_num_warnings("duplicate-warns",
+                    "Deprecated function 'normal_ccdf_log'", 1);
+}

--- a/src/test/unit/lang/parser/redefine_prob_functions_test.cpp
+++ b/src/test/unit/lang/parser/redefine_prob_functions_test.cpp
@@ -35,4 +35,10 @@ TEST(langParser, lpdfReal) {
               "Parse Error.  Probability density functions require"
               " real variates (first argument). Found type = int");
 }
-
+TEST(langParser, badArgs) {
+  test_throws("prob-fun-args-no-bar",
+              "Probabilty functions with suffixes _lpdf, _lpmf,"
+                  " _lcdf, and _lccdf,",
+              "require a vertical bar (|) between the first two"
+                  " arguments.");
+}

--- a/src/test/unit/lang/utility.hpp
+++ b/src/test/unit/lang/utility.hpp
@@ -179,4 +179,20 @@ void expect_matches(int n,
   EXPECT_EQ(n, count_matches(target,model_cpp));
 }
 
+/**
+ * Thest that model of specified name in test/test-models/good
+ * has exactly the specified number of matches 
+ *
+ * @param[in] model_name Name of model file.
+ * @param[in] warning_msg Message to count.
+ * @param[in] n Expected number of message occurrences.
+ */
+void test_num_warnings(const std::string& model_name, 
+                       const std::string& warning_msg,
+                       int n) {
+  std::stringstream msgs;
+  EXPECT_TRUE(is_parsable_folder(model_name, "good", &msgs));
+  EXPECT_EQ(n, count_matches(warning_msg, msgs.str()));
+}
+
 #endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Remove duplicate warnings in expressions.

#### Intended Effect

See summary.  

#### How to Verify

Unit test from @ariddell's issue.

#### Side Effects

No.

#### Documentation

n/a

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
