### PR TITLE
Stop sampling on errors that aren't domain_errors

### DIFF
--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -51,7 +51,11 @@ namespace stan {
        *   be printed to message_writer
        * @param[in,out] message_writer message writer
        * @param[in,out] init_writer init writer (on the unconstrained scale)
-       * @throws std::domain_error if the model could not be initialized
+       * @throws exception passed through from the model if the model has a
+       *   fatal error (not a std::domain_error)
+       * @throws std::domain_error if the model can not be initialized and
+       *   the model does not have a fatal error (only allows for
+       *   std::domain_error)
        * @return valid unconstrained parameters for the model
        */
       template <class Model, class RNG>
@@ -104,13 +108,18 @@ namespace stan {
               (unconstrained, disc_vector, &msg);
             if (msg.str().length() > 0)
               message_writer(msg.str());
-          } catch (std::exception& e) {
+          } catch (std::domain_error& e) {
             message_writer();
             message_writer("Rejecting initial value:");
             message_writer("  Error evaluating the log probability"
-                   " at the initial value.");
+                           " at the initial value.");
             message_writer(e.what());
             continue;
+          } catch (std::exception& e) {
+            message_writer();
+            message_writer("Unrecoverable error evaluating the log probability"
+                           " at the initial value.");
+            throw;
           }
           if (!boost::math::isfinite(log_prob)) {
             message_writer("Rejecting initial value:");


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Stops sampling on errors that aren't `std::domain_error`s.

#### Intended Effect

Stan programs that have `std::invalid_argument` or `std::out_of_range` errors are not recoverable. There's something broken in the Stan program and there's no point continuing. This pull request stops on errors that are not `std::domain_error`s.

For users, this should mask errors less by stopping early and making it look like a rejection.

#### How to Verify

There are additional tests here: `src/test/unit/services/util/initialize_test.cpp`

If you want to see different behavior, run this from your favorite interface:
```
parameters {
   real<lower = 0, upper = 1> theta[1];
}
model {
  theta[2] ~ normal(0, 1);
}
```

With this pull request, it stops almost immediately with this error message:
```
Unrecoverable error evaluating the log probability at the initial value.
Exception thrown at line 5: []: accessing element out of range. index 2 out of range; expecting index to be between 1 and 1; index position = 1theta
```

#### Side Effects

If there are other recoverable errors, they would need to be mapped to `std::domain_error` or we can change the code to only quit on `std::invalid_argument` or `std::out_of_range`.

#### Documentation

Added to doxygen doc.
I haven't added anything to the manual yet.

@bob-carpenter, what's a good way to doc this new behavior.

#### Reviewer Suggestions

@seantalts, @bob-carpenter, @betanalpha 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Stan Group

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
