### PR TITLE
use ifstream in stanc plus tests, fixes #1615

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -148,8 +148,8 @@ $(patsubst %.stan,%.hpp,$(TEST_MODELS)) : %.hpp : %.stan test/test-models/stanc$
 .PHONY: change-file-permissions
 change-file-permissions: 
 ifeq ($(OS_TYPE),win)
-	attrib +r src\test\test-models\good\stanc_helper.stan
-	attrib +r src\test\test-models\bad\stanc_helper.stan
+	attrib +r src\\test\\test-models\\good\\stanc_helper.stan
+	attrib +r src\\test\\test-models\\bad\\stanc_helper.stan
 else
 	chmod 444 src/test/test-models/*/stanc_helper.stan
 endif

--- a/make/tests
+++ b/make/tests
@@ -143,6 +143,22 @@ $(patsubst %.stan,%.hpp,$(TEST_MODELS)) : %.hpp : %.stan test/test-models/stanc$
 	$(WINE) test/test-models/stanc$(EXE) --o=$@ $<
 
 ##
+# src/test/unit/lang/stanc_helper_test.cpp requires files to be read-only.
+##
+.PHONY: change-file-permissions
+change-file-permissions: 
+ifeq ($(OS_TYPE),win)
+	attrib +r src\test\test-models\good\stanc_helper.stan
+	attrib +r src\test\test-models\bad\stanc_helper.stan
+else
+	chmod 444 src/test/test-models/*/stanc_helper.stan
+endif
+
+src/test/unit/lang/stanc_helper_test.cpp: change-file-permissions
+
+
+
+##
 # Explicitly specify dependencies for tests that depend on the generated C++ of Stan programs.
 ##
 src/test/performance/logistic_test.cpp: src/test/test-models/performance/logistic.hpp

--- a/src/stan/command/stanc_helper.hpp
+++ b/src/stan/command/stanc_helper.hpp
@@ -10,7 +10,11 @@
 #include <stdexcept>
 #include <string>
 
