### PR TITLE
Memory corruption when using stan_model class in more than one thread

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -4,7 +4,7 @@
 ##
 LIBGTEST = test/libgtest.a
 GTEST_MAIN = $(GTEST)/src/gtest_main.cc
-CFLAGS_GTEST += -isystem $(GTEST)/include -isystem $(GTEST)
+CFLAGS_GTEST += -isystem $(GTEST)/include -isystem $(GTEST) -std=c++11
 
 ##
 # Build the google test library.

--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ CC = g++
 O = 3
 O_STANC = 0
 AR = ar
-C++11 = false
+C++11 = true
 
 ##
 # Set default compiler options.

--- a/src/test/unit/services/sample/hmc_nuts_diag_e_test.cpp
+++ b/src/test/unit/services/sample/hmc_nuts_diag_e_test.cpp
@@ -212,14 +212,13 @@ TEST_F(ServicesSampleHmcNutsDiagE, output_regression_multiple_threads) {
   stan::test::unit::instrumented_interrupt interrupt;
   EXPECT_EQ(interrupt.call_count(), 0);
 
+  // threads run in parallel
   std::thread t1(&stan::services::sample::hmc_nuts_diag_e<stan_model>,
       std::ref(model1), std::ref(context), random_seed, chain, init_radius,
       num_warmup, num_samples, num_thin, save_warmup, refresh,
       stepsize, stepsize_jitter, max_depth,
       std::ref(interrupt), std::ref(message), std::ref(error), std::ref(init),
       std::ref(parameter), std::ref(diagnostic));
-  t1.join();
-
 
   std::thread t2(&stan::services::sample::hmc_nuts_diag_e<stan_model>,
       std::ref(model2), std::ref(context), random_seed, chain, init_radius,
@@ -227,6 +226,8 @@ TEST_F(ServicesSampleHmcNutsDiagE, output_regression_multiple_threads) {
       stepsize, stepsize_jitter, max_depth,
       std::ref(interrupt), std::ref(message), std::ref(error), std::ref(init),
       std::ref(parameter), std::ref(diagnostic));
+
+  t1.join();
   t2.join();
 
   std::vector<std::string> message_values;


### PR DESCRIPTION
(This is a bug report with a test case in the PR)
The stan_model *class* is not threadsafe. Given two separate instances of a given stan_model, you can't call, say, stan::model::log_prob_grad with them in parallel in different threads. I suspect that there's some unsafe manipulation of the class variables at fault.

The test attached leads to a segfault.

gdb tells me that the problem is memory corruption, "corrupted double-linked list" in ``stan_math/stan/math/rev/core/grad.hpp``:

```
li#1  0x0000555555560bd3 in stan::math::grad (vi=0x55555583dfa0) at lib/stan_math/stan/math/rev/core/grad.hpp:44
44              (*it)->chain();
(gdb) list
39            vi->init_dependent();
40            it_t begin = ChainableStack::var_stack_.rbegin();
41            it_t end = empty_nested()
42              ? ChainableStack::var_stack_.rend() : begin + nested_size();
43            for (it_t it = begin; it < end; ++it) {
44              (*it)->chain();
45            }
46          }
47
48        }
```

The test attached to the PR makes the problem clear, I hope. You should be able to sample using two separate model instances -- but instead you get a segfault.

Being able to sample in parallel in system threads (not processes) is particularly important for PyStan on Windows.

My sense is that this should be easy to fix. Perhaps a variable needs to be an instance variable instead of a class variable? Any ideas?

#### Intended Effect

Segfault

#### How to Verify
```
make test/unit/services/sample/hmc_nuts_diag_e && test/unit/services/sample/hmc_nuts_diag_e
```

#### Reviewer Suggestions
@bob-carpenter @syclik 