### PR TITLE
Bugfix/2227 check input output streams

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -150,8 +150,10 @@ change-file-permissions:
 ifeq ($(OS_TYPE),win)
 	attrib +r src\\test\\test-models\\good\\stanc_helper.stan
 	attrib +r src\\test\\test-models\\bad\\stanc_helper.stan
+	attrib +r src\\test\\test-models\\bad\\read_only
 else
 	chmod 444 src/test/test-models/*/stanc_helper.stan
+	chmod 555 src/test/test-models/bad/read_only
 endif
 
 src/test/unit/lang/stanc_helper_test.cpp: change-file-permissions

--- a/src/stan/command/stanc_helper.hpp
+++ b/src/stan/command/stanc_helper.hpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <string>
 
+
 /**
  * Print the version of stanc with major, minor and patch.
  * 
@@ -125,7 +126,14 @@ int stanc_helper(int argc, const char* argv[],
     }
     std::string in_file_name;
     cmd.bare(0, in_file_name);
+
     std::ifstream in(in_file_name.c_str());
+    if (!in.is_open()) {
+      std::stringstream msg;
+      msg << "Failed to open model file "
+          <<  in_file_name.c_str();
+      throw std::invalid_argument(msg.str());
+    }
 
     std::string model_name;
     if (cmd.has_key("name")) {
@@ -188,7 +196,7 @@ int stanc_helper(int argc, const char* argv[],
           <<  out_file_name.c_str();
       throw std::invalid_argument(msg.str());
     }
-      
+
     bool valid_model
       = stan::lang::compile(err_stream, in, out, model_name, allow_undefined);
 

--- a/src/stan/command/stanc_helper.hpp
+++ b/src/stan/command/stanc_helper.hpp
@@ -181,11 +181,25 @@ int stanc_helper(int argc, const char* argv[],
       *out_stream << "Input file=" << in_file_name << std::endl;
       *out_stream << "Output file=" << out_file_name << std::endl;
     }
-
+    // check that we can write to out before invoking compiler
+    if (!out.is_open()) {
+      std::stringstream msg;
+      msg << "Failed to open output file "
+          <<  out_file_name.c_str();
+      throw std::invalid_argument(msg.str());
+    }
+      
     bool valid_model
       = stan::lang::compile(err_stream, in, out, model_name, allow_undefined);
 
     out.close();
+    if (out.bad()) {
+      std::stringstream msg;
+      msg << "Error writing output file "
+          << out_file_name.c_str();
+      throw std::invalid_argument(msg.str());
+    }
+
     if (!valid_model) {
       if (err_stream)
         *err_stream << "PARSING FAILED." << std::endl;

--- a/src/test/test-models/bad/read_only/m1.stan
+++ b/src/test/test-models/bad/read_only/m1.stan
@@ -1,0 +1,6 @@
+parameters {
+  real y;
+}
+model {
+  y ~ normal(0,1);
+}

--- a/src/test/unit/lang/stanc_helper_test.cpp
+++ b/src/test/unit/lang/stanc_helper_test.cpp
@@ -70,12 +70,12 @@ TEST(commandStancHelper, readOnlyOK) {
   std::stringstream out;
   std::stringstream err;
   int rc = run_helper("src/test/test-models/good/stanc_helper.stan", out, err);
-  
   EXPECT_EQ(0, rc)
     << "out=" << out.str() << std::endl << "err=" << err.str() << std::endl;
   expect_find(out.str(), "Model name=stanc_helper_model");
   expect_find(out.str(), "Input file=src/test/test-models/good/stanc_helper.stan");
   expect_find(out.str(), "Output file=stanc_helper_model.cpp");
+  delete_file(&err, "stanc_helper_model.cpp");
   EXPECT_EQ(0, err.str().size())
     << "error=" << err.str() << std::endl;
 }
@@ -108,14 +108,18 @@ TEST(commandStancHelper, noSuchFile) {
 TEST(commandStancHelper, readOnlyDirReadFile) {
   std::stringstream out;
   std::stringstream err;
-  int argc = 3;
+  int argc = 4;
   std::vector<const char*> argv_vec;
   argv_vec.push_back("main");
   argv_vec.push_back("--name=m1");
+  argv_vec.push_back("--o=src/test/test-models/m1.cpp");
   argv_vec.push_back("src/test/test-models/bad/read_only/m1.stan");
   const char** argv = &argv_vec[0];
   int rc = stanc_helper(argc, argv, &out, &err);
   EXPECT_TRUE(rc == 0);
+  delete_file(&err, "src/test/test-models/m1.cpp");
+  EXPECT_EQ(0, err.str().size())
+    << "error=" << err.str() << std::endl;
 }
 
 TEST(commandStancHelper, readOnlyDirWriteFile) {

--- a/src/test/unit/lang/stanc_helper_test.cpp
+++ b/src/test/unit/lang/stanc_helper_test.cpp
@@ -89,4 +89,37 @@ TEST(commandStancHelper, failRC) {
   // I only tested that it's != 0 to contrast with earlier success
   EXPECT_TRUE(rc != 0);
 }
-    
+
+TEST(commandStancHelper, failWriteCpp) {
+  std::stringstream out;
+  std::stringstream err;
+  int argc = 4;
+  std::vector<const char*> argv_vec;
+  argv_vec.push_back("main");
+  argv_vec.push_back("--name=m1");
+  argv_vec.push_back("--o=src/test/test-models/bad/read_only/m1.hpp");
+  argv_vec.push_back("src/test/test-models/bad/read_only/m1.stan");
+  const char** argv = &argv_vec[0];
+  int rc = stanc_helper(argc, argv, &out, &err);
+  std::cout << out.str() << std::endl;
+  std::cout << err.str() << std::endl;
+  
+  EXPECT_TRUE(rc != 0);
+}
+
+TEST(commandStancHelper, noSuchFile) {
+  std::stringstream out;
+  std::stringstream err;
+  int argc = 4;
+  std::vector<const char*> argv_vec;
+  argv_vec.push_back("main");
+  argv_vec.push_back("--name=m1");
+  argv_vec.push_back("--o=src/test/test-models/bad/read_only/nosuchfile.hpp");
+  argv_vec.push_back("src/test/test-models/bad/read_only/m1.stan");
+  const char** argv = &argv_vec[0];
+  int rc = stanc_helper(argc, argv, &out, &err);
+  std::cout << out.str() << std::endl;
+  std::cout << err.str() << std::endl;
+  
+  EXPECT_TRUE(rc != 0);
+}

--- a/src/test/unit/lang/stanc_helper_test.cpp
+++ b/src/test/unit/lang/stanc_helper_test.cpp
@@ -101,9 +101,9 @@ TEST(commandStancHelper, failWriteCpp) {
   argv_vec.push_back("src/test/test-models/bad/read_only/m1.stan");
   const char** argv = &argv_vec[0];
   int rc = stanc_helper(argc, argv, &out, &err);
-  std::cout << out.str() << std::endl;
-  std::cout << err.str() << std::endl;
-  
+  EXPECT_GT(err.str().size(), 25)
+    << "error=" << err.str() << std::endl;
+  expect_find(err.str(), "Failed to open output file");
   EXPECT_TRUE(rc != 0);
 }
 
@@ -118,8 +118,8 @@ TEST(commandStancHelper, noSuchFile) {
   argv_vec.push_back("src/test/test-models/bad/read_only/m1.stan");
   const char** argv = &argv_vec[0];
   int rc = stanc_helper(argc, argv, &out, &err);
-  std::cout << out.str() << std::endl;
-  std::cout << err.str() << std::endl;
-  
+  EXPECT_GT(err.str().size(), 25)
+    << "error=" << err.str() << std::endl;
+  expect_find(err.str(), "Failed to open output file");
   EXPECT_TRUE(rc != 0);
 }

--- a/src/test/unit/lang/stanc_helper_test.cpp
+++ b/src/test/unit/lang/stanc_helper_test.cpp
@@ -90,22 +90,6 @@ TEST(commandStancHelper, failRC) {
   EXPECT_TRUE(rc != 0);
 }
 
-TEST(commandStancHelper, failWriteCpp) {
-  std::stringstream out;
-  std::stringstream err;
-  int argc = 4;
-  std::vector<const char*> argv_vec;
-  argv_vec.push_back("main");
-  argv_vec.push_back("--name=m1");
-  argv_vec.push_back("--o=src/test/test-models/bad/read_only/m1.hpp");
-  argv_vec.push_back("src/test/test-models/bad/read_only/m1.stan");
-  const char** argv = &argv_vec[0];
-  int rc = stanc_helper(argc, argv, &out, &err);
-  EXPECT_GT(err.str().size(), 25)
-    << "error=" << err.str() << std::endl;
-  expect_find(err.str(), "Failed to open output file");
-  EXPECT_TRUE(rc != 0);
-}
 
 TEST(commandStancHelper, noSuchFile) {
   std::stringstream out;
@@ -114,8 +98,8 @@ TEST(commandStancHelper, noSuchFile) {
   std::vector<const char*> argv_vec;
   argv_vec.push_back("main");
   argv_vec.push_back("--name=m1");
-  argv_vec.push_back("--o=src/test/test-models/bad/read_only/nosuchfile.hpp");
-  argv_vec.push_back("src/test/test-models/bad/read_only/m1.stan");
+  argv_vec.push_back("--o=src/test/test-models/nosuchfile.hpp");
+  argv_vec.push_back("src/test/test-models/nosuchfile.stan");
   const char** argv = &argv_vec[0];
   int rc = stanc_helper(argc, argv, &out, &err);
   EXPECT_GT(err.str().size(), 25)
@@ -123,3 +107,21 @@ TEST(commandStancHelper, noSuchFile) {
   expect_find(err.str(), "Failed to open output file");
   EXPECT_TRUE(rc != 0);
 }
+
+// TODO(morris):  write cross-platform test for read-only directory?
+// TEST(commandStancHelper, failWriteCpp) {
+//   std::stringstream out;
+//   std::stringstream err;
+//   int argc = 4;
+//   std::vector<const char*> argv_vec;
+//   argv_vec.push_back("main");
+//   argv_vec.push_back("--name=m1");
+//   argv_vec.push_back("--o=/tmp/read_only/m1.hpp");
+//   argv_vec.push_back("/tmp/read_only/m1.stan");
+//   const char** argv = &argv_vec[0];
+//   int rc = stanc_helper(argc, argv, &out, &err);
+//   EXPECT_GT(err.str().size(), 25)
+//     << "error=" << err.str() << std::endl;
+//   expect_find(err.str(), "Failed to open output file");
+//   EXPECT_TRUE(rc != 0);
+// }

--- a/src/test/unit/lang/stanc_helper_test.cpp
+++ b/src/test/unit/lang/stanc_helper_test.cpp
@@ -90,38 +90,57 @@ TEST(commandStancHelper, failRC) {
   EXPECT_TRUE(rc != 0);
 }
 
-
 TEST(commandStancHelper, noSuchFile) {
+  std::stringstream out;
+  std::stringstream err;
+  int argc = 2;
+  std::vector<const char*> argv_vec;
+  argv_vec.push_back("main");
+  argv_vec.push_back("src/test/test-models/good/nosuchfile.stan");
+  const char** argv = &argv_vec[0];
+  int rc = stanc_helper(argc, argv, &out, &err);
+  EXPECT_GT(err.str().size(), 10)
+    << "error=" << err.str() << std::endl;
+  expect_find(err.str(), "Failed to open model file");
+  EXPECT_TRUE(rc != 0);
+}
+
+TEST(commandStancHelper, readOnlyDirReadFile) {
+  std::stringstream out;
+  std::stringstream err;
+  int argc = 3;
+  std::vector<const char*> argv_vec;
+  argv_vec.push_back("main");
+  argv_vec.push_back("--name=m1");
+  argv_vec.push_back("src/test/test-models/bad/read_only/m1.stan");
+  const char** argv = &argv_vec[0];
+  int rc = stanc_helper(argc, argv, &out, &err);
+  EXPECT_TRUE(rc == 0);
+}
+
+TEST(commandStancHelper, readOnlyDirWriteFile) {
   std::stringstream out;
   std::stringstream err;
   int argc = 4;
   std::vector<const char*> argv_vec;
   argv_vec.push_back("main");
   argv_vec.push_back("--name=m1");
-  argv_vec.push_back("--o=src/test/test-models/nosuchfile.hpp");
-  argv_vec.push_back("src/test/test-models/nosuchfile.stan");
+  argv_vec.push_back("--o=src/test/test-models/read_only/m1.cpp");
+  argv_vec.push_back("src/test/test-models/bad/read_only/m1.stan");
   const char** argv = &argv_vec[0];
   int rc = stanc_helper(argc, argv, &out, &err);
-  EXPECT_GT(err.str().size(), 25)
-    << "error=" << err.str() << std::endl;
-  expect_find(err.str(), "Failed to open output file");
   EXPECT_TRUE(rc != 0);
 }
 
-// TODO(morris):  write cross-platform test for read-only directory?
-// TEST(commandStancHelper, failWriteCpp) {
-//   std::stringstream out;
-//   std::stringstream err;
-//   int argc = 4;
-//   std::vector<const char*> argv_vec;
-//   argv_vec.push_back("main");
-//   argv_vec.push_back("--name=m1");
-//   argv_vec.push_back("--o=/tmp/read_only/m1.hpp");
-//   argv_vec.push_back("/tmp/read_only/m1.stan");
-//   const char** argv = &argv_vec[0];
-//   int rc = stanc_helper(argc, argv, &out, &err);
-//   EXPECT_GT(err.str().size(), 25)
-//     << "error=" << err.str() << std::endl;
-//   expect_find(err.str(), "Failed to open output file");
-//   EXPECT_TRUE(rc != 0);
-// }
+TEST(commandStancHelper, readOnlyDirBadFile) {
+  std::stringstream out;
+  std::stringstream err;
+  int argc = 2;
+  std::vector<const char*> argv_vec;
+  argv_vec.push_back("main");
+  argv_vec.push_back("src/test/test-models/bad/read_only/nosuchfile.stan");
+  const char** argv = &argv_vec[0];
+  int rc = stanc_helper(argc, argv, &out, &err);
+  EXPECT_TRUE(rc != 0);
+}
+

--- a/src/test/unit/lang/utility.hpp
+++ b/src/test/unit/lang/utility.hpp
@@ -54,6 +54,10 @@ bool is_parsable(const std::string& file_name,
                  bool allow_undefined = false) {
   stan::lang::program prog;
   std::ifstream fs(file_name.c_str());
+  if (fs.fail()) {
+    *msgs <<  "Cannot open model file " << file_name << std::endl; 
+    return false;
+  }
   std::string model_name = file_name_to_model_name(file_name);
   bool parsable
     = stan::lang::parse(msgs, fs, model_name, prog, allow_undefined);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Add checks to Stan transpiler so that it throws an error if it cannot read the model.stan file or write the model.cpp file.

#### Intended Effect
Allow cmdstan's `stanc` program to catch and report errors directly.  See #2227 for details.

#### How to Verify
Unit tests in `src/test/unit/lang/stanc_helper_test.cpp`

#### Side Effects

#### Documentation

#### Reviewer Suggestions
anyone who groks c++ io and cares about error message wording

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses: Mitzi Morris
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)