### PR TITLE
Bugfix/2145 gq rng compound decl define

### DIFF
--- a/src/stan/lang/ast.hpp
+++ b/src/stan/lang/ast.hpp
@@ -4,6 +4,7 @@
 #include <stan/lang/ast/base_expr_type.hpp>
 #include <stan/lang/ast/expr_type.hpp>
 #include <stan/lang/ast/nil.hpp>
+#include <stan/lang/ast/scope_access.hpp>
 #include <stan/lang/ast/var_origin.hpp>
 #include <stan/lang/ast/variable_map.hpp>
 

--- a/src/stan/lang/ast.hpp
+++ b/src/stan/lang/ast.hpp
@@ -4,7 +4,7 @@
 #include <stan/lang/ast/base_expr_type.hpp>
 #include <stan/lang/ast/expr_type.hpp>
 #include <stan/lang/ast/nil.hpp>
-#include <stan/lang/ast/scope_access.hpp>
+#include <stan/lang/ast/origin_block.hpp>
 #include <stan/lang/ast/var_origin.hpp>
 #include <stan/lang/ast/variable_map.hpp>
 

--- a/src/stan/lang/ast/fun/has_non_param_var_vis_def.hpp
+++ b/src/stan/lang/ast/fun/has_non_param_var_vis_def.hpp
@@ -63,8 +63,8 @@ namespace stan {
 
     bool has_non_param_var_vis::operator()(const variable& e) const {
       var_origin vo = var_map_.get_origin(e.name_);
-      return vo == transformed_parameter_origin
-        || vo == local_origin;
+      return vo.program_block_ == transformed_parameter_origin
+        || vo.program_block_ == local_origin;
     }
 
     bool has_non_param_var_vis::operator()(const integrate_ode& e) const {

--- a/src/stan/lang/ast/fun/has_var_vis_def.hpp
+++ b/src/stan/lang/ast/fun/has_var_vis_def.hpp
@@ -31,9 +31,9 @@ namespace stan {
 
     bool has_var_vis::operator()(const variable& e) const {
       var_origin vo = var_map_.get_origin(e.name_);
-      return vo == parameter_origin
-        || vo == transformed_parameter_origin
-        || (vo == local_origin && e.type_.base_type_ != INT_T);
+      return vo.program_block_ == parameter_origin
+        || vo.program_block_ == transformed_parameter_origin
+        || (vo.program_block_ == local_origin && e.type_.base_type_ != INT_T);
     }
 
     bool has_var_vis::operator()(const fun& e) const {

--- a/src/stan/lang/ast/fun/has_var_vis_def.hpp
+++ b/src/stan/lang/ast/fun/has_var_vis_def.hpp
@@ -2,6 +2,7 @@
 #define STAN_LANG_AST_FUN_HAS_VAR_VIS_DEF_HPP
 
 #include <stan/lang/ast.hpp>
+#include <iostream>
 
 namespace stan {
   namespace lang {
@@ -31,9 +32,9 @@ namespace stan {
 
     bool has_var_vis::operator()(const variable& e) const {
       var_origin vo = var_map_.get_origin(e.name_);
-      return vo.program_block_ == parameter_origin
-        || vo.program_block_ == transformed_parameter_origin
-        || (vo.program_block_ == local_origin && e.type_.base_type_ != INT_T);
+      return (vo.program_block_ == parameter_origin && !vo.is_local_)
+        || (vo.program_block_ == transformed_parameter_origin && !vo.is_local_)
+        || (vo.is_local_ && e.type_.base_type_ != INT_T);
     }
 
     bool has_var_vis::operator()(const fun& e) const {

--- a/src/stan/lang/ast/fun/is_data_origin_def.hpp
+++ b/src/stan/lang/ast/fun/is_data_origin_def.hpp
@@ -7,7 +7,8 @@ namespace stan {
   namespace lang {
 
     bool is_data_origin(const var_origin& vo) {
-      return vo.program_block_ == data_origin || vo.program_block_ == transformed_data_origin;
+      return vo.program_block_ == data_origin
+        || vo.program_block_ == transformed_data_origin;
     }
 
   }

--- a/src/stan/lang/ast/fun/is_data_origin_def.hpp
+++ b/src/stan/lang/ast/fun/is_data_origin_def.hpp
@@ -7,7 +7,7 @@ namespace stan {
   namespace lang {
 
     bool is_data_origin(const var_origin& vo) {
-      return vo == data_origin || vo == transformed_data_origin;
+      return vo.program_block_ == data_origin || vo.program_block_ == transformed_data_origin;
     }
 
   }

--- a/src/stan/lang/ast/fun/is_fun_origin_def.hpp
+++ b/src/stan/lang/ast/fun/is_fun_origin_def.hpp
@@ -7,12 +7,12 @@ namespace stan {
   namespace lang {
 
     bool is_fun_origin(const var_origin& vo) {
-      return vo == function_argument_origin
-        || vo == function_argument_origin_lp
-        || vo == function_argument_origin_rng
-        || vo == void_function_argument_origin
-        || vo == void_function_argument_origin_lp
-        || vo == void_function_argument_origin_rng;
+      return vo.program_block_ == function_argument_origin
+        || vo.program_block_ == function_argument_origin_lp
+        || vo.program_block_ == function_argument_origin_rng
+        || vo.program_block_ == void_function_argument_origin
+        || vo.program_block_ == void_function_argument_origin_lp
+        || vo.program_block_ == void_function_argument_origin_rng;
     }
 
   }

--- a/src/stan/lang/ast/fun/print_var_origin_def.hpp
+++ b/src/stan/lang/ast/fun/print_var_origin_def.hpp
@@ -7,34 +7,34 @@ namespace stan {
   namespace lang {
 
     void print_var_origin(std::ostream& o, const var_origin& vo) {
-      if (vo == model_name_origin)
+      if (vo.program_block_ == model_name_origin)
         o << "model name";
-      else if (vo == data_origin)
+      else if (vo.program_block_ == data_origin)
         o << "data";
-      else if (vo == transformed_data_origin)
+      else if (vo.program_block_ == transformed_data_origin)
         o << "transformed data";
-      else if (vo == parameter_origin)
+      else if (vo.program_block_ == parameter_origin)
         o << "parameter";
-      else if (vo == transformed_parameter_origin)
+      else if (vo.program_block_ == transformed_parameter_origin)
         o << "transformed parameter";
-      else if (vo == derived_origin)
+      else if (vo.program_block_ == derived_origin)
         o << "generated quantities";
-      else if (vo == local_origin)
+      else if (vo.program_block_ == local_origin)
         o << "local";
-      else if (vo == function_argument_origin)
+      else if (vo.program_block_ == function_argument_origin)
         o << "function argument";
-      else if (vo == function_argument_origin_lp)
+      else if (vo.program_block_ == function_argument_origin_lp)
         o << "function argument '_lp' suffixed";
-      else if (vo == function_argument_origin_rng)
+      else if (vo.program_block_ == function_argument_origin_rng)
         o << "function argument '_rng' suffixed";
-      else if (vo == void_function_argument_origin)
+      else if (vo.program_block_ == void_function_argument_origin)
         o << "void function argument";
-      else if (vo == void_function_argument_origin_lp)
+      else if (vo.program_block_ == void_function_argument_origin_lp)
         o << "void function argument '_lp' suffixed";
-      else if (vo == void_function_argument_origin_rng)
+      else if (vo.program_block_ == void_function_argument_origin_rng)
         o << "void function argument '_rng' suffixed";
       else
-        o << "UNKNOWN ORIGIN=" << vo;
+        o << "UNKNOWN ORIGIN=" << vo.program_block_ ;
     }
 
   }

--- a/src/stan/lang/ast/fun/print_var_origin_def.hpp
+++ b/src/stan/lang/ast/fun/print_var_origin_def.hpp
@@ -34,7 +34,7 @@ namespace stan {
       else if (vo.program_block_ == void_function_argument_origin_rng)
         o << "void function argument '_rng' suffixed";
       else
-        o << "UNKNOWN ORIGIN=" << vo.program_block_ ;
+        o << "UNKNOWN ORIGIN=" << vo.program_block_;
     }
 
   }

--- a/src/stan/lang/ast/node/array_expr.hpp
+++ b/src/stan/lang/ast/node/array_expr.hpp
@@ -36,8 +36,7 @@ namespace stan {
        * Origin of this array expression.
        *
        */
-      // TODO(carpenter): rename to "array_expr_origin_"
-      var_origin var_origin_;
+      var_origin array_expr_origin_;
 
       /**
        * Construct a default array expression.

--- a/src/stan/lang/ast/origin_block.hpp
+++ b/src/stan/lang/ast/origin_block.hpp
@@ -1,0 +1,87 @@
+#ifndef STAN_LANG_AST_ORIGIN_BLOCK_HPP
+#define STAN_LANG_AST_ORIGIN_BLOCK_HPP
+
+namespace stan {
+  namespace lang {
+    /**
+     * The type of a variable indicating where a variable was
+     * declared.   This is a typedef rather than an enum to get around
+     * forward declaration issues with enums in header files.
+     */
+    typedef int origin_block;
+
+    /**
+     * Origin of variable is the name of the model.
+     */
+    const int model_name_origin = 0;
+
+    /**
+     * The origin of the variable is the data block.
+     */
+    const int data_origin = 1;
+
+    /**
+     * The origin of the variable is the transformed data block.
+     */
+    const int transformed_data_origin = 2;
+
+    /**
+     * The origin of the variable is the parameter block.
+     */
+    const int parameter_origin = 3;
+
+    /**
+     * The origin of the variable is the transformed parameter block.
+     */
+    const int transformed_parameter_origin = 4;
+
+    /**
+     * The origin of the variable is generated quantities.
+     */
+    const int derived_origin = 5;
+
+    /**
+     * The origin of the variable is as a local variable.
+     * Holds for model block as well as nested blocks.
+     */
+    const int local_origin = 6;
+
+    /**
+     * The variable arose as a function argument to a non-void
+     * function that does not end in _lp or _rng.
+     */
+    const int function_argument_origin = 7;
+
+    /**
+     * The variable arose as an argument to a non-void function with
+     * the _lp suffix.
+     */
+    const int function_argument_origin_lp = 8;
+
+    /**
+     * The variable arose as an argument to a non-void function with
+     * the _rng suffix.
+     */
+    const int function_argument_origin_rng = 9;
+
+    /**
+     * The variable arose as an argument to a function returning void
+     * that does not have the _lp or _rng suffix.
+     */
+    const int void_function_argument_origin = 10;
+
+    /**
+     * The variable arose as an argument to a function returning void
+     * with _lp suffix.  function returning void
+     */
+    const int void_function_argument_origin_lp = 11;
+
+    /**
+     * The variable arose as an argument to a function returning void
+     * with an _rng suffix.
+     */
+    const int void_function_argument_origin_rng = 12;
+
+  }
+}
+#endif

--- a/src/stan/lang/ast/var_origin.hpp
+++ b/src/stan/lang/ast/var_origin.hpp
@@ -35,7 +35,8 @@ namespace stan {
        *
        * @param program_block enclosing program block
        */
-      var_origin(const origin_block& program_block);  // NOLINT(runtime/explicit)
+      var_origin(const
+                 origin_block& program_block);   // NOLINT(runtime/explicit)
 
       /**
        * Construct an origin for a variable in specified outer program block,

--- a/src/stan/lang/ast/var_origin.hpp
+++ b/src/stan/lang/ast/var_origin.hpp
@@ -24,31 +24,33 @@ namespace stan {
       bool is_local_;
 
       /**
-       * Construct an empty var_origin
+       * No arg constructor, defaults:
+       * program_block_ : model_name_origin
+       * is_local_ : false
        */
       var_origin();
 
       /**
        * Construct an origin for variable in a specified block
        *
-       * @param program_block - enclosing program block
+       * @param program_block enclosing program block
        */
-      var_origin(const origin_block program_block);  // NOLINT(runtime/explicit)
+      var_origin(const origin_block& program_block);  // NOLINT(runtime/explicit)
 
       /**
        * Construct an origin for a variable in specified outer program block,
        * specify whether or not variable is in local program block 
        *
-       * @param program_block - enclosing program block
-       * @param is_local - flags whether or not in a local block
+       * @param program_block enclosing program block
+       * @param is_local flags whether or not in a local block
        */
-      var_origin(const origin_block program_block,
-                 const bool is_local);  // NOLINT(runtime/explicit)
+      var_origin(const origin_block& program_block,
+                 const bool& is_local);
 
       /**
        * Return true if declared in a local block.
        *
-       * @return bool if declared in a local block.
+       * @return value of is_local_
        */
       bool is_local() const;
     };

--- a/src/stan/lang/ast/var_origin.hpp
+++ b/src/stan/lang/ast/var_origin.hpp
@@ -1,87 +1,58 @@
 #ifndef STAN_LANG_AST_VAR_ORIGIN_HPP
 #define STAN_LANG_AST_VAR_ORIGIN_HPP
 
+
+#include <stan/lang/ast/origin_block.hpp>
+#include <cstddef>
+
 namespace stan {
   namespace lang {
 
     /**
-     * The type of a variable indicating where a variable was
-     * declared.   This is a typedef rather than an enum to get around
-     * forward declaration issues with enums in header files.
+     * Structure describes enclosing program block(s)
+     * in which variable is declared.
      */
-    typedef int var_origin;
+    struct var_origin {
+      /**
+       * Outermost enclosing program block.
+       */
+      origin_block program_block_;
 
-    /**
-     * Origin of variable is the name of the model.
-     */
-    const int model_name_origin = 0;
+      /**
+       * Flags whether in a nested (local) program block.
+       */
+      bool is_local_;
 
-    /**
-     * The origin of the variable is the data block.
-     */
-    const int data_origin = 1;
+      /**
+       * Construct an empty var_origin
+       */
+      var_origin();
 
-    /**
-     * The origin of the variable is the transformed data block.
-     */
-    const int transformed_data_origin = 2;
+      /**
+       * Construct an origin for variable in a specified block
+       *
+       * @param program_block - enclosing program block
+       */
+      var_origin(const origin_block program_block); // NOLINT(runtime/explicit)
 
-    /**
-     * The origin of the variable is the parameter block.
-     */
-    const int parameter_origin = 3;
+      /**
+       * Construct an origin for a variable in specified outer program block,
+       * specify whether or not variable is in local program block 
+       *
+       * @param program_block - enclosing program block
+       * @param is_local - flags whether or not in a local block
+       */
+      var_origin(const origin_block program_block,
+                 const bool is_local);  // NOLINT(runtime/explicit)
 
-    /**
-     * The origin of the variable is the transformed parameter block.
-     */
-    const int transformed_parameter_origin = 4;
+      /**
+       * Return true if declared in a local block.
+       *
+       * @return bool if declared in a local block.
+       */
+      bool is_local() const;
 
-    /**
-     * The origin of the variable is generated quantities.
-     */
-    const int derived_origin = 5;
-
-    /**
-     * The origin of the variable is as a local variable.
-     * Holds for model block as well as nested blocks.
-     */
-    const int local_origin = 6;
-
-    /**
-     * The variable arose as a function argument to a non-void
-     * function that does not end in _lp or _rng.
-     */
-    const int function_argument_origin = 7;
-
-    /**
-     * The variable arose as an argument to a non-void function with
-     * the _lp suffix.
-     */
-    const int function_argument_origin_lp = 8;
-
-    /**
-     * The variable arose as an argument to a non-void function with
-     * the _rng suffix.
-     */
-    const int function_argument_origin_rng = 9;
-
-    /**
-     * The variable arose as an argument to a function returning void
-     * that does not have the _lp or _rng suffix.
-     */
-    const int void_function_argument_origin = 10;
-
-    /**
-     * The variable arose as an argument to a function returning void
-     * with _lp suffix.  function returning void
-     */
-    const int void_function_argument_origin_lp = 11;
-
-    /**
-     * The variable arose as an argument to a function returning void
-     * with an _rng suffix.
-     */
-    const int void_function_argument_origin_rng = 12;
+    };
 
   }
 }

--- a/src/stan/lang/ast/var_origin.hpp
+++ b/src/stan/lang/ast/var_origin.hpp
@@ -37,12 +37,13 @@ namespace stan {
     const int transformed_parameter_origin = 4;
 
     /**
-     * The origin of the variable is ???.
+     * The origin of the variable is generated quantities.
      */
     const int derived_origin = 5;
 
     /**
-     * The origin of the variable is as a local variable
+     * The origin of the variable is as a local variable.
+     * Holds for model block as well as nested blocks.
      */
     const int local_origin = 6;
 

--- a/src/stan/lang/ast/var_origin.hpp
+++ b/src/stan/lang/ast/var_origin.hpp
@@ -33,7 +33,7 @@ namespace stan {
        *
        * @param program_block - enclosing program block
        */
-      var_origin(const origin_block program_block); // NOLINT(runtime/explicit)
+      var_origin(const origin_block program_block);  // NOLINT(runtime/explicit)
 
       /**
        * Construct an origin for a variable in specified outer program block,
@@ -51,7 +51,6 @@ namespace stan {
        * @return bool if declared in a local block.
        */
       bool is_local() const;
-
     };
 
   }

--- a/src/stan/lang/ast/var_origin_def.hpp
+++ b/src/stan/lang/ast/var_origin_def.hpp
@@ -1,0 +1,22 @@
+#ifndef STAN_LANG_AST_VAR_ORIGIN_DEF_HPP
+#define STAN_LANG_AST_VAR_ORIGIN_DEF_HPP
+
+#include <stan/lang/ast/origin_block.hpp>
+#include <stan/lang/ast/var_origin.hpp>
+
+namespace stan {
+  namespace lang {
+
+    var_origin::var_origin()
+      : program_block_(model_name_origin), is_local_(false) { }
+
+    var_origin::var_origin(const origin_block program_block)
+      : program_block_(program_block), is_local_(false) { }
+
+    var_origin::var_origin(const origin_block program_block,
+                           const bool is_local)
+      : program_block_(program_block), is_local_(is_local) { }
+
+  }
+}
+#endif

--- a/src/stan/lang/ast/var_origin_def.hpp
+++ b/src/stan/lang/ast/var_origin_def.hpp
@@ -10,11 +10,11 @@ namespace stan {
     var_origin::var_origin()
       : program_block_(model_name_origin), is_local_(false) { }
 
-    var_origin::var_origin(const origin_block program_block)
+    var_origin::var_origin(const origin_block& program_block)
       : program_block_(program_block), is_local_(false) { }
 
-    var_origin::var_origin(const origin_block program_block,
-                           const bool is_local)
+    var_origin::var_origin(const origin_block& program_block,
+                           const bool& is_local)
       : program_block_(program_block), is_local_(is_local) { }
 
   }

--- a/src/stan/lang/ast_def.cpp
+++ b/src/stan/lang/ast_def.cpp
@@ -7,6 +7,7 @@
 #include <stan/lang/ast.hpp>
 
 #include <stan/lang/ast/expr_type_def.hpp>
+#include <stan/lang/ast/var_origin_def.hpp>
 #include <stan/lang/ast/variable_map_def.hpp>
 
 #include <stan/lang/ast/fun/ends_with_def.hpp>

--- a/src/stan/lang/generator/expression_visgen.hpp
+++ b/src/stan/lang/generator/expression_visgen.hpp
@@ -45,8 +45,8 @@ namespace stan {
 
       void operator()(const array_expr& x) const {
         std::stringstream ssRealType;
-        generate_real_var_type(x.array_expr_origin_, x.has_var_, is_var_context_,
-                               ssRealType);
+        generate_real_var_type(x.array_expr_origin_, x.has_var_,
+                               is_var_context_, ssRealType);
         std::stringstream ssArrayType;
         generate_array_var_type(x.type_.base_type_, ssRealType.str(),
                                 is_var_context_, ssArrayType);

--- a/src/stan/lang/generator/expression_visgen.hpp
+++ b/src/stan/lang/generator/expression_visgen.hpp
@@ -45,7 +45,7 @@ namespace stan {
 
       void operator()(const array_expr& x) const {
         std::stringstream ssRealType;
-        generate_real_var_type(x.var_origin_, x.has_var_, is_var_context_,
+        generate_real_var_type(x.array_expr_origin_, x.has_var_, is_var_context_,
                                ssRealType);
         std::stringstream ssArrayType;
         generate_array_var_type(x.type_.base_type_, ssRealType.str(),

--- a/src/stan/lang/grammars/functions_grammar.hpp
+++ b/src/stan/lang/grammars/functions_grammar.hpp
@@ -41,7 +41,7 @@ namespace stan {
       functions_r;
 
       boost::spirit::qi::rule<Iterator,
-                              boost::spirit::qi::locals<bool, int>,
+                              boost::spirit::qi::locals<bool, var_origin>,
                               function_decl_def(),
                               whitespace_grammar<Iterator> >
       function_r;

--- a/src/stan/lang/grammars/program_grammar.hpp
+++ b/src/stan/lang/grammars/program_grammar.hpp
@@ -35,34 +35,40 @@ namespace stan {
                       bool allow_undefined = false);
 
       boost::spirit::qi::rule<Iterator,
+                              boost::spirit::qi::locals<var_origin>,
                               std::vector<var_decl>(),
                               whitespace_grammar<Iterator> >
       data_var_decls_r;
 
       boost::spirit::qi::rule<Iterator,
+                              boost::spirit::qi::locals<var_origin>,
                               std::pair<std::vector<var_decl>,
                                         std::vector<statement> >(),
                               whitespace_grammar<Iterator> >
       derived_data_var_decls_r;
 
       boost::spirit::qi::rule<Iterator,
+                              boost::spirit::qi::locals<var_origin>,
                               std::pair<std::vector<var_decl>,
                                         std::vector<statement> >(),
                               whitespace_grammar<Iterator> >
       derived_var_decls_r;
 
       boost::spirit::qi::rule<Iterator,
+                              boost::spirit::qi::locals<var_origin>,
                               std::pair<std::vector<var_decl>,
                                         std::vector<statement> >(),
                               whitespace_grammar<Iterator> >
       generated_var_decls_r;
 
       boost::spirit::qi::rule<Iterator,
+                              boost::spirit::qi::locals<var_origin>,
                               statement(),
                               whitespace_grammar<Iterator> >
       model_r;
 
       boost::spirit::qi::rule<Iterator,
+                              boost::spirit::qi::locals<var_origin>,
                               std::vector<var_decl>(),
                               whitespace_grammar<Iterator> >
       param_var_decls_r;

--- a/src/stan/lang/grammars/program_grammar_def.hpp
+++ b/src/stan/lang/grammars/program_grammar_def.hpp
@@ -58,7 +58,8 @@ namespace stan {
         using boost::spirit::qi::labels::_a;
 
         // add model_name to var_map with special origin
-        var_map_.add(model_name, base_var_decl(), var_origin(model_name_origin, true));
+        var_map_.add(model_name, base_var_decl(),
+                     var_origin(model_name_origin, true));
 
         program_r.name("program");
         program_r

--- a/src/stan/lang/grammars/program_grammar_def.hpp
+++ b/src/stan/lang/grammars/program_grammar_def.hpp
@@ -58,7 +58,7 @@ namespace stan {
         using boost::spirit::qi::labels::_a;
 
         // add model_name to var_map with special origin
-        var_map_.add(model_name, base_var_decl(), var_origin(model_name_origin));
+        var_map_.add(model_name, base_var_decl(), var_origin(model_name_origin, true));
 
         program_r.name("program");
         program_r
@@ -75,7 +75,7 @@ namespace stan {
         model_r.name("model declaration (or perhaps an earlier block)");
         model_r
           %= lit("model")
-          > eps[set_var_origin_f(_a, model_name_origin)]
+          > eps[set_var_origin_local_f(_a, model_name_origin)]
           > statement_g(true, _a, false, false);
 
         end_var_decls_r.name(
@@ -108,7 +108,7 @@ namespace stan {
           %= (lit("data")
               > lit('{'))
           > eps[set_var_origin_f(_a, data_origin)]
-          >  var_decls_g(true, _a)  // +constraints
+          >  var_decls_g(true, _a)
           > end_var_decls_r;
 
         derived_data_var_decls_r.name("transformed data block");
@@ -117,7 +117,7 @@ namespace stan {
                >> lit("data"))
               > lit('{'))
           > eps[set_var_origin_f(_a, transformed_data_origin)]
-          > var_decls_g(true, _a)  // -constraints
+          > var_decls_g(true, _a)
           > ((statement_g(false, _a, false, false)
               > *statement_g(false, _a, false, false)
               > end_var_definitions_r)
@@ -129,7 +129,7 @@ namespace stan {
           %= (lit("parameters")
               > lit('{'))
           > eps[set_var_origin_f(_a, parameter_origin)]
-          > var_decls_g(true, _a)  // +constraints
+          > var_decls_g(true, _a)
           > end_var_decls_r;
 
         derived_var_decls_r.name("derived variable declarations");

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -242,7 +242,7 @@ namespace stan {
     // called from: functions_grammar
     struct set_allows_sampling_origin : public phoenix_functor_ternary {
       void operator()(const std::string& identifier, bool& allow_sampling,
-                      int& origin) const;
+                      var_origin& origin) const;
     };
     extern boost::phoenix::function<set_allows_sampling_origin>
     set_allows_sampling_origin_f;
@@ -776,7 +776,7 @@ namespace stan {
     extern boost::phoenix::function<set_int_range_upper> set_int_range_upper_f;
 
     struct validate_int_data_expr : public phoenix_functor_quinary {
-      void operator()(const expression& expr, int var_origin, bool& pass,
+      void operator()(const expression& expr, var_origin var_origin, bool& pass,
                       variable_map& var_map, std::stringstream& error_msgs)
         const;
     };
@@ -823,6 +823,13 @@ namespace stan {
                       std::ostream& error_msgs) const;
     };
     extern boost::phoenix::function<non_void_expression> non_void_expression_f;
+
+    struct set_var_origin : public phoenix_functor_binary {
+      void operator()(var_origin& vo, const origin_block& program_block) const;
+    };
+    extern boost::phoenix::function<set_var_origin> set_var_origin_f;
+
+
   }
 }
 #endif

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -463,8 +463,10 @@ namespace stan {
     extern boost::phoenix::function<add_while_body> add_while_body_f;
 
     // called from: statement_grammar
-    struct add_loop_identifier : public phoenix_functor_quinary {
-      void operator()(const std::string& name, std::string& name_local,
+    struct add_loop_identifier : public phoenix_functor_senary {
+      void operator()(const std::string& name,
+                      std::string& name_local,
+                      const var_origin& origin,
                       bool& pass, variable_map& vm,
                       std::stringstream& error_msgs) const;
     };
@@ -832,7 +834,8 @@ namespace stan {
     struct set_var_origin_local : public phoenix_functor_binary {
       void operator()(var_origin& vo, const origin_block& program_block) const;
     };
-    extern boost::phoenix::function<set_var_origin_local> set_var_origin_local_f;
+    extern boost::phoenix::function<set_var_origin_local>
+    set_var_origin_local_f;
 
     struct reset_var_origin : public phoenix_functor_binary {
       void operator()(var_origin& vo, const var_origin& vo_enclosing) const;

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -206,7 +206,7 @@ namespace stan {
     // called from: expression_grammar
     struct validate_conditional_op : public phoenix_functor_quinary {
       void operator()(conditional_op& cond_expr,
-                      const var_origin& var_origin,
+                      const var_origin& vo,
                       bool& pass,
                       const variable_map& var_map,
                       std::ostream& error_msgs) const;
@@ -406,7 +406,7 @@ namespace stan {
 
     // called from: statement_grammar
     struct identifier_to_var : public phoenix_functor_senary {
-      void operator()(const std::string& name, const var_origin& origin_allowed,
+      void operator()(const std::string& name, const var_origin& origin,
                       variable& v, bool& pass, const variable_map& vm,
                       std::ostream& error_msgs) const;
     };
@@ -421,7 +421,7 @@ namespace stan {
 
     // called from: statement_grammar
     struct validate_assignment : public phoenix_functor_quinary {
-      void operator()(assignment& a, const var_origin& origin_allowed,
+      void operator()(assignment& a, const var_origin& origin,
                       bool& pass, variable_map& vm, std::ostream& error_msgs)
         const;
     };
@@ -561,7 +561,7 @@ namespace stan {
     // called from: term_grammar
     struct set_fun_type_named : public phoenix_functor_quinary {
       void operator()(expression& fun_result, fun& fun,
-                      const var_origin& var_origin, bool& pass,
+                      const var_origin& vo, bool& pass,
                       std::ostream& error_msgs) const;
     };
     extern boost::phoenix::function<set_fun_type_named> set_fun_type_named_f;
@@ -570,7 +570,7 @@ namespace stan {
     struct set_array_expr_type : public phoenix_functor_senary {
       void operator()(expression& e,
                       array_expr& array_expr,
-                      const var_origin& var_origin,
+                      const var_origin& vo,
                       bool& pass,
                       const variable_map& var_map,
                       std::ostream& error_msgs) const;
@@ -580,7 +580,7 @@ namespace stan {
     // called from: term_grammar
     struct exponentiation_expr : public phoenix_functor_quinary {
       void operator()(expression& expr1, const expression& expr2,
-                      const var_origin& var_origin, bool& pass,
+                      const var_origin& vo, bool& pass,
                       std::ostream& error_msgs) const;
     };
     extern boost::phoenix::function<exponentiation_expr> exponentiation_f;
@@ -778,7 +778,7 @@ namespace stan {
     extern boost::phoenix::function<set_int_range_upper> set_int_range_upper_f;
 
     struct validate_int_data_expr : public phoenix_functor_quinary {
-      void operator()(const expression& expr, var_origin var_origin, bool& pass,
+      void operator()(const expression& expr, const var_origin& vo, bool& pass,
                       variable_map& var_map, std::stringstream& error_msgs)
         const;
     };

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -829,6 +829,17 @@ namespace stan {
     };
     extern boost::phoenix::function<set_var_origin> set_var_origin_f;
 
+    struct set_var_origin_local : public phoenix_functor_binary {
+      void operator()(var_origin& vo, const origin_block& program_block) const;
+    };
+    extern boost::phoenix::function<set_var_origin_local> set_var_origin_local_f;
+
+    struct reset_var_origin : public phoenix_functor_binary {
+      void operator()(var_origin& vo, const var_origin& vo_enclosing) const;
+    };
+    extern boost::phoenix::function<reset_var_origin> reset_var_origin_f;
+
+
 
   }
 }

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1727,7 +1727,7 @@ namespace stan {
       }
       ++et.num_dims_;
       array_expr.type_ = et;
-      array_expr.var_origin_ = var_origin;
+      array_expr.array_expr_origin_ = var_origin;
       array_expr.has_var_ = has_var(array_expr, var_map);
       e = array_expr;
       pass = true;

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1290,6 +1290,7 @@ namespace stan {
 
     void add_loop_identifier::operator()(const std::string& name,
                                          std::string& name_local,
+                                         const var_origin& origin,
                                          bool& pass, variable_map& vm,
                                          std::stringstream& error_msgs) const {
       name_local = name;
@@ -1299,7 +1300,7 @@ namespace stan {
                    << " variable name=\"" << name << "\"" << std::endl;
       else
         vm.add(name, base_var_decl(name, std::vector<expression>(), INT_T),
-               local_origin);  // loop var acts like local
+               var_origin(origin.program_block_, true));
     }
     boost::phoenix::function<add_loop_identifier> add_loop_identifier_f;
 

--- a/src/stan/lang/grammars/statement_grammar.hpp
+++ b/src/stan/lang/grammars/statement_grammar.hpp
@@ -171,7 +171,7 @@ namespace stan {
       statement_sub_r;
 
       boost::spirit::qi::rule<Iterator,
-                              boost::spirit::qi::locals<std::vector<var_decl> >,
+                              boost::spirit::qi::locals<std::vector<var_decl>, var_origin>,
                               statements(bool, var_origin, bool, bool),
                               whitespace_grammar<Iterator> >
       statement_seq_r;

--- a/src/stan/lang/grammars/statement_grammar.hpp
+++ b/src/stan/lang/grammars/statement_grammar.hpp
@@ -171,7 +171,8 @@ namespace stan {
       statement_sub_r;
 
       boost::spirit::qi::rule<Iterator,
-                              boost::spirit::qi::locals<std::vector<var_decl>, var_origin>,
+                              boost::spirit::qi::locals<std::vector<var_decl>,
+                                                        var_origin>,
                               statements(bool, var_origin, bool, bool),
                               whitespace_grammar<Iterator> >
       statement_seq_r;

--- a/src/stan/lang/grammars/statement_grammar.hpp
+++ b/src/stan/lang/grammars/statement_grammar.hpp
@@ -136,7 +136,7 @@ namespace stan {
       identifier_r;
 
       boost::spirit::qi::rule<Iterator,
-                              std::vector<var_decl>(),
+                              std::vector<var_decl>(var_origin),
                               whitespace_grammar<Iterator> >
       local_var_decls_r;
 

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -190,7 +190,7 @@ namespace stan {
       for_statement_r
         %= (lit("for") >> no_skip[!char_("a-zA-Z0-9_")])
         > lit('(')
-        > identifier_r[add_loop_identifier_f(_1, _a, _pass,
+        > identifier_r[add_loop_identifier_f(_1, _a, _r2, _pass,
                                          boost::phoenix::ref(var_map_),
                                          boost::phoenix::ref(error_msgs_))]
         > lit("in")

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -100,7 +100,6 @@ namespace stan {
       //   _r2 source of variables allowed for assignments
       //   _r3 true if return_r allowed
       //   _r4 true if in loop (allowing break/continue)
-
       // raw[ ] just to wrap to get line numbers
       statement_r.name("statement");
       statement_r
@@ -132,13 +131,13 @@ namespace stan {
       statement_seq_r.name("sequence of statements");
       statement_seq_r
         %= lit('{')
-        > local_var_decls_r[assign_lhs_f(_a, _1)]
+        > local_var_decls_r(_r2)[assign_lhs_f(_a, _1)]
         > *statement_r(_r1, _r2, _r3, _r4)
         > lit('}')
         > eps[unscope_locals_f(_a, boost::phoenix::ref(var_map_))];
 
       local_var_decls_r
-        %= var_decls_g(false, local_origin);  // - constants
+        %= var_decls_g(false, _r1);  // - constants
 
       // inherited  _r1 = true if samples allowed as statements
       increment_log_prob_statement_r.name("increment log prob statement");

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -87,6 +87,7 @@ namespace stan {
       using boost::spirit::qi::raw;
 
       using boost::spirit::qi::labels::_a;
+      using boost::spirit::qi::labels::_b;
       using boost::spirit::qi::labels::_r1;
       using boost::spirit::qi::labels::_r2;
       using boost::spirit::qi::labels::_r3;
@@ -131,8 +132,9 @@ namespace stan {
       statement_seq_r.name("sequence of statements");
       statement_seq_r
         %= lit('{')
-        > local_var_decls_r(_r2)[assign_lhs_f(_a, _1)]
-        > *statement_r(_r1, _r2, _r3, _r4)
+        > eps[reset_var_origin_f(_b, _r2)]
+        > local_var_decls_r(_b)[assign_lhs_f(_a, _1)]
+        > *statement_r(_r1, _b, _r3, _r4)
         > lit('}')
         > eps[unscope_locals_f(_a, boost::phoenix::ref(var_map_))];
 

--- a/src/test/test-models/good/declare-define-gq-local-rng.stan
+++ b/src/test/test-models/good/declare-define-gq-local-rng.stan
@@ -1,0 +1,22 @@
+transformed data {
+  int a = categorical_rng(rep_vector(0.1, 10));
+  {
+    int b = categorical_rng(rep_vector(0.1, 10));
+  }
+}
+parameters {
+  real y;
+}
+transformed parameters {
+  {
+    int k;
+  }
+}
+model {
+  y ~ normal(0,1);
+}
+generated quantities {
+  {
+    int y_tilde = categorical_rng(rep_vector(0.1, 10));
+  }
+}

--- a/src/test/test-models/good/lang/reject_mult_args.stan
+++ b/src/test/test-models/good/lang/reject_mult_args.stan
@@ -2,8 +2,8 @@ functions {
   real relative_diff(real x, real y, real max, real min) {
     real abs_diff;
     real avg_scale;
-    abs_diff <- fabs(x - y);
-    avg_scale <- (fabs(x) + fabs(y)) / 2;
+    abs_diff = fabs(x - y);
+    avg_scale = (fabs(x) + fabs(y)) / 2;
     if ((abs_diff / avg_scale) > max)
       reject("user-specified rejection, difference above ",max," x:",x," y:",y);
     if ((abs_diff / avg_scale) < min)
@@ -12,20 +12,15 @@ functions {
   }    
 }
 transformed data {
-  real a;
-  real b;
-  real mx;
-  real mn;
-  a <- -9.0;
-  b <- -1.0;
-  mx <- 1.2;
-  mn <- 1.1;
+  real a =  -9.0;
+  real b = -1.0;
+  real mx = 1.2;
+  real mn = 1.1;
 }
 parameters {
   real y;
 }
 model {
-  real c;
-  c <- relative_diff(a,b,mx,mn);
+  real c = relative_diff(a,b,mx,mn);
   y ~ normal(0,1);
 }

--- a/src/test/test-models/good/lang/reject_mult_args.stan
+++ b/src/test/test-models/good/lang/reject_mult_args.stan
@@ -21,6 +21,7 @@ parameters {
   real y;
 }
 model {
-  real c = relative_diff(a,b,mx,mn);
+  real c;
+  c = relative_diff(a,b,mx,mn);
   y ~ normal(0,1);
 }

--- a/src/test/test-models/good/ode-int-segments.stan
+++ b/src/test/test-models/good/ode-int-segments.stan
@@ -21,9 +21,8 @@ parameters {
 transformed parameters {
   real y_hat[T,2]; 
   {
-    int N;
-    N <- 0;
-    y_hat <- integrate_ode(ode, y0, t0, segment(ts, 0, N), theta, x, x_int);
+    int N = 0;
+    y_hat = integrate_ode(ode, y0, t0, segment(ts, 0, N), theta, x, x_int);
   }
 }
 model {

--- a/src/test/unit/lang/parser/var_decls_grammar_test.cpp
+++ b/src/test/unit/lang/parser/var_decls_grammar_test.cpp
@@ -5,7 +5,7 @@ TEST(langParserVarDeclsGrammarDef, addVar) {
   test_throws("validate_add_var_bad1",
               "duplicate declaration of variable");
   test_throws("validate_add_var_bad2",
-              "integer parameters or transformed parameters are not allowed");
+              "parameters or transformed parameters cannot be integer or integer array");
   test_parsable("validate_add_var_good");
 }
 

--- a/src/test/unit/lang/parser/var_decls_grammar_test.cpp
+++ b/src/test/unit/lang/parser/var_decls_grammar_test.cpp
@@ -157,3 +157,7 @@ TEST(langParserVarDeclsGrammarDef, badDefParamBlock) {
   test_throws("declare-define-param-block",
               "variable definition not possible in this block");
 }
+
+TEST(langParserVarDeclsGrammarDef, gqLocalRngFunCall) {
+   test_parsable("declare-define-gq-local-rng");
+}

--- a/src/test/unit/lang/reject/reject_mult_args_test.cpp
+++ b/src/test/unit/lang/reject/reject_mult_args_test.cpp
@@ -8,5 +8,5 @@ TEST(StanCommon, rejectMultArgs) {
   typedef 
     reject_mult_args_model_namespace::reject_mult_args_model
     model_t;
-  reject_test<model_t,std::domain_error>("user-specified rejection", "29", "8");
+  reject_test<model_t,std::domain_error>("user-specified rejection", "25", "8");
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Changed Stan parser to better track program block in which a variable is declared by changing `stan/lang/ast/var_origin.hpp` from an `int` to a `struct` consisting of the type of the enclosing program block and a bool indicating whether or not inside a local block.  This affects any grammar rule which sets or updates program block information and its associated semantic action.

#### Intended Effect
The specific bugfix allows compound declare define statements in local program blocks when the definition statement contains a function call.  The change to type `var_origin` is the first step in refactoring the parser logic to better keep track of what is/isn't allowed in a particular scope.

#### How to Verify
Test model `src/test/test-models/good/declare-define-gq-local-rng.stan` contains the reported bug.  The unit test `src/test/unit/parser/var_decls_grammar_test.cpp` tests that this model is parsable.

#### Side Effects
None

#### Documentation

#### Reviewer Suggestions
Bob Carpenter or Daniel Lee

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Mitzi Morris

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)