### PR TITLE
Feature/1427 model block optional

### DIFF
--- a/src/docs/stan-reference/language.tex
+++ b/src/docs/stan-reference/language.tex
@@ -3950,10 +3950,12 @@ generation.
 
 \subsection{Optionality and Ordering}
 
-All of the blocks other than the \code{model} block are optional.  The
-blocks that occur must occur in the order presented in the skeletal
-program above.  Within each block, both declarations and statements
-are optional, subject to the restriction that the declarations come
+All of the blocks are optional.  A consequence of this is that the
+empty string is a valid Stan program, although it will trigger a
+warning message from the Stan compiler.  The Stan program blocks
+that occur must occur in the order presented in the skeletal program
+above.  Within each block, both declarations and statements are
+optional, subject to the  restriction that the declarations come
 before the statements.
 
 \subsection{Variable Scope}

--- a/src/stan/lang/grammars/program_grammar_def.hpp
+++ b/src/stan/lang/grammars/program_grammar_def.hpp
@@ -68,7 +68,7 @@ namespace stan {
           > -param_var_decls_r
           > eps[add_params_var_f(boost::phoenix::ref(var_map_))]
           > -derived_var_decls_r
-          > model_r
+          > -model_r
           > eps[remove_params_var_f(boost::phoenix::ref(var_map_))]
           > -generated_var_decls_r;
 

--- a/src/stan/lang/parser.hpp
+++ b/src/stan/lang/parser.hpp
@@ -76,7 +76,9 @@ namespace stan {
       std::ostringstream buf;
       buf << input.rdbuf();
       std::string stan_string = buf.str();
-
+      if (!is_nonempty(stan_string)) 
+        *output_stream << std::endl << "WARNING: empty program" << std::endl;
+      
       typedef std::string::const_iterator input_iterator;
       typedef boost::spirit::line_pos_iterator<input_iterator> lp_iterator;
 

--- a/src/stan/lang/parser.hpp
+++ b/src/stan/lang/parser.hpp
@@ -76,9 +76,9 @@ namespace stan {
       std::ostringstream buf;
       buf << input.rdbuf();
       std::string stan_string = buf.str();
-      if (!is_nonempty(stan_string)) 
+      if (!is_nonempty(stan_string))
         *output_stream << std::endl << "WARNING: empty program" << std::endl;
-      
+
       typedef std::string::const_iterator input_iterator;
       typedef boost::spirit::line_pos_iterator<input_iterator> lp_iterator;
 

--- a/src/test/test-models/bad/lang/bad2.stan
+++ b/src/test/test-models/bad/lang/bad2.stan
@@ -1,1 +1,1 @@
-data { real a[3]; } model { a <- 2.0; }
+data { real a[3]; } model { a = 2.0; }

--- a/src/test/test-models/bad/lang/bad3.stan
+++ b/src/test/test-models/bad/lang/bad3.stan
@@ -1,1 +1,1 @@
-data { real a; matrix(2,3) b; } model { a <- b; }
+data { real a; matrix(2,3) b; } model { a = b; }

--- a/src/test/test-models/bad/lang/bad4.stan
+++ b/src/test/test-models/bad/lang/bad4.stan
@@ -1,1 +1,1 @@
-data { real a[5]; } model { for (n in a[1]:5) a[n] <- n; }
+data { real a[5]; } model { for (n in a[1]:5) a[n] = n; }

--- a/src/test/test-models/bad/lang/bad5.stan
+++ b/src/test/test-models/bad/lang/bad5.stan
@@ -1,7 +1,7 @@
 transformed data {
   real y;
-  y <- lp__;
+  y = lp__;
 }
 model {
-    lp__ <- 2.0;
+    lp__ = 2.0;
 }

--- a/src/test/test-models/bad/lang/bad6.stan
+++ b/src/test/test-models/bad/lang/bad6.stan
@@ -4,7 +4,7 @@ data {
 transformed data {
    real z;
    
-   y <- 10.0;
+   y = 10.0;
 }
 model {
 }

--- a/src/test/test-models/bad/lang/bad7.stan
+++ b/src/test/test-models/bad/lang/bad7.stan
@@ -4,7 +4,7 @@ data {
 transformed parameters {
   real z;
 
-  y <- 10.0;
+  y = 10.0;
 }
 model { 
 }

--- a/src/test/test-models/bad/lang/bad8.stan
+++ b/src/test/test-models/bad/lang/bad8.stan
@@ -2,5 +2,5 @@ data {
    real y;
 }
 model {
-    y <- 10.0;
+    y = 10.0;
 }

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_rvec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_rvec_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_2, N_1] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
+  transformed_data_matrix = cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_rvec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_rvec_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_2, N_1] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_qud(d_arr_2, d_vec_1, d_sigma, d_len);
+  transformed_data_matrix <- cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_rvec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_rvec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_2, N_1] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_qud(d_arr_2, d_vec_1, d_sigma, d_len);
+  transformed_param_matrix <- cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_rvec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_rvec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_2, N_1] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
+  transformed_param_matrix = cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_vec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_vec_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_2, N_1] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
+  transformed_data_matrix = cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_vec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_vec_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_2, N_1] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_qud(d_arr_2, d_vec_1, d_sigma, d_len);
+  transformed_data_matrix <- cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_vec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_vec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_2, N_1] transformed_params_matrix;
 
