### PR TITLE
explicit zeroing of descending indexes; fixes #1960

### DIFF
--- a/src/stan/model/indexing/rvalue_index_size.hpp
+++ b/src/stan/model/indexing/rvalue_index_size.hpp
@@ -56,14 +56,15 @@ namespace stan {
     }
 
     /**
-     * Return size of specified min-max index.
+     * Return size of specified min - max index.  If the maximum value
+     * index is less than the minimun index, the size will be zero.
      *
      * @param[in] idx Input index (from 1).
      * @param[in] size Size of container (ignored).
      * @return Size of result.
      */
     inline int rvalue_index_size(const index_min_max& idx, int size) {
-      return idx.max_ - idx.min_ + 1;
+      return (idx.max_ < idx.min_) ? 0 : (idx.max_ - idx.min_ + 1);
     }
 
   }

--- a/src/test/unit/model/indexing/lvalue_test.cpp
+++ b/src/test/unit/model/indexing/lvalue_test.cpp
@@ -527,3 +527,20 @@ TEST(ModelIndexing, doubleToVar) {
   for (int j = 0; j < 3; ++j)
     EXPECT_FLOAT_EQ(c(1, j).val(), d(j));
 }
+TEST(ModelIndexing, resultSizeNegIndexing) {
+  using stan::model::assign;
+  using stan::model::cons_list;
+  using stan::model::index_min_max;
+  using stan::model::nil_index_list;
+  using std::vector;
+
+  vector<double> rhs;
+  rhs.push_back(2);
+  rhs.push_back(5);
+  rhs.push_back(-125);
+
+  vector<double> lhs;
+  assign(rhs, cons_list(index_min_max(1, 0), nil_index_list()), lhs);
+  EXPECT_EQ(0, lhs.size());
+}
+

--- a/src/test/unit/model/indexing/rvalue_index_size_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_index_size_test.cpp
@@ -1,0 +1,58 @@
+#include <stan/model/indexing/rvalue_index_size.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+// error checking is during indexing, not during index construction
+// so no tests here for out of bounds
+
+TEST(modelIndexingRvalueIndexSize, multi) {
+  using stan::model::index_multi;
+  using stan::model::rvalue_index_size;
+
+  std::vector<int> ns;
+  ns.push_back(1);
+  ns.push_back(2);
+  
+  index_multi idx(ns);
+  EXPECT_EQ(2, rvalue_index_size(idx, 10));
+}
+
+TEST(modelIndexingRvalueIndexSize, omni) {
+  using stan::model::index_omni;
+  using stan::model::rvalue_index_size;
+
+  index_omni idx;
+  EXPECT_EQ(10, rvalue_index_size(idx, 10));
+}
+
+TEST(modelIndexingRvalueIndexSize, min) {
+  using stan::model::index_min;
+  using stan::model::rvalue_index_size;
+
+  index_min idx(3);
+  EXPECT_EQ(8, rvalue_index_size(idx, 10));
+}
+
+TEST(modelIndexingRvalueIndexSize, max) {
+  using stan::model::index_max;
+  using stan::model::rvalue_index_size;
+
+  index_max idx(5);
+  EXPECT_EQ(5, rvalue_index_size(idx, 10));
+}
+
+TEST(modelIndexingRvalueIndexSize, minMax) {
+  using stan::model::index_min_max;
+  using stan::model::rvalue_index_size;
+  index_min_max mm(1, 3);
+  EXPECT_EQ(3, rvalue_index_size(mm, 10));
+
+  index_min_max mm2(3, 3);
+  EXPECT_EQ(1, rvalue_index_size(mm2, 10));
+
+  index_min_max mm3(3, 1);
+  EXPECT_EQ(0, rvalue_index_size(mm3, 10));
+
+  index_min_max mm4(1, 0);
+  EXPECT_EQ(0, rvalue_index_size(mm3, 10));
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add explicit test for indexes like `1:0` and set them to size zero.

#### Intended Effect

Avoid 0 - 1 and large allocations if the result is used as unsigned.

#### How to Verify

Run unit new tests.

#### Side Effects

No.

#### Documentation

Added note to user's guide section of manual under range indexing heading.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

