### PR TITLE
Fixes #2045. Making includes to the math library consistent

### DIFF
--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -1,19 +1,15 @@
 #ifndef STAN_IO_DUMP_HPP
 #define STAN_IO_DUMP_HPP
 
+#include <stan/io/validate_zero_buf.hpp>
+#include <stan/io/var_context.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/type_traits/is_floating_point.hpp>
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/utility/enable_if.hpp>
-
-#include <stan/io/validate_zero_buf.hpp>
-#include <stan/io/var_context.hpp>
-#include <stan/math/prim/scal/meta/index_type.hpp>
-#include <stan/math/prim/arr/meta/index_type.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
-
 #include <iostream>
 #include <limits>
 #include <map>

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -2,30 +2,7 @@
 #define STAN_IO_READER_HPP
 
 #include <boost/throw_exception.hpp>
-#include <stan/math/prim/mat/err/check_cholesky_factor.hpp>
-#include <stan/math/prim/mat/err/check_cholesky_factor_corr.hpp>
-#include <stan/math/prim/mat/err/check_corr_matrix.hpp>
-#include <stan/math/prim/mat/err/check_cov_matrix.hpp>
-#include <stan/math/prim/mat/err/check_ordered.hpp>
-#include <stan/math/prim/mat/err/check_positive_ordered.hpp>
-#include <stan/math/prim/mat/err/check_simplex.hpp>
-#include <stan/math/prim/mat/err/check_unit_vector.hpp>
-#include <stan/math/prim/mat/fun/cholesky_corr_constrain.hpp>
-#include <stan/math/prim/mat/fun/cholesky_factor_constrain.hpp>
-#include <stan/math/prim/mat/fun/corr_matrix_constrain.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_constrain.hpp>
-#include <stan/math/prim/mat/fun/ordered_constrain.hpp>
-#include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
-#include <stan/math/prim/mat/fun/simplex_constrain.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/fun/corr_constrain.hpp>
-#include <stan/math/prim/scal/fun/lb_constrain.hpp>
-#include <stan/math/prim/scal/fun/lub_constrain.hpp>
-#include <stan/math/prim/scal/fun/positive_constrain.hpp>
-#include <stan/math/prim/scal/fun/prob_constrain.hpp>
-#include <stan/math/prim/scal/fun/ub_constrain.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <vector>
 
 namespace stan {

--- a/src/stan/io/writer.hpp
+++ b/src/stan/io/writer.hpp
@@ -1,22 +1,7 @@
 #ifndef STAN_IO_WRITER_HPP
 #define STAN_IO_WRITER_HPP
 
-#include <stan/math/prim/arr/meta/index_type.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
-#include <stan/math/prim/scal/meta/index_type.hpp>
-#include <stan/math/prim/mat/err/check_corr_matrix.hpp>
-#include <stan/math/prim/mat/err/check_ordered.hpp>
-#include <stan/math/prim/mat/err/check_positive_ordered.hpp>
-#include <stan/math/prim/mat/err/check_simplex.hpp>
-#include <stan/math/prim/mat/err/check_unit_vector.hpp>
-#include <stan/math/prim/mat/fun/cholesky_corr_free.hpp>
-#include <stan/math/prim/mat/fun/cholesky_factor_free.hpp>
-#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
-#include <stan/math/prim/mat/fun/simplex_free.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_free.hpp>
-#include <stan/math/prim/scal/fun/prob_free.hpp>
-#include <stan/math/prim/scal/fun/lb_free.hpp>
-#include <stan/math/prim/scal/fun/lub_free.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <stdexcept>
 #include <vector>
 

--- a/src/stan/mcmc/chains.hpp
+++ b/src/stan/mcmc/chains.hpp
@@ -2,12 +2,7 @@
 #define STAN_MCMC_CHAINS_HPP
 
 #include <stan/io/stan_csv_reader.hpp>
-#include <stan/math/prim/mat/fun/variance.hpp>
-#include <stan/math/prim/arr/meta/index_type.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
-#include <stan/math/prim/scal/meta/index_type.hpp>
-#include <stan/math/prim/mat/fun/autocorrelation.hpp>
-#include <stan/math/prim/mat/fun/autocovariance.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/mean.hpp>

--- a/src/stan/mcmc/covar_adaptation.hpp
+++ b/src/stan/mcmc/covar_adaptation.hpp
@@ -1,9 +1,8 @@
 #ifndef STAN_MCMC_COVAR_ADAPTATION_HPP
 #define STAN_MCMC_COVAR_ADAPTATION_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <stan/mcmc/windowed_adaptation.hpp>
-#include <stan/math/prim/mat/fun/welford_covar_estimator.hpp>
 #include <vector>
 
 namespace stan {

--- a/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
@@ -2,8 +2,8 @@
 #define STAN_MCMC_HMC_HAMILTONIANS_BASE_HAMILTONIAN_HPP
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/model/util.hpp>
+#include <Eigen/Dense>
 #include <iostream>
 #include <limits>
 #include <stdexcept>

--- a/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
@@ -1,8 +1,7 @@
 #ifndef STAN_MCMC_HMC_HAMILTONIANS_DENSE_E_METRIC_HPP
 #define STAN_MCMC_HMC_HAMILTONIANS_DENSE_E_METRIC_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp>
 #include <stan/mcmc/hmc/hamiltonians/dense_e_point.hpp>
 #include <boost/random/variate_generator.hpp>

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -2,8 +2,8 @@
 #define STAN_MCMC_HMC_HAMILTONIANS_PS_POINT_HPP
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <boost/lexical_cast.hpp>
+#include <Eigen/Dense>
 #include <string>
 #include <vector>
 

--- a/src/stan/mcmc/hmc/hamiltonians/softabs_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/softabs_metric.hpp
@@ -2,10 +2,8 @@
 #define STAN_MCMC_HMC_HAMILTONIANS_SOFTABS_METRIC_HPP
 
 #include <stan/math/mix/mat.hpp>
-
 #include <stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp>
 #include <stan/mcmc/hmc/hamiltonians/softabs_point.hpp>
-
 #include <boost/random/variate_generator.hpp>
 #include <boost/random/normal_distribution.hpp>
 

--- a/src/stan/mcmc/hmc/integrators/expl_leapfrog.hpp
+++ b/src/stan/mcmc/hmc/integrators/expl_leapfrog.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MCMC_HMC_INTEGRATORS_EXPL_LEAPFROG_HPP
 #define STAN_MCMC_HMC_INTEGRATORS_EXPL_LEAPFROG_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <Eigen/Dense>
 #include <stan/mcmc/hmc/integrators/base_leapfrog.hpp>
 
 namespace stan {

--- a/src/stan/mcmc/hmc/integrators/impl_leapfrog.hpp
+++ b/src/stan/mcmc/hmc/integrators/impl_leapfrog.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MCMC_HMC_INTEGRATORS_IMPL_LEAPFROG_HPP
 #define STAN_MCMC_HMC_INTEGRATORS_IMPL_LEAPFROG_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <Eigen/Dense>
 #include <stan/mcmc/hmc/integrators/base_leapfrog.hpp>
 
 namespace stan {

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <stan/math/prim/scal/fun/log_sum_exp.hpp>
+#include <stan/math/prim/scal.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 #include <algorithm>

--- a/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <stan/math/prim/scal/fun/log_sum_exp.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 #include <algorithm>

--- a/src/stan/mcmc/sample.hpp
+++ b/src/stan/mcmc/sample.hpp
@@ -1,8 +1,7 @@
 #ifndef STAN_MCMC_SAMPLE_HPP
 #define STAN_MCMC_SAMPLE_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-
+#include <Eigen/Dense>
 #include <vector>
 #include <string>
 

--- a/src/stan/mcmc/var_adaptation.hpp
+++ b/src/stan/mcmc/var_adaptation.hpp
@@ -1,9 +1,8 @@
 #ifndef STAN_MCMC_VAR_ADAPTATION_HPP
 #define STAN_MCMC_VAR_ADAPTATION_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <stan/mcmc/windowed_adaptation.hpp>
-#include <stan/math/prim/mat/fun/welford_var_estimator.hpp>
 #include <vector>
 
 namespace stan {

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -4,8 +4,7 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <Eigen/Dense>
-#include <stan/math/prim/scal/err/check_equal.hpp>
-#include <stan/math/prim/mat/err/check_range.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/index_list.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -3,8 +3,7 @@
 
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <Eigen/Dense>
-#include <stan/math/prim/mat/err/check_range.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/index_list.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>

--- a/src/stan/model/util.hpp
+++ b/src/stan/model/util.hpp
@@ -2,22 +2,7 @@
 #define STAN_MODEL_UTIL_HPP
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
-#include <stan/math/fwd/scal/fun/square.hpp>
-#include <stan/math/fwd/core.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/rev/mat/fun/grad.hpp>
-#include <stan/math/rev/core.hpp>
-#include <stan/math/mix/mat/functor/derivative.hpp>
-#include <stan/math/mix/mat/functor/grad_hessian.hpp>
-#include <stan/math/mix/mat/functor/grad_tr_mat_times_hessian.hpp>
-#include <stan/math/rev/mat/functor/gradient.hpp>
-#include <stan/math/fwd/mat/functor/gradient.hpp>
-#include <stan/math/mix/mat/functor/gradient_dot_vector.hpp>
-#include <stan/math/mix/mat/functor/hessian.hpp>
-#include <stan/math/mix/mat/functor/hessian_times_vector.hpp>
-#include <stan/math/fwd/mat/functor/jacobian.hpp>
-#include <stan/math/rev/mat/functor/jacobian.hpp>
-#include <stan/math/mix/mat/functor/partial_derivative.hpp>
+#include <stan/math/mix/mat.hpp>
 #include <cmath>
 #include <iomanip>
 #include <iostream>

--- a/src/stan/optimization/bfgs.hpp
+++ b/src/stan/optimization/bfgs.hpp
@@ -1,8 +1,7 @@
 #ifndef STAN_OPTIMIZATION_BFGS_HPP
 #define STAN_OPTIMIZATION_BFGS_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <stan/model/util.hpp>
 #include <stan/optimization/bfgs_linesearch.hpp>
 #include <stan/optimization/bfgs_update.hpp>

--- a/src/stan/optimization/bfgs_update.hpp
+++ b/src/stan/optimization/bfgs_update.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_OPTIMIZATION_BFGS_UPDATE_HPP
 #define STAN_OPTIMIZATION_BFGS_UPDATE_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <Eigen/Dense>
 
 namespace stan {
   namespace optimization {

--- a/src/stan/optimization/lbfgs_update.hpp
+++ b/src/stan/optimization/lbfgs_update.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_OPTIMIZATION_LBFGS_UPDATE_HPP
 #define STAN_OPTIMIZATION_LBFGS_UPDATE_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <Eigen/Dense>
 #include <boost/tuple/tuple.hpp>
 #include <boost/circular_buffer.hpp>
 #include <vector>

--- a/src/stan/services/init/initialize_state.hpp
+++ b/src/stan/services/init/initialize_state.hpp
@@ -12,9 +12,7 @@
 #include <stan/interface_callbacks/var_context_factory/var_context_factory.hpp>
 #include <stan/interface_callbacks/writer/base_writer.hpp>
 #include <stan/services/io/write_error_msg.hpp>
-#include <stan/math/prim/scal/fun/is_inf.hpp>
-#include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <cmath>
 #include <iostream>
 #include <limits>

--- a/src/stan/services/sample/init_adapt.hpp
+++ b/src/stan/services/sample/init_adapt.hpp
@@ -3,9 +3,9 @@
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
 #include <stan/mcmc/base_mcmc.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/services/arguments/categorical_argument.hpp>
 #include <stan/services/arguments/singleton_argument.hpp>
+#include <Eigen/Dense>
 #include <ostream>
 
 namespace stan {

--- a/src/stan/services/sample/init_windowed_adapt.hpp
+++ b/src/stan/services/sample/init_windowed_adapt.hpp
@@ -4,8 +4,8 @@
 #include <stan/interface_callbacks/writer/base_writer.hpp>
 #include <stan/mcmc/base_mcmc.hpp>
 #include <stan/services/arguments/categorical_argument.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/services/sample/init_adapt.hpp>
+#include <Eigen/Dense>
 #include <ostream>
 
 namespace stan {

--- a/src/stan/services/variational/print_progress.hpp
+++ b/src/stan/services/variational/print_progress.hpp
@@ -2,8 +2,7 @@
 #define STAN_SERVICES_VARIATIONAL_PRINT_PROGRESS_HPP
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal.hpp>
 #include <stan/services/io/do_print.hpp>
 #include <cmath>
 #include <iomanip>

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -2,7 +2,7 @@
 #define STAN_VARIATIONAL_BASE_FAMILY_HPP
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <algorithm>
 #include <ostream>
 

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -1,23 +1,7 @@
 #ifndef STAN_VARIATIONAL_NORMAL_FULLRANK_HPP
 #define STAN_VARIATIONAL_NORMAL_FULLRANK_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/mat/meta/get.hpp>
-#include <stan/math/prim/arr/meta/get.hpp>
-#include <stan/math/prim/mat/meta/length.hpp>
-#include <stan/math/prim/mat/meta/is_vector.hpp>
-#include <stan/math/prim/mat/meta/is_vector_like.hpp>
-#include <stan/math/prim/mat/fun/value_of_rec.hpp>
-#include <stan/math/prim/scal/prob/normal_rng.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
-#include <stan/math/prim/mat/err/check_lower_triangular.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/scal/err/domain_error.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <stan/model/util.hpp>
 #include <stan/variational/base_family.hpp>
 #include <algorithm>

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -2,20 +2,7 @@
 #define STAN_VARIATIONAL_NORMAL_MEANFIELD_HPP
 
 #include <stan/interface_callbacks/writer/base_writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/mat/meta/get.hpp>
-#include <stan/math/prim/arr/meta/get.hpp>
-#include <stan/math/prim/mat/meta/length.hpp>
-#include <stan/math/prim/mat/meta/is_vector.hpp>
-#include <stan/math/prim/mat/meta/is_vector_like.hpp>
-#include <stan/math/prim/mat/fun/value_of_rec.hpp>
-#include <stan/math/prim/scal/prob/normal_rng.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/scal/err/domain_error.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <stan/model/util.hpp>
 #include <stan/variational/base_family.hpp>
 #include <algorithm>

--- a/src/test/unit/io/writer_test.cpp
+++ b/src/test/unit/io/writer_test.cpp
@@ -5,7 +5,7 @@
 #include <stan/io/reader.hpp>
 #include <gtest/gtest.h>
 
-#include <stan/math/prim/mat/fun/typedefs.hpp>
+#include <stan/math/prim/mat.hpp>
 
 TEST(ioWriter, infBounds) {
   std::vector<int> theta_i;

--- a/src/test/unit/mcmc/hmc/mock_hmc.hpp
+++ b/src/test/unit/mcmc/hmc/mock_hmc.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN__MCMC__MOCK__HMC__BETA
 #define STAN__MCMC__MOCK__HMC__BETA
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <stan/model/prob_grad.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 #include <stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp>

--- a/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
@@ -1,3 +1,4 @@
+#include <stan/math/rev/mat.hpp>
 #include <stan/interface_callbacks/writer/stream_writer.hpp>
 #include <stan/mcmc/hmc/nuts/softabs_nuts.hpp>
 #include <boost/random/additive_combine.hpp>

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -1,3 +1,4 @@
+#include <stan/math/rev/mat.hpp>
 #include <stan/interface_callbacks/writer/stream_writer.hpp>
 #include <stan/mcmc/hmc/nuts/unit_e_nuts.hpp>
 #include <boost/random/additive_combine.hpp>

--- a/src/test/unit/model/indexing/lvalue_test.cpp
+++ b/src/test/unit/model/indexing/lvalue_test.cpp
@@ -2,7 +2,7 @@
 #include <stdexcept>
 #include <vector>
 #include <stan/model/indexing/lvalue.hpp>
-#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 
 using stan::model::nil_index_list;

--- a/src/test/unit/optimization/bfgs_linesearch_test.cpp
+++ b/src/test/unit/optimization/bfgs_linesearch_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include <stan/optimization/bfgs_linesearch.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat.hpp>
 
 TEST(OptimizationBfgsLinesearch, CubicInterp) {
   using stan::optimization::CubicInterp;

--- a/src/test/unit/services/init/initialize_state_test.cpp
+++ b/src/test/unit/services/init/initialize_state_test.cpp
@@ -5,7 +5,7 @@
 #include <stan/interface_callbacks/writer/stream_writer.hpp>
 #include <stan/services/init/initialize_state.hpp>
 #include <stan/model/prob_grad.hpp>
-#include <stan/math/prim/mat/fun/stan_print.hpp>
+#include <stan/math/prim/mat.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
I replaced the individual includes to the math library with a single include.

#### Intended Effect
This will ensure the traits get instantiated correctly.

#### How to Verify
Look at code.

#### Side Effects
This might include a few more files, but from each of our interfaces, this shouldn't have an effect.

#### Documentation
None necessary.

#### Reviewer Suggestions
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

