### PR TITLE
Fixes #2148. Removes use of check_equal() with check_size_match()

### DIFF
--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -121,7 +121,7 @@ namespace stan {
      * @param[in] name Name of variable (default "ANON").
      * @param[in] depth Indexing depth (default 0).
      * @throw std::out_of_range If any of the indices are out of bounds.
-     * @throw std::domain_error If the value size isn't the same as
+     * @throw std::invalid_argument If the value size isn't the same as
      * the indexed size.
      */
     template <typename T, typename I, typename U>
@@ -130,8 +130,9 @@ namespace stan {
            const cons_index_list<I, nil_index_list>& idxs,
            const Eigen::Matrix<U, Eigen::Dynamic, 1>& y,
            const char* name = "ANON", int depth = 0) {
-      math::check_equal("vector[multi] assign sizes", name, y.size(),
-                        rvalue_index_size(idxs.head_, x.size()));
+      math::check_size_match("vector[multi] assign sizes",
+                             "lhs", rvalue_index_size(idxs.head_, x.size()),
+                             name, y.size());
       for (int n = 0; n < y.size(); ++n) {
         int i = rvalue_at(n, idxs.head_);
         math::check_range("vector[multi] assign range", name, x.size(), i);
@@ -155,7 +156,7 @@ namespace stan {
      * @param[in] name Name of variable (default "ANON").
      * @param[in] depth Indexing depth (default 0).
      * @throw std::out_of_range If any of the indices are out of bounds.
-     * @throw std::domain_error If the value size isn't the same as
+     * @throw std::invalid_argument If the value size isn't the same as
      * the indexed size.
      */
     template <typename T, typename I, typename U>
@@ -164,9 +165,9 @@ namespace stan {
            const cons_index_list<I, nil_index_list>& idxs,
            const Eigen::Matrix<U, 1, Eigen::Dynamic>& y,
            const char* name = "ANON", int depth = 0) {
-      using stan::math::check_equal;
-      check_equal("row_vector[multi] assign sizes",
-                  name, y.size(), rvalue_index_size(idxs.head_, x.size()));
+      math::check_size_match("row_vector[multi] assign sizes",
+                             "lhs", rvalue_index_size(idxs.head_, x.size()),
+                             name, y.size());
       for (int n = 0; n < y.size(); ++n) {
         int i = rvalue_at(n, idxs.head_);
         math::check_range("row_vector[multi] assign range", name, x.size(), i);
@@ -189,7 +190,7 @@ namespace stan {
      * @param[in] name Name of variable (default "ANON").
      * @param[in] depth Indexing depth (default 0).
      * @throw std::out_of_range If any of the indices are out of bounds.
-     * @throw std::domain_error If the number of columns in the row
+     * @throw std::invalid_argument If the number of columns in the row
      * vector and matrix do not match.
      */
     template <typename T, typename U>
@@ -197,7 +198,9 @@ namespace stan {
                 const cons_index_list<index_uni, nil_index_list>& idxs,
                 const Eigen::Matrix<U, 1, Eigen::Dynamic>& y,
                 const char* name = "ANON", int depth = 0) {
-      math::check_equal("matrix[uni] assign sizes", name, y.cols(), x.cols());
+      math::check_size_match("matrix[uni] assign sizes",
+                             "lhs", x.cols(),
+                             name, y.cols());
       int i = idxs.head_.n_;
       math::check_range("matrix[uni] assign range", name, x.rows(), i);
       for (int j = 0; j < x.cols(); ++j)  // loop allows double to var assgn
@@ -219,7 +222,7 @@ namespace stan {
      * @param[in] name Name of variable (default "ANON").
      * @param[in] depth Indexing depth (default 0).
      * @throw std::out_of_range If any of the indices are out of bounds.
-     * @throw std::domain_error If the dimensions of the indexed
+     * @throw std::invalid_argument If the dimensions of the indexed
      * matrix and right-hand side matrix do not match.
      */
     template <typename T, typename I, typename U>
@@ -229,10 +232,12 @@ namespace stan {
            const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,
            const char* name = "ANON", int depth = 0) {
       int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
-      math::check_equal("matrix[multi] assign row sizes", name, y.rows(),
-                        x_idx_rows);
-      math::check_equal("matrix[multi] assign col sizes", name, y.cols(),
-                        x.cols());
+      math::check_size_match("matrix[multi] assign row sizes",
+                             "lhs", x_idx_rows,
+                             name, y.rows());
+      math::check_size_match("matrix[multi] assign col sizes",
+                             "lhs", x.cols(),
+                             name, y.cols());
       for (int i = 0; i < y.rows(); ++i) {
         int m = rvalue_at(i, idxs.head_);
         math::check_range("matrix[multi] assign range", name, x.rows(), m);
@@ -287,7 +292,7 @@ namespace stan {
      * @param[in] name Name of variable (default "ANON").
      * @param[in] depth Indexing depth (default 0).
      * @throw std::out_of_range If any of the indices are out of bounds.
-     * @throw std::domain_error If the dimensions of the indexed
+     * @throw std::invalid_argument If the dimensions of the indexed
      * matrix and right-hand side row vector do not match.
      */
     template <typename T, typename I, typename U>
@@ -298,8 +303,9 @@ namespace stan {
            const Eigen::Matrix<U, 1, Eigen::Dynamic>& y,
            const char* name = "ANON", int depth = 0) {
       int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
-      math::check_equal("matrix[uni,multi] assign sizes", name, y.cols(),
-                        x_idxs_cols);
+      math::check_size_match("matrix[uni,multi] assign sizes",
+                             "lhs", x_idxs_cols,
+                             name, y.cols());
       int m = idxs.head_.n_;
       math::check_range("matrix[uni,multi] assign range", name, x.rows(), m);
       for (int i = 0; i < y.size(); ++i) {
@@ -324,7 +330,7 @@ namespace stan {
      * @param[in] name Name of variable (default "ANON").
      * @param[in] depth Indexing depth (default 0).
      * @throw std::out_of_range If any of the indices are out of bounds.
-     * @throw std::domain_error If the dimensions of the indexed
+     * @throw std::invalid_argument If the dimensions of the indexed
      * matrix and right-hand side vector do not match.
      */
     template <typename T, typename I, typename U>
@@ -336,8 +342,9 @@ namespace stan {
            const Eigen::Matrix<U, Eigen::Dynamic, 1>& y,
            const char* name = "ANON", int depth = 0) {
       int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
-      math::check_equal("matrix[multi,uni] assign sizes", name, y.rows(),
-                        x_idxs_rows);
+      math::check_size_match("matrix[multi,uni] assign sizes",
+                             "lhs", x_idxs_rows,
+                             name, y.rows());
       int n = idxs.tail_.head_.n_;
       math::check_range("matrix[multi,uni] assign range", name, x.cols(), n);
       for (int i = 0; i < y.size(); ++i) {
@@ -363,7 +370,7 @@ namespace stan {
      * @param[in] name Name of variable (default "ANON").
      * @param[in] depth Indexing depth (default 0).
      * @throw std::out_of_range If any of the indices are out of bounds.
-     * @throw std::domain_error If the dimensions of the indexed
+     * @throw std::invalid_argument If the dimensions of the indexed
      * matrix and value matrix do not match.
      */
     template <typename T, typename I1, typename I2, typename U>
@@ -377,10 +384,12 @@ namespace stan {
            const char* name = "ANON", int depth = 0) {
       int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
       int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
-      math::check_equal("matrix[multi,multi] assign sizes", name, y.rows(),
-                        x_idxs_rows);
-      math::check_equal("matrix[multi,multi] assign sizes", name, y.cols(),
-                        x_idxs_cols);
+      math::check_size_match("matrix[multi,multi] assign sizes",
+                             "lhs", x_idxs_rows,
+                             name, y.rows());
+      math::check_size_match("matrix[multi,multi] assign sizes",
+                             "lhs", x_idxs_cols,
+                             name, y.cols());
       for (int j = 0; j < y.cols(); ++j) {
         int n = rvalue_at(j, idxs.tail_.head_);
         math::check_range("matrix[multi,multi] assign range", name,
@@ -414,7 +423,7 @@ namespace stan {
      * @param[in] name Name of variable (default "ANON").
      * @param[in] depth Indexing depth (default 0).
      * @throw std::out_of_range If any of the indices are out of bounds.
-     * @throw std::domain_error If the dimensions do not match in the
+     * @throw std::invalid_argument If the dimensions do not match in the
      * tail assignment.
      */
     template <typename T, typename L, typename U>
@@ -447,7 +456,7 @@ namespace stan {
      * @param[in] name Name of variable (default "ANON").
      * @param[in] depth Indexing depth (default 0).
      * @throw std::out_of_range If any of the indices are out of bounds.
-     * @throw std::domain_error If the size of the multiple indexing
+     * @throw std::invalid_argument If the size of the multiple indexing
      * and size of first dimension of value do not match, or any of
      * the recursive tail assignment dimensions do not match.
      */
@@ -457,8 +466,9 @@ namespace stan {
                   const std::vector<U>& y,
                   const char* name = "ANON", int depth = 0) {
       int x_idx_size = rvalue_index_size(idxs.head_, x.size());
-      math::check_equal("vector[multi,...] assign sizes", name, y.size(),
-                        x_idx_size);
+      math::check_size_match("vector[multi,...] assign sizes",
+                             "lhs", x_idx_size,
+                             name, y.size());
       for (size_t n = 0; n < y.size(); ++n) {
         int i = rvalue_at(n, idxs.head_);
         math::check_range("vector[multi,...] assign range", name, x.size(), i);

--- a/src/test/unit/model/indexing/lvalue_test.cpp
+++ b/src/test/unit/model/indexing/lvalue_test.cpp
@@ -27,8 +27,8 @@ void test_throw(T1& lhs, const I& idxs, const T2& rhs) {
 }
 
 template <typename T1, typename I, typename T2>
-void test_throw_de(T1& lhs, const I& idxs, const T2& rhs) {
-  EXPECT_THROW(stan::model::assign(lhs, idxs, rhs), std::domain_error);
+void test_throw_ia(T1& lhs, const I& idxs, const T2& rhs) {
+  EXPECT_THROW(stan::model::assign(lhs, idxs, rhs), std::invalid_argument);
 }
 
 
@@ -99,13 +99,13 @@ TEST(ModelIndexing, lvalueMulti) {
   assign(x, index_list(index_min(9)), y);
   EXPECT_FLOAT_EQ(y[0], x[8]);
   EXPECT_FLOAT_EQ(y[1], x[9]);
-  test_throw_de(x, index_list(index_min(0)), y);
+  test_throw_ia(x, index_list(index_min(0)), y);
 
   assign(x, index_list(index_max(2)), y);
   EXPECT_FLOAT_EQ(y[0], x[0]);
   EXPECT_FLOAT_EQ(y[1], x[1]);
   EXPECT_FLOAT_EQ(2, x[2]);
-  test_throw_de(x, index_list(index_max(10)), y);
+  test_throw_ia(x, index_list(index_max(10)), y);
   
   vector<int> ns;
   ns.push_back(4);
@@ -121,7 +121,7 @@ TEST(ModelIndexing, lvalueMulti) {
   test_throw(x, index_list(index_multi(ns)), y);
 
   ns.push_back(3);
-  test_throw_de(x, index_list(index_multi(ns)), y);
+  test_throw_ia(x, index_list(index_multi(ns)), y);
 }
 
 TEST(ModelIndexing, lvalueMultiMulti) {
@@ -147,8 +147,8 @@ TEST(ModelIndexing, lvalueMultiMulti) {
     for (int j = 0; j < 3; ++j)
       EXPECT_FLOAT_EQ(ys[i][j], xs[8 + i][j]);
 
-  test_throw_de(xs, index_list(index_min(7), index_max(3)), ys);
-  test_throw_de(xs, index_list(index_min(9), index_max(2)), ys);
+  test_throw_ia(xs, index_list(index_min(7), index_max(3)), ys);
+  test_throw_ia(xs, index_list(index_min(9), index_max(2)), ys);
 }
 
 TEST(ModelIndexing, lvalueUniMulti) {
@@ -171,7 +171,7 @@ TEST(ModelIndexing, lvalueUniMulti) {
 
   test_throw(xs, index_list(index_uni(0), index_min_max(3, 5)), ys);
   test_throw(xs, index_list(index_uni(11), index_min_max(3, 5)), ys);
-  test_throw_de(xs, index_list(index_uni(4), index_min_max(2, 5)), ys);
+  test_throw_ia(xs, index_list(index_uni(4), index_min_max(2, 5)), ys);
 
 }
 
@@ -193,7 +193,7 @@ TEST(ModelIndexing, lvalueMultiUni) {
   for (int j = 0; j < 3; ++j)
     EXPECT_FLOAT_EQ(ys[j], xs[j + 4][7]);
 
-  test_throw_de(xs, index_list(index_min_max(3, 6), index_uni(7)), ys);
+  test_throw_ia(xs, index_list(index_min_max(3, 6), index_uni(7)), ys);
   test_throw(xs, index_list(index_min_max(4, 6), index_uni(0)), ys);
   test_throw(xs, index_list(index_min_max(4, 6), index_uni(30)), ys);
 }
@@ -228,7 +228,7 @@ TEST(ModelIndexing, lvalueVecMulti) {
   EXPECT_FLOAT_EQ(ys(0), xs(2));
   EXPECT_FLOAT_EQ(ys(1), xs(3));
   EXPECT_FLOAT_EQ(ys(2), xs(4));
-  test_throw_de(xs, index_list(index_min(0)), ys);
+  test_throw_ia(xs, index_list(index_min(0)), ys);
 
   xs << 0, 1, 2, 3, 4;
   vector<int> ns;
@@ -248,7 +248,7 @@ TEST(ModelIndexing, lvalueVecMulti) {
 
   ns[ns.size() - 1] = 3;
   ns.push_back(1);
-  test_throw_de(xs, index_list(index_multi(ns)), ys);
+  test_throw_ia(xs, index_list(index_multi(ns)), ys);
 } 
 
 TEST(ModelIndexing, lvalueRowVecMulti) {
@@ -260,8 +260,8 @@ TEST(ModelIndexing, lvalueRowVecMulti) {
   EXPECT_FLOAT_EQ(ys(0), xs(2));
   EXPECT_FLOAT_EQ(ys(1), xs(3));
   EXPECT_FLOAT_EQ(ys(2), xs(4));
-  test_throw_de(xs, index_list(index_min(2)), ys);
-  test_throw_de(xs, index_list(index_min(0)), ys);
+  test_throw_ia(xs, index_list(index_min(2)), ys);
+  test_throw_ia(xs, index_list(index_min(0)), ys);
 
   xs << 0, 1, 2, 3, 4;
   vector<int> ns;
@@ -281,7 +281,7 @@ TEST(ModelIndexing, lvalueRowVecMulti) {
 
   ns[ns.size() - 1] = 3;
   ns.push_back(1);
-  test_throw_de(xs, index_list(index_multi(ns)), ys);
+  test_throw_ia(xs, index_list(index_multi(ns)), ys);
 }  
 
 TEST(ModelIndexing, lvalueMatrixUni) {
@@ -318,13 +318,13 @@ TEST(ModelIndexing, lvalueMatrixMulti) {
   for (int i = 0; i < 2; ++i)
     for (int j = 0; j < 4; ++j)
       EXPECT_FLOAT_EQ(y(i, j), x(i + 1, j));
-  test_throw_de(x, index_list(index_min(1)), y);
+  test_throw_ia(x, index_list(index_min(1)), y);
 
   
   MatrixXd z(1,2);
   z << 10, 20;
-  test_throw_de(x, index_list(index_min(1)), z);
-  test_throw_de(x, index_list(index_min(2)), z);
+  test_throw_ia(x, index_list(index_min(1)), z);
+  test_throw_ia(x, index_list(index_min(2)), z);
 
 }
 
@@ -363,7 +363,7 @@ TEST(ModelIndexing, lvalueMatrixUniMulti) {
   test_throw(x, index_list(index_uni(0), index_min_max(2,4)), y);
   test_throw(x, index_list(index_uni(5), index_min_max(2,4)), y);
   test_throw(x, index_list(index_uni(2), index_min_max(0,2)), y);
-  test_throw_de(x, index_list(index_uni(2), index_min_max(2,5)), y);
+  test_throw_ia(x, index_list(index_uni(2), index_min_max(2,5)), y);
 
   vector<int> ns;
   ns.push_back(4);
@@ -381,7 +381,7 @@ TEST(ModelIndexing, lvalueMatrixUniMulti) {
   test_throw(x, index_list(index_uni(3), index_multi(ns)), y);
 
   ns.push_back(2);
-  test_throw_de(x, index_list(index_uni(3), index_multi(ns)), y);
+  test_throw_ia(x, index_list(index_uni(3), index_multi(ns)), y);
 }
 
 TEST(ModelIndexing, lvalueMatrixMultiUni) {
@@ -401,7 +401,7 @@ TEST(ModelIndexing, lvalueMatrixMultiUni) {
   test_throw(x, index_list(index_min_max(2,3), index_uni(0)), y);
   test_throw(x, index_list(index_min_max(2,3), index_uni(5)), y);
   test_throw(x, index_list(index_min_max(0,1), index_uni(4)), y);
-  test_throw_de(x, index_list(index_min_max(1,3), index_uni(4)), y);
+  test_throw_ia(x, index_list(index_min_max(1,3), index_uni(4)), y);
 
   vector<int> ns;
   ns.push_back(3);
@@ -417,7 +417,7 @@ TEST(ModelIndexing, lvalueMatrixMultiUni) {
   test_throw(x, index_list(index_multi(ns), index_uni(3)), y);
 
   ns.push_back(2);
-  test_throw_de(x, index_list(index_multi(ns), index_uni(3)), y);
+  test_throw_ia(x, index_list(index_multi(ns), index_uni(3)), y);
 }
 
 TEST(ModelIndexing, lvalueMatrixMultiMulti) {
@@ -440,9 +440,9 @@ TEST(ModelIndexing, lvalueMatrixMultiMulti) {
   EXPECT_FLOAT_EQ(y(1,1), x(2,2));
   EXPECT_FLOAT_EQ(y(1,2), x(2,3));
 
-  test_throw_de(x, index_list(index_min_max(2,3), index_min(0)), y);
-  test_throw_de(x, index_list(index_min_max(2,3), index_min(10)), y);
-  test_throw_de(x, index_list(index_min_max(1,3), index_min(2)), y);
+  test_throw_ia(x, index_list(index_min_max(2,3), index_min(0)), y);
+  test_throw_ia(x, index_list(index_min_max(2,3), index_min(10)), y);
+  test_throw_ia(x, index_list(index_min_max(1,3), index_min(2)), y);
 
   x <<
     0.0, 0.1, 0.2, 0.3,


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Removes uses of `check_equal()` with more appropriate function `check_size_match()`.

#### Intended Effect
Removes use of `check_equal()`.

#### How to Verify
Run 
```
./runTests.py src/test/unit/model/indexing/lvalue_test.cpp
```

#### Side Effects
The type of exception is now different. It is now a `std::invalid_argument` instead of `std::domain_error`.

The error message is slightly different too. An example old message:
```
vector[multi,...] assign sizes: ANON is 2, but must be equal to 11
```

The new message:
```
vector[multi,...] assign sizes: lhs (11) and ANON (2) must match in size
```

I think it's equally readable / unreadable. "ANON" will be filled in with the name of the right side.

#### Documentation
Updated doxygen.

#### Reviewer Suggestions
@bob-carpenter 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

