### PR TITLE
Feature/issue 2015 truncation

### DIFF
--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1106,7 +1106,8 @@ namespace stan {
         std::vector<expr_type> arg_types_trunc(arg_types);
         arg_types_trunc[0] = s.truncation_.low_.expression_type();
         std::string function_name_ccdf = get_ccdf(s.dist_.family_);
-        if (!is_double_return(function_name_ccdf, arg_types_trunc,
+        if (function_name_ccdf == s.dist_.family_
+            || !is_double_return(function_name_ccdf, arg_types_trunc,
                               error_msgs)) {
           error_msgs << "lower truncation not defined for specified"
                      << " arguments to "
@@ -1127,8 +1128,9 @@ namespace stan {
         std::vector<expr_type> arg_types_trunc(arg_types);
         arg_types_trunc[0] = s.truncation_.high_.expression_type();
         std::string function_name_cdf = get_cdf(s.dist_.family_);
-        if (!is_double_return(function_name_cdf, arg_types_trunc,
-                              error_msgs)) {
+        if (function_name_cdf == s.dist_.family_
+            || !is_double_return(function_name_cdf, arg_types_trunc,
+                                 error_msgs)) {
           error_msgs << "upper truncation not defined for"
                      << " specified arguments to "
                      << s.dist_.family_ << std::endl;
@@ -1149,8 +1151,9 @@ namespace stan {
         std::vector<expr_type> arg_types_trunc(arg_types);
         arg_types_trunc[0] = s.truncation_.low_.expression_type();
         std::string function_name_cdf = get_cdf(s.dist_.family_);
-        if (!is_double_return(function_name_cdf, arg_types_trunc,
-                              error_msgs)) {
+        if (function_name_cdf == s.dist_.family_
+            || !is_double_return(function_name_cdf, arg_types_trunc,
+                                 error_msgs)) {
           error_msgs << "lower truncation not defined for specified"
                      << " arguments to "
                      << s.dist_.family_ << std::endl;

--- a/src/test/test-models/bad/prob-poisson_log-trunc-both.stan
+++ b/src/test/test-models/bad/prob-poisson_log-trunc-both.stan
@@ -1,0 +1,12 @@
+// poisson_log doesn't have cdf and ccdf functions
+data {
+  int n;
+  int L;
+  int U;
+}
+parameters {
+  real alpha;
+}
+model {
+  n ~ poisson_log(alpha) T[L, U];
+}

--- a/src/test/test-models/bad/prob-poisson_log-trunc-high.stan
+++ b/src/test/test-models/bad/prob-poisson_log-trunc-high.stan
@@ -8,7 +8,5 @@ parameters {
   real alpha;
 }
 model {
-  n ~ poisson_log(alpha) T[L, ];
   n ~ poisson_log(alpha) T[, U];
-  n ~ poisson_log(alpha) T[L, U];
 }

--- a/src/test/test-models/bad/prob-poisson_log-trunc-low.stan
+++ b/src/test/test-models/bad/prob-poisson_log-trunc-low.stan
@@ -1,0 +1,12 @@
+// poisson_log doesn't have cdf and ccdf functions
+data {
+  int n;
+  int L;
+  int U;
+}
+parameters {
+  real alpha;
+}
+model {
+  n ~ poisson_log(alpha) T[L, ];
+}

--- a/src/test/test-models/bad/prob-poisson_log-trunc.stan
+++ b/src/test/test-models/bad/prob-poisson_log-trunc.stan
@@ -1,0 +1,14 @@
+// poisson_log doesn't have cdf and ccdf functions
+data {
+  int n;
+  int L;
+  int U;
+}
+parameters {
+  real alpha;
+}
+model {
+  n ~ poisson_log(alpha) T[L, ];
+  n ~ poisson_log(alpha) T[, U];
+  n ~ poisson_log(alpha) T[L, U];
+}

--- a/src/test/unit/lang/parser/trunc_test.cpp
+++ b/src/test/unit/lang/parser/trunc_test.cpp
@@ -2,7 +2,13 @@
 #include <test/unit/lang/utility.hpp>
 
 TEST(parserTruncTest, poisson_log_log) {
-  test_throws("prob-poisson_log-trunc",
+  test_throws("prob-poisson_log-trunc-low",
               "lower truncation not defined",
-              "to poisson_log");
+              "arguments to poisson_log");
+  test_throws("prob-poisson_log-trunc-high",
+              "upper truncation not defined",
+              "arguments to poisson_log");
+  test_throws("prob-poisson_log-trunc-both",
+              "lower truncation not defined",
+              "arguments to poisson_log");
 }

--- a/src/test/unit/lang/parser/trunc_test.cpp
+++ b/src/test/unit/lang/parser/trunc_test.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+#include <test/unit/lang/utility.hpp>
+
+TEST(parserTruncTest, poisson_log_log) {
+  test_throws("prob-poisson_log-trunc",
+              "lower truncation not defined",
+              "to poisson_log");
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
This will prevent built in distributions without the appropriate cdf functions to be used in truncation.

#### Intended Effect
I took a pass and checked that the function to be used for truncation isn't the same as the distribution function.

#### How to Verify
Run the unit tests. There's an additional unit test. To run that one:
```
./runTests.py src/test/unit/lang/parser/trunc_test.cpp
```

#### Side Effects
This will stop some existing models from being compiled. They shouldn't have been compiled in the first place.

#### Documentation
None.

#### Reviewer Suggestions
@bob-carpenter. There might be a better fix for this. I took the shortest path I could see.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
