### PR TITLE
disallow void arguments to print, fixes #2168

### DIFF
--- a/src/docs/stan-reference/appendices.tex
+++ b/src/docs/stan-reference/appendices.tex
@@ -775,6 +775,10 @@ Both the conditional if-then-else statement and while-loop statement
 require the expression denoting the condition to be a primitive type,
 integer or real.
 
+\subsection{Print Arguments}
+
+The arguments to a print statement cannot be void.
+
 \subsection{Only Break and Continue in Loops}
 
 The \code{break} and \code{continue} statements may only be used

--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -3509,7 +3509,11 @@ u[1] = [1, 4]
 u[2] = [9, 16]
 \end{stancode}
 
+\subsection{Non-void Input}
 
+The input type to a print function cannot be void.  In particular, it
+can't be the result of a user-defined void function.  All other types
+are allowed as arguments to the print function.
 
 \subsection{Print Frequency}
 

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -807,6 +807,11 @@ namespace stan {
     };
     extern boost::phoenix::function<validate_in_loop> validate_in_loop_f;
 
+    struct non_void_expression : public phoenix_functor_ternary {
+      void operator()(const expression& e, bool& pass,
+                      std::ostream& error_msgs) const;
+    };
+    extern boost::phoenix::function<non_void_expression> non_void_expression_f;
   }
 }
 #endif

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -2619,6 +2619,17 @@ namespace stan {
     }
     boost::phoenix::function<validate_in_loop> validate_in_loop_f;
 
+    void non_void_expression::operator()(const expression& e, bool& pass,
+                                         std::ostream& error_msgs) const {
+      // ill-formed shouldn't be possible, but just in case
+      pass = e.expression_type().type() != VOID_T
+        && e.expression_type().type() != ILL_FORMED_T;
+      if (!pass)
+        error_msgs << "ERROR:  expected printable (non-void) expression."
+                   << std::endl;
+    }
+    boost::phoenix::function<non_void_expression> non_void_expression_f;
+
   }
 }
 

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -217,7 +217,8 @@ namespace stan {
       printable_r.name("printable");
       printable_r
         %= printable_string_r
-        | expression_g(_r1);
+        | expression_g(_r1)
+          [non_void_expression_f(_1, _pass, boost::phoenix::ref(error_msgs_))];
 
       printable_string_r.name("printable quoted string");
       printable_string_r

--- a/src/test/test-models/bad/print-void.stan
+++ b/src/test/test-models/bad/print-void.stan
@@ -1,0 +1,10 @@
+functions {
+  void foo(int n) {
+  }
+}
+transformed data {
+  int z;
+  z = 2;
+  print(foo(z));
+}
+model { }

--- a/src/test/unit/lang/parser/print_function_test.cpp
+++ b/src/test/unit/lang/parser/print_function_test.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+#include <test/unit/lang/utility.hpp>
+
+TEST(langParser, printVoidBad) {
+  test_throws("print-void", 
+              "ERROR:  expected printable (non-void) expression.");
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Disallow void arguments to `print()` statements.

#### How to Verify

Unit test with now unparseable model.

#### Side Effects

No.  It didn't compile before.

#### Documentation

Clarified print section and also BNF in manual.

#### Reviewer Suggestions

Anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

