### PR TITLE
Expose choose() function

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -187,7 +187,7 @@ src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp: src/test/test-models/good/mcm
 src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
 src/test/unit/mcmc/hmc/xhmc/softabs_xhmc_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
 src/test/unit/mcmc/hmc/static_uniform/derived_static_uniform_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss.hpp
-src/test/unit/model/finite_diff_grad_test.cpp src/test/unit/model/grad_hess_log_prob_test.cpp src/test/unit/model/grad_tr_mat_times_hessian_test.cpp src/test/unit/model/gradient_test.cpp src/test/unit/model/gradient_dot_vector_test.cpp src/test/unit/model/hessian_test.cpp src/test/unit/model/hessian_times_vector_test.cpp src/test/unit/model/log_prob_grad_test.cpp src/test/unit/model/test_gradients_test.cpp : src/test/test-models/good/model/valid.hpp
+src/test/unit/model/finite_diff_grad_test.cpp src/test/unit/model/grad_hess_log_prob_test.cpp src/test/unit/model/grad_tr_mat_times_hessian_test.cpp src/test/unit/model/gradient_dot_vector_test.cpp src/test/unit/model/gradient_test.cpp src/test/unit/model/hessian_test.cpp src/test/unit/model/hessian_times_vector_test.cpp src/test/unit/model/log_prob_grad_test.cpp src/test/unit/model/log_prob_propto_test.cpp src/test/unit/model/model_functional_test.cpp src/test/unit/model/test_gradients_test.cpp : src/test/test-models/good/model/valid.hpp
 src/test/unit/optimization/bfgs_linesearch_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp
 src/test/unit/optimization/bfgs_minimizer_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp
 src/test/unit/optimization/bfgs_test.cpp: src/test/test-models/good/optimization/rosenbrock.hpp

--- a/src/docs/stan-reference/functions.tex
+++ b/src/docs/stan-reference/functions.tex
@@ -1240,6 +1240,21 @@ distribution function (and its complement).
     = \log\Gamma(x+1) - \log\Gamma(y+1) - \log\Gamma(x-y+1).
     \]}
   %
+  \fitem{int}{choose}{real \farg{x}, real \farg{y}}{
+    Returns the binomial coefficient of \farg{x} and \farg{y}. For 
+    non-negative integer inputs, the binomial coefficient function 
+    is written as $\binom{x}{y}$ and pronounced ``\farg{x} choose 
+    \farg{y}.'' In its the antilog of the \code{lchoose} function
+    but returns an integer rather than a real number with no
+    non-zero decimal places.
+    
+    For $0 \leq y \leq x$, the binomial coefficient function can be
+    defined via the factorial function
+    \[
+    \mbox{\code{choose}}(x,y)
+    = \frac{x!}{\left(y!\right)\left(x - y\right)!}.
+    \]}
+  %  
   \fitem{real}{bessel\_first\_kind}{int \farg{v}, real \farg{x}}{
     Returns the Bessel function of the first kind with order \farg{v}
     applied to \farg{x}.

--- a/src/docs/stan-reference/functions.tex
+++ b/src/docs/stan-reference/functions.tex
@@ -1240,7 +1240,7 @@ distribution function (and its complement).
     = \log\Gamma(x+1) - \log\Gamma(y+1) - \log\Gamma(x-y+1).
     \]}
   %
-  \fitem{int}{choose}{real \farg{x}, real \farg{y}}{
+  \fitem{int}{choose}{int \farg{x}, int \farg{y}}{
     Returns the binomial coefficient of \farg{x} and \farg{y}. For 
     non-negative integer inputs, the binomial coefficient function 
     is written as $\binom{x}{y}$ and pronounced ``\farg{x} choose 

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -211,6 +211,7 @@ for (size_t i = 0; i < vector_types.size(); ++i) {
 }
 add_unary("chi_square_rng");
 add("cholesky_decompose", MATRIX_T, MATRIX_T);
+add("choose", INT_T, INT_T, INT_T);
 add("col", VECTOR_T, MATRIX_T, INT_T);
 add("cols", INT_T, VECTOR_T);
 add("cols", INT_T, ROW_VECTOR_T);

--- a/src/test/test-models/good/function-signatures/math/functions/choose.stan
+++ b/src/test/test-models/good/function-signatures/math/functions/choose.stan
@@ -1,0 +1,16 @@
+data { 
+  int d_int;
+  int r_int;
+  
+}
+transformed data {
+  int transformed_data_int;
+
+  transformed_data_int <- choose(r_int, d_int);
+}
+parameters {
+  real y_p;
+}
+model {  
+  y_p ~ normal(0,1);
+}


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit` gtest is broken but probably passes
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary

Expose the `choose()` function to the Stan language and document it.

#### Intended Effect

Allow people to use the `choose()` function in Stan programs, particularly in declarations like `vector[choose(K,2)] theta;`

#### How to Verify

Parse src/test/test-models/good/function-signatures/math/functions/choose.stan

#### Side Effects

None

#### Documentation

Yes

#### Reviewer Suggestions

Anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
