### PR TITLE
Bugfix/issue 2268 fix nuts classic comp err

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -185,8 +185,8 @@ src/test/unit/mcmc/hmc/integrators/impl_leapfrog_test.cpp: src/test/test-models/
 src/test/unit/mcmc/hmc/integrators/impl_leapfrog2_test.cpp: src/test/test-models/good/mcmc/hmc/integrators/gauss.hpp
 src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
 src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
-src/test/unit/mcmc/hmc/nuts/instantiation_test_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
-src/test/unit/mcmc/hmc/nuts_classic/instantiation_test_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
+src/test/unit/mcmc/hmc/nuts/instantiation_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
+src/test/unit/mcmc/hmc/nuts_classic/instantiation_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
 src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
 src/test/unit/mcmc/hmc/xhmc/softabs_xhmc_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
 src/test/unit/mcmc/hmc/static_uniform/derived_static_uniform_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss.hpp

--- a/make/tests
+++ b/make/tests
@@ -185,6 +185,8 @@ src/test/unit/mcmc/hmc/integrators/impl_leapfrog_test.cpp: src/test/test-models/
 src/test/unit/mcmc/hmc/integrators/impl_leapfrog2_test.cpp: src/test/test-models/good/mcmc/hmc/integrators/gauss.hpp
 src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
 src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
+src/test/unit/mcmc/hmc/nuts/instantiation_test_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
+src/test/unit/mcmc/hmc/nuts_classic/instantiation_test_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
 src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
 src/test/unit/mcmc/hmc/xhmc/softabs_xhmc_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss3D.hpp
 src/test/unit/mcmc/hmc/static_uniform/derived_static_uniform_test.cpp: src/test/test-models/good/mcmc/hmc/common/gauss.hpp

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MCMC_HMC_NUTS_ADAPT_DENSE_E_NUTS_CLASSIC_HPP
-#define STAN_MCMC_HMC_NUTS_ADAPT_DENSE_E_NUTS_CLASSIC_HPP
+#ifndef STAN_MCMC_HMC_NUTS_CLASSIC_ADAPT_DENSE_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_CLASSIC_ADAPT_DENSE_E_NUTS_CLASSIC_HPP
 
 #include <stan/callbacks/writer.hpp>
 #include <stan/mcmc/stepsize_covar_adapter.hpp>
