### PR TITLE
Vectorize in Stan vectorized functions in math

### DIFF
--- a/src/docs/stan-reference/functions.tex
+++ b/src/docs/stan-reference/functions.tex
@@ -147,8 +147,7 @@ This is a no-op.
 
 \begin{description}
 %
-\fitem{int}{abs}{int \farg{x}}{
-  Returns the absolute value of \farg{x}. 
+  \fitemUnaryVec{abs}{absolute value of \farg{x}}{
   \[\mbox{abs}(x) = |x|\]}
 %
 \fitemnobody{int}{int\_step}{int \farg{x}}
@@ -681,10 +680,7 @@ as \code{x~+~y} and \code{-x}, respectively.
 
 \begin{description}
 %
-  \fitem{real}{abs}{real \farg{x}}{     
-    Returns the absolute value of \farg{x}\,;
-    this function is deprecated and will be removed in the future;
-    please use \code{fabs} instead.
+  \fitemUnaryVec{abs}{absolute value of \farg{x}\,; this function is deprecated and will be removed in the future; please use \code{fabs} instead}{
     \[
     \mbox{\code{abs}}(x) = |x|
     \]}
@@ -771,25 +767,17 @@ of these in the future, but as of now, there is no good workaround.
 
 \begin{description}
   %
-  \fitem{real}{floor}{real \farg{x}}{
-    Returns the floor of \farg{x}, which is the largest integer less
-    than or equal to \farg{x}, converted to a real value;
-    see warning at start of \refsection{step-functions}.
+  \fitemUnaryVec{floor}{floor of \farg{x}, which is the largest integer less than or equal to \farg{x}, converted to a real value; see warning at start of \refsection{step-functions}}{
     \[
     \mbox{\code{floor}}(x) = \lfloor x \rfloor
     \]}
   %
-  \fitem{real}{ceil}{real \farg{x}}{
-    Returns the ceiling of \farg{x}, which is the smallest integer greater
-    than or equal to \farg{x}, converted to a real value;
-    see warning at start of \refsection{step-functions}.
+  \fitemUnaryVec{ceil}{ceiling of \farg{x}, which is the smallest integer greater than or equal to \farg{x}, converted to a real value; see warning at start of \refsection{step-functions}}{
     \[
     \mbox{\code{ceil}}(x) = \lceil x\rceil
     \]}
   %
-  \fitem{real}{round}{real \farg{x}}{
-    Returns the nearest integer to \farg{x}, converted to a real value;
-    see warning at start of \refsection{step-functions}.
+  \fitemUnaryVec{round}{nearest integer to \farg{x}, converted to a real value; see warning at start of \refsection{step-functions}}{
     \[
     \mbox{\code{round}}(x) = 
     \begin{cases}
@@ -814,8 +802,7 @@ of these in the future, but as of now, there is no good workaround.
 %
 \begin{description}
   %
-  \fitem{real}{sqrt}{real \farg{x}}{
-    Returns the square root of \farg{x}.
+  \fitemUnaryVec{sqrt}{square root of \farg{x}}{
     \[
     \mbox{\code{sqrt}}(x) = 
     \begin{cases}
@@ -824,19 +811,17 @@ of these in the future, but as of now, there is no good workaround.
     \end{cases}
     \]}
   %
-  \fitem{real}{cbrt}{real \farg{x}}{
-    Returns the cube root of \farg{x}
+  \fitemUnaryVec{cbrt}{cube root of \farg{x}}{
     \[
     \mbox{\code{cbrt}}(x) = \sqrt[3]{x}
     \]}
   %
-  \fitem{real}{square}{real \farg{x}}{
-    Returns the square of \farg{x}.
+  \fitemUnaryVec{square}{square of \farg{x}}{
     \[
     \mbox{\code{square}}(x) = x^2
     \]}
   %
-  \fitemUnaryVec{exp}{natural exponential}{
+  \fitemUnaryVec{exp}{natural exponential of \farg{x}}{
     \[
     \mbox{\code{exp}}(x) \ = \ \exp(x)
     \ = \ e^x
@@ -848,8 +833,7 @@ of these in the future, but as of now, there is no good workaround.
     \mbox{\code{exp2}}(x) = 2^x
     \]}
   %
-  \fitem{real}{log}{real \farg{x}}{
-    Returns the natural logarithm of \farg{x}.
+  \fitemUnaryVec{log}{natural logarithm of \farg{x}}{
     \[
     \mbox{\code{log}}(x) = \log x =
     \begin{cases}
@@ -868,8 +852,7 @@ of these in the future, but as of now, there is no good workaround.
     \end{cases}
     \]}
   %
-  \fitem{real}{log10}{real \farg{x}}{
-    Returns the base-10 logarithm of \farg{x}.
+  \fitemUnaryVec{log10}{base-10 logarithm of \farg{x}}{
     \[
     \mbox{\code{log10}}(x) = 
     \begin{cases}
@@ -884,8 +867,7 @@ of these in the future, but as of now, there is no good workaround.
     \mbox{\code{pow}}(x,y) = x^y
     \]}
   %
-  \fitem{real}{inv}{real \farg{x}}{
-    Returns the inverse of \farg{x}.
+  \fitemUnaryVec{inv}{inverse of \farg{x}}{
     \[
     \mbox{\code{inv}}(x) = \frac{1}{x}
     \]}    
@@ -924,26 +906,22 @@ of these in the future, but as of now, there is no good workaround.
     \end{cases}
     \]}
   %
-  \fitem{real}{cos}{real \farg{x}}{
-    Returns the cosine of the angle \farg{x} (in radians).
+  \fitemUnaryVec{cos}{cosine of the angle \farg{x} (in radians)}{
     \[
     \mbox{\code{cos}}(x) = \cos(x)
     \]}
   %
-  \fitem{real}{sin}{real \farg{x}}{
-    Returns the sine of the angle \farg{x} (in radians).
+  \fitemUnaryVec{sin}{sine of the angle \farg{x} (in radians)}{
     \[
     \mbox{\code{sin}}(x) = \sin(x)
     \]}
   %
-  \fitem{real}{tan}{real \farg{x}}{
-    Returns the tangent of the angle \farg{x} (in radians).
+  \fitemUnaryVec{tan}{tangent of the angle \farg{x} (in radians)}{
     \[
     \mbox{tan}(x) = \tan(x)
     \]}
   %
-  \fitem{real}{acos}{real \farg{x}}{
-    Returns the principal arc (inverse) cosine (in radians) of \farg{x}.
+  \fitemUnaryVec{acos}{principal arc (inverse) cosine (in radians) of \farg{x}}{
     \[
     \mbox{\code{acos}}(x) = 
     \begin{cases}
@@ -952,8 +930,7 @@ of these in the future, but as of now, there is no good workaround.
     \end{cases}
     \]}
   %
-  \fitem{real}{asin}{real \farg{x}}{
-    Returns the principal arc (inverse) sine (in radians) of \farg{x}.
+  \fitemUnaryVec{asin}{principal arc (inverse) sine (in radians) of \farg{x}}{
     \[
     \mbox{\code{asin}}(x) = 
     \begin{cases}
@@ -962,8 +939,7 @@ of these in the future, but as of now, there is no good workaround.
     \end{cases}
     \]}
   %
-  \fitem{real}{atan}{real \farg{x}}{
-    Returns the principal arc (inverse) tangent (in radians) of \farg{x}.
+  \fitemUnaryVec{atan}{principal arc (inverse) tangent (in radians) of \farg{x}}{
     \[
     \mbox{\code{atan}}(x) = \arctan(x)
     \]}
@@ -982,20 +958,17 @@ of these in the future, but as of now, there is no good workaround.
 %
 \begin{description}
   %
-  \fitem{real}{cosh}{real \farg{x}}{
-    Returns the hyperbolic cosine of \farg{x} (in radians).
+  \fitemUnaryVec{cosh}{hyperbolic cosine of \farg{x} (in radians)}{
     \[
     \mbox{\code{cosh}}(x) = \cosh(x)
     \]}
   %
-  \fitem{real}{sinh}{real \farg{x}}{
-    Returns the hyperbolic sine of \farg{x} (in radians).
+  \fitemUnaryVec{sinh}{hyperbolic sine of \farg{x} (in radians)}{
     \[
     \mbox{\code{sinh}}(x) = \sinh(x)
     \]}
   %
-  \fitem{real}{tanh}{real \farg{x}}{
-    Returns the hyperbolic tangent of \farg{x} (in radians).
+  \fitemUnaryVec{tanh}{hyperbolic tangent of \farg{x} (in radians)}{
     \[
     \mbox{\code{tanh}}(x) = \tanh(x)
     \]}
@@ -1078,20 +1051,17 @@ distribution function (and its complement).
 %
 \begin{description}
   %
-  \fitem{real}{erf}{real \farg{x}}{
-    Returns the error function, also known as the Gauss error function, of \farg{x}.
+  \fitemUnaryVec{erf}{error function, also known as the Gauss error function, of \farg{x}}{
     \[
     \mbox{\code{erf}}(x) = \frac{2}{\sqrt{\pi}}\int_0^x e^{-t^2}dt
     \]}
   %
-  \fitem{real}{erfc}{real \farg{x}}{
-    Returns the complementary error function of \farg{x}.
+  \fitemUnaryVec{erfc}{complementary error function of \farg{x}}{
     \[
     \mbox{\code{erfc}}(x) = \frac{2}{\sqrt{\pi}}\int_x^\infty e^{-t^2}dt
     \]}
   %
-  \fitemindexsort{real}{Phi}{real \farg{x}}{
-    Returns the unit normal cumulative distribution function of \farg{x}.
+  \fitemUnaryVec{Phi}{unit normal cumulative distribution function of \farg{x}}{
     \[
     \mbox{\code{Phi}}(x) = \frac{1}{\sqrt{2\pi}} \int_{0}^{x} e^{-t^2/2} dt
     \]}{Phi}{phi}
@@ -1163,11 +1133,7 @@ distribution function (and its complement).
     See \refsection{beta-appendix} for definition of $\mbox{B}(\alpha, \beta)$.
   }
   %
-  \fitem{real}{tgamma}{real \farg{x}}{
-    Returns the gamma function applied to \farg{x}.  The gamma function 
-    is the generalization of the factorial function to continuous variables,
-    defined so that $\Gamma(n+1) = n!$.  The function is defined for
-    positive numbers and non-integral negative numbers.
+  \fitemUnaryVec{tgamma}{gamma function applied to \farg{x}.  The gamma function  is the generalization of the factorial function to continuous variables, defined so that $\Gamma(n+1) = n!$.  The function is defined for positive numbers and non-integral negative numbers}{
     \[
     \mbox{\code{tgamma}}(x) 
     = 
@@ -1193,10 +1159,7 @@ distribution function (and its complement).
     %
     See \refsection{gamma-appendix} for definition of $\Gamma(x)$.}
   %
-  \fitem{real}{digamma}{real \farg{x}}{
-    Returns the digamma function applied to \farg{x}.  The digamma function is the
-    derivative of the natural logarithm of the Gamma function.  The function is defined 
-    for positive numbers and non-integral negative numbers.
+  \fitemUnaryVec{digamma}{digamma function applied to \farg{x}.  The digamma function is the derivative of the natural logarithm of the Gamma function.  The function is defined  for positive numbers and non-integral negative numbers}{
     \[
     \mbox{\code{digamma}}(x) 
     = 
@@ -1414,8 +1377,7 @@ using more basic \Stan functions.
 %
 \begin{description}
   %
-  \fitem{real}{expm1}{real \farg{x}}{
-    Returns the natural exponential of \farg{x} minus 1.
+  \fitemUnaryVec{expm1}{natural exponential of \farg{x} minus 1}{
     \[
     \mbox{\code{expm1}}(x) = e^x - 1
     \]}
@@ -1463,8 +1425,7 @@ using more basic \Stan functions.
     \end{cases}
     \]}
   %
-  \fitem{real}{log1m}{real \farg{x}}{
-    Returns the natural logarithm of 1 minus \farg{x}.
+  \fitemUnaryVec{log1m}{natural logarithm of 1 minus \farg{x}}{
     \[
     \mbox{\code{log1m}}(x) = 
     \begin{cases}
@@ -2163,19 +2124,6 @@ matrix, returning a result of the same shape as the argument.  There
 are many functions that are vectorized in addition to the ad hoc cases
 listed in this section;  see \refsection{fun-vectorization} for the
 general cases.
-
-\begin{description}
-%
-\fitem{vector}{log}{vector \farg{x}}{
-The elementwise natural logarithm of \farg{x}}
-%
-\fitem{row\_vector}{log}{row\_vector \farg{x}}{
-The elementwise natural logarithm of \farg{x}}
-%
-\fitem{matrix}{log}{matrix \farg{x}}{
-The elementwise natural logarithm of \farg{x}}
-%
-\end{description}
 
 
 

--- a/src/docs/stan-reference/stan-manuals.sty
+++ b/src/docs/stan-reference/stan-manuals.sty
@@ -155,7 +155,7 @@
 
 
 \newcommand{\fitemUnaryVec}[3]{
-  \fitem{R}{#1}{T \farg{x}}{Returns the #2 of \farg{x}, defined by #3
+  \fitem{R}{#1}{T \farg{x}}{Returns the #2. It is defined by #3
     Applies elementwise to any scalar, vector, matrix, or array
     argument type \code{T}; the return type is the same as the
     argument type with \code{int} promoted to \code{real};

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -22,9 +22,8 @@ std::vector<expr_type> primitive_types;
 primitive_types.push_back(INT_T);
 primitive_types.push_back(DOUBLE_T);
 
-add_unary("abs");
-add("abs", INT_T, INT_T);
-add_unary("acos");
+add_unary_vectorized("abs");
+add_unary_vectorized("acos");
 add_unary("acosh");
 for (size_t i = 0; i < base_types.size(); ++i) {
   add("add", base_types[i], base_types[i], base_types[i]);
@@ -38,9 +37,9 @@ add("add", MATRIX_T, DOUBLE_T, MATRIX_T);
 for (size_t i = 0; i < base_types.size(); ++i) {
   add("add", base_types[i], base_types[i]);
 }
-add_unary("asin");
-add_unary("asinh");
-add_unary("atan");
+add_unary_vectorized("asin");
+add_unary_vectorized("asinh");
+add_unary_vectorized("atan");
 add_binary("atan2");
 add_unary("atanh");
 for (size_t i = 0; i < int_vector_types.size(); ++i)
@@ -188,8 +187,8 @@ add("append_col", MATRIX_T, VECTOR_T, VECTOR_T);
 add("append_col", ROW_VECTOR_T, ROW_VECTOR_T, ROW_VECTOR_T);
 add("append_col", ROW_VECTOR_T, DOUBLE_T, ROW_VECTOR_T);
 add("append_col", ROW_VECTOR_T, ROW_VECTOR_T, DOUBLE_T);
-add_unary("cbrt");
-add_unary("ceil");
+add_unary_vectorized("cbrt");
+add_unary_vectorized("ceil");
 for (size_t i = 0; i < vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {
       add("chi_square_ccdf_log", DOUBLE_T, vector_types[i],
@@ -220,8 +219,8 @@ add("columns_dot_product", ROW_VECTOR_T, MATRIX_T, MATRIX_T);
 add("columns_dot_self", ROW_VECTOR_T, VECTOR_T);
 add("columns_dot_self", ROW_VECTOR_T, ROW_VECTOR_T);
 add("columns_dot_self", ROW_VECTOR_T, MATRIX_T);
-add_unary("cos");
-add_unary("cosh");
+add_unary_vectorized("cos");
+add_unary_vectorized("cosh");
 add("cov_exp_quad", MATRIX_T, expr_type(DOUBLE_T, 1U), DOUBLE_T, DOUBLE_T);
 add("cov_exp_quad", MATRIX_T, expr_type(VECTOR_T, 1U), DOUBLE_T, DOUBLE_T);
 add("cov_exp_quad", MATRIX_T, expr_type(ROW_VECTOR_T, 1U), DOUBLE_T, DOUBLE_T);
@@ -247,7 +246,7 @@ add("diag_post_multiply", MATRIX_T, MATRIX_T, ROW_VECTOR_T);
 add("diag_pre_multiply", MATRIX_T, VECTOR_T, MATRIX_T);
 add("diag_pre_multiply", MATRIX_T, ROW_VECTOR_T, MATRIX_T);
 add("diagonal", VECTOR_T, MATRIX_T);
-add_unary("digamma");
+add_unary_vectorized("digamma");
 for (size_t i = 0; i < 8; ++i) {
   add("dims", expr_type(INT_T, 1), expr_type(INT_T, i));
   add("dims", expr_type(INT_T, 1), expr_type(DOUBLE_T, i));
@@ -313,8 +312,8 @@ add("elt_divide", MATRIX_T, DOUBLE_T, MATRIX_T);
 add("elt_multiply", VECTOR_T, VECTOR_T, VECTOR_T);
 add("elt_multiply", ROW_VECTOR_T, ROW_VECTOR_T, ROW_VECTOR_T);
 add("elt_multiply", MATRIX_T, MATRIX_T, MATRIX_T);
-add_unary("erf");
-add_unary("erfc");
+add_unary_vectorized("erf");
+add_unary_vectorized("erfc");
 add_unary_vectorized("exp");
 add_unary("exp2");
 for (size_t i = 0; i < vector_types.size(); ++i) {
@@ -340,7 +339,7 @@ for (size_t i = 0; i < vector_types.size(); ++i) {
   }
 }
 add_ternary("exp_mod_normal_rng");
-add_unary("expm1");
+add_unary_vectorized("expm1");
 for (size_t i = 0; i < vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {
       add("exponential_ccdf_log", DOUBLE_T, vector_types[i], vector_types[j]);
@@ -356,7 +355,7 @@ add_unary("exponential_rng");
 add_unary("fabs");
 add_binary("falling_factorial");
 add_binary("fdim");
-add_unary("floor");
+add_unary_vectorized("floor");
 add_ternary("fma");
 add_binary("fmax");
 add_binary("fmin");
@@ -453,7 +452,7 @@ add("if_else", DOUBLE_T, INT_T, DOUBLE_T, DOUBLE_T);
 add("inc_beta", DOUBLE_T, DOUBLE_T, DOUBLE_T, DOUBLE_T);
 add("int_step", INT_T, DOUBLE_T);
 add("int_step", INT_T, INT_T);
-add_unary("inv");
+add_unary_vectorized("inv");
 for (size_t i = 0; i < vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {
     add("inv_chi_square_ccdf_log", DOUBLE_T, vector_types[i], vector_types[j]);
@@ -466,7 +465,7 @@ for (size_t i = 0; i < vector_types.size(); ++i) {
   }
 }
 add_unary("inv_chi_square_rng");
-add_unary("inv_cloglog");
+add_unary_vectorized("inv_cloglog");
 for (size_t i = 0; i < vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {
     for (size_t k = 0; k < vector_types.size(); ++k) {
@@ -488,10 +487,10 @@ for (size_t i = 0; i < vector_types.size(); ++i) {
   }
 }
 add_binary("inv_gamma_rng");
-add_unary("inv_logit");
-add_unary("inv_Phi");
-add_unary("inv_sqrt");
-add_unary("inv_square");
+add_unary_vectorized("inv_logit");
+add_unary_vectorized("inv_Phi");
+add_unary_vectorized("inv_sqrt");
+add_unary_vectorized("inv_square");
 add("inv_wishart_log", DOUBLE_T, MATRIX_T, DOUBLE_T, MATRIX_T);
 add("inv_wishart_lpdf", DOUBLE_T, MATRIX_T, DOUBLE_T, MATRIX_T);
 add("inv_wishart_rng", MATRIX_T, DOUBLE_T, MATRIX_T);
@@ -511,17 +510,14 @@ add("lkj_corr_rng", MATRIX_T, INT_T, DOUBLE_T);
 add("lkj_cov_log", DOUBLE_T, MATRIX_T, VECTOR_T, VECTOR_T, DOUBLE_T);
 add("lmgamma", DOUBLE_T, INT_T, DOUBLE_T);
 add_binary("lmultiply");
-add_unary("log");
-add("log", VECTOR_T, VECTOR_T);
-add("log", ROW_VECTOR_T, ROW_VECTOR_T);
-add("log", MATRIX_T, MATRIX_T);
+add_unary_vectorized("log");
 add_nullary("log10");
-add_unary("log10");
-add_unary("log1m");
-add_unary("log1m_exp");
+add_unary_vectorized("log10");
+add_unary_vectorized("log1m");
+add_unary_vectorized("log1m_exp");
 add_unary("log1m_inv_logit");
 add_unary("log1p");
-add_unary("log1p_exp");
+add_unary_vectorized("log1p_exp");
 add_nullary("log2");
 add_unary("log2");
 add("log_determinant", DOUBLE_T, MATRIX_T);
@@ -824,7 +820,7 @@ for (size_t i = 0; i < vector_types.size(); ++i) {
   }
 }
 add_ternary("pareto_type_2_rng");
-add_unary("Phi");
+add_unary_vectorized("Phi");
 add_unary("Phi_approx");
 add_nullary("pi");
 for (size_t i = 0; i < int_vector_types.size(); ++i) {
@@ -911,7 +907,7 @@ add("rep_matrix", MATRIX_T, ROW_VECTOR_T, INT_T);
 add("rep_row_vector", ROW_VECTOR_T, DOUBLE_T, INT_T);
 add("rep_vector", VECTOR_T, DOUBLE_T, INT_T);
 add_binary("rising_factorial");
-add_unary("round");
+add_unary_vectorized("round");
 add("row", ROW_VECTOR_T, MATRIX_T, INT_T);
 add("rows", INT_T, VECTOR_T);
 add("rows", INT_T, ROW_VECTOR_T);
@@ -957,9 +953,9 @@ for (size_t i = 0; i < base_types.size(); ++i) {
   add("segment", expr_type(base_types[i], 3U),
       expr_type(base_types[i], 3U), INT_T, INT_T);
 }
-add_unary("sin");
+add_unary_vectorized("sin");
 add("singular_values", VECTOR_T, MATRIX_T);
-add_unary("sinh");
+add_unary_vectorized("sinh");
 // size() is polymorphic over arrays, so start i at 1
 for (size_t i = 1; i < 8; ++i) {
   add("size", INT_T, expr_type(INT_T, i));
@@ -1014,9 +1010,9 @@ add("squared_distance", DOUBLE_T, VECTOR_T, VECTOR_T);
 add("squared_distance", DOUBLE_T, ROW_VECTOR_T, ROW_VECTOR_T);
 add("squared_distance", DOUBLE_T, VECTOR_T, ROW_VECTOR_T);
 add("squared_distance", DOUBLE_T, ROW_VECTOR_T, VECTOR_T);
-add_unary("sqrt");
+add_unary_vectorized("sqrt");
 add_nullary("sqrt2");
-add_unary("square");
+add_unary_vectorized("square");
 add_unary("step");
 for (size_t i = 0; i < vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {
@@ -1067,11 +1063,11 @@ for (size_t i = 0; i < base_types.size(); ++i) {
   add("tail", expr_type(base_types[i], 3U),
       expr_type(base_types[i], 3U), INT_T);
 }
-add_unary("tan");
-add_unary("tanh");
+add_unary_vectorized("tan");
+add_unary_vectorized("tanh");
 add_nullary("target");  // converted to "get_lp" in term_grammar semantics
 add("tcrossprod", MATRIX_T, MATRIX_T);
-add_unary("tgamma");
+add_unary_vectorized("tgamma");
 add("to_array_1d", expr_type(DOUBLE_T, 1), MATRIX_T);
 add("to_array_1d", expr_type(DOUBLE_T, 1), VECTOR_T);
 add("to_array_1d", expr_type(DOUBLE_T, 1), ROW_VECTOR_T);

--- a/src/test/test-models/good/function-signatures/math/functions/abs.stan
+++ b/src/test/test-models/good/function-signatures/math/functions/abs.stan
@@ -6,8 +6,8 @@ transformed data {
   int transformed_data_int;
   real transformed_data_real;
  
-   transformed_data_int <- abs(d_int);
-   transformed_data_real <- abs(d_real);
+  transformed_data_real <- abs(d_int);
+  transformed_data_real <- abs(d_real);
 }
 parameters {
   real p_real;

--- a/src/test/test-models/good/function-signatures/math/matrix/Phi.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/Phi.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- Phi(d_matrix);
+  transformed_data_vector <- Phi(d_vector);
+  transformed_data_row_vector <- Phi(d_row_vector);
+  trans_x3y <- Phi(x3y);
+  trans_x4y <- Phi(x4y);
+  trans_x5y <- Phi(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- Phi(x1z);
+  trans_x2z <- Phi(x2z);
+  trans_x3z <- Phi(x3z);
+  trans_x4z <- Phi(x4z);
+  trans_x5z <- Phi(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- Phi(x1w);
+  trans_x2w <- Phi(x2w);
+  trans_x3w <- Phi(x3w);
+  trans_x4w <- Phi(x4w);
+  trans_x5w <- Phi(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- Phi(d_matrix);
+  transformed_param_vector <- Phi(d_vector);
+  transformed_param_row_vector <- Phi(d_row_vector);
+  transformed_param_matrix <- Phi(p_matrix);
+  transformed_param_vector <- Phi(p_vector);
+  transformed_param_row_vector <- Phi(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- Phi(p_x3y);
+  trans_p_x4y <- Phi(p_x4y);
+  trans_p_x5y <- Phi(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- Phi(p_x2z);
+  trans_p_x3z <- Phi(p_x3z);
+  trans_p_x4z <- Phi(p_x4z);
+  trans_p_x5z <- Phi(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- Phi(p_x2w);
+  trans_p_x3w <- Phi(p_x3w);
+  trans_p_x4w <- Phi(p_x4w);
+  trans_p_x5w <- Phi(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/abs.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/abs.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- abs(d_matrix);
+  transformed_data_vector <- abs(d_vector);
+  transformed_data_row_vector <- abs(d_row_vector);
+  trans_x3y <- abs(x3y);
+  trans_x4y <- abs(x4y);
+  trans_x5y <- abs(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- abs(x1z);
+  trans_x2z <- abs(x2z);
+  trans_x3z <- abs(x3z);
+  trans_x4z <- abs(x4z);
+  trans_x5z <- abs(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- abs(x1w);
+  trans_x2w <- abs(x2w);
+  trans_x3w <- abs(x3w);
+  trans_x4w <- abs(x4w);
+  trans_x5w <- abs(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- abs(d_matrix);
+  transformed_param_vector <- abs(d_vector);
+  transformed_param_row_vector <- abs(d_row_vector);
+  transformed_param_matrix <- abs(p_matrix);
+  transformed_param_vector <- abs(p_vector);
+  transformed_param_row_vector <- abs(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- abs(p_x3y);
+  trans_p_x4y <- abs(p_x4y);
+  trans_p_x5y <- abs(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- abs(p_x2z);
+  trans_p_x3z <- abs(p_x3z);
+  trans_p_x4z <- abs(p_x4z);
+  trans_p_x5z <- abs(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- abs(p_x2w);
+  trans_p_x3w <- abs(p_x3w);
+  trans_p_x4w <- abs(p_x4w);
+  trans_p_x5w <- abs(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/acos.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/acos.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- acos(d_matrix);
+  transformed_data_vector <- acos(d_vector);
+  transformed_data_row_vector <- acos(d_row_vector);
+  trans_x3y <- acos(x3y);
+  trans_x4y <- acos(x4y);
+  trans_x5y <- acos(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- acos(x1z);
+  trans_x2z <- acos(x2z);
+  trans_x3z <- acos(x3z);
+  trans_x4z <- acos(x4z);
+  trans_x5z <- acos(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- acos(x1w);
+  trans_x2w <- acos(x2w);
+  trans_x3w <- acos(x3w);
+  trans_x4w <- acos(x4w);
+  trans_x5w <- acos(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- acos(d_matrix);
+  transformed_param_vector <- acos(d_vector);
+  transformed_param_row_vector <- acos(d_row_vector);
+  transformed_param_matrix <- acos(p_matrix);
+  transformed_param_vector <- acos(p_vector);
+  transformed_param_row_vector <- acos(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- acos(p_x3y);
+  trans_p_x4y <- acos(p_x4y);
+  trans_p_x5y <- acos(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- acos(p_x2z);
+  trans_p_x3z <- acos(p_x3z);
+  trans_p_x4z <- acos(p_x4z);
+  trans_p_x5z <- acos(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- acos(p_x2w);
+  trans_p_x3w <- acos(p_x3w);
+  trans_p_x4w <- acos(p_x4w);
+  trans_p_x5w <- acos(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/asin.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/asin.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- asin(d_matrix);
+  transformed_data_vector <- asin(d_vector);
+  transformed_data_row_vector <- asin(d_row_vector);
+  trans_x3y <- asin(x3y);
+  trans_x4y <- asin(x4y);
+  trans_x5y <- asin(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- asin(x1z);
+  trans_x2z <- asin(x2z);
+  trans_x3z <- asin(x3z);
+  trans_x4z <- asin(x4z);
+  trans_x5z <- asin(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- asin(x1w);
+  trans_x2w <- asin(x2w);
+  trans_x3w <- asin(x3w);
+  trans_x4w <- asin(x4w);
+  trans_x5w <- asin(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- asin(d_matrix);
+  transformed_param_vector <- asin(d_vector);
+  transformed_param_row_vector <- asin(d_row_vector);
+  transformed_param_matrix <- asin(p_matrix);
+  transformed_param_vector <- asin(p_vector);
+  transformed_param_row_vector <- asin(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- asin(p_x3y);
+  trans_p_x4y <- asin(p_x4y);
+  trans_p_x5y <- asin(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- asin(p_x2z);
+  trans_p_x3z <- asin(p_x3z);
+  trans_p_x4z <- asin(p_x4z);
+  trans_p_x5z <- asin(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- asin(p_x2w);
+  trans_p_x3w <- asin(p_x3w);
+  trans_p_x4w <- asin(p_x4w);
+  trans_p_x5w <- asin(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/asinh.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/asinh.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- asinh(d_matrix);
+  transformed_data_vector <- asinh(d_vector);
+  transformed_data_row_vector <- asinh(d_row_vector);
+  trans_x3y <- asinh(x3y);
+  trans_x4y <- asinh(x4y);
+  trans_x5y <- asinh(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- asinh(x1z);
+  trans_x2z <- asinh(x2z);
+  trans_x3z <- asinh(x3z);
+  trans_x4z <- asinh(x4z);
+  trans_x5z <- asinh(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- asinh(x1w);
+  trans_x2w <- asinh(x2w);
+  trans_x3w <- asinh(x3w);
+  trans_x4w <- asinh(x4w);
+  trans_x5w <- asinh(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- asinh(d_matrix);
+  transformed_param_vector <- asinh(d_vector);
+  transformed_param_row_vector <- asinh(d_row_vector);
+  transformed_param_matrix <- asinh(p_matrix);
+  transformed_param_vector <- asinh(p_vector);
+  transformed_param_row_vector <- asinh(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- asinh(p_x3y);
+  trans_p_x4y <- asinh(p_x4y);
+  trans_p_x5y <- asinh(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- asinh(p_x2z);
+  trans_p_x3z <- asinh(p_x3z);
+  trans_p_x4z <- asinh(p_x4z);
+  trans_p_x5z <- asinh(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- asinh(p_x2w);
+  trans_p_x3w <- asinh(p_x3w);
+  trans_p_x4w <- asinh(p_x4w);
+  trans_p_x5w <- asinh(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/atan.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/atan.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- atan(d_matrix);
+  transformed_data_vector <- atan(d_vector);
+  transformed_data_row_vector <- atan(d_row_vector);
+  trans_x3y <- atan(x3y);
+  trans_x4y <- atan(x4y);
+  trans_x5y <- atan(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- atan(x1z);
+  trans_x2z <- atan(x2z);
+  trans_x3z <- atan(x3z);
+  trans_x4z <- atan(x4z);
+  trans_x5z <- atan(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- atan(x1w);
+  trans_x2w <- atan(x2w);
+  trans_x3w <- atan(x3w);
+  trans_x4w <- atan(x4w);
+  trans_x5w <- atan(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- atan(d_matrix);
+  transformed_param_vector <- atan(d_vector);
+  transformed_param_row_vector <- atan(d_row_vector);
+  transformed_param_matrix <- atan(p_matrix);
+  transformed_param_vector <- atan(p_vector);
+  transformed_param_row_vector <- atan(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- atan(p_x3y);
+  trans_p_x4y <- atan(p_x4y);
+  trans_p_x5y <- atan(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- atan(p_x2z);
+  trans_p_x3z <- atan(p_x3z);
+  trans_p_x4z <- atan(p_x4z);
+  trans_p_x5z <- atan(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- atan(p_x2w);
+  trans_p_x3w <- atan(p_x3w);
+  trans_p_x4w <- atan(p_x4w);
+  trans_p_x5w <- atan(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/cbrt.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/cbrt.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- cbrt(d_matrix);
+  transformed_data_vector <- cbrt(d_vector);
+  transformed_data_row_vector <- cbrt(d_row_vector);
+  trans_x3y <- cbrt(x3y);
+  trans_x4y <- cbrt(x4y);
+  trans_x5y <- cbrt(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- cbrt(x1z);
+  trans_x2z <- cbrt(x2z);
+  trans_x3z <- cbrt(x3z);
+  trans_x4z <- cbrt(x4z);
+  trans_x5z <- cbrt(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- cbrt(x1w);
+  trans_x2w <- cbrt(x2w);
+  trans_x3w <- cbrt(x3w);
+  trans_x4w <- cbrt(x4w);
+  trans_x5w <- cbrt(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- cbrt(d_matrix);
+  transformed_param_vector <- cbrt(d_vector);
+  transformed_param_row_vector <- cbrt(d_row_vector);
+  transformed_param_matrix <- cbrt(p_matrix);
+  transformed_param_vector <- cbrt(p_vector);
+  transformed_param_row_vector <- cbrt(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- cbrt(p_x3y);
+  trans_p_x4y <- cbrt(p_x4y);
+  trans_p_x5y <- cbrt(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- cbrt(p_x2z);
+  trans_p_x3z <- cbrt(p_x3z);
+  trans_p_x4z <- cbrt(p_x4z);
+  trans_p_x5z <- cbrt(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- cbrt(p_x2w);
+  trans_p_x3w <- cbrt(p_x3w);
+  trans_p_x4w <- cbrt(p_x4w);
+  trans_p_x5w <- cbrt(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/ceil.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/ceil.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- ceil(d_matrix);
+  transformed_data_vector <- ceil(d_vector);
+  transformed_data_row_vector <- ceil(d_row_vector);
+  trans_x3y <- ceil(x3y);
+  trans_x4y <- ceil(x4y);
+  trans_x5y <- ceil(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- ceil(x1z);
+  trans_x2z <- ceil(x2z);
+  trans_x3z <- ceil(x3z);
+  trans_x4z <- ceil(x4z);
+  trans_x5z <- ceil(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- ceil(x1w);
+  trans_x2w <- ceil(x2w);
+  trans_x3w <- ceil(x3w);
+  trans_x4w <- ceil(x4w);
+  trans_x5w <- ceil(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- ceil(d_matrix);
+  transformed_param_vector <- ceil(d_vector);
+  transformed_param_row_vector <- ceil(d_row_vector);
+  transformed_param_matrix <- ceil(p_matrix);
+  transformed_param_vector <- ceil(p_vector);
+  transformed_param_row_vector <- ceil(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- ceil(p_x3y);
+  trans_p_x4y <- ceil(p_x4y);
+  trans_p_x5y <- ceil(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- ceil(p_x2z);
+  trans_p_x3z <- ceil(p_x3z);
+  trans_p_x4z <- ceil(p_x4z);
+  trans_p_x5z <- ceil(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- ceil(p_x2w);
+  trans_p_x3w <- ceil(p_x3w);
+  trans_p_x4w <- ceil(p_x4w);
+  trans_p_x5w <- ceil(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/cos.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/cos.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- cos(d_matrix);
+  transformed_data_vector <- cos(d_vector);
+  transformed_data_row_vector <- cos(d_row_vector);
+  trans_x3y <- cos(x3y);
+  trans_x4y <- cos(x4y);
+  trans_x5y <- cos(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- cos(x1z);
+  trans_x2z <- cos(x2z);
+  trans_x3z <- cos(x3z);
+  trans_x4z <- cos(x4z);
+  trans_x5z <- cos(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- cos(x1w);
+  trans_x2w <- cos(x2w);
+  trans_x3w <- cos(x3w);
+  trans_x4w <- cos(x4w);
+  trans_x5w <- cos(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- cos(d_matrix);
+  transformed_param_vector <- cos(d_vector);
+  transformed_param_row_vector <- cos(d_row_vector);
+  transformed_param_matrix <- cos(p_matrix);
+  transformed_param_vector <- cos(p_vector);
+  transformed_param_row_vector <- cos(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- cos(p_x3y);
+  trans_p_x4y <- cos(p_x4y);
+  trans_p_x5y <- cos(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- cos(p_x2z);
+  trans_p_x3z <- cos(p_x3z);
+  trans_p_x4z <- cos(p_x4z);
+  trans_p_x5z <- cos(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- cos(p_x2w);
+  trans_p_x3w <- cos(p_x3w);
+  trans_p_x4w <- cos(p_x4w);
+  trans_p_x5w <- cos(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/cosh.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/cosh.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- cosh(d_matrix);
+  transformed_data_vector <- cosh(d_vector);
+  transformed_data_row_vector <- cosh(d_row_vector);
+  trans_x3y <- cosh(x3y);
+  trans_x4y <- cosh(x4y);
+  trans_x5y <- cosh(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- cosh(x1z);
+  trans_x2z <- cosh(x2z);
+  trans_x3z <- cosh(x3z);
+  trans_x4z <- cosh(x4z);
+  trans_x5z <- cosh(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- cosh(x1w);
+  trans_x2w <- cosh(x2w);
+  trans_x3w <- cosh(x3w);
+  trans_x4w <- cosh(x4w);
+  trans_x5w <- cosh(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- cosh(d_matrix);
+  transformed_param_vector <- cosh(d_vector);
+  transformed_param_row_vector <- cosh(d_row_vector);
+  transformed_param_matrix <- cosh(p_matrix);
+  transformed_param_vector <- cosh(p_vector);
+  transformed_param_row_vector <- cosh(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- cosh(p_x3y);
+  trans_p_x4y <- cosh(p_x4y);
+  trans_p_x5y <- cosh(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- cosh(p_x2z);
+  trans_p_x3z <- cosh(p_x3z);
+  trans_p_x4z <- cosh(p_x4z);
+  trans_p_x5z <- cosh(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- cosh(p_x2w);
+  trans_p_x3w <- cosh(p_x3w);
+  trans_p_x4w <- cosh(p_x4w);
+  trans_p_x5w <- cosh(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/digamma.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/digamma.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- digamma(d_matrix);
+  transformed_data_vector <- digamma(d_vector);
+  transformed_data_row_vector <- digamma(d_row_vector);
+  trans_x3y <- digamma(x3y);
+  trans_x4y <- digamma(x4y);
+  trans_x5y <- digamma(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- digamma(x1z);
+  trans_x2z <- digamma(x2z);
+  trans_x3z <- digamma(x3z);
+  trans_x4z <- digamma(x4z);
+  trans_x5z <- digamma(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- digamma(x1w);
+  trans_x2w <- digamma(x2w);
+  trans_x3w <- digamma(x3w);
+  trans_x4w <- digamma(x4w);
+  trans_x5w <- digamma(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- digamma(d_matrix);
+  transformed_param_vector <- digamma(d_vector);
+  transformed_param_row_vector <- digamma(d_row_vector);
+  transformed_param_matrix <- digamma(p_matrix);
+  transformed_param_vector <- digamma(p_vector);
+  transformed_param_row_vector <- digamma(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- digamma(p_x3y);
+  trans_p_x4y <- digamma(p_x4y);
+  trans_p_x5y <- digamma(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- digamma(p_x2z);
+  trans_p_x3z <- digamma(p_x3z);
+  trans_p_x4z <- digamma(p_x4z);
+  trans_p_x5z <- digamma(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- digamma(p_x2w);
+  trans_p_x3w <- digamma(p_x3w);
+  trans_p_x4w <- digamma(p_x4w);
+  trans_p_x5w <- digamma(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/erf.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/erf.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- erf(d_matrix);
+  transformed_data_vector <- erf(d_vector);
+  transformed_data_row_vector <- erf(d_row_vector);
+  trans_x3y <- erf(x3y);
+  trans_x4y <- erf(x4y);
+  trans_x5y <- erf(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- erf(x1z);
+  trans_x2z <- erf(x2z);
+  trans_x3z <- erf(x3z);
+  trans_x4z <- erf(x4z);
+  trans_x5z <- erf(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- erf(x1w);
+  trans_x2w <- erf(x2w);
+  trans_x3w <- erf(x3w);
+  trans_x4w <- erf(x4w);
+  trans_x5w <- erf(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- erf(d_matrix);
+  transformed_param_vector <- erf(d_vector);
+  transformed_param_row_vector <- erf(d_row_vector);
+  transformed_param_matrix <- erf(p_matrix);
+  transformed_param_vector <- erf(p_vector);
+  transformed_param_row_vector <- erf(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- erf(p_x3y);
+  trans_p_x4y <- erf(p_x4y);
+  trans_p_x5y <- erf(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- erf(p_x2z);
+  trans_p_x3z <- erf(p_x3z);
+  trans_p_x4z <- erf(p_x4z);
+  trans_p_x5z <- erf(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- erf(p_x2w);
+  trans_p_x3w <- erf(p_x3w);
+  trans_p_x4w <- erf(p_x4w);
+  trans_p_x5w <- erf(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/erfc.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/erfc.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- erfc(d_matrix);
+  transformed_data_vector <- erfc(d_vector);
+  transformed_data_row_vector <- erfc(d_row_vector);
+  trans_x3y <- erfc(x3y);
+  trans_x4y <- erfc(x4y);
+  trans_x5y <- erfc(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- erfc(x1z);
+  trans_x2z <- erfc(x2z);
+  trans_x3z <- erfc(x3z);
+  trans_x4z <- erfc(x4z);
+  trans_x5z <- erfc(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- erfc(x1w);
+  trans_x2w <- erfc(x2w);
+  trans_x3w <- erfc(x3w);
+  trans_x4w <- erfc(x4w);
+  trans_x5w <- erfc(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- erfc(d_matrix);
+  transformed_param_vector <- erfc(d_vector);
+  transformed_param_row_vector <- erfc(d_row_vector);
+  transformed_param_matrix <- erfc(p_matrix);
+  transformed_param_vector <- erfc(p_vector);
+  transformed_param_row_vector <- erfc(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- erfc(p_x3y);
+  trans_p_x4y <- erfc(p_x4y);
+  trans_p_x5y <- erfc(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- erfc(p_x2z);
+  trans_p_x3z <- erfc(p_x3z);
+  trans_p_x4z <- erfc(p_x4z);
+  trans_p_x5z <- erfc(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- erfc(p_x2w);
+  trans_p_x3w <- erfc(p_x3w);
+  trans_p_x4w <- erfc(p_x4w);
+  trans_p_x5w <- erfc(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/expm1.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/expm1.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- expm1(d_matrix);
+  transformed_data_vector <- expm1(d_vector);
+  transformed_data_row_vector <- expm1(d_row_vector);
+  trans_x3y <- expm1(x3y);
+  trans_x4y <- expm1(x4y);
+  trans_x5y <- expm1(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- expm1(x1z);
+  trans_x2z <- expm1(x2z);
+  trans_x3z <- expm1(x3z);
+  trans_x4z <- expm1(x4z);
+  trans_x5z <- expm1(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- expm1(x1w);
+  trans_x2w <- expm1(x2w);
+  trans_x3w <- expm1(x3w);
+  trans_x4w <- expm1(x4w);
+  trans_x5w <- expm1(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- expm1(d_matrix);
+  transformed_param_vector <- expm1(d_vector);
+  transformed_param_row_vector <- expm1(d_row_vector);
+  transformed_param_matrix <- expm1(p_matrix);
+  transformed_param_vector <- expm1(p_vector);
+  transformed_param_row_vector <- expm1(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- expm1(p_x3y);
+  trans_p_x4y <- expm1(p_x4y);
+  trans_p_x5y <- expm1(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- expm1(p_x2z);
+  trans_p_x3z <- expm1(p_x3z);
+  trans_p_x4z <- expm1(p_x4z);
+  trans_p_x5z <- expm1(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- expm1(p_x2w);
+  trans_p_x3w <- expm1(p_x3w);
+  trans_p_x4w <- expm1(p_x4w);
+  trans_p_x5w <- expm1(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/floor.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/floor.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- floor(d_matrix);
+  transformed_data_vector <- floor(d_vector);
+  transformed_data_row_vector <- floor(d_row_vector);
+  trans_x3y <- floor(x3y);
+  trans_x4y <- floor(x4y);
+  trans_x5y <- floor(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- floor(x1z);
+  trans_x2z <- floor(x2z);
+  trans_x3z <- floor(x3z);
+  trans_x4z <- floor(x4z);
+  trans_x5z <- floor(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- floor(x1w);
+  trans_x2w <- floor(x2w);
+  trans_x3w <- floor(x3w);
+  trans_x4w <- floor(x4w);
+  trans_x5w <- floor(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- floor(d_matrix);
+  transformed_param_vector <- floor(d_vector);
+  transformed_param_row_vector <- floor(d_row_vector);
+  transformed_param_matrix <- floor(p_matrix);
+  transformed_param_vector <- floor(p_vector);
+  transformed_param_row_vector <- floor(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- floor(p_x3y);
+  trans_p_x4y <- floor(p_x4y);
+  trans_p_x5y <- floor(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- floor(p_x2z);
+  trans_p_x3z <- floor(p_x3z);
+  trans_p_x4z <- floor(p_x4z);
+  trans_p_x5z <- floor(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- floor(p_x2w);
+  trans_p_x3w <- floor(p_x3w);
+  trans_p_x4w <- floor(p_x4w);
+  trans_p_x5w <- floor(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/inv.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/inv.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- inv(d_matrix);
+  transformed_data_vector <- inv(d_vector);
+  transformed_data_row_vector <- inv(d_row_vector);
+  trans_x3y <- inv(x3y);
+  trans_x4y <- inv(x4y);
+  trans_x5y <- inv(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- inv(x1z);
+  trans_x2z <- inv(x2z);
+  trans_x3z <- inv(x3z);
+  trans_x4z <- inv(x4z);
+  trans_x5z <- inv(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- inv(x1w);
+  trans_x2w <- inv(x2w);
+  trans_x3w <- inv(x3w);
+  trans_x4w <- inv(x4w);
+  trans_x5w <- inv(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- inv(d_matrix);
+  transformed_param_vector <- inv(d_vector);
+  transformed_param_row_vector <- inv(d_row_vector);
+  transformed_param_matrix <- inv(p_matrix);
+  transformed_param_vector <- inv(p_vector);
+  transformed_param_row_vector <- inv(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- inv(p_x3y);
+  trans_p_x4y <- inv(p_x4y);
+  trans_p_x5y <- inv(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- inv(p_x2z);
+  trans_p_x3z <- inv(p_x3z);
+  trans_p_x4z <- inv(p_x4z);
+  trans_p_x5z <- inv(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- inv(p_x2w);
+  trans_p_x3w <- inv(p_x3w);
+  trans_p_x4w <- inv(p_x4w);
+  trans_p_x5w <- inv(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/inv_Phi.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/inv_Phi.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- inv_Phi(d_matrix);
+  transformed_data_vector <- inv_Phi(d_vector);
+  transformed_data_row_vector <- inv_Phi(d_row_vector);
+  trans_x3y <- inv_Phi(x3y);
+  trans_x4y <- inv_Phi(x4y);
+  trans_x5y <- inv_Phi(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- inv_Phi(x1z);
+  trans_x2z <- inv_Phi(x2z);
+  trans_x3z <- inv_Phi(x3z);
+  trans_x4z <- inv_Phi(x4z);
+  trans_x5z <- inv_Phi(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- inv_Phi(x1w);
+  trans_x2w <- inv_Phi(x2w);
+  trans_x3w <- inv_Phi(x3w);
+  trans_x4w <- inv_Phi(x4w);
+  trans_x5w <- inv_Phi(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- inv_Phi(d_matrix);
+  transformed_param_vector <- inv_Phi(d_vector);
+  transformed_param_row_vector <- inv_Phi(d_row_vector);
+  transformed_param_matrix <- inv_Phi(p_matrix);
+  transformed_param_vector <- inv_Phi(p_vector);
+  transformed_param_row_vector <- inv_Phi(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- inv_Phi(p_x3y);
+  trans_p_x4y <- inv_Phi(p_x4y);
+  trans_p_x5y <- inv_Phi(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- inv_Phi(p_x2z);
+  trans_p_x3z <- inv_Phi(p_x3z);
+  trans_p_x4z <- inv_Phi(p_x4z);
+  trans_p_x5z <- inv_Phi(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- inv_Phi(p_x2w);
+  trans_p_x3w <- inv_Phi(p_x3w);
+  trans_p_x4w <- inv_Phi(p_x4w);
+  trans_p_x5w <- inv_Phi(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/inv_cloglog.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/inv_cloglog.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- inv_cloglog(d_matrix);
+  transformed_data_vector <- inv_cloglog(d_vector);
+  transformed_data_row_vector <- inv_cloglog(d_row_vector);
+  trans_x3y <- inv_cloglog(x3y);
+  trans_x4y <- inv_cloglog(x4y);
+  trans_x5y <- inv_cloglog(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- inv_cloglog(x1z);
+  trans_x2z <- inv_cloglog(x2z);
+  trans_x3z <- inv_cloglog(x3z);
+  trans_x4z <- inv_cloglog(x4z);
+  trans_x5z <- inv_cloglog(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- inv_cloglog(x1w);
+  trans_x2w <- inv_cloglog(x2w);
+  trans_x3w <- inv_cloglog(x3w);
+  trans_x4w <- inv_cloglog(x4w);
+  trans_x5w <- inv_cloglog(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- inv_cloglog(d_matrix);
+  transformed_param_vector <- inv_cloglog(d_vector);
+  transformed_param_row_vector <- inv_cloglog(d_row_vector);
+  transformed_param_matrix <- inv_cloglog(p_matrix);
+  transformed_param_vector <- inv_cloglog(p_vector);
+  transformed_param_row_vector <- inv_cloglog(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- inv_cloglog(p_x3y);
+  trans_p_x4y <- inv_cloglog(p_x4y);
+  trans_p_x5y <- inv_cloglog(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- inv_cloglog(p_x2z);
+  trans_p_x3z <- inv_cloglog(p_x3z);
+  trans_p_x4z <- inv_cloglog(p_x4z);
+  trans_p_x5z <- inv_cloglog(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- inv_cloglog(p_x2w);
+  trans_p_x3w <- inv_cloglog(p_x3w);
+  trans_p_x4w <- inv_cloglog(p_x4w);
+  trans_p_x5w <- inv_cloglog(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/inv_logit.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/inv_logit.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- inv_logit(d_matrix);
+  transformed_data_vector <- inv_logit(d_vector);
+  transformed_data_row_vector <- inv_logit(d_row_vector);
+  trans_x3y <- inv_logit(x3y);
+  trans_x4y <- inv_logit(x4y);
+  trans_x5y <- inv_logit(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- inv_logit(x1z);
+  trans_x2z <- inv_logit(x2z);
+  trans_x3z <- inv_logit(x3z);
+  trans_x4z <- inv_logit(x4z);
+  trans_x5z <- inv_logit(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- inv_logit(x1w);
+  trans_x2w <- inv_logit(x2w);
+  trans_x3w <- inv_logit(x3w);
+  trans_x4w <- inv_logit(x4w);
+  trans_x5w <- inv_logit(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- inv_logit(d_matrix);
+  transformed_param_vector <- inv_logit(d_vector);
+  transformed_param_row_vector <- inv_logit(d_row_vector);
+  transformed_param_matrix <- inv_logit(p_matrix);
+  transformed_param_vector <- inv_logit(p_vector);
+  transformed_param_row_vector <- inv_logit(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- inv_logit(p_x3y);
+  trans_p_x4y <- inv_logit(p_x4y);
+  trans_p_x5y <- inv_logit(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- inv_logit(p_x2z);
+  trans_p_x3z <- inv_logit(p_x3z);
+  trans_p_x4z <- inv_logit(p_x4z);
+  trans_p_x5z <- inv_logit(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- inv_logit(p_x2w);
+  trans_p_x3w <- inv_logit(p_x3w);
+  trans_p_x4w <- inv_logit(p_x4w);
+  trans_p_x5w <- inv_logit(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/inv_sqrt.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/inv_sqrt.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- inv_sqrt(d_matrix);
+  transformed_data_vector <- inv_sqrt(d_vector);
+  transformed_data_row_vector <- inv_sqrt(d_row_vector);
+  trans_x3y <- inv_sqrt(x3y);
+  trans_x4y <- inv_sqrt(x4y);
+  trans_x5y <- inv_sqrt(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- inv_sqrt(x1z);
+  trans_x2z <- inv_sqrt(x2z);
+  trans_x3z <- inv_sqrt(x3z);
+  trans_x4z <- inv_sqrt(x4z);
+  trans_x5z <- inv_sqrt(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- inv_sqrt(x1w);
+  trans_x2w <- inv_sqrt(x2w);
+  trans_x3w <- inv_sqrt(x3w);
+  trans_x4w <- inv_sqrt(x4w);
+  trans_x5w <- inv_sqrt(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- inv_sqrt(d_matrix);
+  transformed_param_vector <- inv_sqrt(d_vector);
+  transformed_param_row_vector <- inv_sqrt(d_row_vector);
+  transformed_param_matrix <- inv_sqrt(p_matrix);
+  transformed_param_vector <- inv_sqrt(p_vector);
+  transformed_param_row_vector <- inv_sqrt(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- inv_sqrt(p_x3y);
+  trans_p_x4y <- inv_sqrt(p_x4y);
+  trans_p_x5y <- inv_sqrt(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- inv_sqrt(p_x2z);
+  trans_p_x3z <- inv_sqrt(p_x3z);
+  trans_p_x4z <- inv_sqrt(p_x4z);
+  trans_p_x5z <- inv_sqrt(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- inv_sqrt(p_x2w);
+  trans_p_x3w <- inv_sqrt(p_x3w);
+  trans_p_x4w <- inv_sqrt(p_x4w);
+  trans_p_x5w <- inv_sqrt(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/inv_square.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/inv_square.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- inv_square(d_matrix);
+  transformed_data_vector <- inv_square(d_vector);
+  transformed_data_row_vector <- inv_square(d_row_vector);
+  trans_x3y <- inv_square(x3y);
+  trans_x4y <- inv_square(x4y);
+  trans_x5y <- inv_square(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- inv_square(x1z);
+  trans_x2z <- inv_square(x2z);
+  trans_x3z <- inv_square(x3z);
+  trans_x4z <- inv_square(x4z);
+  trans_x5z <- inv_square(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- inv_square(x1w);
+  trans_x2w <- inv_square(x2w);
+  trans_x3w <- inv_square(x3w);
+  trans_x4w <- inv_square(x4w);
+  trans_x5w <- inv_square(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- inv_square(d_matrix);
+  transformed_param_vector <- inv_square(d_vector);
+  transformed_param_row_vector <- inv_square(d_row_vector);
+  transformed_param_matrix <- inv_square(p_matrix);
+  transformed_param_vector <- inv_square(p_vector);
+  transformed_param_row_vector <- inv_square(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- inv_square(p_x3y);
+  trans_p_x4y <- inv_square(p_x4y);
+  trans_p_x5y <- inv_square(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- inv_square(p_x2z);
+  trans_p_x3z <- inv_square(p_x3z);
+  trans_p_x4z <- inv_square(p_x4z);
+  trans_p_x5z <- inv_square(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- inv_square(p_x2w);
+  trans_p_x3w <- inv_square(p_x3w);
+  trans_p_x4w <- inv_square(p_x4w);
+  trans_p_x5w <- inv_square(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/log10.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/log10.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- log10(d_matrix);
+  transformed_data_vector <- log10(d_vector);
+  transformed_data_row_vector <- log10(d_row_vector);
+  trans_x3y <- log10(x3y);
+  trans_x4y <- log10(x4y);
+  trans_x5y <- log10(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- log10(x1z);
+  trans_x2z <- log10(x2z);
+  trans_x3z <- log10(x3z);
+  trans_x4z <- log10(x4z);
+  trans_x5z <- log10(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- log10(x1w);
+  trans_x2w <- log10(x2w);
+  trans_x3w <- log10(x3w);
+  trans_x4w <- log10(x4w);
+  trans_x5w <- log10(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- log10(d_matrix);
+  transformed_param_vector <- log10(d_vector);
+  transformed_param_row_vector <- log10(d_row_vector);
+  transformed_param_matrix <- log10(p_matrix);
+  transformed_param_vector <- log10(p_vector);
+  transformed_param_row_vector <- log10(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- log10(p_x3y);
+  trans_p_x4y <- log10(p_x4y);
+  trans_p_x5y <- log10(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- log10(p_x2z);
+  trans_p_x3z <- log10(p_x3z);
+  trans_p_x4z <- log10(p_x4z);
+  trans_p_x5z <- log10(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- log10(p_x2w);
+  trans_p_x3w <- log10(p_x3w);
+  trans_p_x4w <- log10(p_x4w);
+  trans_p_x5w <- log10(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/log1m.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/log1m.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- log1m(d_matrix);
+  transformed_data_vector <- log1m(d_vector);
+  transformed_data_row_vector <- log1m(d_row_vector);
+  trans_x3y <- log1m(x3y);
+  trans_x4y <- log1m(x4y);
+  trans_x5y <- log1m(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- log1m(x1z);
+  trans_x2z <- log1m(x2z);
+  trans_x3z <- log1m(x3z);
+  trans_x4z <- log1m(x4z);
+  trans_x5z <- log1m(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- log1m(x1w);
+  trans_x2w <- log1m(x2w);
+  trans_x3w <- log1m(x3w);
+  trans_x4w <- log1m(x4w);
+  trans_x5w <- log1m(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- log1m(d_matrix);
+  transformed_param_vector <- log1m(d_vector);
+  transformed_param_row_vector <- log1m(d_row_vector);
+  transformed_param_matrix <- log1m(p_matrix);
+  transformed_param_vector <- log1m(p_vector);
+  transformed_param_row_vector <- log1m(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- log1m(p_x3y);
+  trans_p_x4y <- log1m(p_x4y);
+  trans_p_x5y <- log1m(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- log1m(p_x2z);
+  trans_p_x3z <- log1m(p_x3z);
+  trans_p_x4z <- log1m(p_x4z);
+  trans_p_x5z <- log1m(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- log1m(p_x2w);
+  trans_p_x3w <- log1m(p_x3w);
+  trans_p_x4w <- log1m(p_x4w);
+  trans_p_x5w <- log1m(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/log1m_exp.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/log1m_exp.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- log1m_exp(d_matrix);
+  transformed_data_vector <- log1m_exp(d_vector);
+  transformed_data_row_vector <- log1m_exp(d_row_vector);
+  trans_x3y <- log1m_exp(x3y);
+  trans_x4y <- log1m_exp(x4y);
+  trans_x5y <- log1m_exp(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- log1m_exp(x1z);
+  trans_x2z <- log1m_exp(x2z);
+  trans_x3z <- log1m_exp(x3z);
+  trans_x4z <- log1m_exp(x4z);
+  trans_x5z <- log1m_exp(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- log1m_exp(x1w);
+  trans_x2w <- log1m_exp(x2w);
+  trans_x3w <- log1m_exp(x3w);
+  trans_x4w <- log1m_exp(x4w);
+  trans_x5w <- log1m_exp(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- log1m_exp(d_matrix);
+  transformed_param_vector <- log1m_exp(d_vector);
+  transformed_param_row_vector <- log1m_exp(d_row_vector);
+  transformed_param_matrix <- log1m_exp(p_matrix);
+  transformed_param_vector <- log1m_exp(p_vector);
+  transformed_param_row_vector <- log1m_exp(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- log1m_exp(p_x3y);
+  trans_p_x4y <- log1m_exp(p_x4y);
+  trans_p_x5y <- log1m_exp(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- log1m_exp(p_x2z);
+  trans_p_x3z <- log1m_exp(p_x3z);
+  trans_p_x4z <- log1m_exp(p_x4z);
+  trans_p_x5z <- log1m_exp(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- log1m_exp(p_x2w);
+  trans_p_x3w <- log1m_exp(p_x3w);
+  trans_p_x4w <- log1m_exp(p_x4w);
+  trans_p_x5w <- log1m_exp(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/log1p_exp.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/log1p_exp.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- log1p_exp(d_matrix);
+  transformed_data_vector <- log1p_exp(d_vector);
+  transformed_data_row_vector <- log1p_exp(d_row_vector);
+  trans_x3y <- log1p_exp(x3y);
+  trans_x4y <- log1p_exp(x4y);
+  trans_x5y <- log1p_exp(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- log1p_exp(x1z);
+  trans_x2z <- log1p_exp(x2z);
+  trans_x3z <- log1p_exp(x3z);
+  trans_x4z <- log1p_exp(x4z);
+  trans_x5z <- log1p_exp(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- log1p_exp(x1w);
+  trans_x2w <- log1p_exp(x2w);
+  trans_x3w <- log1p_exp(x3w);
+  trans_x4w <- log1p_exp(x4w);
+  trans_x5w <- log1p_exp(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- log1p_exp(d_matrix);
+  transformed_param_vector <- log1p_exp(d_vector);
+  transformed_param_row_vector <- log1p_exp(d_row_vector);
+  transformed_param_matrix <- log1p_exp(p_matrix);
+  transformed_param_vector <- log1p_exp(p_vector);
+  transformed_param_row_vector <- log1p_exp(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- log1p_exp(p_x3y);
+  trans_p_x4y <- log1p_exp(p_x4y);
+  trans_p_x5y <- log1p_exp(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- log1p_exp(p_x2z);
+  trans_p_x3z <- log1p_exp(p_x3z);
+  trans_p_x4z <- log1p_exp(p_x4z);
+  trans_p_x5z <- log1p_exp(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- log1p_exp(p_x2w);
+  trans_p_x3w <- log1p_exp(p_x3w);
+  trans_p_x4w <- log1p_exp(p_x4w);
+  trans_p_x5w <- log1p_exp(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/round.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/round.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- round(d_matrix);
+  transformed_data_vector <- round(d_vector);
+  transformed_data_row_vector <- round(d_row_vector);
+  trans_x3y <- round(x3y);
+  trans_x4y <- round(x4y);
+  trans_x5y <- round(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- round(x1z);
+  trans_x2z <- round(x2z);
+  trans_x3z <- round(x3z);
+  trans_x4z <- round(x4z);
+  trans_x5z <- round(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- round(x1w);
+  trans_x2w <- round(x2w);
+  trans_x3w <- round(x3w);
+  trans_x4w <- round(x4w);
+  trans_x5w <- round(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- round(d_matrix);
+  transformed_param_vector <- round(d_vector);
+  transformed_param_row_vector <- round(d_row_vector);
+  transformed_param_matrix <- round(p_matrix);
+  transformed_param_vector <- round(p_vector);
+  transformed_param_row_vector <- round(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- round(p_x3y);
+  trans_p_x4y <- round(p_x4y);
+  trans_p_x5y <- round(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- round(p_x2z);
+  trans_p_x3z <- round(p_x3z);
+  trans_p_x4z <- round(p_x4z);
+  trans_p_x5z <- round(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- round(p_x2w);
+  trans_p_x3w <- round(p_x3w);
+  trans_p_x4w <- round(p_x4w);
+  trans_p_x5w <- round(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/sin.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/sin.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- sin(d_matrix);
+  transformed_data_vector <- sin(d_vector);
+  transformed_data_row_vector <- sin(d_row_vector);
+  trans_x3y <- sin(x3y);
+  trans_x4y <- sin(x4y);
+  trans_x5y <- sin(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- sin(x1z);
+  trans_x2z <- sin(x2z);
+  trans_x3z <- sin(x3z);
+  trans_x4z <- sin(x4z);
+  trans_x5z <- sin(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- sin(x1w);
+  trans_x2w <- sin(x2w);
+  trans_x3w <- sin(x3w);
+  trans_x4w <- sin(x4w);
+  trans_x5w <- sin(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- sin(d_matrix);
+  transformed_param_vector <- sin(d_vector);
+  transformed_param_row_vector <- sin(d_row_vector);
+  transformed_param_matrix <- sin(p_matrix);
+  transformed_param_vector <- sin(p_vector);
+  transformed_param_row_vector <- sin(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- sin(p_x3y);
+  trans_p_x4y <- sin(p_x4y);
+  trans_p_x5y <- sin(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- sin(p_x2z);
+  trans_p_x3z <- sin(p_x3z);
+  trans_p_x4z <- sin(p_x4z);
+  trans_p_x5z <- sin(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- sin(p_x2w);
+  trans_p_x3w <- sin(p_x3w);
+  trans_p_x4w <- sin(p_x4w);
+  trans_p_x5w <- sin(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/sinh.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/sinh.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- sinh(d_matrix);
+  transformed_data_vector <- sinh(d_vector);
+  transformed_data_row_vector <- sinh(d_row_vector);
+  trans_x3y <- sinh(x3y);
+  trans_x4y <- sinh(x4y);
+  trans_x5y <- sinh(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- sinh(x1z);
+  trans_x2z <- sinh(x2z);
+  trans_x3z <- sinh(x3z);
+  trans_x4z <- sinh(x4z);
+  trans_x5z <- sinh(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- sinh(x1w);
+  trans_x2w <- sinh(x2w);
+  trans_x3w <- sinh(x3w);
+  trans_x4w <- sinh(x4w);
+  trans_x5w <- sinh(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- sinh(d_matrix);
+  transformed_param_vector <- sinh(d_vector);
+  transformed_param_row_vector <- sinh(d_row_vector);
+  transformed_param_matrix <- sinh(p_matrix);
+  transformed_param_vector <- sinh(p_vector);
+  transformed_param_row_vector <- sinh(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- sinh(p_x3y);
+  trans_p_x4y <- sinh(p_x4y);
+  trans_p_x5y <- sinh(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- sinh(p_x2z);
+  trans_p_x3z <- sinh(p_x3z);
+  trans_p_x4z <- sinh(p_x4z);
+  trans_p_x5z <- sinh(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- sinh(p_x2w);
+  trans_p_x3w <- sinh(p_x3w);
+  trans_p_x4w <- sinh(p_x4w);
+  trans_p_x5w <- sinh(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/sqrt.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/sqrt.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- sqrt(d_matrix);
+  transformed_data_vector <- sqrt(d_vector);
+  transformed_data_row_vector <- sqrt(d_row_vector);
+  trans_x3y <- sqrt(x3y);
+  trans_x4y <- sqrt(x4y);
+  trans_x5y <- sqrt(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- sqrt(x1z);
+  trans_x2z <- sqrt(x2z);
+  trans_x3z <- sqrt(x3z);
+  trans_x4z <- sqrt(x4z);
+  trans_x5z <- sqrt(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- sqrt(x1w);
+  trans_x2w <- sqrt(x2w);
+  trans_x3w <- sqrt(x3w);
+  trans_x4w <- sqrt(x4w);
+  trans_x5w <- sqrt(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- sqrt(d_matrix);
+  transformed_param_vector <- sqrt(d_vector);
+  transformed_param_row_vector <- sqrt(d_row_vector);
+  transformed_param_matrix <- sqrt(p_matrix);
+  transformed_param_vector <- sqrt(p_vector);
+  transformed_param_row_vector <- sqrt(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- sqrt(p_x3y);
+  trans_p_x4y <- sqrt(p_x4y);
+  trans_p_x5y <- sqrt(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- sqrt(p_x2z);
+  trans_p_x3z <- sqrt(p_x3z);
+  trans_p_x4z <- sqrt(p_x4z);
+  trans_p_x5z <- sqrt(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- sqrt(p_x2w);
+  trans_p_x3w <- sqrt(p_x3w);
+  trans_p_x4w <- sqrt(p_x4w);
+  trans_p_x5w <- sqrt(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/square.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/square.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- square(d_matrix);
+  transformed_data_vector <- square(d_vector);
+  transformed_data_row_vector <- square(d_row_vector);
+  trans_x3y <- square(x3y);
+  trans_x4y <- square(x4y);
+  trans_x5y <- square(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- square(x1z);
+  trans_x2z <- square(x2z);
+  trans_x3z <- square(x3z);
+  trans_x4z <- square(x4z);
+  trans_x5z <- square(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- square(x1w);
+  trans_x2w <- square(x2w);
+  trans_x3w <- square(x3w);
+  trans_x4w <- square(x4w);
+  trans_x5w <- square(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- square(d_matrix);
+  transformed_param_vector <- square(d_vector);
+  transformed_param_row_vector <- square(d_row_vector);
+  transformed_param_matrix <- square(p_matrix);
+  transformed_param_vector <- square(p_vector);
+  transformed_param_row_vector <- square(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- square(p_x3y);
+  trans_p_x4y <- square(p_x4y);
+  trans_p_x5y <- square(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- square(p_x2z);
+  trans_p_x3z <- square(p_x3z);
+  trans_p_x4z <- square(p_x4z);
+  trans_p_x5z <- square(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- square(p_x2w);
+  trans_p_x3w <- square(p_x3w);
+  trans_p_x4w <- square(p_x4w);
+  trans_p_x5w <- square(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/tan.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/tan.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- tan(d_matrix);
+  transformed_data_vector <- tan(d_vector);
+  transformed_data_row_vector <- tan(d_row_vector);
+  trans_x3y <- tan(x3y);
+  trans_x4y <- tan(x4y);
+  trans_x5y <- tan(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- tan(x1z);
+  trans_x2z <- tan(x2z);
+  trans_x3z <- tan(x3z);
+  trans_x4z <- tan(x4z);
+  trans_x5z <- tan(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- tan(x1w);
+  trans_x2w <- tan(x2w);
+  trans_x3w <- tan(x3w);
+  trans_x4w <- tan(x4w);
+  trans_x5w <- tan(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- tan(d_matrix);
+  transformed_param_vector <- tan(d_vector);
+  transformed_param_row_vector <- tan(d_row_vector);
+  transformed_param_matrix <- tan(p_matrix);
+  transformed_param_vector <- tan(p_vector);
+  transformed_param_row_vector <- tan(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- tan(p_x3y);
+  trans_p_x4y <- tan(p_x4y);
+  trans_p_x5y <- tan(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- tan(p_x2z);
+  trans_p_x3z <- tan(p_x3z);
+  trans_p_x4z <- tan(p_x4z);
+  trans_p_x5z <- tan(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- tan(p_x2w);
+  trans_p_x3w <- tan(p_x3w);
+  trans_p_x4w <- tan(p_x4w);
+  trans_p_x5w <- tan(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/tanh.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/tanh.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- tanh(d_matrix);
+  transformed_data_vector <- tanh(d_vector);
+  transformed_data_row_vector <- tanh(d_row_vector);
+  trans_x3y <- tanh(x3y);
+  trans_x4y <- tanh(x4y);
+  trans_x5y <- tanh(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- tanh(x1z);
+  trans_x2z <- tanh(x2z);
+  trans_x3z <- tanh(x3z);
+  trans_x4z <- tanh(x4z);
+  trans_x5z <- tanh(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- tanh(x1w);
+  trans_x2w <- tanh(x2w);
+  trans_x3w <- tanh(x3w);
+  trans_x4w <- tanh(x4w);
+  trans_x5w <- tanh(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- tanh(d_matrix);
+  transformed_param_vector <- tanh(d_vector);
+  transformed_param_row_vector <- tanh(d_row_vector);
+  transformed_param_matrix <- tanh(p_matrix);
+  transformed_param_vector <- tanh(p_vector);
+  transformed_param_row_vector <- tanh(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- tanh(p_x3y);
+  trans_p_x4y <- tanh(p_x4y);
+  trans_p_x5y <- tanh(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- tanh(p_x2z);
+  trans_p_x3z <- tanh(p_x3z);
+  trans_p_x4z <- tanh(p_x4z);
+  trans_p_x5z <- tanh(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- tanh(p_x2w);
+  trans_p_x3w <- tanh(p_x3w);
+  trans_p_x4w <- tanh(p_x4w);
+  trans_p_x5w <- tanh(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/math/matrix/tgamma.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/tgamma.stan
@@ -42,24 +42,24 @@ transformed data {
   row_vector[2] trans_x4w[3,4,5];
   matrix[2,3] trans_x5w[3,4,5];
 
-  transformed_data_matrix <- log(d_matrix);
-  transformed_data_vector <- log(d_vector);
-  transformed_data_row_vector <- log(d_row_vector);
-  trans_x3y <- log(x3y);
-  trans_x4y <- log(x4y);
-  trans_x5y <- log(x5y);
+  transformed_data_matrix <- tgamma(d_matrix);
+  transformed_data_vector <- tgamma(d_vector);
+  transformed_data_row_vector <- tgamma(d_row_vector);
+  trans_x3y <- tgamma(x3y);
+  trans_x4y <- tgamma(x4y);
+  trans_x5y <- tgamma(x5y);
 
-  trans_x2z <- log(x1z);
-  trans_x2z <- log(x2z);
-  trans_x3z <- log(x3z);
-  trans_x4z <- log(x4z);
-  trans_x5z <- log(x5z);
+  trans_x2z <- tgamma(x1z);
+  trans_x2z <- tgamma(x2z);
+  trans_x3z <- tgamma(x3z);
+  trans_x4z <- tgamma(x4z);
+  trans_x5z <- tgamma(x5z);
 
-  trans_x2w <- log(x1w);
-  trans_x2w <- log(x2w);
-  trans_x3w <- log(x3w);
-  trans_x4w <- log(x4w);
-  trans_x5w <- log(x5w);
+  trans_x2w <- tgamma(x1w);
+  trans_x2w <- tgamma(x2w);
+  trans_x3w <- tgamma(x3w);
+  trans_x4w <- tgamma(x4w);
+  trans_x5w <- tgamma(x5w);
 }
 parameters {
   real p_real;
@@ -101,26 +101,26 @@ transformed parameters {
   row_vector[2] trans_p_x4w[3,4,5];
   matrix[2,3] trans_p_x5w[3,4,5];
 
-  transformed_param_matrix <- log(d_matrix);
-  transformed_param_vector <- log(d_vector);
-  transformed_param_row_vector <- log(d_row_vector);
-  transformed_param_matrix <- log(p_matrix);
-  transformed_param_vector <- log(p_vector);
-  transformed_param_row_vector <- log(p_row_vector);
+  transformed_param_matrix <- tgamma(d_matrix);
+  transformed_param_vector <- tgamma(d_vector);
+  transformed_param_row_vector <- tgamma(d_row_vector);
+  transformed_param_matrix <- tgamma(p_matrix);
+  transformed_param_vector <- tgamma(p_vector);
+  transformed_param_row_vector <- tgamma(p_row_vector);
 
-  trans_p_x3y <- log(p_x3y);
-  trans_p_x4y <- log(p_x4y);
-  trans_p_x5y <- log(p_x5y);
+  trans_p_x3y <- tgamma(p_x3y);
+  trans_p_x4y <- tgamma(p_x4y);
+  trans_p_x5y <- tgamma(p_x5y);
 
-  trans_p_x2z <- log(p_x2z);
-  trans_p_x3z <- log(p_x3z);
-  trans_p_x4z <- log(p_x4z);
-  trans_p_x5z <- log(p_x5z);
+  trans_p_x2z <- tgamma(p_x2z);
+  trans_p_x3z <- tgamma(p_x3z);
+  trans_p_x4z <- tgamma(p_x4z);
+  trans_p_x5z <- tgamma(p_x5z);
 
-  trans_p_x2w <- log(p_x2w);
-  trans_p_x3w <- log(p_x3w);
-  trans_p_x4w <- log(p_x4w);
-  trans_p_x5w <- log(p_x5w);
+  trans_p_x2w <- tgamma(p_x2w);
+  trans_p_x3w <- tgamma(p_x3w);
+  trans_p_x4w <- tgamma(p_x4w);
+  trans_p_x5w <- tgamma(p_x5w);
 }
 model {  
   y_p ~ normal(0,1);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
This is to vectorize in Stan the functions already vectorized in `stan/math/` (see [here](https://github.com/stan-dev/math/pull/240) and [here](https://github.com/stan-dev/math/pull/276)).

#### Intended Effect
For a vectorized function, users can now use that function element-wise on a vector or matrix without writing a for loop. For instance, if `a` is a matrix, users can write `log(a)` to apply `log` element-wise on `a`.

#### How to Verify
It can be verified by applying a vectorized function on a vector or matrix and checking that the function was applied to each element. This pull request also adds function signature tests for these functions in Stan and there are tests in `stan/math`. 

#### Side Effects
Before, `int abs` would have a return type of `int`. Now it'll have a return type of `real`.

#### Documentation
`functions.tex` has been updated to include the vectorized functions. The macro used was also updated to be more flexible.

#### Reviewer Suggestions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Per Michigan's copyright policies, Rayleigh Lei is the copyright holder.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
