### PR TITLE
Added Stan hooks for categorical_logit_rng (feature 517)

### DIFF
--- a/src/docs/stan-reference/distributions.tex
+++ b/src/docs/stan-reference/distributions.tex
@@ -642,8 +642,12 @@ of integers (type \code{int[]}).
   categorical variate with $N$-simplex distribution parameter
 \farg{theta}; may only be used in generated quantities block}
 \end{description}
-
-
+%
+\begin{description}
+\fitem{int}{categorical\_logit\_rng}{vector \farg{beta}}{Generate a
+  categorical variate with outcome in range $1:N$ from log-odds vector
+\farg{beta}; may only be used in generated quantities block}
+\end{description}
 
 \section{Ordered Logistic Distribution}
 

--- a/src/docs/stan-reference/examples.tex
+++ b/src/docs/stan-reference/examples.tex
@@ -5145,7 +5145,7 @@ draws a random value for \code{s} at every iteration.
 \begin{stancode}
 generated quantities {
   int<lower=1,upper=T> s;
-  s = categorical_rng(softmax(lp));
+  s = categorical_logit_rng(lp);
 }
 \end{stancode}
 %

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -161,6 +161,7 @@ for (size_t i = 0; i < int_vector_types.size(); ++i) {
       VECTOR_T);
 }
 add("categorical_rng", INT_T, VECTOR_T);
+add("categorical_logit_rng", INT_T, VECTOR_T);
 for (size_t i = 0; i < vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {
     for (size_t k = 0; k < vector_types.size(); ++k) {

--- a/src/test/test-models/good/function-signatures/distributions/rngs.stan
+++ b/src/test/test-models/good/function-signatures/distributions/rngs.stan
@@ -29,6 +29,7 @@ generated quantities {
   n <- poisson_log_rng(2.7);
 
   n <- categorical_rng(theta);
+  n <- categorical_logit_rng(theta);
   ns <- multinomial_rng(theta,20);
 
   z <- normal_rng(0,1);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
These are the changes to expose categorical_logit_rng to the Stan interfaces.

I changed how the example random numbers were generated in the changepoint model (Section 14.2). Tested it in cmdstan. Seemed to be producing the same histogram of changepoint dates.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): University of California Santa Barbara

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
