### PR TITLE
Bugfix/2054 lower-bound discrete truncations off by 1

### DIFF
--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -2907,154 +2907,295 @@ target += - log(fabs(y));
 
 \subsection{Truncated Distributions}
 
-A density function $p(x)$ may be truncated to an interval $(a,b)$ to
-define a new density $p_{(a,b)}\!(x)$ by setting
+Stan supports truncating distributions with lower bounds, upper
+bounds, or both.
+
+\subsubsection{Truncating with lower and upper bounds}
+
+A probability density function $p(x)$ for a continuous distribution
+may be truncated to an interval $[a,b]$ to define a new density
+$p_{[a,b]}(x)$ with support $[a,b]$ by setting
 %
 \[
-p_{\!(a,b)\!}(x) = \frac{p(x)}
-                  {\int_a^b p(x') \, dx'}.
+p_{[a,b]}(x)
+= \frac{p(x)}
+       {\int_a^b p(u) \, du}.
 \]
+%
+A probability mass function $p(x)$ for a discrete distribution may be
+truncated to the closed interval $[a,b]$ by
+\[
+p_{[a,b]}(x) = \frac{p(x)}
+                  {\sum_{u = a}^b p(u)}.
+\]
+
+\subsubsection{Truncating with a lower bound}
+
+A probability density function $p(x)$ can be truncated to $[a, \infty]$ by
+defining
+%
+\[
+p_{[a,\infty]}(x)
+= \frac{p(x)}
+       {\int_a^{\infty} p(u) \, du}.
+\]
+%
+A probability mass function $p(x)$ is truncated to $[a, \infty]$ by
+defining 
+%
+\[
+p_{[a,\infty]}(x) = \frac{p(x)}
+                  {\sum_{a <= u} p(u)}.
+\]
+
+\subsubsection{Truncating with an upper bound}
+
+A probability density function $p(x)$ can be truncated to $[-\infty, b]$ by
+defining
+%
+\[
+p_{[-\infty,b]}(x)
+= \frac{p(x)}
+       {\int_{-\infty}^b p(u) \, du}.
+\]
+%
+A probability mass function $p(x)$ is truncated to $[-\infty, b]$ by
+defining 
+%
+\[
+p_{[-\infty,b]}(x) = \frac{p(x)}
+                  {\sum_{u <= b} p(u)}.
+\]
+
+
+\subsubsection{Cumulative distribution functions}
+
 Given a probability function $p_X(x)$ for a random variable $X$, its
 cumulative distribution function (cdf) $F_X(x)$ is defined to be the
-probability that $X \leq a$.  For continuous random variables, this is
+probability that $X \leq x$,
+%
 \[
-F_X(x) = \int_{-\infty}^{x} p_X(x') \, dx',
+F_X(x) = \mbox{Pr}[X \leq x].
 \]
-whereas for discrete variables, it's
+The upper-case variable $X$ is the random variable whereas the
+lower-case variable $x$ is just an ordinary bound variable.  For
+continuous random variables, the definition of the cdf works out to
 \[
-F_X(x) = \sum_{n \leq x} p_X(x).
+F_X(x) \ = \ \int_{-\infty}^{x} p_X(u) \, du,
+\]
+For discrete variables, the cdf is defined to include the upper bound
+given by the argument,
+\[
+F_X(x) = \sum_{u \leq x} p_X(u).
 \]
 %
-The complementary cumulative distribution function (ccdf) is $1 -
-F_X(x)$.
 
-Cumulative distribution functions are useful for defining truncated
-distributions, because
+\subsubsection{Complementary cumulative distribution functions}
+
+The complementary cumulative distribution function (ccdf) in both the
+continuous and discrete cases is given by
 \[
-\int_a^b p(x') \, dx' = F(b) - F(a),
+F^C_X(x)
+\ = \ \mbox{Pr}[X > x]
+\ = \ 1 - F_X(x).
 \]
-so that
+Unlike the cdf, the ccdf is exclusive of the bound, hence the event
+$X > x$ rather than the cdf's event $X \leq x$.
+
+For continous distributions, the ccdf works out to 
 \[
-p_{\!(a,b)\!}(x) = \frac{p_X(x)}
-                  {F(b) - F(a)}.
+F^C_X(x)
+\ = \ 1 - \int_{-\infty}^x p_X(u) \, du
+\ = \ \int_x^{\infty} p_X(u) \, du.
 \]
-On the log scale,
+The lower boundary can be included in the integration bounds because
+it is a single point on a line and hence has no probability mass.
+For the discrete case, the lower bound must be excluded in the
+summation explicitly by summing over $u > x$,
 \[
-\log p_{\!(a,b)\!}(x)
-\ = \
-\log p_X(x)
-- \log \left( F(b) - F(a) \right).
+F^C_X(x)
+\ = \ 1 - \sum_{u \leq x} p_X(u)
+\ = \ \sum_{u > x} p_X(u).
 \]
-The denominator is more stably computed using Stan's
-log\_diff\_exp operation as
-\begin{eqnarray*}
-\log \left( F(b) - F(a) \right)
-& = & \log \left( \exp(\log F(b)) - \exp(\log F(a)) \right)
-\\[6pt]
-& = & \mbox{log\_diff\_exp}\!\left( \log F(b), \log F(a) \right).
-\end{eqnarray*}
 
 
+Cumulative distribution functions provide the necessary integral
+calculations to define truncated distributions.  For truncation with
+lower and upper bounds, the denominator is defined by
+\[
+\int_a^b p(u) \, du = F_X(b) - F_X(a).
+\]
+This allows truncated distributions to be defined as
+\[
+p_{[a,b]}(x) = \frac{p_X(x)}
+                  {F_X(b) - F_X(a)}.
+\]
+
+For discrete distributions, a slightly more complicated form is
+required to explicitly insert the lower truncation point, which is
+otherwise excluded from $F_X(b) - F_X(a)$,
+\[
+p_{[a,b]}(x) = \frac{p_X(x)}
+                  {F_X(b) - F_X(a) + p_X(a)}.
+\]
+
+\subsubsection{Truncation with lower and upper bounds in Stan}
 
 Stan allows probability functions to be truncated.  For example, a
-truncated unit normal distribution restricted to $(-0.5, 2.1)$ is
-encoded as follows.
+truncated unit normal distributions restricted to $[-0.5, 2.1]$
+can be coded with the following sampling statement.
 %
 \begin{stancode}
 y ~ normal(0,1) T[-0.5, 2.1];
 \end{stancode}
 %
-Truncated distributions are translated as an addition summation for
-the accumulated log probability.  For instance, this example has the
-same translation (up to arithmetic precision issues; see below) as
+Truncated distributions are translated as an additional term in the
+accumulated log density function plus error checking to make sure the
+variate in the sampling statement is within the bounds of the
+truncation.
+
+In general, the truncation bounds and parameters may be parameters or
+local variables.
+
+Because the example above involves a continuous distribution, it
+behaves the same way as the following more verbose form.
+%
+\begin{stancode}
+y ~ normal(0, 1);
+if (y < -0.5 || y > 2.1)
+  target += negative_infinity();
+else
+  target += -log_diff_exp(normal_lcdf(2.1 | 0, 1),
+                          normal_lcdf(-0.5 | 0, 1));
+\end{stancode}
+%
+Because a Stan program defines a log density function, all
+calculations are on the log scale.  The function \code{normal\_lcdf}
+is the log of the cumulative normal distribution function and the
+function \code{log\_diff\_exp(a, b)} is a more arithmetically stable
+form of \code{log(exp(a) - exp(b))}.
+
+For a discrete distribution, another term is necessary in the
+denominator to account for the excluded boundary.  The truncated
+discrete distribution
+%
+\begin{stancode}
+y ~ poisson(3.7) T[2, 10];
+\end{stancode}
+%
+behaves in the same way as the following code.
+%
+\begin{stancode}
+y ~ poisson(3.7);
+if (y < 2 || y > 10) 
+  target += negative_infinity();
+else
+  target += -log_sum_exp(poisson_lpmf(2 | 3.7),
+                         log_diff_exp(poisson_lcdf(10 | 3.7),
+                                      poisson_lcdf(2 | 3.7)));
+\end{stancode}
+%
+Recall that \code{log\_sum\_exp(a, b)} is just the arithmetically
+stable form of \code{log(exp(a) + exp(b))}.
+
+
+\subsubsection{Truncation with lower bounds in Stan}
+
+For truncating with only a lower bound, the upper limit is left blank.
+%
+\begin{stancode}
+y ~ normal(0,1) T[-0.5, ];
+\end{stancode}
+%
+This truncated sampling statement has the same behavior as the
+following code.
+%
+\begin{stancode}
+y ~ normal(0, 1);
+if (y < -0.5)
+  target += negative_infinity();
+else
+  target += -normal_lccdf(-0.5 | 0, 1);
+\end{stancode}
+%
+The \code{normal\_lccdf} function is the normal complementary cumulative
+distribution function.
+
+As with lower and upper truncation, the discrete case requires a more
+complicated denominator to add back in the probability mass for the
+lower bound.  Thus
+%
+\begin{stancode}
+y ~ poisson(3.7) T[2, ];
+\end{stancode}
+%
+behaves the same way as
+%
+\begin{stancode}
+y ~ poisson(3.7);
+if (y < 2)
+  target += negative_infinity();
+else
+  target += -log_sum_exp(poisson_lpdf(2 | 3.7),
+                         poisson_lccdf(2 | 3.7));
+\end{stancode}
+
+
+\subsubsection{Truncation with upper bounds in Stan}
+
+To truncate with only an upper bound, the lower bound is left blank.  
+The upper truncated sampling statement
+%
+\begin{stancode}
+y ~ normal(0,1) T[ , 2.1];
+\end{stancode}
+%
+produces the same result as the following code.
 %
 \begin{stancode}
 target += normal_lpdf(y | 0, 1);
-target += -log_diff_exp(normal_lcdf(2.1 | 0, 1),
-                        normal_lcdf(-0.5 | 0, 1));
-\end{stancode}
-%
-The function \code{normal\_lcdf} represents the cumulative normal
-distribution function.  For example, 
-\code{normal\_lcdf(2.1 | 0, 1)} evaluates to
-\[
-\log \int_{-\infty}^{2.1} \mbox{\sf Normal}(x | 0, 1) \, \mathrm{d}x,
-\]
-%
-which is the log of the probability that a unit normal variable takes
-on a value less than 2.1, or about $\log 0.98$.
-
-Arithmetic precision is handled by working on the log scale and using
-Stan's log scale cdf implementations.  The logarithm of the cdf for
-the normal distribution is \code{normal\_lcdf} and the log of the ccdf
-is \code{normal\_lccdf}.  The function \code{log\_diff\_exp(a, b)} is
-equivalent to the less stable form \code{log(exp(a) - exp(b))}.
-
-As with constrained variable declarations, truncation can be one
-sided.  The density $p(x)$ can be truncated below by $a$ to define a
-density $p_{(a,)}(x)$ with support $(a,\infty)$ by setting
-%
-\[
-p_{(a,)}(x) = \frac{p(x)}
-                 {\int_a^{\infty} p(x') \, dx'}.
-\]
-For example, the unit normal distribution truncated below at -0.5 would
-be represented as
-%
-\begin{stancode}
-y ~ normal(0, 1) T[-0.5,];
-\end{stancode}
-%
-The truncation has the same effect as the following direct update to
-the accumulated log probability (see the subsection of
-\refsection{sampling-statements} contrasting log probability increment
-and sampling statements for more information).
-%
-\begin{stancode}
-target += normal_lpdf(y | 0, 1);
-target += -normal_lccdf(-0.5 | 0, 1);
-\end{stancode}
-%
-The \code{lccdf} function is the complementary cumulative distribution
-function (cdf);  if $F(x)$ is the cumulative distribution function for
-$x$, then $G(x) = 1 - F(x)$ is its complement.
-
-The density $p(x)$ can be truncated above by $b$ to define a density
-$p_{(,b)}(x)$ with support $(-\infty,b)$ by setting
-\[
-p_{(,b)}(x) = \frac{p(x)}
-                    {\int_{-\infty}^b p(x') \, \mathrm{d}x'}.
-\]
-For example, the unit normal distribution truncated above at 2.1 would
-be represented as
-%
-\begin{stancode}
-y ~ normal(0, 1) T[,2.1];
-\end{stancode}
-%
-The truncation has the same effect as the following direct update to
-the accumulated log probability.
-%
-\begin{stancode}
-target += normal_lpdf(y | 0, 1);
-target += -normal_lcdf(2.1 | 0, 1);
+if (y > 2.1)
+  target += negative_infinity();
+else 
+  target += -normal_lcdf(2.1 | 0, 1);
 \end{stancode}
 
-In all cases, the truncation is only well formed if the
-appropriate log cumulative distribution functions are defined.%
+With only an upper bound, the discrete case does not need a boundary
+adjustment.  The upper-truncated sampling statement
 %
-\footnote{Although most distributions have cdfs and ccdfs implemented,
-  some cumulative distribution functions and their gradients present
-  computational challenges because they lack simple, analytic forms.}
+\begin{stancode}
+y ~ poisson(3.7) T[ , 10];
+\end{stancode}
 %
+behaves the same way as the following code.
+%
+\begin{stancode}
+y ~ poisson(3.7);
+if (y > 10)
+  target += negative_infinity();
+else 
+  target += -poisson_lcdf(10 | 3.7);
+\end{stancode}
+
+\subsubsection{Cumulative distributions must be defined}
+
+In all cases, the truncation is only well formed if the appropriate
+log density or mass function and necessary log cumulative distribution
+functions are defined.  Not every distribution built into Stan has log
+cdf and log ccdfs defined, nor will every user-defined distribution.
 \refpart{discrete-prob-functions} and
 \refpart{continuous-prob-functions} document the available discrete
 and continuous cumulative distribution functions; most univariate
 distributions have log cdf and log ccdf functions.
 
+
+\subsubsection{Type constraints on bounds}
+
 For continuous distributions, truncation points must be expressions of
 type \code{int} or \code{real}.  For discrete distributions, truncation
 points must be expressions of type \code{int}.
+
+\subsubsection{Variates outside of truncation bounds}
 
 For a truncated sampling statement, if the value sampled is not within
 the bounds specified by the truncation expression, the result is zero
@@ -3683,10 +3824,10 @@ it.
 %
 The conceptual issue is that the prior does not integrate to one over
 the admissible parameter space; it integrates to one over all real
-numbers and integrates to something less than one over $(a,b)$; in these
+numbers and integrates to something less than one over $[a,b]$; in these
 simple univariate cases, we can overcome that with the T[,] notation,
 which essentially divides by whatever the prior integrates to over
-$(a,b)$.  
+$[a,b]$.  
 
 This problem is exactly the same problem as you would get using reject
 statements to enforce complicated inequalities on multivariate

--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -3046,7 +3046,7 @@ truncated unit normal distributions restricted to $[-0.5, 2.1]$
 can be coded with the following sampling statement.
 %
 \begin{stancode}
-y ~ normal(0,1) T[-0.5, 2.1];
+y ~ normal(0, 1) T[-0.5, 2.1];
 \end{stancode}
 %
 Truncated distributions are translated as an additional term in the
@@ -3104,7 +3104,7 @@ stable form of \code{log(exp(a) + exp(b))}.
 For truncating with only a lower bound, the upper limit is left blank.
 %
 \begin{stancode}
-y ~ normal(0,1) T[-0.5, ];
+y ~ normal(0, 1) T[-0.5, ];
 \end{stancode}
 %
 This truncated sampling statement has the same behavior as the
@@ -3147,7 +3147,7 @@ To truncate with only an upper bound, the lower bound is left blank.
 The upper truncated sampling statement
 %
 \begin{stancode}
-y ~ normal(0,1) T[ , 2.1];
+y ~ normal(0, 1) T[ , 2.1];
 \end{stancode}
 %
 produces the same result as the following code.

--- a/src/stan/lang/ast.hpp
+++ b/src/stan/lang/ast.hpp
@@ -202,6 +202,7 @@ namespace stan {
       bool has_user_defined_key(const std::string& name) const;
       std::set<std::string> key_set() const;
       bool has_key(const std::string& key) const;
+      bool discrete_first_arg(const std::string& name) const;
 
     private:
       function_signatures();

--- a/src/stan/lang/ast.hpp
+++ b/src/stan/lang/ast.hpp
@@ -1061,10 +1061,12 @@ namespace stan {
       expression expr_;
       distribution dist_;
       range truncation_;
+      bool is_discrete_;
       sample();
       sample(expression& e,
              distribution& dist);
       bool is_ill_formed() const;
+      bool is_discrete() const;
     };
 
     struct assignment {

--- a/src/stan/lang/ast_def.cpp
+++ b/src/stan/lang/ast_def.cpp
@@ -1966,6 +1966,9 @@ namespace stan {
                && expr_.expression_type()
                   != truncation_.high_.expression_type());
     }
+    bool sample::is_discrete() const {
+      return is_discrete_;
+    }
 
     assignment::assignment() {
     }

--- a/src/stan/lang/ast_def.cpp
+++ b/src/stan/lang/ast_def.cpp
@@ -153,6 +153,7 @@ namespace stan {
         sigs_ = new function_signatures;
       return *sigs_;
     }
+
     void
     function_signatures::set_user_defined(const
                                           std::pair<std::string,
@@ -160,12 +161,14 @@ namespace stan {
                                           name_sig) {
       user_defined_set_.insert(name_sig);
     }
+
     bool
     function_signatures::is_user_defined(const std::pair<std::string,
                                                          function_signature_t>&
                                               name_sig) {
       return user_defined_set_.find(name_sig) != user_defined_set_.end();
     }
+
     bool function_signatures::is_defined(const std::string& name,
                                          const function_signature_t& sig) {
       if (sigs_map_.find(name) == sigs_map_.end())
@@ -175,6 +178,24 @@ namespace stan {
         if (sig.second  == sigs[i].second)
           return true;
       return false;
+    }
+
+    bool function_signatures::discrete_first_arg(const std::string& fun)
+      const {
+      using std::map;
+      using std::string;
+      using std::vector;
+      map<string, vector<function_signature_t> >::const_iterator it
+        = sigs_map_.find(fun);
+      if (it == sigs_map_.end())
+        return false;
+      const vector<function_signature_t> sigs = it->second;
+      for (size_t i = 0; i < sigs.size(); ++i) {
+        if (sigs[i].second.size() == 0
+            || sigs[i].second[0].base_type_ != INT_T)
+          return false;
+      }
+      return true;
     }
 
     void function_signatures::add(const std::string& name,

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -428,7 +428,7 @@ namespace stan {
 
     // called from: statement_grammar
     struct validate_sample : public phoenix_functor_quaternary {
-      void operator()(const sample& s, const variable_map& var_map,
+      void operator()(sample& s, const variable_map& var_map,
                       bool& pass, std::ostream& error_msgs) const;
     };
     extern boost::phoenix::function<validate_sample> validate_sample_f;

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1017,25 +1017,10 @@ namespace stan {
       arg_types.push_back(s.expr_.expression_type());
       for (size_t i = 0; i < s.dist_.args_.size(); ++i)
         arg_types.push_back(s.dist_.args_[i].expression_type());
-      // FIXME(carpenter): still not picking up user-defined _log discretes
       std::string function_name(s.dist_.family_);
       std::string internal_function_name = get_prob_fun(function_name);
-      s.is_discrete_
-        = ends_with("_lpmf", internal_function_name)  // user defined
-        || internal_function_name == "bernoulli_log"
-        || internal_function_name == "bernoulli_logit_log"
-        || internal_function_name == "binomial_log"
-        || internal_function_name == "binomial_logit_log"
-        || internal_function_name == "beta_binomial_log"
-        || internal_function_name == "hypergeometric_log"
-        || internal_function_name == "categorical_log"
-        || internal_function_name == "ordered_logistic_log"
-        || internal_function_name == "neg_binomial_log"
-        || internal_function_name == "neg_binomial_2_log"
-        || internal_function_name == "neg_binomial_2_log_log"
-        || internal_function_name == "poisson_log"
-        || internal_function_name == "poisson_log_log"
-        || internal_function_name == "multinomial_log";
+      s.is_discrete_ = function_signatures::instance()
+        .discrete_first_arg(internal_function_name);
 
       if (internal_function_name.size() == 0) {
         pass = false;

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1019,24 +1019,24 @@ namespace stan {
         arg_types.push_back(s.dist_.args_[i].expression_type());
       // FIXME(carpenter): still not picking up user-defined _log discretes
       std::string function_name(s.dist_.family_);
-      s.is_discrete_
-        = ends_with("_lpdf", function_name)
-        || function_name == "bernoulli_log"
-        || function_name == "bernoulli_logit_log"
-        || function_name == "binomial_log"
-        || function_name == "binomial_logit_log"
-        || function_name == "beta_binomial_log"
-        || function_name == "hypergeometric_log"
-        || function_name == "categorical_log"
-        || function_name == "ordered_logistic_log"
-        || function_name == "neg_binomial_log"
-        || function_name == "neg_binomial_2_log"
-        || function_name == "neg_binomial_2_log_log"
-        || function_name == "poisson_log"
-        || function_name == "poisson_log_log"
-        || function_name == "multinomial_log";
-
       std::string internal_function_name = get_prob_fun(function_name);
+      s.is_discrete_
+        = ends_with("_lpmf", internal_function_name)  // user defined
+        || internal_function_name == "bernoulli_log"
+        || internal_function_name == "bernoulli_logit_log"
+        || internal_function_name == "binomial_log"
+        || internal_function_name == "binomial_logit_log"
+        || internal_function_name == "beta_binomial_log"
+        || internal_function_name == "hypergeometric_log"
+        || internal_function_name == "categorical_log"
+        || internal_function_name == "ordered_logistic_log"
+        || internal_function_name == "neg_binomial_log"
+        || internal_function_name == "neg_binomial_2_log"
+        || internal_function_name == "neg_binomial_2_log_log"
+        || internal_function_name == "poisson_log"
+        || internal_function_name == "poisson_log_log"
+        || internal_function_name == "multinomial_log";
+
       if (internal_function_name.size() == 0) {
         pass = false;
         error_msgs << "Error: couldn't find distribution named "

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1009,7 +1009,7 @@ namespace stan {
             || et.base_type_ == DOUBLE_T);
     }
 
-    void validate_sample::operator()(const sample& s,
+    void validate_sample::operator()(sample& s,
                                      const variable_map& var_map, bool& pass,
                                      std::ostream& error_msgs) const {
       static const bool user_facing = true;
@@ -1017,7 +1017,24 @@ namespace stan {
       arg_types.push_back(s.expr_.expression_type());
       for (size_t i = 0; i < s.dist_.args_.size(); ++i)
         arg_types.push_back(s.dist_.args_[i].expression_type());
+      // FIXME(carpenter): still not picking up user-defined _log discretes
       std::string function_name(s.dist_.family_);
+      s.is_discrete_
+        = ends_with("_lpdf", function_name)
+        || function_name == "bernoulli_log"
+        || function_name == "bernoulli_logit_log"
+        || function_name == "binomial_log"
+        || function_name == "binomial_logit_log"
+        || function_name == "beta_binomial_log"
+        || function_name == "hypergeometric_log"
+        || function_name == "categorical_log"
+        || function_name == "ordered_logistic_log"
+        || function_name == "neg_binomial_log"
+        || function_name == "neg_binomial_2_log"
+        || function_name == "neg_binomial_2_log_log"
+        || function_name == "poisson_log"
+        || function_name == "poisson_log_log"
+        || function_name == "multinomial_log";
 
       std::string internal_function_name = get_prob_fun(function_name);
       if (internal_function_name.size() == 0) {

--- a/src/test/test-models/good/lower-trunc-discrete.stan
+++ b/src/test/test-models/good/lower-trunc-discrete.stan
@@ -1,0 +1,32 @@
+functions {
+  real foo_lpmf(int y, real lambda) {
+    return 1.0;
+  }
+  real foo_lcdf(int y, real lambda) {
+    return 1.0;
+  }
+  real foo_lccdf(int y, real lambda) {
+    return 1.0;
+  }
+}
+
+data {
+  int N;
+  int y[N];
+  int L;
+  int U;
+}
+parameters {
+  real<lower=0> lambda;
+}
+model {
+  for (n in 1:N) {
+    y[n] ~ poisson(lambda) T[L, ];
+    y[n] ~ poisson(lambda) T[L, U];
+    y[n] ~ poisson(lambda) T[ , U];
+
+    y[n] ~ foo(lambda) T[L, ];
+    y[n] ~ foo(lambda) T[L, U];
+    y[n] ~ foo(lambda) T[ , U];
+  }
+}

--- a/src/test/test-models/good/lower-trunc-discrete.stan
+++ b/src/test/test-models/good/lower-trunc-discrete.stan
@@ -1,4 +1,5 @@
 functions {
+  // new syntax
   real foo_lpmf(int y, real lambda) {
     return 1.0;
   }
@@ -8,11 +9,46 @@ functions {
   real foo_lccdf(int y, real lambda) {
     return 1.0;
   }
+
+  // deprecated syntax
+  real bar_log(int y, real lambda) {
+    return 1.0;
+  }
+  real bar_cdf_log(int y, real lambda) {
+    return 1.0;
+  }
+  real bar_ccdf_log(int y, real lambda) {
+    return 1.0;
+  }
+
+  // new syntax
+  real baz_lpdf(real y, real lambda) {
+    return 1.0;
+  }
+  real baz_lcdf(real y, real lambda) {
+    return 1.0;
+  }
+  real baz_lccdf(real y, real lambda) {
+    return 1.0;
+  }
+
+  // deprecated syntax
+  real quux_log(real y, real lambda) {
+    return 1.0;
+  }
+  real quux_cdf_log(real y, real lambda) {
+    return 1.0;
+  }
+  real quux_ccdf_log(real y, real lambda) {
+    return 1.0;
+  }
+
 }
 
 data {
   int N;
   int y[N];
+  real u[N];
   int L;
   int U;
 }
@@ -21,12 +57,36 @@ parameters {
 }
 model {
   for (n in 1:N) {
+
+    // discrete, built-in
     y[n] ~ poisson(lambda) T[L, ];
     y[n] ~ poisson(lambda) T[L, U];
     y[n] ~ poisson(lambda) T[ , U];
 
+    // discrete, user-defined, new syntax
     y[n] ~ foo(lambda) T[L, ];
     y[n] ~ foo(lambda) T[L, U];
     y[n] ~ foo(lambda) T[ , U];
+
+    // discrete, user-defined, deprecated syntax
+    y[n] ~ bar(lambda) T[L, ];
+    y[n] ~ bar(lambda) T[L, U];
+    y[n] ~ bar(lambda) T[ , U];
+
+    // continuous, built-in
+    u[n] ~ normal(0, 1) T[L, ];
+    u[n] ~ normal(0, 1) T[ , U];
+    u[n] ~ normal(0, 1) T[L, U];
+
+    // continuous, user-defined, new syntax
+    y[n] ~ baz(lambda) T[L, ];
+    y[n] ~ baz(lambda) T[L, U];
+    y[n] ~ baz(lambda) T[ , U];
+
+    // continuous, user-defined, deprecated syntax
+    y[n] ~ quux(lambda) T[L, ];
+    y[n] ~ quux(lambda) T[L, U];
+    y[n] ~ quux(lambda) T[ , U];
+
   }
 }

--- a/src/test/unit/lang/ast_test.cpp
+++ b/src/test/unit/lang/ast_test.cpp
@@ -21,6 +21,13 @@ using stan::lang::ROW_VECTOR_T;
 using stan::lang::MATRIX_T;
 using std::vector;
 
+TEST(langAst, discreteFirstArg) {
+  // true if first argument to function is always discrete
+  EXPECT_TRUE(function_signatures::instance()
+              .discrete_first_arg("poisson_log"));
+  EXPECT_FALSE(function_signatures::instance()
+              .discrete_first_arg("normal_log"));
+}
 
 TEST(langAst, printSignature) {
   std::vector<expr_type> arg_types;

--- a/src/test/unit/lang/generator_test.cpp
+++ b/src/test/unit/lang/generator_test.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <sstream>
-#include <boost/random/additive_combine.hpp> // L'Ecuyer RNG
+#include <boost/random/additive_combine.hpp>
 #include <stan/lang/ast_def.cpp>
 #include <stan/lang/generator.hpp>
 #include <stan/io/dump.hpp>

--- a/src/test/unit/lang/parser/lower_trunc_adjust_test.cpp
+++ b/src/test/unit/lang/parser/lower_trunc_adjust_test.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include <test/unit/lang/utility.hpp>
+
+TEST(langParser, lowerTruncAdjust) {
+  test_parsable("lower-trunc-discrete");
+  // built-in T[L, ]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-log_sum_exp(poisson_ccdf_log(L, lambda), poisson_log(L, lambda)));");
+  // built-in T[L, U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-log_sum_exp(log_diff_exp(poisson_cdf_log(U, lambda), poisson_cdf_log(L, lambda)), poisson_log(L, lambda)));");
+  // built-in T[ , U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-poisson_cdf_log(U, lambda));");
+  // user-defined T[L, ]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-log_sum_exp(foo_lccdf(L, lambda, pstream__), foo_lpmf(L, lambda, pstream__)));");
+  // user-defined T[L, U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-log_sum_exp(log_diff_exp(foo_lcdf(U, lambda, pstream__), foo_lcdf(L, lambda, pstream__)), foo_lpmf(L, lambda, pstream__)));");
+  // user-defined T[ , U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-foo_lcdf(U, lambda, pstream__));");
+}

--- a/src/test/unit/lang/parser/lower_trunc_adjust_test.cpp
+++ b/src/test/unit/lang/parser/lower_trunc_adjust_test.cpp
@@ -1,6 +1,10 @@
 #include <gtest/gtest.h>
 #include <test/unit/lang/utility.hpp>
 
+// these tests make sure the built-in and user-defined
+// discrete and continuous distributions generate the right code
+// if the exact form of the code changes, these tests must be changed
+
 TEST(langParser, lowerTruncAdjust) {
   test_parsable("lower-trunc-discrete");
   // built-in T[L, ]
@@ -12,13 +16,74 @@ TEST(langParser, lowerTruncAdjust) {
   // built-in T[ , U]
   expect_match("lower-trunc-discrete",
                "lp_accum__.add(-poisson_cdf_log(U, lambda));");
+
   // user-defined T[L, ]
   expect_match("lower-trunc-discrete",
-               "lp_accum__.add(-log_sum_exp(foo_lccdf(L, lambda, pstream__), foo_lpmf(L, lambda, pstream__)));");
+               "lp_accum__.add(-log_sum_exp(foo_lccdf(L, lambda, pstream__),"
+               " foo_lpmf(L, lambda, pstream__)));");
   // user-defined T[L, U]
   expect_match("lower-trunc-discrete",
-               "lp_accum__.add(-log_sum_exp(log_diff_exp(foo_lcdf(U, lambda, pstream__), foo_lcdf(L, lambda, pstream__)), foo_lpmf(L, lambda, pstream__)));");
+               "lp_accum__.add(-log_sum_exp(log_diff_exp(foo_lcdf(U, lambda,"
+               " pstream__), foo_lcdf(L, lambda, pstream__)), foo_lpmf(L,"
+               " lambda, pstream__)));");
   // user-defined T[ , U]
   expect_match("lower-trunc-discrete",
                "lp_accum__.add(-foo_lcdf(U, lambda, pstream__));");
+
+  // user-defined (deprecated) T[L, ]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-log_sum_exp(bar_ccdf_log(L, lambda,"
+               " pstream__), bar_log(L, lambda, pstream__)));");
+  // user-defined (deprecated) T[L, U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-log_sum_exp(log_diff_exp(bar_cdf_log(U,"
+               " lambda, pstream__), bar_cdf_log(L, lambda, pstream__)),"
+               " bar_log(L, lambda, pstream__)));");
+  // user-defined (deprecated) T[ , U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-bar_cdf_log(U, lambda, pstream__));");
+
+  // built-in continuous T[L, ]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-normal_ccdf_log(L, 0, 1));");
+
+  // built-in continuous T[ , U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-normal_cdf_log(U, 0, 1));");
+
+  // built-in continuous T[L, U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-log_diff_exp(normal_cdf_log(U, 0, 1),"
+               " normal_cdf_log(L, 0, 1)));");
+
+  // user-defined continuous T[L, ]
+  expect_match("lower-trunc-discrete",
+               " lp_accum__.add(-baz_lccdf(L, lambda, pstream__));");
+
+  // user-defined continuous T[ , U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-log_diff_exp(baz_lcdf(U, lambda,"
+               " pstream__), baz_lcdf(L, lambda, pstream__)));");
+
+  // user-defined continuous T[L, U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-baz_lcdf(U, lambda, pstream__));");
+
+  // user-defined, deprecated continuous T[L, ]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-quux_ccdf_log(L, lambda,"
+               " pstream__));");
+
+  // user-defined, deprecated continuous T[ , U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-log_diff_exp(quux_cdf_log(U,"
+               " lambda, pstream__), quux_cdf_log(L, lambda,"
+               " pstream__)));");
+
+  // user-defined, deprecated continuous T[L, U]
+  expect_match("lower-trunc-discrete",
+               "lp_accum__.add(-quux_cdf_log(U, lambda,"
+               " pstream__));");
+
+
 }

--- a/src/test/unit/lang/utility.hpp
+++ b/src/test/unit/lang/utility.hpp
@@ -195,11 +195,12 @@ void expect_match(const std::string& model_name,
                   bool allow_undefined = false) {
   std::stringstream msgs;
   std::string file_name = get_file_name("good", model_name);
-  std::ifstream file_stream(file_name);
+  std::ifstream file_stream(file_name.c_str());
   std::stringstream cpp_out_stream;
   stan::lang::compile(&msgs, file_stream, cpp_out_stream,
                       model_name, allow_undefined);
   std::string cpp_out = cpp_out_stream.str();
+  file_stream.close();
   EXPECT_TRUE(count_matches(target, cpp_out) > 0);
 }
 

--- a/src/test/unit/lang/utility.hpp
+++ b/src/test/unit/lang/utility.hpp
@@ -12,6 +12,7 @@
 #include <boost/lexical_cast.hpp>
 
 #include <stan/lang/ast.hpp>
+#include <stan/lang/compiler.hpp>
 #include <stan/lang/parser.hpp>
 #include <stan/lang/generator.hpp>
 #include <stan/lang/grammars/program_grammar.hpp>
@@ -88,8 +89,6 @@ void test_parsable(const std::string& model_name) {
     EXPECT_TRUE(is_parsable_folder(model_name, "good"));
   }
 }
-
-
 
 /** test that model with specified name in folder "bad" throws
  * an exception containing the second arg as a substring
@@ -179,6 +178,29 @@ void expect_matches(int n,
                     const std::string& target) {
   std::string model_cpp = model_to_cpp(stan_code);
   EXPECT_EQ(n, count_matches(target,model_cpp));
+}
+
+std::string get_file_name(const std::string& folder,
+                          const std::string& model_name) {
+  std::string path("src/test/test-models/");
+  path += folder;
+  path += "/";
+  path += model_name;
+  path += ".stan";
+  return path;
+}
+
+void expect_match(const std::string& model_name,
+                  const std::string& target,
+                  bool allow_undefined = false) {
+  std::stringstream msgs;
+  std::string file_name = get_file_name("good", model_name);
+  std::ifstream file_stream(file_name);
+  std::stringstream cpp_out_stream;
+  stan::lang::compile(&msgs, file_stream, cpp_out_stream,
+                      model_name, allow_undefined);
+  std::string cpp_out = cpp_out_stream.str();
+  EXPECT_TRUE(count_matches(target, cpp_out) > 0);
 }
 
 /**


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes off-by-one error in lower bound truncations for discrete distributions and updates manual to explain discrete vs. continuous translations.

#### How to Verify

Unit tests checking for all combinations of discrete/continuous distributions and built-in/lpdf/log probability function definitions.  Desired output explained and derived in the doc language section.

#### Side Effects

None.

#### Documentation

Yes, updated manual.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