@@ -28,7 +28,8 @@ namespace stan {
                  callbacks::writer& error_writer) {
         sample s
           = dense_e_nuts_classic<Model, BaseRNG>::transition(init_sample,
-                                                             info_writer);
+                                                             info_writer,
+                                                             error_writer);
 
         if (this->adapt_flag_) {
           this->stepsize_adaptation_.learn_stepsize(this->nom_epsilon_,
@@ -38,7 +39,7 @@ namespace stan {
                                                                  this->z_.q);
 
           if (update) {
-            this->init_stepsize(info_writer);
+            this->init_stepsize(info_writer, error_writer);
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MCMC_HMC_NUTS_ADAPT_DIAG_E_NUTS_CLASSIC_HPP
-#define STAN_MCMC_HMC_NUTS_ADAPT_DIAG_E_NUTS_CLASSIC_HPP
+#ifndef STAN_MCMC_HMC_NUTS_CLASSIC_ADAPT_DIAG_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_CLASSIC_ADAPT_DIAG_E_NUTS_CLASSIC_HPP
 
 #include <stan/callbacks/writer.hpp>
 #include <stan/mcmc/stepsize_var_adapter.hpp>
@@ -40,7 +40,7 @@ namespace stan {
                                                              this->z_.q);
 
           if (update) {
-            this->init_stepsize(info_writer);
+            this->init_stepsize(info_writer, error_writer);
 
             this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
             this->stepsize_adaptation_.restart();

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_unit_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_unit_e_nuts_classic.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MCMC_HMC_NUTS_ADAPT_UNIT_E_NUTS_CLASSIC_HPP
-#define STAN_MCMC_HMC_NUTS_ADAPT_UNIT_E_NUTS_CLASSIC_HPP
+#ifndef STAN_MCMC_HMC_NUTS_CLASSIC_ADAPT_UNIT_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_CLASSIC_ADAPT_UNIT_E_NUTS_CLASSIC_HPP
 
 #include <stan/callbacks/writer.hpp>
 #include <stan/mcmc/hmc/nuts_classic/unit_e_nuts_classic.hpp>

--- a/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MCMC_HMC_NUTS_BASE_NUTS_HPP
-#define STAN_MCMC_HMC_NUTS_BASE_NUTS_HPP
+#ifndef STAN_MCMC_HMC_NUTS_CLASSIC_BASE_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_CLASSIC_BASE_NUTS_CLASSIC_HPP
 
 #include <stan/callbacks/writer.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>

--- a/src/stan/mcmc/hmc/nuts_classic/dense_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/dense_e_nuts_classic.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MCMC_HMC_NUTS_DENSE_E_NUTS_CLASSIC_HPP
-#define STAN_MCMC_HMC_NUTS_DENSE_E_NUTS_CLASSIC_HPP
+#ifndef STAN_MCMC_HMC_NUTS_CLASSIC_DENSE_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_CLASSIC_DENSE_E_NUTS_CLASSIC_HPP
 
 #include <stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp>
 #include <stan/mcmc/hmc/hamiltonians/dense_e_point.hpp>

--- a/src/stan/mcmc/hmc/nuts_classic/diag_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/diag_e_nuts_classic.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MCMC_HMC_NUTS_DIAG_E_NUTS_CLASSIC_HPP
-#define STAN_MCMC_HMC_NUTS_DIAG_E_NUTS_CLASSIC_HPP
+#ifndef STAN_MCMC_HMC_NUTS_CLASSIC_DIAG_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_CLASSIC_DIAG_E_NUTS_CLASSIC_HPP
 
 #include <stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp>
 #include <stan/mcmc/hmc/hamiltonians/diag_e_point.hpp>

--- a/src/stan/mcmc/hmc/nuts_classic/unit_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/unit_e_nuts_classic.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MCMC_HMC_NUTS_UNIT_E_NUTS_CLASSIC_HPP
-#define STAN_MCMC_HMC_NUTS_UNIT_E_NUTS_CLASSIC_HPP
+#ifndef STAN_MCMC_HMC_NUTS_CLASSIC_UNIT_E_NUTS_CLASSIC_HPP
+#define STAN_MCMC_HMC_NUTS_CLASSIC_UNIT_E_NUTS_CLASSIC_HPP
 
 #include <stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp>
 #include <stan/mcmc/hmc/hamiltonians/unit_e_point.hpp>

--- a/src/test/unit/mcmc/hmc/nuts/instantiation_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/instantiation_test.cpp
@@ -1,0 +1,46 @@
+#include <test/test-models/good/mcmc/hmc/common/gauss3D.hpp>
+#include <stan/callbacks/stream_writer.hpp>
+#include <stan/mcmc/hmc/nuts/unit_e_nuts.hpp>
+#include <stan/mcmc/hmc/nuts/diag_e_nuts.hpp>
+#include <stan/mcmc/hmc/nuts/dense_e_nuts.hpp>
+#include <stan/mcmc/hmc/nuts/adapt_unit_e_nuts.hpp>
+#include <stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp>
+#include <stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp>
+#include <boost/random/additive_combine.hpp>
+#include <stan/io/dump.hpp>
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+typedef boost::ecuyer1988 rng_t;
+
+TEST(McmcNuts, instantiaton_test) {
+  rng_t base_rng(4839294);
+
+  std::stringstream output;
+  stan::callbacks::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::callbacks::stream_writer error_writer(error_stream);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+  gauss3D_model_namespace::gauss3D_model model(data_var_context);
+
+  stan::mcmc::unit_e_nuts<gauss3D_model_namespace::gauss3D_model, rng_t>
+    unit_e_sampler(model, base_rng);
+  
+  stan::mcmc::diag_e_nuts<gauss3D_model_namespace::gauss3D_model, rng_t>
+    diag_e_sampler(model, base_rng);
+  
+  stan::mcmc::dense_e_nuts<gauss3D_model_namespace::gauss3D_model, rng_t>
+    dense_e_sampler(model, base_rng);
+  
+  stan::mcmc::adapt_unit_e_nuts<gauss3D_model_namespace::gauss3D_model, rng_t>
+    adapt_unit_e_sampler(model, base_rng);
+  
+  stan::mcmc::adapt_diag_e_nuts<gauss3D_model_namespace::gauss3D_model, rng_t>
+    adapt_diag_e_sampler(model, base_rng);
+  
+  stan::mcmc::adapt_dense_e_nuts<gauss3D_model_namespace::gauss3D_model, rng_t>
+    adapt_dense_e_sampler(model, base_rng);
+}

--- a/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
@@ -1,8 +1,7 @@
-#include <stan/math/rev/mat.hpp>
+#include <test/test-models/good/mcmc/hmc/common/gauss3D.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 #include <stan/mcmc/hmc/nuts/softabs_nuts.hpp>
 #include <boost/random/additive_combine.hpp>
-#include <test/test-models/good/mcmc/hmc/common/gauss3D.hpp>
 #include <stan/io/dump.hpp>
 #include <fstream>
 

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -1,8 +1,7 @@
-#include <stan/math/rev/mat.hpp>
+#include <test/test-models/good/mcmc/hmc/common/gauss3D.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 #include <stan/mcmc/hmc/nuts/unit_e_nuts.hpp>
 #include <boost/random/additive_combine.hpp>
-#include <test/test-models/good/mcmc/hmc/common/gauss3D.hpp>
 #include <stan/io/dump.hpp>
 #include <fstream>
 

--- a/src/test/unit/mcmc/hmc/nuts_classic/instantiation_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts_classic/instantiation_test.cpp
@@ -1,0 +1,46 @@
+#include <test/test-models/good/mcmc/hmc/common/gauss3D.hpp>
+#include <stan/callbacks/stream_writer.hpp>
+#include <stan/mcmc/hmc/nuts_classic/unit_e_nuts_classic.hpp>
+#include <stan/mcmc/hmc/nuts_classic/diag_e_nuts_classic.hpp>
+#include <stan/mcmc/hmc/nuts_classic/dense_e_nuts_classic.hpp>
+#include <stan/mcmc/hmc/nuts_classic/adapt_unit_e_nuts_classic.hpp>
+#include <stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp>
+#include <stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp>
+#include <boost/random/additive_combine.hpp>
+#include <stan/io/dump.hpp>
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+typedef boost::ecuyer1988 rng_t;
+
+TEST(McmcNutsClassic, instantiaton_test) {
+  rng_t base_rng(4839294);
+
+  std::stringstream output;
+  stan::callbacks::stream_writer writer(output);
+  std::stringstream error_stream;
+  stan::callbacks::stream_writer error_writer(error_stream);
+
+  std::fstream empty_stream("", std::fstream::in);
+  stan::io::dump data_var_context(empty_stream);
+  gauss3D_model_namespace::gauss3D_model model(data_var_context);
+
+  stan::mcmc::unit_e_nuts_classic<gauss3D_model_namespace::gauss3D_model, rng_t>
+    unit_e_sampler(model, base_rng);
+  
+  stan::mcmc::diag_e_nuts_classic<gauss3D_model_namespace::gauss3D_model, rng_t>
+    diag_e_sampler(model, base_rng);
+  
+  stan::mcmc::dense_e_nuts_classic<gauss3D_model_namespace::gauss3D_model, rng_t>
+    dense_e_sampler(model, base_rng);
+  
+  stan::mcmc::adapt_unit_e_nuts_classic<gauss3D_model_namespace::gauss3D_model, rng_t>
+    adapt_unit_e_sampler(model, base_rng);
+  
+  stan::mcmc::adapt_diag_e_nuts_classic<gauss3D_model_namespace::gauss3D_model, rng_t>
+    adapt_diag_e_sampler(model, base_rng);
+  
+  stan::mcmc::adapt_dense_e_nuts_classic<gauss3D_model_namespace::gauss3D_model, rng_t>
+    adapt_dense_e_sampler(model, base_rng);
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes some variants of `nuts_classic` addressing #2268 and added some tests that tries to instantiate each variant to avoid missing these errors in the future.

#### Intended Effect

Fix non-user-facing code that wouldn't compile.

#### How to Verify

./runTests.py src/test/unit/mcmc/hmc/nuts_classic/instantiation_test.cpp

#### Side Effects

None.

#### Documentation

None.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)