-
+/**
+ * Print the version of stanc with major, minor and patch.
+ * 
+ * @param[in, out] out_stream stream to which version is written.
+ */
 void print_version(std::ostream* out_stream) {
   if (!out_stream) return;
   *out_stream << "stanc version "
@@ -24,6 +28,8 @@ void print_version(std::ostream* out_stream) {
 
 /**
  * Prints the Stan compiler (stanc) help.
+ *
+ * @param[in, out] out_stream stream to which help is written
  */
 void print_stanc_help(std::ostream* out_stream) {
   using stan::io::print_help_option;
@@ -56,16 +62,41 @@ void print_stanc_help(std::ostream* out_stream) {
                     "Do not fail if a function is declared but not defined");
 }
 
+/**
+ * Delte the file at the specified path, writing messages to error
+ * stream if not possible.  Do nothing on zero size file name input.
+ * Only write to error stream if it is non-null.
+ *
+ * @param[in, out] err_stream stream to which error messages are
+ * written
+ * @param[in] file_name path of file
+ */
 void delete_file(std::ostream* err_stream,
                  const std::string& file_name) {
-  int deleted = std::remove(file_name.c_str());
-  if (deleted != 0 && file_name.size() > 0)
+  if (file_name.size() == 0)
+    return;
+  int return_code = std::remove(file_name.c_str());
+  if (return_code != 0)
     if (err_stream)
       *err_stream << "Could not remove output file=" << file_name
                   << std::endl;
 }
 
-
+/**
+ * Invoke the stanc command on the specified argument list, writing
+ * output and error messages to the specified streams, return a return
+ * code.
+ *
+ * <p>The return codes are: 0 for success, -1 for an exception,
+ * -2 is parsing failed, and -3 if there are invalid arguments.
+ *
+ * @param[in] argc number of arguments
+ * @param[in] argv arguments
+ * @parma[in, out] out_stream stream to which output is written
+ * @param[in, out] err_stream stream to which error messages are
+ * written 
+ * @return return code
+ */
 int stanc_helper(int argc, const char* argv[],
                  std::ostream* out_stream, std::ostream* err_stream) {
   static const int SUCCESS_RC = 0;
@@ -94,7 +125,7 @@ int stanc_helper(int argc, const char* argv[],
     }
     std::string in_file_name;
     cmd.bare(0, in_file_name);
-    std::fstream in(in_file_name.c_str());
+    std::ifstream in(in_file_name.c_str());
 
     std::string model_name;
     if (cmd.has_key("name")) {
@@ -125,6 +156,7 @@ int stanc_helper(int argc, const char* argv[],
       cmd.val("o", out_file_name);
     } else {
       out_file_name = model_name;
+      // TODO(carpenter): shouldn't this be .hpp without a main()?
       out_file_name += ".cpp";
     }
 

--- a/src/stan/command/stanc_helper.hpp
+++ b/src/stan/command/stanc_helper.hpp
@@ -13,7 +13,7 @@
 /**
  * Print the version of stanc with major, minor and patch.
  * 
- * @param[in, out] out_stream stream to which version is written.
+ * @param[in,out] out_stream stream to which version is written.
  */
 void print_version(std::ostream* out_stream) {
   if (!out_stream) return;
@@ -29,7 +29,7 @@ void print_version(std::ostream* out_stream) {
 /**
  * Prints the Stan compiler (stanc) help.
  *
- * @param[in, out] out_stream stream to which help is written
+ * @param[in,out] out_stream stream to which help is written
  */
 void print_stanc_help(std::ostream* out_stream) {
   using stan::io::print_help_option;
@@ -67,7 +67,7 @@ void print_stanc_help(std::ostream* out_stream) {
  * stream if not possible.  Do nothing on zero size file name input.
  * Only write to error stream if it is non-null.
  *
- * @param[in, out] err_stream stream to which error messages are
+ * @param[in,out] err_stream stream to which error messages are
  * written
  * @param[in] file_name path of file
  */
@@ -92,8 +92,8 @@ void delete_file(std::ostream* err_stream,
  *
  * @param[in] argc number of arguments
  * @param[in] argv arguments
- * @parma[in, out] out_stream stream to which output is written
- * @param[in, out] err_stream stream to which error messages are
+ * @param[in,out] out_stream stream to which output is written
+ * @param[in,out] err_stream stream to which error messages are
  * written 
  * @return return code
  */

--- a/src/test/test-models/bad/stanc_helper.stan
+++ b/src/test/test-models/bad/stanc_helper.stan
@@ -1,0 +1,6 @@
+parameters {
+  real y;
+}
+model {
+  y ~ ormal(0, 1);
+}

--- a/src/test/test-models/good/stanc_helper.stan
+++ b/src/test/test-models/good/stanc_helper.stan
@@ -1,0 +1,6 @@
+parameters {
+  real y;
+}
+model {
+  y ~ normal(0, 1);
+}

--- a/src/test/unit/lang/stanc_helper_test.cpp
+++ b/src/test/unit/lang/stanc_helper_test.cpp
@@ -26,36 +26,6 @@ TEST(commandStancHelper, printStancHelp) {
   expect_find(ss.str(), "OPTIONS:");
 }
 
-bool create_test_file(const std::string& path, const std::string& program) {
-  std::string cmd = "echo \"";
-  cmd += program;
-  cmd += "\" > ";
-  cmd += path;
-  cmd += "; chmod 444 ";
-  cmd += path;
-  int return_code = system(cmd.c_str());
-  return return_code == 0;
-}
-
-bool create_test_file() {
-  std::string program
-    = "parameters { real y; } model { y ~ normal(0, 1); }";
-  return create_test_file("test/test-models/temp-bar.stan", program);
-}
-
-TEST(commandStancHelper, deleteFile) {
-  if (!create_test_file()) return;
-  std::stringstream ss;
-  delete_file(&ss, "test/test-models/temp-bar.stan");
-  // test there's no error message
-  EXPECT_EQ(0, ss.str().size());
-  // and then test the file stream can't be opened
-  std::fstream fs;
-  fs.open("test/test-models/temp-bar.stan", std::fstream::in);
-  EXPECT_FALSE(fs.is_open());
-  fs.close();
-}
-
 int run_helper(const std::string& path,
                std::ostream& out, std::ostream& err) {
   int argc = 2;
@@ -67,38 +37,26 @@ int run_helper(const std::string& path,
 }
 
 TEST(commandStancHelper, readOnlyOK) {
-  if (!create_test_file()) return;
-
   std::stringstream out;
   std::stringstream err;
-  int rc = run_helper("test/test-models/temp-bar.stan", out, err);
-
+  int rc = run_helper("src/test/test-models/good/stanc_helper.stan", out, err);
+  
   EXPECT_EQ(0, rc)
     << "out=" << out.str() << std::endl << "err=" << err.str() << std::endl;
-  expect_find(out.str(), "Model name=temp_bar_model");
-  expect_find(out.str(), "Input file=test/test-models/temp-bar.stan");
-  expect_find(out.str(), "Output file=temp_bar_model.cpp");
+  expect_find(out.str(), "Model name=stanc_helper_model");
+  expect_find(out.str(), "Input file=src/test/test-models/good/stanc_helper.stan");
+  expect_find(out.str(), "Output file=stanc_helper_model.cpp");
   EXPECT_EQ(0, err.str().size())
     << "error=" << err.str() << std::endl;
-
-  delete_file(&err, "test/test-models/temp-bar.stan");
-  delete_file(&err, "bar_model.cpp");
 }
 
 TEST(commandStancHelper, failRC) {
-  std::string path = "test/test-models/temp-bar.stan";
-  std::string prog
-    = "parameters { real y; } model { y ~ ormal(0, 1); }";
-  if (!create_test_file(path, prog)) return;
-
   std::stringstream out;
   std::stringstream err;
-  int rc = run_helper(path, out, err);
+  int rc = run_helper("src/test/test-models/bad/stanc_helper.stan", out, err);
 
   // TODO(carpenter): This should be -2 but it's -3 so
   // I only tested that it's != 0 to contrast with earlier success
   EXPECT_TRUE(rc != 0);
-
-  delete_file(&err, "test/test-models/temp-bar.stan");
 }
     

--- a/src/test/unit/lang/stanc_helper_test.cpp
+++ b/src/test/unit/lang/stanc_helper_test.cpp
@@ -73,11 +73,13 @@ TEST(commandStancHelper, readOnlyOK) {
   std::stringstream err;
   int rc = run_helper("test/test-models/temp-bar.stan", out, err);
 
-  EXPECT_EQ(0, rc);
+  EXPECT_EQ(0, rc)
+    << "out=" << out.str() << std::endl << "err=" << err.str() << std::endl;
   expect_find(out.str(), "Model name=temp_bar_model");
   expect_find(out.str(), "Input file=test/test-models/temp-bar.stan");
   expect_find(out.str(), "Output file=temp_bar_model.cpp");
-  EXPECT_EQ(0, err.str().size());
+  EXPECT_EQ(0, err.str().size())
+    << "error=" << err.str() << std::endl;
 
   delete_file(&err, "test/test-models/temp-bar.stan");
   delete_file(&err, "bar_model.cpp");

--- a/src/test/unit/lang/stanc_helper_test.cpp
+++ b/src/test/unit/lang/stanc_helper_test.cpp
@@ -26,6 +26,34 @@ TEST(commandStancHelper, printStancHelp) {
   expect_find(ss.str(), "OPTIONS:");
 }
 
+bool create_test_file(const std::string& path, const std::string& program) {
+  std::string cmd = "echo ";
+  cmd += program;
+  cmd += " > ";
+  cmd += path;
+  int return_code = system(cmd.c_str());
+  return return_code == 0;
+}
+
+bool create_test_file() {
+  std::string program
+    = "parameters { real y; } model { y ~ normal(0, 1); }";
+  return create_test_file("test/test-models/temp-bar.stan", program);
+}
+
+TEST(commandStancHelper, deleteFile) {
+  if (!create_test_file()) return;
+  std::stringstream ss;
+  delete_file(&ss, "test/test-models/temp-bar.stan");
+  // test there's no error message
+  EXPECT_EQ(0, ss.str().size());
+  // and then test the file stream can't be opened
+  std::fstream fs;
+  fs.open("test/test-models/temp-bar.stan", std::fstream::in);
+  EXPECT_FALSE(fs.is_open());
+  fs.close();
+}
+
 int run_helper(const std::string& path,
                std::ostream& out, std::ostream& err) {
   int argc = 2;

--- a/src/test/unit/lang/stanc_helper_test.cpp
+++ b/src/test/unit/lang/stanc_helper_test.cpp
@@ -1,0 +1,102 @@
+// TODO(carpenter): move this into test/unit/command
+//                  it's here now because it won't compile there
+
+#include <gtest/gtest.h>
+#include <stan/lang/compiler.hpp>
+#include <stan/command/stanc_helper.hpp>
+#include <test/unit/util.hpp>
+#include <fstream>
+#include <sstream>
+
+void expect_find(const std::string& str, const std::string& target) {
+  EXPECT_TRUE(str.find(target) != std::string::npos)
+    << str << " does not contain " << target << std::endl;
+}
+
+TEST(commandStancHelper, printVersion) {
+  std::stringstream ss;
+  print_version(&ss);
+  expect_find(ss.str(), "stanc version 2.");
+}
+
+TEST(commandStancHelper, printStancHelp) {
+  std::stringstream ss;
+  print_stanc_help(&ss);
+  expect_find(ss.str(), "USAGE:  stanc [options] <model_file>");
+  expect_find(ss.str(), "OPTIONS:");
+}
+
+bool create_test_file(const std::string& path, const std::string& program) {
+  std::string cmd = "echo \"";
+  cmd += program;
+  cmd += "\" > ";
+  cmd += path;
+  cmd += "; chmod 444 ";
+  cmd += path;
+  int return_code = system(cmd.c_str());
+  return return_code == 0;
+}
+
+bool create_test_file() {
+  std::string program
+    = "parameters { real y; } model { y ~ normal(0, 1); }";
+  return create_test_file("test/test-models/temp-bar.stan", program);
+}
+
+TEST(commandStancHelper, deleteFile) {
+  if (!create_test_file()) return;
+  std::stringstream ss;
+  delete_file(&ss, "test/test-models/temp-bar.stan");
+  // test there's no error message
+  EXPECT_EQ(0, ss.str().size());
+  // and then test the file stream can't be opened
+  std::fstream fs;
+  fs.open("test/test-models/temp-bar.stan", std::fstream::in);
+  EXPECT_FALSE(fs.is_open());
+  fs.close();
+}
+
+int run_helper(const std::string& path,
+               std::ostream& out, std::ostream& err) {
+  int argc = 2;
+  std::vector<const char*> argv_vec;
+  argv_vec.push_back("main");
+  argv_vec.push_back(path.c_str());
+  const char** argv = &argv_vec[0];
+  return stanc_helper(argc, argv, &out, &err);
+}
+
+TEST(commandStancHelper, readOnlyOK) {
+  if (!create_test_file()) return;
+
+  std::stringstream out;
+  std::stringstream err;
+  int rc = run_helper("test/test-models/temp-bar.stan", out, err);
+
+  EXPECT_EQ(0, rc);
+  expect_find(out.str(), "Model name=temp_bar_model");
+  expect_find(out.str(), "Input file=test/test-models/temp-bar.stan");
+  expect_find(out.str(), "Output file=temp_bar_model.cpp");
+  EXPECT_EQ(0, err.str().size());
+
+  delete_file(&err, "test/test-models/temp-bar.stan");
+  delete_file(&err, "bar_model.cpp");
+}
+
+TEST(commandStancHelper, failRC) {
+  std::string path = "test/test-models/temp-bar.stan";
+  std::string prog
+    = "parameters { real y; } model { y ~ ormal(0, 1); }";
+  if (!create_test_file(path, prog)) return;
+
+  std::stringstream out;
+  std::stringstream err;
+  int rc = run_helper(path, out, err);
+
+  // TODO(carpenter): This should be -2 but it's -3 so
+  // I only tested that it's != 0 to contrast with earlier success
+  EXPECT_TRUE(rc != 0);
+
+  delete_file(&err, "test/test-models/temp-bar.stan");
+}
+    


### PR DESCRIPTION
#### Submisison Checklist
- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below
#### Summary

Allow stanc to read read-only files.
#### Intended Effect

See summary.  Also added tests for stanc_helper.

_Help_:  Can't get the tests running in `src/test/unit/command` so dropped it in `src/test/unit/lang` instead.  I think it's a build issue.

_Help 2_:  If it matters, I can't get the right return code for an ill-formed model.  It returns illegal arguments.  But there wasn't any doc and I couldn't easily trace through the logic.

_Help 3_:  I created files from within C++ using a system call.  If there's a better way to do this through make or something, please fix.  I tried to code the test defensively, but may have failed.
#### How to Verify

Unit test.
#### Side Effects

none
#### Documentation

n/a
#### Reviewer Suggestions

@syclik 
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
