### PR TITLE
Bugfix/issue 2138 compound declare define inits

### DIFF
--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -544,7 +544,7 @@ namespace stan {
 
     // use to disambiguate VectorXd(0) ctor from Scalar* alternative
     void generate_eigen_index_expression(const expression& e,
-                                    std::ostream& o) {
+                                         std::ostream& o) {
       o << "static_cast<Eigen::VectorXd::Index>(";
       generate_expression(e.expr_, o);
       o << ")";
@@ -1660,9 +1660,9 @@ namespace stan {
     }
 
     void generate_define_vars(const std::vector<var_decl>& vs,
-                            int indent,
-                            bool is_var_context,
-                            std::ostream& o) {
+                              int indent,
+                              bool is_var_context,
+                              std::ostream& o) {
       generate_comment("assign variable definitions",
                        indent, o);
       for (size_t i = 0; i < vs.size(); ++i) {

--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -1661,6 +1661,7 @@ namespace stan {
 
     void generate_define_vars(const std::vector<var_decl>& vs,
                             int indent,
+                            bool is_var_context,
                             std::ostream& o) {
       generate_comment("assign variable definitions",
                        indent, o);
@@ -1670,7 +1671,7 @@ namespace stan {
           o << "stan::math::assign("
             << vs[i].name()
             << ",";
-          generate_expression(vs[i].def(), false, o);
+          generate_expression(vs[i].def(), false, is_var_context, o);
           o << ");" << EOL;
         }
       }
@@ -2106,7 +2107,7 @@ namespace stan {
                                    is_var_context_, is_fun_return_);
           generate_local_var_init_nan(x.local_decl_, indent, o_,
                                       is_var_context_, is_fun_return_);
-          generate_define_vars(x.local_decl_, indent, o_);
+          generate_define_vars(x.local_decl_, indent, is_var_context_, o_);
         }
         o_ << EOL;
 
@@ -2350,7 +2351,7 @@ namespace stan {
       generate_local_var_decls(p.derived_decl_.first, 2, o, is_var_context,
                                is_fun_return);
       generate_init_vars(p.derived_decl_.first, 2, o);
-      generate_define_vars(p.derived_decl_.first, 2, o);
+      generate_define_vars(p.derived_decl_.first, 2, is_var_context, o);
       o << EOL;
 
       bool include_sampling = true;
@@ -3185,12 +3186,13 @@ namespace stan {
       o << INDENT2
         << "(void) DUMMY_VAR__;  // suppress unused var warning" << EOL2;
       generate_init_vars(prog.derived_data_decl_.first, 2, o);
-      generate_define_vars(prog.derived_data_decl_.first, 2, o);
-      o << EOL;
 
       bool include_sampling = false;
       bool is_var_context = false;
       bool is_fun_return = false;
+      generate_define_vars(prog.derived_data_decl_.first, 2, is_var_context, o);
+      o << EOL;
+
       // need to fix generate_located_statements
       generate_located_statements(prog.derived_data_decl_.second,
                                   2, o, include_sampling, is_var_context,
@@ -4404,7 +4406,7 @@ namespace stan {
       o << INDENT2 << "(void) DUMMY_VAR__;  // suppress unused var warning"
         << EOL2;
       generate_init_vars(prog.generated_decl_.first, 2, o);
-      generate_define_vars(prog.generated_decl_.first, 2, o);
+      generate_define_vars(prog.generated_decl_.first, 2, is_var_context, o);
       o << EOL;
       generate_located_statements(prog.generated_decl_.second, 2, o,
                                   include_sampling, is_var_context,

--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -689,8 +689,7 @@ namespace stan {
                                  const std::string& base_type,
                                  const std::vector<expression>& dims,
                                  const expression& type_arg1 = expression(),
-                                 const expression& type_arg2 = expression(),
-                                 const expression& definition = expression()) {
+                                 const expression& type_arg2 = expression()) {
       // validate all dims are positive
       for (size_t i = 0; i < dims.size(); ++i)
         generate_validate_positive(var_name, dims[i], o);
@@ -699,13 +698,11 @@ namespace stan {
       if (!is_nil(type_arg2))
         generate_validate_positive(var_name, type_arg2, o);
 
-      // initialize variable or use definition
-      if (is_nil(definition)) {
-        o << INDENT2
-          << var_name << " = ";
-        generate_type(base_type, dims, dims.size(), o);
-        generate_initializer(o, base_type, dims, type_arg1, type_arg2);
-      }
+      // initialize variable
+      o << INDENT2
+        << var_name << " = ";
+      generate_type(base_type, dims, dims.size(), o);
+      generate_initializer(o, base_type, dims, type_arg1, type_arg2);
     }
 
     struct var_resizing_visgen : public visgen {
@@ -715,19 +712,19 @@ namespace stan {
       void operator()(nil const& /*x*/) const { }  // dummy
       void operator()(int_var_decl const& x) const {
         generate_initialization(o_, x.name_, "int", x.dims_,
-                                nil(), nil(), x.def_);
+                                nil(), nil());
       }
       void operator()(double_var_decl const& x) const {
         generate_initialization(o_, x.name_, "double", x.dims_, nil(),
-                                nil(), x.def_);
+                                nil());
       }
       void operator()(vector_var_decl const& x) const {
         generate_initialization(o_, x.name_, "vector_d", x.dims_, x.M_,
-                                nil(), x.def_);
+                                nil());
       }
       void operator()(row_vector_var_decl const& x) const {
         generate_initialization(o_, x.name_, "row_vector_d", x.dims_, x.N_,
-                                nil(), x.def_);
+                                nil());
       }
       void operator()(unit_vector_var_decl const& x) const {
         generate_initialization(o_, x.name_, "vector_d", x.dims_, x.K_);
@@ -743,7 +740,7 @@ namespace stan {
       }
       void operator()(matrix_var_decl const& x) const {
         generate_initialization(o_, x.name_, "matrix_d",
-                                x.dims_, x.M_, x.N_, x.def_);
+                                x.dims_, x.M_, x.N_);
       }
       void operator()(cholesky_factor_var_decl const& x) const {
         generate_initialization(o_, x.name_, "matrix_d", x.dims_, x.M_, x.N_);
@@ -1474,19 +1471,16 @@ namespace stan {
         generate_indent(indents_, o_);
         generate_type(type, dims.size());
         o_ << ' '  << name;
-        if (is_nil(definition)) {
-          generate_init_args(type, ctor_args, dims, 0);
-        }
+        generate_init_args(type, ctor_args, dims, 0);
         o_ << ";" << EOL;
         if (dims.size() == 0) {
           generate_indent(indents_, o_);
           generate_void_statement(name);
           o_ << EOL;
         }
-        if (is_nil(definition)
-            && (type == "Eigen::Matrix<T__, Eigen::Dynamic, Eigen::Dynamic> "
-                 || type == "Eigen::Matrix<T__, 1, Eigen::Dynamic> "
-                 || type == "Eigen::Matrix<T__, Eigen::Dynamic, 1> ")) {
+        if (type == "Eigen::Matrix<T__, Eigen::Dynamic, Eigen::Dynamic> "
+            || type == "Eigen::Matrix<T__, 1, Eigen::Dynamic> "
+            || type == "Eigen::Matrix<T__, Eigen::Dynamic, 1> ") {
           generate_indent(indents_, o_);
           o_ << "stan::math::fill(" << name << ", DUMMY_VAR__);" << EOL;
         }
@@ -1582,10 +1576,9 @@ namespace stan {
                                      bool is_fun_return) {
       generate_local_var_init_nan_visgen vis(indent, is_var_context,
                                              is_fun_return, indent, o);
-      for (size_t i = 0; i < vs.size(); ++i)
-        if (!vs[i].has_def()) {
-          boost::apply_visitor(vis, vs[i].decl_);
-        }
+      for (size_t i = 0; i < vs.size(); ++i) {
+        boost::apply_visitor(vis, vs[i].decl_);
+      }
     }
 
     // see member_var_decl_visgen cut & paste
@@ -1662,8 +1655,7 @@ namespace stan {
                        " avoid seg fault on val access",
                        indent, o);
       for (size_t i = 0; i < vs.size(); ++i) {
-        if (!(vs[i].has_def()))
-          boost::apply_visitor(vis, vs[i].decl_);
+        boost::apply_visitor(vis, vs[i].decl_);
       }
     }
 
@@ -3384,9 +3376,8 @@ namespace stan {
         o_ << INDENT2;
         generate_type(base_type, dims, dims.size(), o_);
         o_ << ' ' << name;
-        if (is_nil(definition)) {
-          generate_initializer(o_, base_type, dims, type_arg1, type_arg2);
-        } else {
+        generate_initializer(o_, base_type, dims, type_arg1, type_arg2);
+        if (! is_nil(definition)) {
           o_ << ";" << EOL;
           o_ << INDENT2;
           o_ << "stan::math::assign(" << name << ", ";

--- a/src/stan/lang/generator.hpp
+++ b/src/stan/lang/generator.hpp
@@ -3377,7 +3377,7 @@ namespace stan {
         generate_type(base_type, dims, dims.size(), o_);
         o_ << ' ' << name;
         generate_initializer(o_, base_type, dims, type_arg1, type_arg2);
-        if (! is_nil(definition)) {
+        if (!is_nil(definition)) {
           o_ << ";" << EOL;
           o_ << INDENT2;
           o_ << "stan::math::assign(" << name << ", ";

--- a/src/test/test-models/good/declare-define-conditional-op.stan
+++ b/src/test/test-models/good/declare-define-conditional-op.stan
@@ -1,0 +1,23 @@
+data { 
+  int<lower=0> N; 
+  int<lower=0,upper=1> y[N];
+} 
+parameters {
+  real<lower=0,upper=1> theta;
+  real z;
+}
+transformed parameters {
+  real y1 = 1 ? y[1] : z;
+  {
+    real loc_y1 = 1 ? y[1] : z;
+  }
+}
+model {
+  theta ~ beta(1,1);
+  for (n in 1:N) 
+    y[n] ~ bernoulli(theta);
+}
+generated quantities {
+  real y2 = 1 ? y[2] : z;
+}
+

--- a/src/test/test-models/good/declare-define-vector.stan
+++ b/src/test/test-models/good/declare-define-vector.stan
@@ -1,0 +1,16 @@
+data { 
+  int<lower=0> N; 
+  int<lower=0,upper=1> y[N];
+} 
+transformed data {
+  vector[7] foo;
+  vector[7] bar = foo;
+}
+parameters {
+  real<lower=0,upper=1> theta;
+} 
+model {
+  theta ~ beta(1,1);
+  for (n in 1:N) 
+    y[n] ~ bernoulli(theta);
+}

--- a/src/test/test-models/good/declare-define-vector.stan
+++ b/src/test/test-models/good/declare-define-vector.stan
@@ -5,12 +5,27 @@ data {
 transformed data {
   vector[7] foo;
   vector[7] bar = foo;
+  row_vector[7] baz;
+  {
+    vector[7] loc_td_b1 = bar;
+  }
 }
 parameters {
   real<lower=0,upper=1> theta;
 } 
+transformed parameters {
+  vector[7] tpar_b = bar;
+}
 model {
   theta ~ beta(1,1);
   for (n in 1:N) 
     y[n] ~ bernoulli(theta);
+}
+generated quantities {
+  vector[7] gq_b1 = bar;
+  row_vector[7] gq_c1 = baz;
+  {
+    vector[7] loc_gq_b1 = bar;
+    row_vector[7] loc_gq_c1 = baz;
+  }
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

changed Stan compiler so that all variables are initialized before definitions applied.

#### Intended Effect

removes runtime error caused by Stan math lib's function "assign" - see issue 2138.

#### How to Verify

using cmdstan, run stan model src/test/test-models/good/declare-define-vector using Bernoulli data file.  model will run.

#### Side Effects

initialization before applying definition adds to computation.

#### Documentation

#### Reviewer Suggestions

Daniel Lee  or Bob Carpenter

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Mitzi Morris

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
