### PR TITLE
Bugfix/2030 rethrow loc test

### DIFF
--- a/src/test/unit/lang/rethrow_located_test.cpp
+++ b/src/test/unit/lang/rethrow_located_test.cpp
@@ -48,7 +48,7 @@ void test_rethrow_located_nullary(const std::string& original_type) {
 
 
 struct my_test_exception : public std::exception {
-  const std::string& what_;
+  const std::string what_;
   my_test_exception(const std::string& what) throw() : what_(what) { }
   ~my_test_exception() throw() { }
   const char* what() const throw() { return what_.c_str(); }

--- a/src/test/unit/lang/rethrow_located_test.cpp
+++ b/src/test/unit/lang/rethrow_located_test.cpp
@@ -71,7 +71,6 @@ TEST(langRethrowLocated, allExpected) {
   test_rethrow_located<std::runtime_error>();
 
   test_rethrow_located_nullary<std::exception>("std::exception");
-
   test_rethrow_located_2<my_test_exception,std::exception>();
 }
 TEST(langRethrowLocated, locatedException) {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Change reference to copy in exception (d'oh!) to fix broken test.

#### Intended Effect

Make tests work with g++ 5.4 at -O3

#### How to Verify

Unit test on g++ 5.4 at -O3

#### Side Effects

No.

#### Documentation

n/a

#### Reviewer Suggestions

anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
