### PR TITLE
Updates test to be compatible with math#382

### DIFF
--- a/src/test/unit/io/reader_test.cpp
+++ b/src/test/unit/io/reader_test.cpp
@@ -938,7 +938,7 @@ TEST(io_reader,cholesky_factor_constrain) {
     theta.push_back(-static_cast<double>(i));
   stan::io::reader<double> reader(theta,theta_i);
   Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> L(reader.cholesky_factor_constrain(3U,3U));
-  EXPECT_TRUE(stan::math::check_cholesky_factor("test_cholesky_factor_constrain","L",L));
+  EXPECT_NO_THROW(stan::math::check_cholesky_factor("test_cholesky_factor_constrain","L",L));
   EXPECT_EQ(3,L.rows());
   EXPECT_EQ(3,L.cols());
   EXPECT_EQ(9,L.size());
@@ -951,7 +951,7 @@ TEST(io_reader,cholesky_factor_constrain_asymmetric) {
     theta.push_back(-static_cast<double>(i));
   stan::io::reader<double> reader(theta,theta_i);
   Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> L(reader.cholesky_factor_constrain(3U,2U));
-  EXPECT_TRUE(stan::math::check_cholesky_factor("test_cholesky_factor_constrain","L",L));
+  EXPECT_NO_THROW(stan::math::check_cholesky_factor("test_cholesky_factor_constrain","L",L));
   EXPECT_EQ(3,L.rows());
   EXPECT_EQ(2,L.cols());
   EXPECT_EQ(6,L.size());
@@ -965,7 +965,7 @@ TEST(io_reader,cholesky_factor_constrain_jacobian) {
   stan::io::reader<double> reader(theta,theta_i);
   double lp = 1.9;
   Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> L(reader.cholesky_factor_constrain(3U,3U,lp));
-  EXPECT_TRUE(stan::math::check_cholesky_factor("test_cholesky_factor_constrain","L",L));
+  EXPECT_NO_THROW(stan::math::check_cholesky_factor("test_cholesky_factor_constrain","L",L));
   EXPECT_EQ(3,L.rows());
   EXPECT_EQ(3,L.cols());
   EXPECT_EQ(9,L.size());
@@ -981,7 +981,7 @@ TEST(io_reader,cholesky_factor_constrain_jacobian_asymmetric) {
   stan::io::reader<double> reader(theta,theta_i);
   double lp = 1.9;
   Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> L(reader.cholesky_factor_constrain(4U,3U,lp));
-  EXPECT_TRUE(stan::math::check_cholesky_factor("test_cholesky_factor_constrain","L",L));
+  EXPECT_NO_THROW(stan::math::check_cholesky_factor("test_cholesky_factor_constrain","L",L));
   EXPECT_EQ(4,L.rows());
   EXPECT_EQ(3,L.cols());
   EXPECT_EQ(12,L.size());


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Update to test code that stopped compiling with fix to stan-dev/math#382.

#### Intended Effect
Fixes Stan test code.

#### How to Verify
Run tests.

#### Side Effects
None.

#### Documentation
None.

#### Reviewer Suggestions
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

