### PR TITLE
Fixes #2294. Reports errors in initialization

### DIFF
--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -109,6 +109,7 @@ namespace stan {
             message_writer("Rejecting initial value:");
             message_writer("  Error evaluating the log probability"
                    " at the initial value.");
+            message_writer(e.what());
             continue;
           }
           if (!boost::math::isfinite(log_prob)) {

--- a/src/test/unit/services/util/initialize_test.cpp
+++ b/src/test/unit/services/util/initialize_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/services/util/initialize.hpp>
 #include <gtest/gtest.h>
+#include <test/unit/util.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 #include <sstream>
 #include <test/test-models/good/services/test_lp.hpp>
@@ -25,7 +26,7 @@ public:
 
 TEST_F(ServicesUtilInitialize, radius_zero__print_false) {
   std::vector<double> params;
-    
+
   double init_radius = 0;
   bool print_timing = false;
   params = stan::services::util::initialize(model, empty_context, rng,
@@ -42,10 +43,10 @@ TEST_F(ServicesUtilInitialize, radius_zero__print_false) {
   EXPECT_EQ(params[0], init.vector_double_values()[0][0]);
   EXPECT_EQ(params[1], init.vector_double_values()[0][1]);
 }
-  
+
 TEST_F(ServicesUtilInitialize, radius_zero__print_true) {
   std::vector<double> params;
-    
+
   double init_radius = 0;
   bool print_timing = true;
   params = stan::services::util::initialize(model, empty_context, rng,
@@ -65,7 +66,7 @@ TEST_F(ServicesUtilInitialize, radius_zero__print_true) {
 
 TEST_F(ServicesUtilInitialize, radius_two__print_false) {
   std::vector<double> params;
-    
+
   double init_radius = 2;
   bool print_timing = false;
   params = stan::services::util::initialize(model, empty_context, rng,
@@ -87,7 +88,7 @@ TEST_F(ServicesUtilInitialize, radius_two__print_false) {
 
 TEST_F(ServicesUtilInitialize, radius_two__print_true) {
   std::vector<double> params;
-    
+
   double init_radius = 2;
   bool print_timing = true;
   params = stan::services::util::initialize(model, empty_context, rng,
@@ -113,7 +114,7 @@ TEST_F(ServicesUtilInitialize, full_init__print_false) {
   std::vector<std::vector<size_t> > dim_r;
   names_r.push_back("y");
   values_r.push_back(6.35149);   // 1.5 unconstrained: -10 + 20 * inv.logit(1.5)
-  values_r.push_back(-2.449187); // -0.5 unconstrained 
+  values_r.push_back(-2.449187); // -0.5 unconstrained
   std::vector<size_t> d;
   d.push_back(2);
   dim_r.push_back(d);
@@ -121,7 +122,7 @@ TEST_F(ServicesUtilInitialize, full_init__print_false) {
 
 
   std::vector<double> params;
-    
+
   double init_radius = 2;
   bool print_timing = false;
   params = stan::services::util::initialize(model, init_context, rng,
@@ -145,7 +146,7 @@ TEST_F(ServicesUtilInitialize, full_init__print_true) {
   std::vector<std::vector<size_t> > dim_r;
   names_r.push_back("y");
   values_r.push_back(6.35149);   // 1.5 unconstrained: -10 + 20 * inv.logit(1.5)
-  values_r.push_back(-2.449187); // -0.5 unconstrained 
+  values_r.push_back(-2.449187); // -0.5 unconstrained
   std::vector<size_t> d;
   d.push_back(2);
   dim_r.push_back(d);
@@ -153,7 +154,7 @@ TEST_F(ServicesUtilInitialize, full_init__print_true) {
 
 
   std::vector<double> params;
-    
+
   double init_radius = 2;
   bool print_timing = true;
   params = stan::services::util::initialize(model, init_context, rng,
@@ -256,15 +257,53 @@ namespace test {
   };
 }
 
-TEST_F(ServicesUtilInitialize, model_throws) {
+TEST_F(ServicesUtilInitialize, model_throws__radius_zero) {
   std::vector<double> params;
   test::mock_throwing_model throwing_model;
-    
+
+  double init_radius = 0;
+  bool print_timing = false;
+  EXPECT_THROW(params = stan::services::util::initialize(throwing_model, empty_context, rng,
+                                                         init_radius, print_timing,
+                                                         message, init),
+               std::domain_error);
+
+  EXPECT_EQ(1, count_matches("throwing within log_prob", message_ss.str()));
+}
+
+TEST_F(ServicesUtilInitialize, model_throws__radius_two) {
+  std::vector<double> params;
+  test::mock_throwing_model throwing_model;
+
   double init_radius = 2;
   bool print_timing = false;
-  EXPECT_THROW(params
-               = stan::services::util::initialize(throwing_model, empty_context, rng,
-                                                  init_radius, print_timing,
-                                                  message, init),
+  EXPECT_THROW(params = stan::services::util::initialize(throwing_model, empty_context, rng,
+                                                         init_radius, print_timing,
+                                                         message, init),
                std::domain_error);
+  EXPECT_EQ(100, count_matches("throwing within log_prob", message_ss.str()));
+}
+
+TEST_F(ServicesUtilInitialize, model_throws__full_init) {
+  std::vector<std::string> names_r;
+  std::vector<double> values_r;
+  std::vector<std::vector<size_t> > dim_r;
+  names_r.push_back("y");
+  values_r.push_back(6.35149);   // 1.5 unconstrained: -10 + 20 * inv.logit(1.5)
+  values_r.push_back(-2.449187); // -0.5 unconstrained
+  std::vector<size_t> d;
+  d.push_back(2);
+  dim_r.push_back(d);
+  stan::io::array_var_context init_context(names_r, values_r, dim_r);
+
+  std::vector<double> params;
+  test::mock_throwing_model throwing_model;
+
+  double init_radius = 2;
+  bool print_timing = false;
+  EXPECT_THROW(params = stan::services::util::initialize(throwing_model, init_context, rng,
+                                                         init_radius, print_timing,
+                                                         message, init),
+               std::domain_error);
+  EXPECT_EQ(100, count_matches("throwing within log_prob", message_ss.str()));
 }

--- a/src/test/unit/services/util/initialize_test.cpp
+++ b/src/test/unit/services/util/initialize_test.cpp
@@ -258,28 +258,26 @@ namespace test {
 }
 
 TEST_F(ServicesUtilInitialize, model_throws__radius_zero) {
-  std::vector<double> params;
   test::mock_throwing_model throwing_model;
 
   double init_radius = 0;
   bool print_timing = false;
-  EXPECT_THROW(params = stan::services::util::initialize(throwing_model, empty_context, rng,
-                                                         init_radius, print_timing,
-                                                         message, init),
+  EXPECT_THROW(stan::services::util::initialize(throwing_model, empty_context, rng,
+                                                init_radius, print_timing,
+                                                message, init),
                std::domain_error);
 
   EXPECT_EQ(1, count_matches("throwing within log_prob", message_ss.str()));
 }
 
 TEST_F(ServicesUtilInitialize, model_throws__radius_two) {
-  std::vector<double> params;
   test::mock_throwing_model throwing_model;
 
   double init_radius = 2;
   bool print_timing = false;
-  EXPECT_THROW(params = stan::services::util::initialize(throwing_model, empty_context, rng,
-                                                         init_radius, print_timing,
-                                                         message, init),
+  EXPECT_THROW(stan::services::util::initialize(throwing_model, empty_context, rng,
+                                                init_radius, print_timing,
+                                                message, init),
                std::domain_error);
   EXPECT_EQ(100, count_matches("throwing within log_prob", message_ss.str()));
 }
@@ -296,14 +294,13 @@ TEST_F(ServicesUtilInitialize, model_throws__full_init) {
   dim_r.push_back(d);
   stan::io::array_var_context init_context(names_r, values_r, dim_r);
 
-  std::vector<double> params;
   test::mock_throwing_model throwing_model;
 
   double init_radius = 2;
   bool print_timing = false;
-  EXPECT_THROW(params = stan::services::util::initialize(throwing_model, init_context, rng,
-                                                         init_radius, print_timing,
-                                                         message, init),
+  EXPECT_THROW(stan::services::util::initialize(throwing_model, init_context, rng,
+                                                init_radius, print_timing,
+                                                message, init),
                std::domain_error);
   EXPECT_EQ(100, count_matches("throwing within log_prob", message_ss.str()));
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Exceptions thrown in initialization are now reported.

#### How to Verify

Run 
```
./runTests.py src/test/unit/services/util/initialize_test.cpp 
```
or create a Stan program with a `reject()` statement. The tagged version won't output the error message.

#### Side Effects

None.

#### Documentation

None.

#### Reviewer Suggestions

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Stan Group

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
