### PR TITLE
allow variables ending in _lpdf in expressions, fixes #2123

### DIFF
--- a/src/stan/lang/grammars/term_grammar_def.hpp
+++ b/src/stan/lang/grammars/term_grammar_def.hpp
@@ -223,7 +223,9 @@ namespace stan {
 
       fun_r.name("function and argument expressions");
       fun_r
-        %= (hold[identifier_r[is_prob_fun_f(_1, _pass)]] > prob_args_r(_r1))
+        %= (hold[identifier_r[is_prob_fun_f(_1, _pass)]]
+            >> &lit('(')
+            > prob_args_r(_r1))
         | (identifier_r >> args_r(_r1));
 
       identifier_r.name("identifier");

--- a/src/test/test-models/good/var-ending-lpdf.stan
+++ b/src/test/test-models/good/var-ending-lpdf.stan
@@ -1,0 +1,6 @@
+parameters {
+  real mu_lpdf;
+}
+model {
+  target += mu_lpdf;
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fix bug in parser so that variables ending in `_lpdf` may be used in expressions.  It was assuming that anything ending in `_lpdf` was a log probability density function before.

#### How to Verify

New model checked into tests that parses with the patch but didn't parse before.

#### Side Effects

No.

#### Documentation

No, behavior now matches doc.

#### Reviewer Suggestions

anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

