### PR TITLE
Closes #2211. Expose to_matrix(vector v, int m, int n)

### DIFF
--- a/src/docs/stan-reference/functions.tex
+++ b/src/docs/stan-reference/functions.tex
@@ -3239,18 +3239,8 @@ sparse matrix.
 
 \chapter{Mixed Operations}\label{mixed-operations.chapter}
 
-These functions perform conversions between Stan containers matrix,
+\noindent These functions perform conversions between Stan containers matrix,
 vector, row vector and arrays.
-
-Whenever a conversion implies reduction of dimensionality (like
-converting a matrix to a vector or a two dimensional array to a one
-dimensional array), the conversion is proceed in row-major order when
-the input is an array and in column-major order when the input is a
-vector, a row vector or a matrix.
-
-If the dimensionality is preserved (like when converting a matrix to a
-two dimensional array), then the indexes are also fully preserved
-which implies easy reversibility of the operation.
 
 \begin{description}
 %
@@ -3262,6 +3252,10 @@ Convert the column vector \farg{v} to a \code{size(\farg{v})} by 1 matrix.}
 %
 \fitem{matrix}{to\_matrix}{row\_vector \farg{v}}{
 Convert the row vector \farg{v} to a 1 by \code{size(\farg{v})} matrix.}
+%
+\fitem{matrix}{to\_matrix}{real[] \farg{a}, int \farg{m}, int \farg{n}}{
+Convert a one-dimensional array \farg{a} to a matrix with \farg{m} rows and
+\farg{n} columns filled in column-major order. }
 %
 \fitem{matrix}{to\_matrix}{real[,] \farg{a}}{
 Convert the two dimensional array \farg{a} to a matrix with the same

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -1084,6 +1084,7 @@ add("to_array_2d", expr_type(DOUBLE_T, 2), MATRIX_T);
 add("to_matrix", MATRIX_T, MATRIX_T);
 add("to_matrix", MATRIX_T, VECTOR_T);
 add("to_matrix", MATRIX_T, ROW_VECTOR_T);
+add("to_matrix", MATRIX_T, expr_type(DOUBLE_T, 1), INT_T, INT_T);
 add("to_matrix", MATRIX_T, expr_type(DOUBLE_T, 2));
 add("to_matrix", MATRIX_T, expr_type(INT_T, 2));
 add("to_row_vector", ROW_VECTOR_T, MATRIX_T);

--- a/src/test/test-models/good/function-signatures/math/matrix/to_matrix.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/to_matrix.stan
@@ -1,22 +1,27 @@
 data { 
   int d_int;
   matrix[d_int,d_int] d_matrix;
+  real d_array[6];
 }
 
 transformed data {
   matrix[d_int,d_int] transformed_data_matrix;
 
-  transformed_data_matrix <- to_matrix(d_matrix);
+  transformed_data_matrix = to_matrix(d_matrix);
+  transformed_data_matrix = to_matrix(d_array, 2, 3);
 }
 parameters {
   real y_p;
   matrix[d_int,d_int] p_matrix;
+  real p_array[6];
 }
 transformed parameters {
   matrix[d_int,d_int] transformed_param_matrix;
 
-  transformed_param_matrix <- to_matrix(d_matrix);
-  transformed_param_matrix <- to_matrix(p_matrix);
+  transformed_param_matrix = to_matrix(d_matrix);
+  transformed_param_matrix = to_matrix(p_matrix);
+  transformed_param_matrix = to_matrix(d_array, 3, 2);
+  transformed_param_matrix = to_matrix(p_array, 3, 2);
 }
 model {  
   y_p ~ normal(0,1);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Expose the new to_matrix function from stan-math in the language.

#### How to Verify
A test has also been added that uses this in a model: src/test/test-models/good/function-signatures/math/matrix/to_matrix.stan
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Dual Space LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