-  transformed_params_matrix <- cov_exp_qud(d_arr_2, d_vec_1, d_sigma, d_len);
+  transformed_params_matrix <- cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_vec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_arr_vec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_2, N_1] transformed_params_matrix;
 
-  transformed_params_matrix <- cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
+  transformed_params_matrix = cov_exp_quad(d_arr_2, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_len_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_len_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_1, N_2] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_qud(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_len_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_len_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_1, N_2] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_data_matrix = cov_exp_quad(d_vec_1, d_rvec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_len_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_len_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix = cov_exp_quad(d_vec_1, d_rvec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_len_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_len_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_qud(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_len_rvec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_len_rvec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix = cov_exp_quad(d_vec_1, d_rvec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_len_rvec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_len_rvec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_qud(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_len_vec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_len_vec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix = cov_exp_quad(d_vec_1, d_rvec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_len_vec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_len_vec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_qud(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_arr_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_arr_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_1, N_2] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
+  transformed_data_matrix = cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_arr_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_arr_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_1, N_2] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_qud(d_vec_1, d_arr_2, d_sigma, d_len);
+  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_arr_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_arr_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_params_matrix;
 
-  transformed_params_matrix <- cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
+  transformed_params_matrix = cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_arr_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_arr_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_params_matrix;
 
-  transformed_params_matrix <- cov_exp_qud(d_vec_1, d_arr_2, d_sigma, d_len);
+  transformed_params_matrix <- cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_data.stan
@@ -9,7 +9,7 @@ data {
 transformed data {
   matrix[N_2, N_1] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_sigma, d_len);
+  transformed_data_matrix = cov_exp_quad(d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_data.stan
@@ -9,7 +9,7 @@ data {
 transformed data {
   matrix[N_2, N_1] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_qud(d_vec_1, d_sigma, d_len);
+  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_vec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_vec_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_2, N_1] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_quad(d_rvec_2, d_vec_1, d_sigma, d_len);
+  transformed_data_matrix = cov_exp_quad(d_rvec_1, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_vec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_vec_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_2, N_1] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_qud(d_rvec_2, d_vec_1, d_sigma, d_len);
+  transformed_data_matrix <- cov_exp_quad(d_rvec_2, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_vec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_vec_param.stan
@@ -10,9 +10,9 @@ parameters {
   row_vector[K] d_rvec_1[N_2]; // bad mixed Eigen vector types
 }
 transformed parameters {
-  matrix[N_1, N_2] transformed_params_matrix;
+  matrix[N_2, N_1] transformed_params_matrix;
 
-  transformed_params_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_params_matrix = cov_exp_quad(d_rvec_1, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_vec_params.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_rvec_vec_params.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_2, N_1] transformed_params_matrix;
 
-  transformed_params_matrix <- cov_exp_qud(d_rvec_2, d_vec_1, d_sigma, d_len);
+  transformed_params_matrix <- cov_exp_quad(d_rvec_2, d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_1, N_2] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_qud(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_1, N_2] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_data_matrix = cov_exp_quad(d_vec_1, d_rvec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix = cov_exp_quad(d_vec_1, d_rvec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_qud(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_rvec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_rvec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix = cov_exp_quad(d_vec_1, d_rvec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_rvec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_rvec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_qud(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_vec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_vec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix = cov_exp_quad(d_vec_1, d_rvec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_vec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_sigma_vec_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_param_matrix;
 
-  transformed_param_matrix <- cov_exp_qud(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_param_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_arr_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_arr_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_1, N_2] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
+  transformed_data_matrix = cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_arr_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_arr_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_1, N_2] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_qud(d_vec_1, d_arr_2, d_sigma, d_len);
+  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_arr_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_arr_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_params_matrix;
 
-  transformed_params_matrix <- cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
+  transformed_params_matrix = cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_arr_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_arr_param.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_params_matrix;
 
-  transformed_params_matrix <- cov_exp_qud(d_vec_1, d_arr_2, d_sigma, d_len);
+  transformed_params_matrix <- cov_exp_quad(d_vec_1, d_arr_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_data.stan
@@ -9,7 +9,7 @@ data {
 transformed data {
   matrix[N_2, N_1] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_sigma, d_len);
+  transformed_data_matrix = cov_exp_quad(d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_data.stan
@@ -9,7 +9,7 @@ data {
 transformed data {
   matrix[N_2, N_1] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_qud(d_vec_1, d_sigma, d_len);
+  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_rvec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_rvec_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_1, N_2] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_qud(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_rvec_data.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_rvec_data.stan
@@ -10,7 +10,7 @@ data {
 transformed data {
   matrix[N_1, N_2] transformed_data_matrix;
 
-  transformed_data_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_data_matrix = cov_exp_quad(d_vec_1, d_rvec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_rvec_param.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_rvec_param.stan
@@ -10,9 +10,9 @@ parameters {
   row_vector[K] d_rvec_1[N_2]; // bad mixed Eigen vector types
 }
 transformed parameters {
-  matrix[N_2, N_1] transformed_params_matrix;
+  matrix[N_1, N_2] transformed_params_matrix;
 
-  transformed_params_matrix <- cov_exp_quad(d_rvec_2, d_vec_1, d_sigma, d_len);
+  transformed_params_matrix = cov_exp_quad(d_vec_1, d_rvec_1, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_rvec_params.stan
+++ b/src/test/test-models/bad/lang/bad_cov_exp_quad_vec_rvec_params.stan
@@ -12,7 +12,7 @@ parameters {
 transformed parameters {
   matrix[N_1, N_2] transformed_params_matrix;
 
-  transformed_params_matrix <- cov_exp_qud(d_vec_1, d_rvec_2, d_sigma, d_len);
+  transformed_params_matrix <- cov_exp_quad(d_vec_1, d_rvec_2, d_sigma, d_len);
 }
 parameters {
   real y;

--- a/src/test/test-models/bad/lang/bad_periods_gqs.stan
+++ b/src/test/test-models/bad/lang/bad_periods_gqs.stan
@@ -6,5 +6,5 @@ model {
 }
 generated quantities {
   real x.y;
-  x.y <- z * 2;
+  x.y = z * 2;
 }

--- a/src/test/test-models/bad/lang/bad_periods_tparams.stan
+++ b/src/test/test-models/bad/lang/bad_periods_tparams.stan
@@ -1,6 +1,6 @@
 transformed parameters {
   real x.;
-  x. <- 1.0;
+  x. = 1.0;
 }
 model {
   2.0 ~ normal(x.,1);

--- a/src/test/test-models/bad/lang/good_all.stan
+++ b/src/test/test-models/bad/lang/good_all.stan
@@ -22,68 +22,68 @@ data {
 }
 
 model {
-  m <- m;
-  rv <- m[1];
-  s <- m[1,2];
-  s <- m[1][2];
+  m = m;
+  rv = m[1];
+  s = m[1,2];
+  s = m[1][2];
 
-  rv <- rv;
-  s <- rv[1];
+  rv = rv;
+  s = rv[1];
 
-  s <- s;
+  s = s;
 
-  m <- m_a[1];
-  rv <- m_a[1,1];
-  s <- m_a[1,1,1];
+  m = m_a[1];
+  rv = m_a[1,1];
+  s = m_a[1,1,1];
 
-  rv <- rv_a[1];
-  s <- rv_a[1,1];
+  rv = rv_a[1];
+  s = rv_a[1,1];
 
-  s <- s_a[1];
+  s = s_a[1];
 
-  m_a <- m_aa[1];
-  m <- m_aa[1,1];
-  rv <- m_aa[1,1,1];
-  s <- m_aa[1,1,1,1];
+  m_a = m_aa[1];
+  m = m_aa[1,1];
+  rv = m_aa[1,1,1];
+  s = m_aa[1,1,1,1];
 
-  rv_a <- rv_aa[1];
-  rv <- rv_aa[1,1];
-  s <- rv_aa[1,1,1];
+  rv_a = rv_aa[1];
+  rv = rv_aa[1,1];
+  s = rv_aa[1,1,1];
   
-  s_a <- s_aa[1];
-  s <- s_aa[1,1];
+  s_a = s_aa[1];
+  s = s_aa[1,1];
 
 
-  m <- m;
-  m[1] <- rv;
-  m[1,2] <- s;
-  // not on LHS: m[1][2] <- s;
+  m = m;
+  m[1] = rv;
+  m[1,2] = s;
+  // not on LHS: m[1][2] = s;
 
-  rv <- rv;
-  rv[1] <- s;
+  rv = rv;
+  rv[1] = s;
 
-  s <- s;
+  s = s;
 
-  m_a[1] <- m;
-  m_a[1,1] <- rv;
-  m_a[1,1,1] <- s;
+  m_a[1] = m;
+  m_a[1,1] = rv;
+  m_a[1,1,1] = s;
 
-  rv_a[1] <- rv;
-  rv_a[1,1] <- s;
+  rv_a[1] = rv;
+  rv_a[1,1] = s;
 
-  s_a[1] <- s;
+  s_a[1] = s;
 
-  m_aa[1] <- m_a;
-  m_aa[1,1] <- m;
-  m_aa[1,1,1] <- rv;
-  m_aa[1,1,1,1] <- s;
+  m_aa[1] = m_a;
+  m_aa[1,1] = m;
+  m_aa[1,1,1] = rv;
+  m_aa[1,1,1,1] = s;
 
-  rv_aa[1] <- rv_a;
-  rv_aa[1,1] <- rv;
-  rv_aa[1,1,1] <- s;
+  rv_aa[1] = rv_a;
+  rv_aa[1,1] = rv;
+  rv_aa[1,1,1] = s;
   
-  s_aa[1] <- s_a;
-  s_aa[1,1] <- s;
+  s_aa[1] = s_a;
+  s_aa[1,1] = s;
 
 
 

--- a/src/test/test-models/bad/lang/good_const.stan
+++ b/src/test/test-models/bad/lang/good_const.stan
@@ -1,6 +1,6 @@
 transformed data {
   real y;
-  y <- pi();
+  y = pi();
 }
 model {
 }

--- a/src/test/test-models/bad/lang/good_funs.stan
+++ b/src/test/test-models/bad/lang/good_funs.stan
@@ -4,9 +4,9 @@ transformed data {
   real z;
   int n;
 
-  z <- if_else(n,x,y);
+  z = if_else(n,x,y);
 
-  z <- binomial_coefficient_log(x,y);
+  z = binomial_coefficient_log(x,y);
 }
 model {
 }

--- a/src/test/test-models/bad/lang/good_intercept_var.stan
+++ b/src/test/test-models/bad/lang/good_intercept_var.stan
@@ -6,7 +6,7 @@ data {
 }
 transformed data {
   int intercept;
-  intercept <- 5;  // failed in 1.0.2
+  intercept = 5;  // failed in 1.0.2
 }
 model {
 

--- a/src/test/test-models/bad/lang/good_local_var_array_size.stan
+++ b/src/test/test-models/bad/lang/good_local_var_array_size.stan
@@ -4,8 +4,8 @@ data {
 
 transformed data {
   int N[2];
-  N[1] <- 1;
-  N[2] <- 4;
+  N[1] = 1;
+  N[2] = 4;
 }
 parameters {
   real y;
@@ -16,7 +16,7 @@ model {
   for (i in 1:10) {
     real x[i];  // should allow i here.
     for (j in 1:i)
-      x[j] <- j * j;
+      x[j] = j * j;
   }
 
   for (i in 1:5) {

--- a/src/test/test-models/bad/lang/good_matrix_ops.stan
+++ b/src/test/test-models/bad/lang/good_matrix_ops.stan
@@ -8,22 +8,22 @@ transformed data {
   row_vector[5] c;
   row_vector[5] y;
 
-  C <- A / B;
-  C <- B \ A;
+  C = A / B;
+  C = B \ A;
 
-  x <- A \ b;
+  x = A \ b;
   
-  y <- c / A;
+  y = c / A;
 
-  A <- A ./ A;
+  A = A ./ A;
 
-  A <- A .* A;
+  A = A .* A;
 
-  x <- x ./ x;
-  x <- x .* x;
+  x = x ./ x;
+  x = x .* x;
 
-  y <- y ./ y;
-  y <- y .* y;
+  y = y ./ y;
+  y = y .* y;
 
 }
 model {

--- a/src/test/test-models/bad/lang/good_vars.stan
+++ b/src/test/test-models/bad/lang/good_vars.stan
@@ -3,12 +3,12 @@ data {
 }
 transformed data {
     real b;
-    b <- 1.0; 
-    b <- a + b + 1.0;
+    b = 1.0; 
+    b = a + b + 1.0;
     {
         real b_local; // init to 0 locally
-        b <- a + b + b_local;  
-        b_local <- a + b + b_local;
+        b = a + b + b_local;  
+        b_local = a + b + b_local;
 
     }
 }
@@ -17,33 +17,33 @@ parameters {
 }
 transformed parameters {
     real d; 
-    d <- 1.0;
-    d <- a + b + c + d;
+    d = 1.0;
+    d = a + b + c + d;
     {
         real d_local;
-        d <- a + b + c + d + d_local;
-        d_local <- a + b + c + d + d_local;
+        d = a + b + c + d + d_local;
+        d_local = a + b + c + d + d_local;
     }
 }
 model {
     real e_local;
-    e_local <- 1.0; 
-    e_local <- a + b + c + d + e_local;
+    e_local = 1.0; 
+    e_local = a + b + c + d + e_local;
     {
        real f_local;
-       f_local <- 1.0;
-       e_local <- a + b + c + d + e_local + f_local;
-       f_local <- a + b + c + d + e_local + f_local;
+       f_local = 1.0;
+       e_local = a + b + c + d + e_local + f_local;
+       f_local = a + b + c + d + e_local + f_local;
     }
 }
 generated quantities {
     real g;
-    g <- 1.0;
-    g <- a + b + c + d + g;
+    g = 1.0;
+    g = a + b + c + d + g;
     {
         real g_local;
-        g_local <- 1.0;
-        g <- a + b + c + d + g + g_local;
-        g_local <- a + b + c + d + g + g_local;
+        g_local = 1.0;
+        g = a + b + c + d + g + g_local;
+        g_local = a + b + c + d + g + g_local;
     }
 }

--- a/src/test/test-models/good/illegal_generated_quantities.stan
+++ b/src/test/test-models/good/illegal_generated_quantities.stan
@@ -6,6 +6,5 @@ model {
 }
 generated quantities {
   real<lower=0> x;
-
-  x <- -1;
+  x = -1;
 }

--- a/src/test/test-models/good/model_block_empty.stan
+++ b/src/test/test-models/good/model_block_empty.stan
@@ -1,0 +1,4 @@
+functions {
+  real foo(real x) {
+    return x; }
+} model {}

--- a/src/test/unit/lang/compiler_test.cpp
+++ b/src/test/unit/lang/compiler_test.cpp
@@ -5,32 +5,20 @@
 TEST(LangCompiler, compile) {
   std::stringstream msgs, stan_lang_in, cpp_out;
   std::string model_name = "m";
-  
-
   stan_lang_in << "model { }";
   
   stan::lang::compile(&msgs, stan_lang_in, cpp_out, model_name);
-  
   EXPECT_EQ("", msgs.str());
   EXPECT_EQ(std::string::npos, cpp_out.str().find("int main("));
 }
 
-TEST(LangCompiler, streams) {
-  stan::test::capture_std_streams();
-
+TEST(LangCompiler, emptyProgram) {
   std::stringstream msgs, stan_lang_in, cpp_out;
   std::string model_name = "m";
-
-  stan_lang_in.str("model { }");
-  EXPECT_NO_THROW(stan::lang::compile(0, stan_lang_in, cpp_out, model_name));
-
-  stan_lang_in.str("model { }");
-  std::stringstream out;
-  EXPECT_NO_THROW(stan::lang::compile(&out, stan_lang_in, cpp_out, model_name));
+  stan_lang_in << "";
   
-  // TODO(carpenter): wrong place to test basic test util behavior
-  // TODO(carpenter): functions failing have no doc
-  stan::test::reset_std_streams();
-  EXPECT_EQ("", stan::test::cout_ss.str());
-  EXPECT_EQ("", stan::test::cerr_ss.str());
+  stan::lang::compile(&msgs, stan_lang_in, cpp_out, model_name);
+  
+  EXPECT_EQ(1,count_matches("WARNING: empty program",msgs.str()));
+  EXPECT_EQ(std::string::npos, cpp_out.str().find("int main("));
 }

--- a/src/test/unit/lang/compiler_test.cpp
+++ b/src/test/unit/lang/compiler_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <stan/lang/compiler.hpp>
 #include <test/unit/util.hpp>
+#include <boost/algorithm/string.hpp>
 
 TEST(LangCompiler, compile) {
   std::stringstream msgs, stan_lang_in, cpp_out;
@@ -21,4 +22,24 @@ TEST(LangCompiler, emptyProgram) {
   
   EXPECT_EQ(1,count_matches("WARNING: empty program",msgs.str()));
   EXPECT_EQ(std::string::npos, cpp_out.str().find("int main("));
+}
+
+TEST(LangCompiler, equivEmpty) {
+  std::stringstream msgs, empty_prog_in, empty_model_in, empty_prog_out,
+    empty_model_out;
+  std::string model_name = "m";
+
+  empty_prog_in << "";
+  stan::lang::compile(&msgs, empty_prog_in, empty_prog_out, model_name);
+
+  empty_model_in << "model { }";
+  stan::lang::compile(&msgs, empty_model_in, empty_model_out, model_name);
+
+  // empty model contains extra newline, remove all for comparison
+  std::string emptyprog(empty_prog_out.str());
+  boost::algorithm::erase_all(emptyprog, "\n");
+  std::string emptymodel(empty_model_out.str());
+  boost::algorithm::erase_all(emptymodel, "\n");
+
+  EXPECT_EQ(emptyprog, emptymodel);
 }

--- a/src/test/unit/lang/parser/error_messages_test.cpp
+++ b/src/test/unit/lang/parser/error_messages_test.cpp
@@ -9,7 +9,7 @@ TEST(LangGrammars,test1) {
   test_throws("err-transformed-params", 
               "PARSER EXPECTED: \"parameters");
   test_throws("err-expected-model", 
-              "PARSER EXPECTED: <model");
+              "PARSER EXPECTED: whitespace to end of file");
   test_throws("err-expected-generated", 
               "PARSER EXPECTED: \"quantities");
   test_throws("err-expected-bracket", 

--- a/src/test/unit/lang/parser/other_test.cpp
+++ b/src/test/unit/lang/parser/other_test.cpp
@@ -242,23 +242,23 @@ TEST(lang_parser, infVariableName) {
   test_parsable("good_inf");
 }
 
-TEST(lang_parser, declarations_funciton_signatures) {
+TEST(lang_parser, declarations_function_signatures) {
   test_parsable("declarations");
 }
 
+// illegal, but will parse
 TEST(lang_parser, illegal_generated_quantities) {
-  EXPECT_THROW(is_parsable("illegal_generated_quantities"),
-               std::invalid_argument);
+  test_parsable("illegal_generated_quantities");
 }
 
+// illegal, but will parse
 TEST(lang_parser, illegal_transformed_data) {
-  EXPECT_THROW(is_parsable("illegal_transformed_data"),
-               std::invalid_argument);
+  test_parsable("illegal_transformed_data");
 }
 
+// illegal, but will parse
 TEST(lang_parser, illegal_transformed_parameters) {
-  EXPECT_THROW(is_parsable("illegal_transformed_parameters"),
-               std::invalid_argument);
+  test_parsable("illegal_transformed_parameters");
 }
 
 TEST(lang_parser, increment_log_prob) {

--- a/src/test/unit/util_test.hpp
+++ b/src/test/unit/util_test.hpp
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+TEST(TestUnitUtil, streams) {
+
+  std::cout << "foo";
+  std::cerr << "bar";
+  stan::test::capture_std_streams();
+  EXPECT_EQ("foo", stan::test::cout_ss.str());
+  EXPECT_EQ("bar", stan::test::cerr_ss.str());
+
+  stan::test::reset_std_streams();
+  EXPECT_EQ("", stan::test::cout_ss.str());
+  EXPECT_EQ("", stan::test::cerr_ss.str());
+}  


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Remove requirement that all Stan programs contain model block.

#### Intended Effect
Make it easier for users to write Stan programs for their own nefarious purposes, e.g., a functions-only program.

#### How to Verify
Added tests to unit tests:  `src/test/unit/lang/compiler_test.cpp`

#### Side Effects
The empty string is now a valid Stan program; previously, the compiler would throw an exception.  This caused some of the existing tests in `src/test/unit/lang/other_test.cpp` and `src/test/unit/lang/error_messages.cpp` to break.  These tests tried to compile models in `src/test/test-models/bad`, however there were typos in the model name.  The utility would try to read the contents of a non-existent file; the result is the empty string. The file names were changed accordingly; while investigating I updated the syntax of many of the programs in test/test-models/bad.
While adding tests to `src/test/unit/lang/compiler_test.cpp` I found a "TODO" note about splitting out tests of the streams utility and moved these tests into their own test file.

#### Documentation
Changed the user manual to note that all program blocks are optional.

#### Reviewer Suggestions
Bob Carpenter

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Mitzi Morris

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
