### PR TITLE
Bugfix/issue 2178 fix nuts criterion

### DIFF
--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -76,7 +76,6 @@ namespace stan {
         while (this->depth_ < this->max_depth_) {
           // Build a new subtree in a random direction
           Eigen::VectorXd rho_subtree = Eigen::VectorXd::Zero(rho.size());
-
           bool valid_subtree = false;
           double log_sum_weight_subtree
             = -std::numeric_limits<double>::infinity();

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -85,7 +85,7 @@ namespace stan {
             this->z_.ps_point::operator=(z_plus);
             valid_subtree
               = build_tree(this->depth_, z_propose,
-                           p_sharp_dummy, p_sharp_plus, rho_subtree, 
+                           p_sharp_dummy, p_sharp_plus, rho_subtree,
                            H0, 1, n_leapfrog,
                            log_sum_weight_subtree, sum_metro_prob,
                            info_writer, error_writer);
@@ -152,9 +152,9 @@ namespace stan {
         values.push_back(this->energy_);
       }
 
-      bool compute_criterion(Eigen::VectorXd& p_sharp_minus,
-                             Eigen::VectorXd& p_sharp_plus,
-                             Eigen::VectorXd& rho) {
+      virtual bool compute_criterion(Eigen::VectorXd& p_sharp_minus,
+                                     Eigen::VectorXd& p_sharp_plus,
+                                     Eigen::VectorXd& rho) {
         return    p_sharp_plus.dot(rho) > 0
                && p_sharp_minus.dot(rho) > 0;
       }

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -166,7 +166,7 @@ namespace stan {
        * @param depth Depth of the desired subtree
        * @param z_propose State proposed from subtree
        * @param p_sharp_left p_sharp from left boundary of returned tree
-       * @param p_shart_right p_sharp from the right boundary of returned tree
+       * @param p_sharp_right p_sharp from the right boundary of returned tree
        * @param rho Summed momentum across trajectory
        * @param H0 Hamiltonian of initial state
        * @param sign Direction in time to built subtree

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -70,7 +70,7 @@ namespace stan {
 
         // Build a trajectory until the NUTS criterion is no longer satisfied
         this->depth_ = 0;
-        this->divergent_ = 0;
+        this->divergent_ = false;
 
         while (this->depth_ < this->max_depth_) {
           // Build a new subtree in a random direction
@@ -118,7 +118,7 @@ namespace stan {
           log_sum_weight
             = math::log_sum_exp(log_sum_weight, log_sum_weight_subtree);
 
-          // Break when NUTS criterion is not longer satisfied
+          // Break when NUTS criterion is no longer satisfied
           rho += rho_subtree;
           if (!compute_criterion(p_sharp_minus, p_sharp_plus, rho))
             break;
@@ -175,11 +175,11 @@ namespace stan {
        * @param info_writer Stream for information messages
        * @param error_writer Stream for error messages
       */
-      int build_tree(int depth, Eigen::VectorXd& rho, ps_point& z_propose,
-                     double H0, double sign, int& n_leapfrog,
-                     double& log_sum_weight, double& sum_metro_prob,
-                     interface_callbacks::writer::base_writer& info_writer,
-                     interface_callbacks::writer::base_writer& error_writer) {
+      bool build_tree(int depth, Eigen::VectorXd& rho, ps_point& z_propose,
+                      double H0, double sign, int& n_leapfrog,
+                      double& log_sum_weight, double& sum_metro_prob,
+                      interface_callbacks::writer::base_writer& info_writer,
+                      interface_callbacks::writer::base_writer& error_writer) {
         // Base case
         if (depth == 0) {
           this->integrator_.evolve(this->z_, this->hamiltonian_,
@@ -266,7 +266,7 @@ namespace stan {
       double max_deltaH_;
 
       int n_leapfrog_;
-      int divergent_;
+      bool divergent_;
       double energy_;
     };
 

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -108,16 +108,16 @@ TEST_F(performance, values_from_tagged_version) {
     << "last tagged version, 2.9.0, had " << N_values << " elements";
 
   std::vector<double> first_run = last_draws_per_run[0];
-  EXPECT_FLOAT_EQ(-65.742996, first_run[0])
+  EXPECT_FLOAT_EQ(-65.201302, first_run[0])
     << "lp__: index 0";
 
-  EXPECT_FLOAT_EQ(0.622922, first_run[1])
+  EXPECT_FLOAT_EQ(0.93779498, first_run[1])
     << "accept_stat__: index 1";
 
-  EXPECT_FLOAT_EQ(1.15558, first_run[2])
+  EXPECT_FLOAT_EQ(1.20701, first_run[2])
     << "stepsize__: index 2";
 
-  EXPECT_FLOAT_EQ(1, first_run[3])
+  EXPECT_FLOAT_EQ(2, first_run[3])
     << "treedepth__: index 3";
 
   EXPECT_FLOAT_EQ(3, first_run[4])
@@ -126,13 +126,13 @@ TEST_F(performance, values_from_tagged_version) {
   EXPECT_FLOAT_EQ(0, first_run[5])
     << "divergent__: index 5";
 
-  EXPECT_FLOAT_EQ(67.453796, first_run[6])
+  EXPECT_FLOAT_EQ(65.755402, first_run[6])
     << "energy__: index 6";
 
-  EXPECT_FLOAT_EQ(1.40756, first_run[7])
+  EXPECT_FLOAT_EQ(1.29672, first_run[7])
     << "beta.1: index 7";
 
-  EXPECT_FLOAT_EQ(-0.763035, first_run[8])
+  EXPECT_FLOAT_EQ(-0.47478199, first_run[8])
     << "beta.2: index 8";
 
   matches_tagged_version = !HasNonfatalFailure();

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -2,6 +2,7 @@
 #include <stan/interface_callbacks/writer/stream_writer.hpp>
 #include <stan/mcmc/hmc/nuts/base_nuts.hpp>
 #include <stan/mcmc/hmc/integrators/expl_leapfrog.hpp>
+#include <vector>
 #include <boost/random/additive_combine.hpp>
 #include <gtest/gtest.h>
 
@@ -19,6 +20,25 @@ namespace stan {
       mock_nuts(const mock_model &m, rng_t& rng)
         : base_nuts<mock_model,mock_hamiltonian,mock_integrator,rng_t>(m, rng)
       { }
+    };
+
+    class rho_inspector_mock_nuts: public base_nuts<mock_model,
+                                                    mock_hamiltonian,
+                                                    mock_integrator,
+                                                    rng_t> {
+
+    public:
+      std::vector<double> rho_values;
+      rho_inspector_mock_nuts(const mock_model &m, rng_t& rng)
+        : base_nuts<mock_model,mock_hamiltonian,mock_integrator,rng_t>(m, rng)
+      { }
+
+      bool compute_criterion(Eigen::VectorXd& p_sharp_minus,
+                             Eigen::VectorXd& p_sharp_plus,
+                             Eigen::VectorXd& rho) {
+        rho_values.push_back(rho(0));
+        return true;
+      }
     };
 
     // Mock Hamiltonian
@@ -90,7 +110,7 @@ namespace stan {
   }
 }
 
-TEST(McmcNutsBaseNuts, set_max_depth) {
+TEST(McmcNutsBaseNuts, set_max_depth_test) {
 
   rng_t base_rng(0);
 
@@ -110,7 +130,7 @@ TEST(McmcNutsBaseNuts, set_max_depth) {
 }
 
 
-TEST(McmcNutsBaseNuts, set_max_delta) {
+TEST(McmcNutsBaseNuts, set_max_delta_test) {
   rng_t base_rng(0);
 
   Eigen::VectorXd q(2);
@@ -125,7 +145,7 @@ TEST(McmcNutsBaseNuts, set_max_delta) {
   EXPECT_EQ(old_max_delta, sampler.get_max_delta());
 }
 
-TEST(McmcNutsBaseNuts, build_tree) {
+TEST(McmcNutsBaseNuts, build_tree_test) {
 
   rng_t base_rng(0);
 
@@ -138,6 +158,8 @@ TEST(McmcNutsBaseNuts, build_tree) {
 
   stan::mcmc::ps_point z_propose(model_size);
 
+  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(model_size);
   Eigen::VectorXd rho = z_init.p;
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
@@ -159,13 +181,16 @@ TEST(McmcNutsBaseNuts, build_tree) {
   stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
 
-  bool valid_subtree = sampler.build_tree(3, rho, z_propose,
+  bool valid_subtree = sampler.build_tree(3, z_propose,
+                                          p_sharp_left, p_sharp_right, rho,
                                           H0, 1, n_leapfrog, log_sum_weight,
                                           sum_metro_prob, writer, error_writer);
 
   EXPECT_TRUE(valid_subtree);
 
   EXPECT_EQ(init_momentum * (n_leapfrog + 1), rho(0));
+  EXPECT_EQ(1, p_sharp_left(0));
+  EXPECT_EQ(1, p_sharp_right(0));
 
   EXPECT_EQ(8 * init_momentum, sampler.z().q(0));
   EXPECT_EQ(init_momentum, sampler.z().p(0));
@@ -176,6 +201,57 @@ TEST(McmcNutsBaseNuts, build_tree) {
 
   EXPECT_EQ("", output.str());
   EXPECT_EQ("", error_stream.str());
+}
+
+TEST(McmcNutsBaseNuts, rho_aggregation_test) {
+
+  rng_t base_rng(0);
+
+  int model_size = 1;
+  double init_momentum = 1.5;
+
+  stan::mcmc::ps_point z_init(model_size);
+  z_init.q(0) = 0;
+  z_init.p(0) = init_momentum;
+
+  stan::mcmc::ps_point z_propose(model_size);
+
+  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd rho = z_init.p;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
+
+  double H0 = -0.1;
+  int n_leapfrog = 0;
+  double sum_metro_prob = 0;
+
+  stan::mcmc::mock_model model(model_size);
+  stan::mcmc::rho_inspector_mock_nuts sampler(model, base_rng);
+
+  sampler.set_nominal_stepsize(1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+  sampler.z() = z_init;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
+
+  sampler.build_tree(3, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, 1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob, writer, error_writer);
+
+  EXPECT_EQ(7, sampler.rho_values.size());
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(0));
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(1));
+  EXPECT_EQ(4 * init_momentum, sampler.rho_values.at(2));
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(3));
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(4));
+  EXPECT_EQ(4 * init_momentum, sampler.rho_values.at(5));
+  EXPECT_EQ(8 * init_momentum, sampler.rho_values.at(6));
 }
 
 TEST(McmcNutsBaseNuts, divergence_test) {
@@ -191,6 +267,8 @@ TEST(McmcNutsBaseNuts, divergence_test) {
 
   stan::mcmc::ps_point z_propose(model_size);
 
+  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(model_size);
   Eigen::VectorXd rho = z_init.p;
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
@@ -215,30 +293,33 @@ TEST(McmcNutsBaseNuts, divergence_test) {
   bool valid_subtree = 0;
 
   sampler.z().V = -750;
-  valid_subtree = sampler.build_tree(0, rho, z_propose,
+  valid_subtree = sampler.build_tree(0, z_propose,
+                                     p_sharp_left, p_sharp_right, rho,
                                      H0, 1, n_leapfrog, log_sum_weight,
                                      sum_metro_prob,
                                      writer, error_writer);
   EXPECT_TRUE(valid_subtree);
-  EXPECT_EQ(0, sampler.divergent_);
+  EXPECT_FALSE(sampler.divergent_);
 
   sampler.z().V = -250;
-  valid_subtree = sampler.build_tree(0, rho, z_propose,
+  valid_subtree = sampler.build_tree(0, z_propose,
+                                     p_sharp_left, p_sharp_right, rho,
                                      H0, 1, n_leapfrog, log_sum_weight,
                                      sum_metro_prob,
                                      writer, error_writer);
 
   EXPECT_TRUE(valid_subtree);
-  EXPECT_EQ(0, sampler.divergent_);
+  EXPECT_FALSE(sampler.divergent_);
 
   sampler.z().V = 750;
-  valid_subtree = sampler.build_tree(0, rho, z_propose,
+  valid_subtree = sampler.build_tree(0, z_propose,
+                                     p_sharp_left, p_sharp_right, rho,
                                      H0, 1, n_leapfrog, log_sum_weight,
                                      sum_metro_prob,
                                      writer, error_writer);
 
   EXPECT_FALSE(valid_subtree);
-  EXPECT_EQ(1, sampler.divergent_);
+  EXPECT_TRUE(sampler.divergent_);
 
   EXPECT_EQ("", output.str());
   EXPECT_EQ("", error_stream.str());
@@ -270,9 +351,14 @@ TEST(McmcNutsBaseNuts, transition) {
 
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
+  // Transition will expand trajectory until max_depth is hit
   stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
-  EXPECT_EQ(31.5, s.cont_params()(0));
+  EXPECT_EQ(sampler.get_max_depth(), sampler.depth_);
+  EXPECT_EQ((2 << (sampler.get_max_depth() - 1)) - 1, sampler.n_leapfrog_);
+  EXPECT_FALSE(sampler.divergent_);
+
+  EXPECT_EQ(21 * init_momentum, s.cont_params()(0));
   EXPECT_EQ(0, s.log_prob());
   EXPECT_EQ(1, s.accept_stat());
   EXPECT_EQ("", output_stream.str());

--- a/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
@@ -10,7 +10,7 @@
 
 typedef boost::ecuyer1988 rng_t;
 
-TEST(McmcSoftAbsNuts, build_tree) {
+TEST(McmcSoftAbsNuts, build_tree_test) {
   rng_t base_rng(4839294);
 
   stan::mcmc::softabs_point z_init(3);
@@ -41,6 +41,8 @@ TEST(McmcSoftAbsNuts, build_tree) {
 
   stan::mcmc::ps_point z_propose = z_init;
 
+  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(z_init.p.size());
   Eigen::VectorXd rho = z_init.p;
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
@@ -48,7 +50,8 @@ TEST(McmcSoftAbsNuts, build_tree) {
   int n_leapfrog = 0;
   double sum_metro_prob = 0;
 
-  bool valid_subtree = sampler.build_tree(3, rho, z_propose,
+  bool valid_subtree = sampler.build_tree(3, z_propose,
+                                          p_sharp_left, p_sharp_right, rho,
                                           H0, 1, n_leapfrog, log_sum_weight,
                                           sum_metro_prob, writer, error_writer);
 
@@ -76,7 +79,7 @@ TEST(McmcSoftAbsNuts, build_tree) {
   EXPECT_EQ("", error_stream.str());
 }
 
-TEST(McmcSoftAbsNuts, transition) {
+TEST(McmcSoftAbsNuts, tree_boundary_test) {
   rng_t base_rng(4839294);
 
   stan::mcmc::softabs_point z_init(3);
@@ -92,6 +95,211 @@ TEST(McmcSoftAbsNuts, transition) {
   std::stringstream error_stream;
   stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+
+  typedef gauss3D_model_namespace::gauss3D_model model_t;
+  model_t model(data_var_context);
+
+  // Compute expected tree boundaries
+  typedef stan::mcmc::softabs_metric<model_t, rng_t> metric_t;
+  metric_t metric(model);
+
+  stan::mcmc::impl_leapfrog<metric_t> softabs_integrator;
+  double epsilon = 0.1;
+
+  stan::mcmc::softabs_point z_test = z_init;
+  metric.init(z_test, writer, error_writer);
+
+  softabs_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_forward_1 = metric.dtau_dp(z_test);
+
+  softabs_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_forward_2 = metric.dtau_dp(z_test);
+
+  softabs_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  softabs_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_forward_3 = metric.dtau_dp(z_test);
+
+  softabs_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  softabs_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  softabs_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  softabs_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_forward_4 = metric.dtau_dp(z_test);
+
+  z_test = z_init;
+  metric.init(z_test, writer, error_writer);
+
+  softabs_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_backward_1 = metric.dtau_dp(z_test);
+
+  softabs_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_backward_2 = metric.dtau_dp(z_test);
+
+  softabs_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  softabs_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_backward_3 = metric.dtau_dp(z_test);
+
+  softabs_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  softabs_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  softabs_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  softabs_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_backward_4 = metric.dtau_dp(z_test);
+
+  // Check expected tree boundaries to those dynamically geneated by NUTS
+  stan::mcmc::softabs_nuts<model_t, rng_t> sampler(model, base_rng);
+
+  sampler.set_nominal_stepsize(epsilon);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+
+  stan::mcmc::ps_point z_propose = z_init;
+
+  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd rho = z_init.p;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
+
+  double H0 = -0.1;
+  int n_leapfrog = 0;
+  double sum_metro_prob = 0;
+
+  // Depth 0 forward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(0, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, 1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_right(n));
+
+  // Depth 1 forward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(1, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, 1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_2(n), p_sharp_right(n));
+
+  // Depth 2 forward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(2, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, 1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_3(n), p_sharp_right(n));
+
+  // Depth 3 forward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(3, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, 1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_4(n), p_sharp_right(n));
+
+  // Depth 0 backward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(0, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, -1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_right(n));
+
+  // Depth 1 backward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(1, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, -1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_2(n), p_sharp_right(n));
+
+  // Depth 2 backward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(2, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, -1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_3(n), p_sharp_right(n));
+
+  // Depth 3 backward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(3, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, -1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_4(n), p_sharp_right(n));
+}
+
+TEST(McmcSoftAbsNuts, transition_test) {
+  rng_t base_rng(4839294);
+
+  stan::mcmc::softabs_point z_init(3);
+  z_init.q(0) = 1;
+  z_init.q(1) = -1;
+  z_init.q(2) = 1;
+  z_init.p(0) = -1;
+  z_init.p(1) = 1;
+  z_init.p(2) = -1;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
 
   std::fstream empty_stream("", std::fstream::in);
   stan::io::dump data_var_context(empty_stream);
@@ -109,6 +317,10 @@ TEST(McmcSoftAbsNuts, transition) {
   stan::mcmc::sample init_sample(z_init.q, 0, 0);
 
   stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
+
+  EXPECT_EQ(4, sampler.depth_);
+  EXPECT_EQ((2 << 3) - 1, sampler.n_leapfrog_);
+  EXPECT_FALSE(sampler.divergent_);
 
   EXPECT_FLOAT_EQ(1.9313564, s.cont_params()(0));
   EXPECT_FLOAT_EQ(-0.86902142, s.cont_params()(1));

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -10,7 +10,7 @@
 
 typedef boost::ecuyer1988 rng_t;
 
-TEST(McmcUnitENuts, build_tree) {
+TEST(McmcUnitENuts, build_tree_test) {
   rng_t base_rng(4839294);
 
   stan::mcmc::unit_e_point z_init(3);
@@ -41,6 +41,8 @@ TEST(McmcUnitENuts, build_tree) {
 
   stan::mcmc::ps_point z_propose = z_init;
 
+  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(z_init.p.size());
   Eigen::VectorXd rho = z_init.p;
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
@@ -48,7 +50,8 @@ TEST(McmcUnitENuts, build_tree) {
   int n_leapfrog = 0;
   double sum_metro_prob = 0;
 
-  bool valid_subtree = sampler.build_tree(3, rho, z_propose,
+  bool valid_subtree = sampler.build_tree(3, z_propose,
+                                          p_sharp_left, p_sharp_right, rho,
                                           H0, 1, n_leapfrog, log_sum_weight,
                                           sum_metro_prob,
                                           writer, error_writer);
@@ -77,7 +80,214 @@ TEST(McmcUnitENuts, build_tree) {
   EXPECT_EQ("", error_stream.str());
 }
 
-TEST(McmcUnitENuts, transition) {
+
+TEST(McmcUnitENuts, tree_boundary_test) {
+  rng_t base_rng(4839294);
+
+  stan::mcmc::unit_e_point z_init(3);
+  z_init.q(0) = 1;
+  z_init.q(1) = -1;
+  z_init.q(2) = 1;
+  z_init.p(0) = -1;
+  z_init.p(1) = 1;
+  z_init.p(2) = -1;
+
+  std::stringstream output;
+  stan::interface_callbacks::writer::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::interface_callbacks::writer::stream_writer error_writer(error_stream);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+
+  typedef gauss3D_model_namespace::gauss3D_model model_t;
+  model_t model(data_var_context);
+
+  // Compute expected tree boundaries
+  typedef stan::mcmc::unit_e_metric<model_t, rng_t> metric_t;
+  metric_t metric(model);
+
+  stan::mcmc::expl_leapfrog<metric_t> unit_e_integrator;
+  double epsilon = 0.1;
+
+  stan::mcmc::unit_e_point z_test = z_init;
+  metric.init(z_test, writer, error_writer);
+
+  unit_e_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_forward_1 = metric.dtau_dp(z_test);
+
+  unit_e_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_forward_2 = metric.dtau_dp(z_test);
+
+  unit_e_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  unit_e_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_forward_3 = metric.dtau_dp(z_test);
+
+  unit_e_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  unit_e_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  unit_e_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  unit_e_integrator.evolve(z_test, metric, epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_forward_4 = metric.dtau_dp(z_test);
+
+  z_test = z_init;
+  metric.init(z_test, writer, error_writer);
+
+  unit_e_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_backward_1 = metric.dtau_dp(z_test);
+
+  unit_e_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_backward_2 = metric.dtau_dp(z_test);
+
+  unit_e_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  unit_e_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_backward_3 = metric.dtau_dp(z_test);
+
+  unit_e_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  unit_e_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  unit_e_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  unit_e_integrator.evolve(z_test, metric, -epsilon, writer, error_writer);
+  Eigen::VectorXd p_sharp_backward_4 = metric.dtau_dp(z_test);
+
+  // Check expected tree boundaries to those dynamically geneated by NUTS
+  stan::mcmc::unit_e_nuts<model_t, rng_t> sampler(model, base_rng);
+
+  sampler.set_nominal_stepsize(epsilon);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+
+  stan::mcmc::ps_point z_propose = z_init;
+
+  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd rho = z_init.p;
+  double log_sum_weight = -std::numeric_limits<double>::infinity();
+
+  double H0 = -0.1;
+  int n_leapfrog = 0;
+  double sum_metro_prob = 0;
+
+  // Depth 0 forward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(0, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, 1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_right(n));
+
+  // Depth 1 forward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(1, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, 1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_2(n), p_sharp_right(n));
+
+  // Depth 2 forward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(2, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, 1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_3(n), p_sharp_right(n));
+
+  // Depth 3 forward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(3, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, 1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_forward_4(n), p_sharp_right(n));
+
+  // Depth 0 backward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(0, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, -1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_right(n));
+
+  // Depth 1 backward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(1, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, -1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_2(n), p_sharp_right(n));
+
+  // Depth 2 backward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(2, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, -1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_3(n), p_sharp_right(n));
+
+  // Depth 3 backward
+  sampler.z() = z_init;
+  sampler.init_hamiltonian(writer, error_writer);
+  sampler.build_tree(3, z_propose,
+                     p_sharp_left, p_sharp_right, rho,
+                     H0, -1, n_leapfrog, log_sum_weight,
+                     sum_metro_prob,
+                     writer, error_writer);
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
+
+  for (int n = 0; n < rho.size(); ++n)
+    EXPECT_FLOAT_EQ(p_sharp_backward_4(n), p_sharp_right(n));
+}
+
+TEST(McmcUnitENuts, transition_test) {
   rng_t base_rng(4839294);
 
   stan::mcmc::unit_e_point z_init(3);
@@ -110,10 +320,14 @@ TEST(McmcUnitENuts, transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, writer, error_writer);
 
-  EXPECT_FLOAT_EQ(1.6761723, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-1.1139321, s.cont_params()(1));
-  EXPECT_FLOAT_EQ(1.5012255, s.cont_params()(2));
-  EXPECT_FLOAT_EQ(-3.1520379, s.log_prob());
+  EXPECT_EQ(4, sampler.depth_);
+  EXPECT_EQ((2 << 3) - 1, sampler.n_leapfrog_);
+  EXPECT_FALSE(sampler.divergent_);
+
+  EXPECT_FLOAT_EQ(1.8718261, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-0.74208695, s.cont_params()(1));
+  EXPECT_FLOAT_EQ( 1.5202962, s.cont_params()(2));
+  EXPECT_FLOAT_EQ(-3.1828632, s.log_prob());
   EXPECT_FLOAT_EQ(0.99629009, s.accept_stat());
   EXPECT_EQ("", output_stream.str());
   EXPECT_EQ("", error_stream.str());

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -80,7 +80,6 @@ TEST(McmcUnitENuts, build_tree_test) {
   EXPECT_EQ("", error_stream.str());
 }
 
-
 TEST(McmcUnitENuts, tree_boundary_test) {
   rng_t base_rng(4839294);
 


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run unit tests: `./runTests.py src/test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary

Addresses #2178 by modifying the build_tree code to return proper tree boundaries and fixing the rho used for the right subtree.

#### Intended Effect

Restores exact validity of the NUTS sampler.  The NUTS tests were expanded to catch these issues.

#### How to Verify

Run unit tests in src/test/unit/mcmc/hmc/nuts.

Also, run the modified model I posted in the comments of #2178 to see that the two marginal variances and the correlation are both within the MCMC standard error, even with one million iterations.

#### Side Effects

Small changes to the sampler behavior which should decrease with the sampler step size.  May break the upstream integration test.

#### Documentation

None user facing.  Inline doc was updated.

#### Reviewer Suggestions

@syclik @bob-carpenter 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)