### PR TITLE
Add informational message to exception during initialization

### DIFF
--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -174,7 +174,7 @@ namespace stan {
                            " reducing ranges of constrained values,"
                            " or reparameterizing the model.");
           }
-          throw std::domain_error("");
+          throw std::domain_error("Initialization failed.");
         }
 
         init_writer(unconstrained);


### PR DESCRIPTION
Adds a short message to the thrown `std::domain_error`. Interfaces which
are able to handle C++ exceptions may not be able to detect the
exception class; providing a message solves this problem.

Very minor change for PyStan (and similar interfaces unable to detect the type of the exception).

By submitting this pull request, I agree to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
