### PR TITLE
fix sed failure on makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -40,7 +40,7 @@ WINE =
 # Library locations
 ##
 STAN ?= 
-MATH ?= /
+MATH ?= lib/stan_math/
 -include $(MATH)make/libraries
 
 ##


### PR DESCRIPTION
During the release the makefile wasn't corrected back to the old version - this fixes that. 

Might want to make the tag-* scripts more robust for future releases...


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Dual Space LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
