### PR TITLE
Bugfix/issue 2270 cygwin tests

### DIFF
--- a/runTests.py
+++ b/runTests.py
@@ -30,6 +30,7 @@ def stopErr(msg, returncode):
 
 def isWin():
     if (platform.system().lower().startswith("windows")
+        or platform.system().lower().startswith("cygwin")
         or os.name.lower().startswith("windows")):
         return True
     return False


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit` - NOT APPLICABLE
- [ ] Run cpplint: `make cpplint` - NOT APPLICABLE
- [x] Declare copyright holder and open-source license: see below

#### Summary
Fixes #2270 by recognizing CygWin as a Windows platform in runTests.py

#### Intended Effect
Lets you build tests under CygWin

#### How to Verify
Try running ```python runTests.py src/test``` on Windows with CygWin. It should compile.

#### Side Effects
Hopefully no

#### Documentation
Not applicable

#### Reviewer Suggestions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Martin Černý

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
