### PR TITLE
Fixes #2142. Adding higher order tests

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -91,6 +91,66 @@ endif
 src/test/test-models/good/%.hpp-test : src/test/test-models/good/%.hpp test/test-model-main.cpp
 	$(COMPILE.c) -O0 -include $< -o $(DEV_NULL) test/test-model-main.cpp
 
+.PHONY: %.hpp-fwd-test
+src/test/test-models/good/%.hpp-fwd-test : src/test/test-models/good/%.hpp test/test-model-fwd-main.cpp
+	$(COMPILE.c) -O0 -include $< -o $(DEV_NULL) test/test-model-fwd-main.cpp
+
+.PHONY: %.hpp-mix-test
+src/test/test-models/good/%.hpp-mix-test : src/test/test-models/good/%.hpp test/test-model-mix-main.cpp
+	$(COMPILE.c) -O0 -include $< -o $(DEV_NULL) test/test-model-mix-main.cpp
+
+test/test-model-mix-main.cpp:
+	@mkdir -p test
+	@touch $@
+	@echo "#include <stan/math/mix/mat.hpp>" >> $@
+	@echo >> $@
+	@echo "int main() {" >> $@
+	@echo "  stan::io::var_context *data = NULL;" >> $@
+	@echo "  stan_model model(*data);" >> $@
+	@echo >> $@
+	@echo "  std::vector<stan::math::fvar<stan::math::var> > params;" >> $@
+	@echo "  std::vector<double> x_r;" >> $@
+	@echo "  std::vector<int> x_i;" >> $@
+	@echo >> $@
+	@echo "  model.log_prob<false, false>(params, x_i);" >> $@
+	@echo "  model.log_prob<false, true>(params, x_i);" >> $@
+	@echo "  model.log_prob<true, false>(params, x_i);" >> $@
+	@echo "  model.log_prob<true, true>(params, x_i);" >> $@
+	@echo "  model.log_prob<false, false>(x_r, x_i);" >> $@
+	@echo "  model.log_prob<false, true>(x_r, x_i);" >> $@
+	@echo "  model.log_prob<true, false>(x_r, x_i);" >> $@
+	@echo "  model.log_prob<true, true>(x_r, x_i);" >> $@
+	@echo >> $@
+	@echo "  return 0;" >> $@
+	@echo "}" >> $@
+	@echo >> $@
+
+test/test-model-fwd-main.cpp:
+	@mkdir -p test
+	@touch $@
+	@echo "#include <stan/math/fwd/mat.hpp>" >> $@
+	@echo >> $@
+	@echo "int main() {" >> $@
+	@echo "  stan::io::var_context *data = NULL;" >> $@
+	@echo "  stan_model model(*data);" >> $@
+	@echo >> $@
+	@echo "  std::vector<stan::math::fvar<double> > params;" >> $@
+	@echo "  std::vector<double> x_r;" >> $@
+	@echo "  std::vector<int> x_i;" >> $@
+	@echo >> $@
+	@echo "  model.log_prob<false, false>(params, x_i);" >> $@
+	@echo "  model.log_prob<false, true>(params, x_i);" >> $@
+	@echo "  model.log_prob<true, false>(params, x_i);" >> $@
+	@echo "  model.log_prob<true, true>(params, x_i);" >> $@
+	@echo "  model.log_prob<false, false>(x_r, x_i);" >> $@
+	@echo "  model.log_prob<false, true>(x_r, x_i);" >> $@
+	@echo "  model.log_prob<true, false>(x_r, x_i);" >> $@
+	@echo "  model.log_prob<true, true>(x_r, x_i);" >> $@
+	@echo >> $@
+	@echo "  return 0;" >> $@
+	@echo "}" >> $@
+	@echo >> $@
+
 test/test-model-main.cpp:
 	@mkdir -p test
 	@touch $@
@@ -219,6 +279,10 @@ src/test/unit/variational/eta_adapt_small_test.cpp:src/test/test-models/good/var
 # the compiler using the -fsyntax-only flag
 ##
 test/integration/compile_models$(EXE) : $(patsubst %.stan,%.hpp-test,$(shell find src/test/test-models/good -type f -name '*.stan'))
+
+test/integration/compile_models_fwd$(EXE) : $(patsubst %.stan,%.hpp-fwd-test,$(shell find src/test/test-models/good -type f -name '*.stan'))
+
+test/integration/compile_models_mix$(EXE) : $(patsubst %.stan,%.hpp-mix-test,$(shell find src/test/test-models/good -type f -name '*.stan'))
 
 
 test_name = $(shell echo $(1) | sed 's,_[0-9]\{5\},_test.hpp,g')

--- a/src/test/integration/compile_models_fwd_test.cpp
+++ b/src/test/integration/compile_models_fwd_test.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+TEST(lang, compile_models_fwd) {
+  SUCCEED() 
+    << "Model compilation done through makefile dependencies." << std::endl
+    << "Should have compiled: src/test/test-models/good/*.stan" << std::endl
+    << "under forward mode autodiff" << std::endl;
+}

--- a/src/test/integration/compile_models_mix_test.cpp
+++ b/src/test/integration/compile_models_mix_test.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+TEST(lang, compile_models_mix) {
+  SUCCEED() 
+    << "Model compilation done through makefile dependencies." << std::endl
+    << "Should have compiled: src/test/test-models/good/*.stan" << std::endl
+    << "under mixed mode autodiff" << std::endl;
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Adds tests verifying that forward mode and mixed mode autodiff compile.

#### How to Verify
There are two new tests:
- `./runTests.py compile_models_fwd_test.cpp`
- `./runTests.py compile_models_mix_test.cpp`

These will attempt to instantiate the model with forward mode (`stan::math::fvar<double>`) and mix mode (`stan::math::fvar<stan::math::var>`) variables.

Do we need to add a separate test for `fvar<fvar<var> >`? I think this will ensure compilation for that instantiation, but perhaps I'm missing something.

This does not do any runtime evaluation. This merely checks that forward mode and mixed mode are compilable.

#### Side Effects
None. Testing time will go up. This will put more work on the compiler.

#### Documentation
None. If this needs doc, it should go into the wiki.

#### Reviewer Suggestions
@bob-carpenter. I think.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

