### PR TITLE
Jacobian message uses target +=, fixes #2066

### DIFF
--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1066,7 +1066,6 @@ namespace stan {
         pass = false;
         return;
       }
-
       // test for LHS not being purely a variable
       if (has_non_param_var(s.expr_, var_map)) {
         error_msgs << "Warning (non-fatal):"
@@ -1074,8 +1073,8 @@ namespace stan {
                    << "Left-hand side of sampling statement (~) may contain a"
                    << " non-linear transform of a parameter or local variable."
                    << std::endl
-                   << "If so, you need to call increment_log_prob() with"
-                   << " the log absolute determinant of the Jacobian of"
+                   << "If it does, you need to include a target += statement"
+                   << " with the log absolute determinant of the Jacobian of"
                    << " the transform."
                    << std::endl
                    << "Left-hand-side of sampling statement:"

--- a/src/test/unit/lang/parser/statement_grammar_test.cpp
+++ b/src/test/unit/lang/parser/statement_grammar_test.cpp
@@ -53,17 +53,23 @@ TEST(langParserStatementGrammar, deprecateIncrementLogProb) {
 TEST(langParserStatementGrammarDef, jacobianAdjustmentWarning) {
   test_parsable("validate_jacobian_warning_good");
   test_warning("validate_jacobian_warning1",
-               "If so, you need to call increment_log_prob() with the log");
+               "you need to include a target += statement with"
+               " the log absolute determinant of the Jacobian of the transform.");
   test_warning("validate_jacobian_warning2",
-               "If so, you need to call increment_log_prob() with the log");
+               "you need to include a target += statement with"
+               " the log absolute determinant of the Jacobian of the transform.");
   test_warning("validate_jacobian_warning3",
-               "If so, you need to call increment_log_prob() with the log");
+               "you need to include a target += statement with"
+               " the log absolute determinant of the Jacobian of the transform.");
   test_warning("validate_jacobian_warning4",
-               "If so, you need to call increment_log_prob() with the log");
+               "you need to include a target += statement with"
+               " the log absolute determinant of the Jacobian of the transform.");
   test_warning("validate_jacobian_warning5",
-               "If so, you need to call increment_log_prob() with the log");
+               "you need to include a target += statement with"
+               " the log absolute determinant of the Jacobian of the transform.");
   test_warning("validate_jacobian_warning6",
-               "If so, you need to call increment_log_prob() with the log");
+               "you need to include a target += statement with"
+               " the log absolute determinant of the Jacobian of the transform.");
 }
 
 TEST(langParserStatementGrammarDef, jacobianUserFacing) {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Use "target +=" instead of "increment_log_prob()" in warning message for Jacobian.

#### Intended Effect

Bring up to date with non-deprecated functions.

#### How to Verify

Changed the unit tests to match.

#### Side Effects

No.

#### Documentation

N/A.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

