### PR TITLE
Test dedupe - for now we run os x tests on Jenkins.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 os:
   - linux
-  - osx
   
 compiler:
   - clang
@@ -16,9 +15,6 @@ before_script: echo "CC=$CXX" > make/local
 
 matrix:
   fast_finish: true
-  exclude:
-    - os: osx
-      compiler: gcc
 
 env:
   -  TESTFOLDER=src/test/unit/callbacks


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Test dedupe - for now we run os x tests on Jenkins.
And as Travis is the slowest part of Stan builds, we'll cut off the OS X builds to save time
and get feedback to developers sooner. They're still covered by the Jenkins tests.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Dual Space LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)