### PR TITLE
Tweak average metro prob calc to not use initial state

### DIFF
--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -67,7 +67,7 @@ namespace stan {
         double log_sum_weight = 0;  // log(exp(H0 - H0))
         double H0 = this->hamiltonian_.H(this->z_);
         int n_leapfrog = 0;
-        double sum_metro_prob = 1;  // exp(H0 - H0)
+        double sum_metro_prob = 0;
 
         // Build a trajectory until the NUTS criterion is no longer satisfied
         this->depth_ = 0;
@@ -128,7 +128,7 @@ namespace stan {
         // Compute average acceptance probabilty across entire trajectory,
         // even over subtrees that may have been rejected
         double accept_prob
-          = sum_metro_prob / static_cast<double>(n_leapfrog + 1);
+          = sum_metro_prob / static_cast<double>(n_leapfrog);
 
         this->z_.ps_point::operator=(z_sample);
         this->energy_ = this->hamiltonian_.H(this->z_);

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -108,13 +108,13 @@ TEST_F(performance, values_from_tagged_version) {
     << "last tagged version, 2.9.0, had " << N_values << " elements";
 
   std::vector<double> first_run = last_draws_per_run[0];
-  EXPECT_FLOAT_EQ(-65.201302, first_run[0])
+  EXPECT_FLOAT_EQ(-65.319603, first_run[0])
     << "lp__: index 0";
 
-  EXPECT_FLOAT_EQ(0.93779498, first_run[1])
+  EXPECT_FLOAT_EQ(0.96712297, first_run[1])
     << "accept_stat__: index 1";
 
-  EXPECT_FLOAT_EQ(1.20701, first_run[2])
+  EXPECT_FLOAT_EQ(1.06545, first_run[2])
     << "stepsize__: index 2";
 
   EXPECT_FLOAT_EQ(2, first_run[3])
@@ -126,13 +126,13 @@ TEST_F(performance, values_from_tagged_version) {
   EXPECT_FLOAT_EQ(0, first_run[5])
     << "divergent__: index 5";
 
-  EXPECT_FLOAT_EQ(65.755402, first_run[6])
+  EXPECT_FLOAT_EQ(66.090698, first_run[6])
     << "energy__: index 6";
 
-  EXPECT_FLOAT_EQ(1.29672, first_run[7])
+  EXPECT_FLOAT_EQ(1.4068201, first_run[7])
     << "beta.1: index 7";
 
-  EXPECT_FLOAT_EQ(-0.47478199, first_run[8])
+  EXPECT_FLOAT_EQ(-0.59367198, first_run[8])
     << "beta.2: index 8";
 
   matches_tagged_version = !HasNonfatalFailure();

--- a/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
@@ -326,7 +326,7 @@ TEST(McmcSoftAbsNuts, transition_test) {
   EXPECT_FLOAT_EQ(-0.86902142, s.cont_params()(1));
   EXPECT_FLOAT_EQ(1.6008, s.cont_params()(2));
   EXPECT_FLOAT_EQ(-3.5239484, s.log_prob());
-  EXPECT_FLOAT_EQ(0.99709648, s.accept_stat());
+  EXPECT_FLOAT_EQ(0.99690288, s.accept_stat());
   EXPECT_EQ("", output.str());
   EXPECT_EQ("", error_stream.str());
 }

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -327,7 +327,7 @@ TEST(McmcUnitENuts, transition_test) {
   EXPECT_FLOAT_EQ(-0.74208695, s.cont_params()(1));
   EXPECT_FLOAT_EQ( 1.5202962, s.cont_params()(2));
   EXPECT_FLOAT_EQ(-3.1828632, s.log_prob());
-  EXPECT_FLOAT_EQ(0.99629009, s.accept_stat());
+  EXPECT_FLOAT_EQ(0.99604273, s.accept_stat());
   EXPECT_EQ("", output_stream.str());
   EXPECT_EQ("", error_stream.str());
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Removes initial state from the calculation of the average Metropolis acceptance probability.

#### Intended Effect

Reduces the average Metropolis acceptance probability to be consistent with the average probability of accepting a jump to each new state in the HMC trajectory from the initial state.

#### How to Verify

Run unit tests or try it on your favorite model.

#### Side Effects

Should make adaptation a bit more robust by allowing a change in step size to more strongly affect the average acceptance probability.

#### Documentation

None user facing.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)