### PR TITLE
Feature/issue 1259 anonymous namespaces

### DIFF
--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -13,14 +13,12 @@ namespace stan {
 
   namespace io {
 
-    namespace {
-      template<typename T>
-      T product(std::vector<T> dims) {
-         T y = 1;
-         for (size_t i = 0; i < dims.size(); ++i)
-           y *= dims[i];
-         return y;
-       }
+    template<typename T>
+    T product(std::vector<T> dims) {
+      T y = 1;
+      for (size_t i = 0; i < dims.size(); ++i)
+        y *= dims[i];
+      return y;
     }
 
     /**

--- a/src/stan/io/json/json_data_handler.hpp
+++ b/src/stan/io/json/json_data_handler.hpp
@@ -20,19 +20,17 @@ namespace stan {
 
   namespace json {
 
-    namespace {
-      typedef
-      std::map<std::string,
-               std::pair<std::vector<double>,
-                         std::vector<size_t> > >
-      vars_map_r;
+    typedef
+    std::map<std::string,
+             std::pair<std::vector<double>,
+                       std::vector<size_t> > >
+    vars_map_r;
 
-      typedef
-      std::map<std::string,
-               std::pair<std::vector<int>,
-                         std::vector<size_t> > >
-      vars_map_i;
-    }
+    typedef
+    std::map<std::string,
+             std::pair<std::vector<int>,
+                       std::vector<size_t> > >
+    vars_map_i;
 
     /**
      * A <code>json_data_handler</code> is an implementation of a

--- a/src/stan/io/json/json_parser.hpp
+++ b/src/stan/io/json/json_parser.hpp
@@ -16,408 +16,405 @@ namespace stan {
 
   namespace json {
 
-    namespace {
+    const unsigned int MIN_HIGH_SURROGATE = 0xD800;
+    const unsigned int MAX_HIGH_SURROGATE = 0xDBFF;
+    const unsigned int MIN_LOW_SURROGATE = 0xDC00;
+    const unsigned int MAX_LOW_SURROGATE = 0xDFFF;
+    const unsigned int MIN_SUPPLEMENTARY_CODE_POINT = 0x010000;
 
-      const unsigned int MIN_HIGH_SURROGATE = 0xD800;
-      const unsigned int MAX_HIGH_SURROGATE = 0xDBFF;
-      const unsigned int MIN_LOW_SURROGATE = 0xDC00;
-      const unsigned int MAX_LOW_SURROGATE = 0xDFFF;
-      const unsigned int MIN_SUPPLEMENTARY_CODE_POINT = 0x010000;
+    inline bool is_high_surrogate(unsigned int cp) {
+      return (cp >= MIN_HIGH_SURROGATE && cp <= MAX_HIGH_SURROGATE);
+    }
 
-      inline bool is_high_surrogate(unsigned int cp) {
-        return (cp >= MIN_HIGH_SURROGATE && cp <= MAX_HIGH_SURROGATE);
+    inline bool is_low_surrogate(unsigned int cp) {
+      return (cp >= MIN_LOW_SURROGATE && cp <= MAX_LOW_SURROGATE);
+    }
+
+    inline bool is_whitespace(char c) {
+      return c == ' ' || c == '\n' || c == '\t' || c == '\r';
+    }
+
+    /**
+     * A <code>json_parser</code> is a SAX-style streaming parser
+     * that enforces JSON syntax and parses JSON elements
+     * from an input stream, sending callbacks to a user-supplied
+     * <code>json_handler</code>.
+     */
+    template <typename Handler, bool Validate_UTF_8>
+    class parser {
+    public:
+      parser(Handler& h,
+             std::istream& in)
+        : h_(h),
+          in_(in),
+          next_char_(0),
+          line_(0),
+          column_(0)
+      {  }
+
+      ~parser() {
       }
 
-      inline bool is_low_surrogate(unsigned int cp) {
-        return (cp >= MIN_LOW_SURROGATE && cp <= MAX_LOW_SURROGATE);
+      void parse() {
+        h_.start_text();
+        parse_text();
+        h_.end_text();
       }
 
-      inline bool is_whitespace(char c) {
-        return c == ' ' || c == '\n' || c == '\t' || c == '\r';
+    private:
+      json_error json_exception(const std::string& msg) const {
+        std::stringstream ss;
+        ss << "Error in JSON parsing at"
+           << " line=" << line_ << " column=" << column_
+           << std::endl
+           << msg
+           << std::endl;
+        return json_error(ss.str());
       }
 
-      /**
-       * A <code>json_parser</code> is a SAX-style streaming parser
-       * that enforces JSON syntax and parses JSON elements
-       * from an input stream, sending callbacks to a user-supplied
-       * <code>json_handler</code>.
-       */
-      template <typename Handler, bool Validate_UTF_8>
-      class parser {
-      public:
-        parser(Handler& h,
-               std::istream& in)
-          : h_(h),
-            in_(in),
-            next_char_(0),
-            line_(0),
-            column_(0)
-        {  }
-
-        ~parser() {
+      // JSON-text = object / array
+      void parse_text() {
+        char c = get_non_ws_char();
+        if (c == '{') {              // begin-object
+          h_.start_object();
+          parse_object_members_end_object();
+          h_.end_object();
+        } else if (c == '[') {      // begin-array
+          // array
+          h_.start_array();
+          parse_array_values_end_array();
+          h_.end_array();
+        } else {
+          throw json_exception("expecting start of object ({) or array ([)");
         }
+      }
 
-        void parse() {
-          h_.start_text();
+      // value =  false / null / true / object / array / number / string
+      void parse_value() {
+        // value
+        char c = get_non_ws_char();
+        if (c == 'f') {
+          // false
+          parse_false_literal();
+        } else if (c == 'n') {
+          // null
+          parse_null_literal();
+        } else if (c == 't') {
+          // true
+          parse_true_literal();
+        } else if (c == '"') {
+          // string
+          h_.string(parse_string_chars_quotation_mark());
+        } else if (c == '{' || c == '[') {
+          // object / array
+          unget_char();
           parse_text();
-          h_.end_text();
+        } else if (c == '-' ||
+                   (c >= '0' && c <= '9') ) {
+          unget_char();
+          parse_number();
+        } else {
+          throw json_exception("illegal value, expecting object, array, "
+                               "number, string, or literal true/false/null");
         }
+      }
 
-      private:
-        json_error json_exception(const std::string& msg) const {
-          std::stringstream ss;
-          ss << "Error in JSON parsing at"
-             << " line=" << line_ << " column=" << column_
-             << std::endl
-             << msg
-             << std::endl;
-          return json_error(ss.str());
-        }
+      void parse_number() {
+        bool is_positive = true;
 
-        // JSON-text = object / array
-        void parse_text() {
-          char c = get_non_ws_char();
-          if (c == '{') {              // begin-object
-            h_.start_object();
-            parse_object_members_end_object();
-            h_.end_object();
-          } else if (c == '[') {      // begin-array
-            // array
-            h_.start_array();
-            parse_array_values_end_array();
-            h_.end_array();
-          } else {
-            throw json_exception("expecting start of object ({) or array ([)");
-          }
-        }
-
-        // value =  false / null / true / object / array / number / string
-        void parse_value() {
-          // value
-          char c = get_non_ws_char();
-          if (c == 'f') {
-            // false
-            parse_false_literal();
-          } else if (c == 'n') {
-            // null
-            parse_null_literal();
-          } else if (c == 't') {
-            // true
-            parse_true_literal();
-          } else if (c == '"') {
-            // string
-            h_.string(parse_string_chars_quotation_mark());
-          } else if (c == '{' || c == '[') {
-            // object / array
-            unget_char();
-            parse_text();
-          } else if (c == '-' ||
-                     (c >= '0' && c <= '9') ) {
-            unget_char();
-            parse_number();
-          } else {
-            throw json_exception("illegal value, expecting object, array, "
-                                 "number, string, or literal true/false/null");
-          }
-        }
-
-        void parse_number() {
-          bool is_positive = true;
-
-          std::stringstream ss;
-          char c = get_non_ws_char();
-          // minus
-          if (c == '-') {
-            is_positive = false;
-            ss << c;
-            c = get_char();
-          }
-
-          // int
-          //   zero / digit1-9
-          if (c < '0' || c > '9')
-            throw json_exception("expecting int part of number");
+        std::stringstream ss;
+        char c = get_non_ws_char();
+        // minus
+        if (c == '-') {
+          is_positive = false;
           ss << c;
-
-          //   *DIGIT
-          bool leading_zero = (c == '0');
           c = get_char();
-          if (leading_zero && (c == '0'))
-              throw json_exception("zero padded numbers not allowed");
+        }
+
+        // int
+        //   zero / digit1-9
+        if (c < '0' || c > '9')
+          throw json_exception("expecting int part of number");
+        ss << c;
+
+        //   *DIGIT
+        bool leading_zero = (c == '0');
+        c = get_char();
+        if (leading_zero && (c == '0'))
+          throw json_exception("zero padded numbers not allowed");
+        while (c >= '0' && c <= '9') {
+          ss << c;
+          c = get_char();
+        }
+
+        // frac
+        bool is_integer = true;
+        if (c == '.') {
+          is_integer = false;
+          ss << '.';
+          c = get_char();
+          if (c < '0' || c > '9')
+            throw json_exception("expected digit after decimal");
+          ss << c;
+          c = get_char();
           while (c >= '0' && c <= '9') {
             ss << c;
             c = get_char();
           }
+        }
 
-          // frac
-          bool is_integer = true;
-          if (c == '.') {
-            is_integer = false;
-            ss << '.';
-            c = get_char();
-            if (c < '0' || c > '9')
-              throw json_exception("expected digit after decimal");
+        // exp
+        if (c == 'e' || c == 'E') {
+          is_integer = false;
+          ss << c;
+          c = get_char();
+          // minus / plus
+          if (c == '+' || c == '-') {
             ss << c;
             c = get_char();
-            while (c >= '0' && c <= '9') {
-              ss << c;
-              c = get_char();
-            }
           }
-
-          // exp
-          if (c == 'e' || c == 'E') {
-            is_integer = false;
+          // 1*DIGIT
+          if (c < '0' || c > '9')
+            throw json_exception("expected digit after e/E");
+          while (c >= '0' && c <= '9') {
             ss << c;
             c = get_char();
-            // minus / plus
-            if (c == '+' || c == '-') {
-              ss << c;
-              c = get_char();
-            }
-            // 1*DIGIT
-            if (c < '0' || c > '9')
-              throw json_exception("expected digit after e/E");
-            while (c >= '0' && c <= '9') {
-              ss << c;
-              c = get_char();
-            }
           }
-          unget_char();
+        }
+        unget_char();
 
-          if (is_integer) {
-            if (is_positive) {
-              unsigned long n;  // NOLINT(runtime/int)
-              try {
-                // NOLINTNEXTLINE(runtime/int)
-                n = boost::lexical_cast<unsigned long>(ss.str());
-              } catch (const boost::bad_lexical_cast & ) {
-                throw json_exception("number exceeds integer range");
-              }
-              ss >> n;
-              h_.number_unsigned_long(n);
-            } else {
-              long n;  // NOLINT(runtime/int)
-              try {
-                // NOLINTNEXTLINE(runtime/int)
-                n = boost::lexical_cast<unsigned long>(ss.str());
-              } catch (const boost::bad_lexical_cast & ) {
-                throw json_exception("number exceeds integer range");
-              }
-              ss >> n;
-              h_.number_long(n);
-            }
-          } else {
-            double x;
+        if (is_integer) {
+          if (is_positive) {
+            unsigned long n;  // NOLINT(runtime/int)
             try {
-              std::string ss_str = ss.str();
-              x = boost::lexical_cast<double>(ss_str);
-              if (x == 0)
-                io::validate_zero_buf(ss_str);
+              // NOLINTNEXTLINE(runtime/int)
+              n = boost::lexical_cast<unsigned long>(ss.str());
             } catch (const boost::bad_lexical_cast & ) {
-              throw json_exception("number exceeds double range");
+              throw json_exception("number exceeds integer range");
             }
-            ss >> x;
-            h_.number_double(x);
-          }
-        }
-
-        std::string parse_string_chars_quotation_mark() {
-          std::stringstream s;
-          while (true) {
-            char c = get_char();
-            if (c == '"') {
-              return s.str();
-            } else if (c == '\\') {
-              c = get_char();
-              if (c == '\\'  || c == '/' || c == '"') {
-                s << c;
-              } else if (c == 'b') {
-                s << '\b';
-              } else if (c == 'f') {
-                s << '\f';
-              } else if (c == 'n') {
-                s << '\n';
-              } else if (c == 'r') {
-                s << '\r';
-              } else if (c == 't') {
-                s << '\t';
-              } else if (c == 'u') {
-                get_escaped_unicode(s);
-              } else {
-                throw json_exception("expecting legal escape");
-              }
-              continue;
-            } else if (c > 0 && c < 0x20) {  // ASCII control characters
-              throw json_exception("found control character, char values less "
-                                   "than U+0020 must be \\u escaped");
-            }
-            s << c;
-          }
-        }
-
-        void parse_true_literal() {
-          get_chars("rue");
-          h_.boolean(true);
-        }
-
-        void parse_false_literal() {
-          get_chars("alse");
-          h_.boolean(false);
-        }
-
-        void parse_null_literal() {
-          get_chars("ull");
-          h_.null();
-        }
-
-        void get_escaped_unicode(std::stringstream& s) {
-          unsigned int codepoint = get_int_as_hex_chars();
-          if (!(is_high_surrogate(codepoint) || is_low_surrogate(codepoint))) {
-            putCodepoint(s, codepoint);
-          } else if (!is_high_surrogate(codepoint)) {
-              throw json_exception("illegal unicode values, found "
-                                   "low-surrogate, missing high-surrogate");
+            ss >> n;
+            h_.number_unsigned_long(n);
           } else {
-            char c = get_char();
-            if (!(c == '\\'))
-              throw json_exception("illegal unicode values, found "
-                                   "high-surrogate, expecting low-surrogate");
+            long n;  // NOLINT(runtime/int)
+            try {
+              // NOLINTNEXTLINE(runtime/int)
+              n = boost::lexical_cast<unsigned long>(ss.str());
+            } catch (const boost::bad_lexical_cast & ) {
+              throw json_exception("number exceeds integer range");
+            }
+            ss >> n;
+            h_.number_long(n);
+          }
+        } else {
+          double x;
+          try {
+            std::string ss_str = ss.str();
+            x = boost::lexical_cast<double>(ss_str);
+            if (x == 0)
+              io::validate_zero_buf(ss_str);
+          } catch (const boost::bad_lexical_cast & ) {
+            throw json_exception("number exceeds double range");
+          }
+          ss >> x;
+          h_.number_double(x);
+        }
+      }
+
+      std::string parse_string_chars_quotation_mark() {
+        std::stringstream s;
+        while (true) {
+          char c = get_char();
+          if (c == '"') {
+            return s.str();
+          } else if (c == '\\') {
             c = get_char();
-            if (!(c == 'u'))
-              throw json_exception("illegal unicode values, found "
-                                   "high-surrogate, expecting low-surrogate");
-            unsigned int codepoint2 = get_int_as_hex_chars();
-            unsigned int supplemental
-              = ((codepoint - MIN_HIGH_SURROGATE) << 10)
-              + (codepoint2 - MIN_LOW_SURROGATE)
-              + MIN_SUPPLEMENTARY_CODE_POINT;
-            putCodepoint(s, supplemental);
+            if (c == '\\'  || c == '/' || c == '"') {
+              s << c;
+            } else if (c == 'b') {
+              s << '\b';
+            } else if (c == 'f') {
+              s << '\f';
+            } else if (c == 'n') {
+              s << '\n';
+            } else if (c == 'r') {
+              s << '\r';
+            } else if (c == 't') {
+              s << '\t';
+            } else if (c == 'u') {
+              get_escaped_unicode(s);
+            } else {
+              throw json_exception("expecting legal escape");
+            }
+            continue;
+          } else if (c > 0 && c < 0x20) {  // ASCII control characters
+            throw json_exception("found control character, char values less "
+                                 "than U+0020 must be \\u escaped");
           }
+          s << c;
         }
+      }
 
-        unsigned int get_int_as_hex_chars() {
-          std::stringstream s;
-          s << std::hex;
-          for (int i = 0; i < 4; i++) {
-            char c = get_char();
-            if (!((c >= 'a' && c<= 'f')
-                  || (c >= 'A' && c<= 'F')
-                  || (c >= '0' && c<= '9')))
-              throw json_exception("illegal unicode code point");
-            s << c;
-          }
-          unsigned int hex;
-          s >> hex;
-          return hex;
+      void parse_true_literal() {
+        get_chars("rue");
+        h_.boolean(true);
+      }
+
+      void parse_false_literal() {
+        get_chars("alse");
+        h_.boolean(false);
+      }
+
+      void parse_null_literal() {
+        get_chars("ull");
+        h_.null();
+      }
+
+      void get_escaped_unicode(std::stringstream& s) {
+        unsigned int codepoint = get_int_as_hex_chars();
+        if (!(is_high_surrogate(codepoint) || is_low_surrogate(codepoint))) {
+          putCodepoint(s, codepoint);
+        } else if (!is_high_surrogate(codepoint)) {
+          throw json_exception("illegal unicode values, found "
+                               "low-surrogate, missing high-surrogate");
+        } else {
+          char c = get_char();
+          if (!(c == '\\'))
+            throw json_exception("illegal unicode values, found "
+                                 "high-surrogate, expecting low-surrogate");
+          c = get_char();
+          if (!(c == 'u'))
+            throw json_exception("illegal unicode values, found "
+                                 "high-surrogate, expecting low-surrogate");
+          unsigned int codepoint2 = get_int_as_hex_chars();
+          unsigned int supplemental
+            = ((codepoint - MIN_HIGH_SURROGATE) << 10)
+            + (codepoint2 - MIN_LOW_SURROGATE)
+            + MIN_SUPPLEMENTARY_CODE_POINT;
+          putCodepoint(s, supplemental);
         }
+      }
 
-        void putCodepoint(std::stringstream& s, unsigned int codepoint) {
-          if (codepoint <= 0x7f) {
-            s.put(codepoint);
-          } else if (codepoint <= 0x7ff) {
-            s.put(0xc0 | ((codepoint >> 6) & 0x1f));
-            s.put(0x80 | (codepoint & 0x3f));
-          } else if (codepoint <= 0xffff) {
-            s.put(0xe0 | ((codepoint >> 12) & 0x0f));
-            s.put(0x80 | ((codepoint >> 6) & 0x3f));
-            s.put(0x80 | (codepoint & 0x3f));
-          } else {
-            s.put(0xf0 | ((codepoint >> 18) & 0x07));
-            s.put(0x80 | ((codepoint >> 12) & 0x3f));
-            s.put(0x80 | ((codepoint >> 6) & 0x3f));
-            s.put(0x80 | (codepoint & 0x3f));
-          }
+      unsigned int get_int_as_hex_chars() {
+        std::stringstream s;
+        s << std::hex;
+        for (int i = 0; i < 4; i++) {
+          char c = get_char();
+          if (!((c >= 'a' && c<= 'f')
+                || (c >= 'A' && c<= 'F')
+                || (c >= '0' && c<= '9')))
+            throw json_exception("illegal unicode code point");
+          s << c;
         }
+        unsigned int hex;
+        s >> hex;
+        return hex;
+      }
 
-        void get_chars(const std::string& s) {
-          for (size_t i = 0; i < s.size(); ++i) {
-            char c = get_char();
-            if (c != s[i])
-              throw json_exception("expecting rest of literal: "
-                                   + s.substr(i));
-          }
+      void putCodepoint(std::stringstream& s, unsigned int codepoint) {
+        if (codepoint <= 0x7f) {
+          s.put(codepoint);
+        } else if (codepoint <= 0x7ff) {
+          s.put(0xc0 | ((codepoint >> 6) & 0x1f));
+          s.put(0x80 | (codepoint & 0x3f));
+        } else if (codepoint <= 0xffff) {
+          s.put(0xe0 | ((codepoint >> 12) & 0x0f));
+          s.put(0x80 | ((codepoint >> 6) & 0x3f));
+          s.put(0x80 | (codepoint & 0x3f));
+        } else {
+          s.put(0xf0 | ((codepoint >> 18) & 0x07));
+          s.put(0x80 | ((codepoint >> 12) & 0x3f));
+          s.put(0x80 | ((codepoint >> 6) & 0x3f));
+          s.put(0x80 | (codepoint & 0x3f));
         }
+      }
 
-        void parse_array_values_end_array() {
+      void get_chars(const std::string& s) {
+        for (size_t i = 0; i < s.size(); ++i) {
+          char c = get_char();
+          if (c != s[i])
+            throw json_exception("expecting rest of literal: "
+                                 + s.substr(i));
+        }
+      }
+
+      void parse_array_values_end_array() {
+        char c = get_non_ws_char();
+        if (c == ']') return;
+        unget_char();
+        while (true) {
+          parse_value();
           char c = get_non_ws_char();
           if (c == ']') return;
+          if (c != ',') {
+            throw json_exception("in array, expecting ] or ,");
+          }
+          c = get_non_ws_char();
+          if (c == ']')
+            throw json_exception("in array, expecting value");
           unget_char();
-          while (true) {
-            parse_value();
-            char c = get_non_ws_char();
-            if (c == ']') return;
-            if (c != ',') {
-              throw json_exception("in array, expecting ] or ,");
-            }
-            c = get_non_ws_char();
-            if (c == ']')
-              throw json_exception("in array, expecting value");
-            unget_char();
-          }
         }
+      }
 
-        void parse_object_members_end_object() {
-          char c = get_non_ws_char();
-          if (c == '}') return;
-          while (true) {
-            // string (key)
-            if (c != '"')
-              throw json_exception("expecting member key"
-                                   " or end of object marker (})");
-            std::string key = parse_string_chars_quotation_mark();
-            h_.key(key);
-            // name-separator separator
-            c = get_non_ws_char();
-            if (c != ':')
-              throw json_exception("expecting key-value separator :");
-            // value
-            parse_value();
+      void parse_object_members_end_object() {
+        char c = get_non_ws_char();
+        if (c == '}') return;
+        while (true) {
+          // string (key)
+          if (c != '"')
+            throw json_exception("expecting member key"
+                                 " or end of object marker (})");
+          std::string key = parse_string_chars_quotation_mark();
+          h_.key(key);
+          // name-separator separator
+          c = get_non_ws_char();
+          if (c != ':')
+            throw json_exception("expecting key-value separator :");
+          // value
+          parse_value();
 
-            // continuation
-            c = get_non_ws_char();
-            if (c == '}')
-              return;
-            if (c != ',')
-              throw json_exception("expecting end of object } or separator ,");
-            c = get_non_ws_char();
-          }
+          // continuation
+          c = get_non_ws_char();
+          if (c == '}')
+            return;
+          if (c != ',')
+            throw json_exception("expecting end of object } or separator ,");
+          c = get_non_ws_char();
         }
+      }
 
-        char get_char() {
-          char c = in_.get();
-          if (!in_.good())
-            throw json_exception("unexpected end of stream");
-          if (c == '\n') {
-            ++line_;
-            column_ = 1;
-          } else {
-            ++column_;
-          }
+      char get_char() {
+        char c = in_.get();
+        if (!in_.good())
+          throw json_exception("unexpected end of stream");
+        if (c == '\n') {
+          ++line_;
+          column_ = 1;
+        } else {
+          ++column_;
+        }
+        return c;
+      }
+
+      char get_non_ws_char() {
+        while (true) {
+          char c = get_char();
+          if (is_whitespace(c)) continue;
           return c;
         }
+      }
 
-        char get_non_ws_char() {
-          while (true) {
-            char c = get_char();
-            if (is_whitespace(c)) continue;
-            return c;
-          }
-        }
+      void unget_char() {
+        in_.unget();
+        --column_;
+      }
 
-        void unget_char() {
-          in_.unget();
-          --column_;
-        }
+      Handler& h_;
+      std::istream& in_;
+      char next_char_;
+      size_t line_;
+      size_t column_;
+    };
 
-        Handler& h_;
-        std::istream& in_;
-        char next_char_;
-        size_t line_;
-        size_t column_;
-      };
-
-    }
 
     /**
      * Parse the JSON text represented by the specified input stream,

--- a/src/stan/lang/grammars/program_grammar_def.hpp
+++ b/src/stan/lang/grammars/program_grammar_def.hpp
@@ -15,13 +15,11 @@
 #include <utility>
 #include <vector>
 
-namespace {
-  // hack to pass pair into macro below to adapt; in namespace to hide
-  struct DUMMY_STRUCT {
-    typedef std::pair<std::vector<stan::lang::var_decl>,
-                      std::vector<stan::lang::statement> > type;
-  };
-}
+// hack to pass pair into macro below to adapt; in namespace to hide
+struct DUMMY_STRUCT {
+  typedef std::pair<std::vector<stan::lang::var_decl>,
+                    std::vector<stan::lang::statement> > type;
+};
 
 BOOST_FUSION_ADAPT_STRUCT(stan::lang::program,
                           (std::vector<stan::lang::function_decl_def>,

--- a/src/stan/optimization/bfgs_linesearch.hpp
+++ b/src/stan/optimization/bfgs_linesearch.hpp
@@ -106,70 +106,68 @@ namespace stan {
       return x0 + CubicInterp(df0, x1-x0, f1-f0, df1, loX-x0, hiX-x0);
     }
 
-    namespace {
-      /**
-       * An internal utility function for implementing WolfeLineSearch()
-       **/
-      template<typename FunctorType, typename Scalar, typename XType>
-      int WolfLSZoom(Scalar &alpha, XType &newX, Scalar &newF, XType &newDF,
-                     FunctorType &func,
-                     const XType &x, const Scalar &f, const Scalar &dfp,
-                     const Scalar &c1dfp, const Scalar &c2dfp, const XType &p,
-                     Scalar alo, Scalar aloF, Scalar aloDFp,
-                     Scalar ahi, Scalar ahiF, Scalar ahiDFp,
-                     const Scalar &min_range) {
-        Scalar d1, d2, newDFp;
-        int itNum(0);
+    /**
+     * An internal utility function for implementing WolfeLineSearch()
+     **/
+    template<typename FunctorType, typename Scalar, typename XType>
+    int WolfLSZoom(Scalar &alpha, XType &newX, Scalar &newF, XType &newDF,
+                   FunctorType &func,
+                   const XType &x, const Scalar &f, const Scalar &dfp,
+                   const Scalar &c1dfp, const Scalar &c2dfp, const XType &p,
+                   Scalar alo, Scalar aloF, Scalar aloDFp,
+                   Scalar ahi, Scalar ahiF, Scalar ahiDFp,
+                   const Scalar &min_range) {
+      Scalar d1, d2, newDFp;
+      int itNum(0);
 
-        while (1) {
-          itNum++;
+      while (1) {
+        itNum++;
 
-          if (std::fabs(alo-ahi) < min_range)
-            return 1;
+        if (std::fabs(alo-ahi) < min_range)
+          return 1;
 
-          if (itNum%5 == 0) {
-            alpha = 0.5*(alo+ahi);
-          } else {
-            // Perform cubic interpolation to determine next point to try
-            d1 = aloDFp + ahiDFp - 3*(aloF-ahiF)/(alo-ahi);
-            d2 = std::sqrt(d1*d1 - aloDFp*ahiDFp);
-            if (ahi < alo)
-              d2 = -d2;
-            alpha = ahi
-              - (ahi - alo) * (ahiDFp + d2 - d1) / (ahiDFp - aloDFp + 2*d2);
-            if (!boost::math::isfinite(alpha) ||
-                alpha < std::min(alo, ahi) + 0.01 * std::fabs(alo - ahi) ||
-                alpha > std::max(alo, ahi) - 0.01 * std::fabs(alo - ahi))
-              alpha = 0.5 * (alo + ahi);
-          }
-
-          newX = x + alpha * p;
-          while (func(newX, newF, newDF)) {
-            alpha = 0.5 * (alpha + std::min(alo, ahi));
-            if (std::fabs(std::min(alo, ahi) - alpha) < min_range)
-              return 1;
-            newX = x + alpha * p;
-          }
-          newDFp = newDF.dot(p);
-          if (newF > (f + alpha * c1dfp) || newF >= aloF) {
-            ahi = alpha;
-            ahiF = newF;
-            ahiDFp = newDFp;
-          } else {
-            if (std::fabs(newDFp) <= -c2dfp)
-              break;
-            if (newDFp*(ahi-alo) >= 0) {
-              ahi = alo;
-              ahiF = aloF;
-              ahiDFp = aloDFp;
-            }
-            alo = alpha;
-            aloF = newF;
-            aloDFp = newDFp;
-          }
+        if (itNum%5 == 0) {
+          alpha = 0.5*(alo+ahi);
+        } else {
+          // Perform cubic interpolation to determine next point to try
+          d1 = aloDFp + ahiDFp - 3*(aloF-ahiF)/(alo-ahi);
+          d2 = std::sqrt(d1*d1 - aloDFp*ahiDFp);
+          if (ahi < alo)
+            d2 = -d2;
+          alpha = ahi
+            - (ahi - alo) * (ahiDFp + d2 - d1) / (ahiDFp - aloDFp + 2*d2);
+          if (!boost::math::isfinite(alpha) ||
+              alpha < std::min(alo, ahi) + 0.01 * std::fabs(alo - ahi) ||
+              alpha > std::max(alo, ahi) - 0.01 * std::fabs(alo - ahi))
+            alpha = 0.5 * (alo + ahi);
         }
-        return 0;
+
+        newX = x + alpha * p;
+        while (func(newX, newF, newDF)) {
+          alpha = 0.5 * (alpha + std::min(alo, ahi));
+          if (std::fabs(std::min(alo, ahi) - alpha) < min_range)
+            return 1;
+          newX = x + alpha * p;
+        }
+        newDFp = newDF.dot(p);
+        if (newF > (f + alpha * c1dfp) || newF >= aloF) {
+          ahi = alpha;
+          ahiF = newF;
+          ahiDFp = newDFp;
+        } else {
+          if (std::fabs(newDFp) <= -c2dfp)
+            break;
+          if (newDFp*(ahi-alo) >= 0) {
+            ahi = alo;
+            ahiF = aloF;
+            ahiDFp = aloDFp;
+          }
+          alo = alpha;
+          aloF = newF;
+          aloDFp = newDFp;
+        }
       }
+      return 0;
     }
 
     /**

--- a/src/stan/optimization/newton.hpp
+++ b/src/stan/optimization/newton.hpp
@@ -14,20 +14,18 @@ namespace stan {
     typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> matrix_d;
     typedef Eigen::Matrix<double, Eigen::Dynamic, 1> vector_d;
 
-    namespace {
-      // Negates any positive eigenvalues in H so that H is negative
-      // definite, and then solves Hu = g and stores the result into
-      // g. Avoids problems due to non-log-concave distributions.
-      void make_negative_definite_and_solve(matrix_d& H, vector_d& g) {
-        Eigen::SelfAdjointEigenSolver<matrix_d> solver(H);
-        matrix_d eigenvectors = solver.eigenvectors();
-        vector_d eigenvalues = solver.eigenvalues();
-        vector_d eigenprojections = eigenvectors.transpose() * g;
-        for (int i = 0; i < g.size(); i++) {
-          eigenprojections[i] = -eigenprojections[i] / fabs(eigenvalues[i]);
-        }
-        g = eigenvectors * eigenprojections;
+    // Negates any positive eigenvalues in H so that H is negative
+    // definite, and then solves Hu = g and stores the result into
+    // g. Avoids problems due to non-log-concave distributions.
+    void make_negative_definite_and_solve(matrix_d& H, vector_d& g) {
+      Eigen::SelfAdjointEigenSolver<matrix_d> solver(H);
+      matrix_d eigenvectors = solver.eigenvectors();
+      vector_d eigenvalues = solver.eigenvalues();
+      vector_d eigenprojections = eigenvectors.transpose() * g;
+      for (int i = 0; i < g.size(); i++) {
+        eigenprojections[i] = -eigenprojections[i] / fabs(eigenvalues[i]);
       }
+      g = eigenvectors * eigenprojections;
     }
 
     template <typename M>


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
This removes anonymous namespaces from the Stan codebase.

#### Intended Effect
Anonymous namespaces don't do anything in our codebase since we're still header-only.

This won't pass tests and won't be ready to merge until #1751. I'm going to continue to queue things up until it gets in. 

#### How to Verify
Search for `namespace {` in the codebase:
```
grep -rl "namespace {" src/stan
```

There is one instance and it's in the generator.

#### Side Effects
This needs to wait for #1751. Once that is in, the diff will be manageable.

#### Documentation
None.

#### Reviewer Suggestions
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
