### PR TITLE
Feature/2267 standalone functions

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -143,6 +143,14 @@ $(patsubst %.stan,%.hpp,$(TEST_MODELS)) : %.hpp : %.stan test/test-models/stanc$
 	$(WINE) test/test-models/stanc$(EXE) --o=$@ $<
 
 ##
+# Generate C++ from Stan standalone functions
+##
+TEST_FUNCTIONS := $(shell find src/test/test-models -type f -name '*.stanfuncs')
+$(patsubst %.stanfuncs,%.hpp,$(TEST_FUNCTIONS)) : %.hpp : %.stanfuncs test/test-models/stanc$(EXE)
+	$(WINE) test/test-models/stanc$(EXE) --o=$@ $<
+
+
+##
 # src/test/unit/lang/stanc_helper_test.cpp requires files to be read-only.
 ##
 .PHONY: change-file-permissions
@@ -165,6 +173,7 @@ src/test/performance/logistic_test.cpp: src/test/test-models/performance/logisti
 src/test/unit/lang/generator_test.cpp: src/test/test-models/good/lang/test_lp.hpp
 src/test/unit/lang/parser_generator_test.cpp: $(patsubst %.stan,%.hpp,$(shell find src/test/test-models/good/parser-generator -type f -name '*.stan'))
 src/test/unit/io/random_var_context_test.cpp: src/test/test-models/good/services/test_lp.hpp
+src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp: src/test/test-models/good-standalone-functions/basic.hpp
 src/test/unit/lang/reject/reject_func_call_generated_quantities_test.cpp: src/test/test-models/good/lang/reject_func_call_generated_quantities.hpp
 src/test/unit/lang/reject/reject_func_call_model_test.cpp: src/test/test-models/good/lang/reject_func_call_model.hpp
 src/test/unit/lang/reject/reject_func_call_transformed_data_test.cpp: src/test/test-models/good/lang/reject_func_call_transformed_data.hpp

--- a/make/tests
+++ b/make/tests
@@ -175,7 +175,7 @@ src/test/performance/logistic_test.cpp: src/test/test-models/performance/logisti
 src/test/unit/lang/generator_test.cpp: src/test/test-models/good/lang/test_lp.hpp
 src/test/unit/lang/parser_generator_test.cpp: $(patsubst %.stan,%.hpp,$(shell find src/test/test-models/good/parser-generator -type f -name '*.stan'))
 src/test/unit/io/random_var_context_test.cpp: src/test/test-models/good/services/test_lp.hpp
-src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp: src/test/test-models/good-standalone-functions/basic.hpp src/test/test-models/good-standalone-functions/special_functions.hpp
+src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp: src/test/test-models/good-standalone-functions/basic.hpp src/test/test-models/good-standalone-functions/special_functions.hpp src/test/test-models/good-standalone-functions/integrate.hpp
 src/test/unit/lang/reject/reject_func_call_generated_quantities_test.cpp: src/test/test-models/good/lang/reject_func_call_generated_quantities.hpp
 src/test/unit/lang/reject/reject_func_call_model_test.cpp: src/test/test-models/good/lang/reject_func_call_model.hpp
 src/test/unit/lang/reject/reject_func_call_transformed_data_test.cpp: src/test/test-models/good/lang/reject_func_call_transformed_data.hpp

--- a/make/tests
+++ b/make/tests
@@ -173,7 +173,7 @@ src/test/performance/logistic_test.cpp: src/test/test-models/performance/logisti
 src/test/unit/lang/generator_test.cpp: src/test/test-models/good/lang/test_lp.hpp
 src/test/unit/lang/parser_generator_test.cpp: $(patsubst %.stan,%.hpp,$(shell find src/test/test-models/good/parser-generator -type f -name '*.stan'))
 src/test/unit/io/random_var_context_test.cpp: src/test/test-models/good/services/test_lp.hpp
-src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp: src/test/test-models/good-standalone-functions/basic.hpp
+src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp: src/test/test-models/good-standalone-functions/basic.hpp src/test/test-models/good-standalone-functions/special_functions.hpp
 src/test/unit/lang/reject/reject_func_call_generated_quantities_test.cpp: src/test/test-models/good/lang/reject_func_call_generated_quantities.hpp
 src/test/unit/lang/reject/reject_func_call_model_test.cpp: src/test/test-models/good/lang/reject_func_call_model.hpp
 src/test/unit/lang/reject/reject_func_call_transformed_data_test.cpp: src/test/test-models/good/lang/reject_func_call_transformed_data.hpp

--- a/src/stan/command/stanc_helper.hpp
+++ b/src/stan/command/stanc_helper.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/version.hpp>
 #include <stan/lang/compiler.hpp>
+#include <stan/lang/compile_functions.hpp>
 #include <stan/io/cmd_line.hpp>
 #include <exception>
 #include <fstream>
@@ -60,6 +61,7 @@ void print_stanc_help(std::ostream* out_stream) {
 
   print_help_option(out_stream, "allow_undefined", "",
                     "Do not fail if a function is declared but not defined");
+  //TODO(martincerny) help for standalone function compilation
 }
 
 /**
@@ -83,6 +85,82 @@ void delete_file(std::ostream* err_stream,
 }
 
 /**
+ * Transform a provided input file name into a valid C++ identifier
+ * @param[in] in_file_name the name of the input file
+ * @return a valid C++ identifier based on the file name.
+ */
+std::string identifier_from_file_name(const std::string& in_file_name) {
+  size_t slashInd = in_file_name.rfind('/');
+  size_t ptInd = in_file_name.rfind('.');
+  if (ptInd == std::string::npos)
+    ptInd = in_file_name.length();
+  if (slashInd == std::string::npos) {
+    slashInd = in_file_name.rfind('\\');
+  }
+  if (slashInd == std::string::npos) {
+    slashInd = 0;
+  } else {
+    slashInd++;
+  }
+  std::string result = 
+    in_file_name.substr(slashInd, ptInd - slashInd);
+  for (std::string::iterator strIt = result.begin();
+      strIt != result.end(); strIt++) {
+    if (!isalnum(*strIt) && *strIt != '_') {
+      *strIt = '_';
+    }
+  }
+
+  return result;
+}
+
+
+/**
+ * Check whether a given file has the specified extension.
+ * 
+ * @param[in] file_name The name of the file
+ * @param[in] extension The extension (WITHOUT dot)- e.g. "stan".
+ * @return true if the file has the extension
+ */
+bool has_extension(const std::string& file_name, const std::string& extension)
+{
+  if (file_name.length() >= extension.length() + 1) { //+1 for the dot
+    if (0 == file_name.compare (file_name.length() - extension.length(), 
+        extension.length(), extension)
+      && file_name[file_name.length() - extension.length() - 1] == '.') 
+        return true;
+    else
+      return false;
+  } else {
+    return false;
+  }  
+}
+
+/**
+ * Test whether a given string is a valid C++ identifier and throw
+ * an exception when it is not.
+ * @param[in] identifier the identifier to be checked
+ * @param[in] identifier_type the type of the identifier to be reported 
+ * in error messages
+ */
+void check_identifier(const std::string& identifier, 
+                      const std::string& identifier_type) {
+  if (!isalpha(identifier[0]) && identifier[0] != '_') {
+    std::string msg(identifier_type + " must not start with a "
+                    "number or symbol other than _");
+    throw std::invalid_argument(msg);
+  }
+  for (std::string::const_iterator strIt = identifier.begin();
+      strIt != identifier.end(); strIt++) {
+    if (!isalnum(*strIt) && *strIt != '_') {
+      std::string msg(identifier_type 
+        + " must contain only letters, numbers and _");
+      throw std::invalid_argument(msg);
+    }
+  }
+}
+
+/**
  * Invoke the stanc command on the specified argument list, writing
  * output and error messages to the specified streams, return a return
  * code.
@@ -99,6 +177,10 @@ void delete_file(std::ostream* err_stream,
  */
 int stanc_helper(int argc, const char* argv[],
                  std::ostream* out_stream, std::ostream* err_stream) {
+  enum CompilationType {
+    kModel,
+    kStandaloneFunctions
+  };
   static const int SUCCESS_RC = 0;
   static const int EXCEPTION_RC = -1;
   static const int PARSE_FAIL_RC = -2;
@@ -125,68 +207,108 @@ int stanc_helper(int argc, const char* argv[],
     }
     std::string in_file_name;
     cmd.bare(0, in_file_name);
+
+    CompilationType compilation_type;
+    if (has_extension(in_file_name, "stanfuncs")) {
+      compilation_type = kStandaloneFunctions;
+    } else {
+      compilation_type = kModel;
+    }
+
     std::ifstream in(in_file_name.c_str());
-
-    std::string model_name;
-    if (cmd.has_key("name")) {
-      cmd.val("name", model_name);
-    } else {
-      size_t slashInd = in_file_name.rfind('/');
-      size_t ptInd = in_file_name.rfind('.');
-      if (ptInd == std::string::npos)
-        ptInd = in_file_name.length();
-      if (slashInd == std::string::npos) {
-        slashInd = in_file_name.rfind('\\');
-      }
-      if (slashInd == std::string::npos) {
-        slashInd = 0;
-      } else {
-        slashInd++;
-      }
-      model_name = in_file_name.substr(slashInd, ptInd - slashInd) + "_model";
-      for (std::string::iterator strIt = model_name.begin();
-           strIt != model_name.end(); strIt++) {
-        if (!isalnum(*strIt) && *strIt != '_') {
-          *strIt = '_';
-        }
-      }
-    }
-
-    if (cmd.has_key("o")) {
-      cmd.val("o", out_file_name);
-    } else {
-      out_file_name = model_name;
-      // TODO(carpenter): shouldn't this be .hpp without a main()?
-      out_file_name += ".cpp";
-    }
-
-    if (!isalpha(model_name[0]) && model_name[0] != '_') {
-      std::string msg("model_name must not start with a "
-                      "number or symbol other than _");
-      throw std::invalid_argument(msg);
-    }
-    for (std::string::iterator strIt = model_name.begin();
-         strIt != model_name.end(); strIt++) {
-      if (!isalnum(*strIt) && *strIt != '_') {
-        std::string msg("model_name must contain only letters, numbers and _");
-        throw std::invalid_argument(msg);
-      }
-    }
 
     bool allow_undefined = cmd.has_flag("allow_undefined");
 
-    std::fstream out(out_file_name.c_str(), std::fstream::out);
-    if (out_stream) {
-      *out_stream << "Model name=" << model_name << std::endl;
-      *out_stream << "Input file=" << in_file_name << std::endl;
-      *out_stream << "Output file=" << out_file_name << std::endl;
+    bool valid_input = false;
+
+    switch (compilation_type) {
+      case kModel: {
+        std::string model_name;
+        if (cmd.has_key("name")) {
+          cmd.val("name", model_name);
+        } else {
+          model_name = identifier_from_file_name(in_file_name) + "_model";
+        }
+
+        //TODO(martincerny) Check that the -namespace flag is not set
+
+        if (cmd.has_key("o")) {
+          cmd.val("o", out_file_name);
+        } else {
+          out_file_name = model_name;
+          // TODO(carpenter): shouldn't this be .hpp without a main()?
+          out_file_name += ".cpp";
+        }
+
+        check_identifier(model_name,"model_name");
+
+        std::fstream out(out_file_name.c_str(), std::fstream::out);
+        if (out_stream) {
+          *out_stream << "Model name=" << model_name << std::endl;
+          *out_stream << "Input file=" << in_file_name << std::endl;
+          *out_stream << "Output file=" << out_file_name << std::endl;
+        }
+
+        valid_input = stan::lang::compile(err_stream, in, out, 
+                        model_name, allow_undefined);
+
+        out.close();          
+        break;
+      }
+      case kStandaloneFunctions: {
+
+        if (cmd.has_key("o")) {
+          cmd.val("o", out_file_name);
+        } else {
+          out_file_name = identifier_from_file_name(in_file_name);
+          out_file_name += ".hpp";
+        }
+        
+        //TODO(martincerny) Allow multiple namespaces 
+        //(split namespace argument by "::")
+        std::vector<std::string> namespaces;
+        if (cmd.has_key("namespace")) {
+          std::string ns;
+          cmd.val("namespace", ns);          
+          namespaces.push_back(ns);
+        } else {
+          namespaces.push_back(identifier_from_file_name(in_file_name) + "_functions");
+        }
+
+        //TODO(martincerny) Check that the -name flag is not set
+
+        for(size_t namespace_i = 0; 
+            namespace_i < namespaces.size(); ++namespace_i) {
+          check_identifier(namespaces[namespace_i],"namespace");
+        };
+
+        std::fstream out(out_file_name.c_str(), std::fstream::out);
+        if (out_stream) {
+          *out_stream << "Parsing a fuctions-only file" << std::endl;
+
+          *out_stream << "Target namespace= "; 
+          for(size_t namespace_i = 0; 
+              namespace_i < namespaces.size(); ++namespace_i) {
+            *out_stream << "::" << namespaces[namespace_i];
+          }          
+          *out_stream << std::endl;
+
+          *out_stream << "Input file=" << in_file_name << std::endl;
+          *out_stream << "Output file=" << out_file_name << std::endl;
+        }
+
+        valid_input = stan::lang::compile_functions(err_stream, in, out, 
+                        namespaces, allow_undefined);
+
+        out.close();
+        break;        
+      }
+      default: {
+        assert(false);
+      }
     }
 
-    bool valid_model
-      = stan::lang::compile(err_stream, in, out, model_name, allow_undefined);
-
-    out.close();
-    if (!valid_model) {
+    if (!valid_input) {
       if (err_stream)
         *err_stream << "PARSING FAILED." << std::endl;
       // FIXME: how to remove triple cut-and-paste?

--- a/src/stan/command/stanc_helper.hpp
+++ b/src/stan/command/stanc_helper.hpp
@@ -260,7 +260,7 @@ int stanc_helper(int argc, const char* argv[],
           msg << "Failed to open output file "
               <<  out_file_name.c_str();
           throw std::invalid_argument(msg.str());
-        }        
+        }
 
         valid_input = stan::lang::compile(err_stream, in, out,
                         model_name, allow_undefined);

--- a/src/stan/command/stanc_helper.hpp
+++ b/src/stan/command/stanc_helper.hpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 /**
  * Print the version of stanc with major, minor and patch.
@@ -61,7 +62,7 @@ void print_stanc_help(std::ostream* out_stream) {
 
   print_help_option(out_stream, "allow_undefined", "",
                     "Do not fail if a function is declared but not defined");
-  //TODO(martincerny) help for standalone function compilation
+  // TODO(martincerny) help for standalone function compilation
 }
 
 /**
@@ -102,7 +103,7 @@ std::string identifier_from_file_name(const std::string& in_file_name) {
   } else {
     slashInd++;
   }
-  std::string result = 
+  std::string result =
     in_file_name.substr(slashInd, ptInd - slashInd);
   for (std::string::iterator strIt = result.begin();
       strIt != result.end(); strIt++) {
@@ -122,18 +123,17 @@ std::string identifier_from_file_name(const std::string& in_file_name) {
  * @param[in] extension The extension (WITHOUT dot)- e.g. "stan".
  * @return true if the file has the extension
  */
-bool has_extension(const std::string& file_name, const std::string& extension)
-{
-  if (file_name.length() >= extension.length() + 1) { //+1 for the dot
-    if (0 == file_name.compare (file_name.length() - extension.length(), 
+bool has_extension(const std::string& file_name, const std::string& extension) {
+  if (file_name.length() >= extension.length() + 1) {  // +1 for the dot
+    if (0 == file_name.compare (file_name.length() - extension.length(),
         extension.length(), extension)
-      && file_name[file_name.length() - extension.length() - 1] == '.') 
+      && file_name[file_name.length() - extension.length() - 1] == '.')
         return true;
     else
       return false;
   } else {
     return false;
-  }  
+  }
 }
 
 /**
@@ -143,7 +143,7 @@ bool has_extension(const std::string& file_name, const std::string& extension)
  * @param[in] identifier_type the type of the identifier to be reported 
  * in error messages
  */
-void check_identifier(const std::string& identifier, 
+void check_identifier(const std::string& identifier,
                       const std::string& identifier_type) {
   if (!isalpha(identifier[0]) && identifier[0] != '_') {
     std::string msg(identifier_type + " must not start with a "
@@ -153,7 +153,7 @@ void check_identifier(const std::string& identifier,
   for (std::string::const_iterator strIt = identifier.begin();
       strIt != identifier.end(); strIt++) {
     if (!isalnum(*strIt) && *strIt != '_') {
-      std::string msg(identifier_type 
+      std::string msg(identifier_type
         + " must contain only letters, numbers and _");
       throw std::invalid_argument(msg);
     }
@@ -230,7 +230,7 @@ int stanc_helper(int argc, const char* argv[],
           model_name = identifier_from_file_name(in_file_name) + "_model";
         }
 
-        //TODO(martincerny) Check that the -namespace flag is not set
+        // TODO(martincerny) Check that the -namespace flag is not set
 
         if (cmd.has_key("o")) {
           cmd.val("o", out_file_name);
@@ -240,7 +240,7 @@ int stanc_helper(int argc, const char* argv[],
           out_file_name += ".cpp";
         }
 
-        check_identifier(model_name,"model_name");
+        check_identifier(model_name, "model_name");
 
         std::fstream out(out_file_name.c_str(), std::fstream::out);
         if (out_stream) {
@@ -249,59 +249,59 @@ int stanc_helper(int argc, const char* argv[],
           *out_stream << "Output file=" << out_file_name << std::endl;
         }
 
-        valid_input = stan::lang::compile(err_stream, in, out, 
+        valid_input = stan::lang::compile(err_stream, in, out,
                         model_name, allow_undefined);
 
-        out.close();          
+        out.close();
         break;
       }
       case kStandaloneFunctions: {
-
         if (cmd.has_key("o")) {
           cmd.val("o", out_file_name);
         } else {
           out_file_name = identifier_from_file_name(in_file_name);
           out_file_name += ".hpp";
         }
-        
-        //TODO(martincerny) Allow multiple namespaces 
-        //(split namespace argument by "::")
+
+        // TODO(martincerny) Allow multiple namespaces
+        // (split namespace argument by "::")
         std::vector<std::string> namespaces;
         if (cmd.has_key("namespace")) {
           std::string ns;
-          cmd.val("namespace", ns);          
+          cmd.val("namespace", ns);
           namespaces.push_back(ns);
         } else {
-          namespaces.push_back(identifier_from_file_name(in_file_name) + "_functions");
+          namespaces.push_back(
+            identifier_from_file_name(in_file_name) + "_functions");
         }
 
-        //TODO(martincerny) Check that the -name flag is not set
+        // TODO(martincerny) Check that the -name flag is not set
 
-        for(size_t namespace_i = 0; 
+        for (size_t namespace_i = 0;
             namespace_i < namespaces.size(); ++namespace_i) {
-          check_identifier(namespaces[namespace_i],"namespace");
-        };
+          check_identifier(namespaces[namespace_i], "namespace");
+        }
 
         std::fstream out(out_file_name.c_str(), std::fstream::out);
         if (out_stream) {
           *out_stream << "Parsing a fuctions-only file" << std::endl;
 
-          *out_stream << "Target namespace= "; 
-          for(size_t namespace_i = 0; 
+          *out_stream << "Target namespace= ";
+          for (size_t namespace_i = 0;
               namespace_i < namespaces.size(); ++namespace_i) {
             *out_stream << "::" << namespaces[namespace_i];
-          }          
+          }
           *out_stream << std::endl;
 
           *out_stream << "Input file=" << in_file_name << std::endl;
           *out_stream << "Output file=" << out_file_name << std::endl;
         }
 
-        valid_input = stan::lang::compile_functions(err_stream, in, out, 
+        valid_input = stan::lang::compile_functions(err_stream, in, out,
                         namespaces, allow_undefined);
 
         out.close();
-        break;        
+        break;
       }
       default: {
         assert(false);

--- a/src/stan/lang/compile_functions.hpp
+++ b/src/stan/lang/compile_functions.hpp
@@ -34,16 +34,16 @@ namespace stan {
                  const bool allow_undefined = false) {
       program prog;
 
-      //TODO(martincerny) the model_name below probably should not be a constant
-      //but it seems to have no impact on the generated .hpp file
+      // TODO(martincerny) the model_name below probably should not be a
+      // constant but it seems to have no impact on the generated .hpp file
       bool parsed_ok = parse(msgs, stan_funcs_in,
-                             "functions_only_model", 
+                             "functions_only_model",
                              prog, allow_undefined);
       if (!parsed_ok)
         return false;  // syntax error in program
-        
-      //TODO(martincerny) raise error or warning when other blocks than 
-      //functions are present
+
+      // TODO(martincerny) raise error or warning when other blocks than
+      // functions are present
       generate_standalone_functions(prog, namespaces, cpp_out);
       return true;
     }

--- a/src/stan/lang/compile_functions.hpp
+++ b/src/stan/lang/compile_functions.hpp
@@ -1,0 +1,54 @@
+#ifndef STAN_LANG_COMPILE_FUNCTIONS_HPP
+#define STAN_LANG_COMPILE_FUNCTIONS_HPP
+
+#include <stan/lang/ast.hpp>
+#include <stan/lang/generator/generate_standalone_functions.hpp>
+#include <stan/lang/parser.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace stan {
+  namespace lang {
+
+    /**
+     * Read a Stan file with only the functions block from the
+     * specified input, parse it, and write the C++ code for it
+     * to the specified output.
+     *
+     * @param[in] msgs Output stream for warning messages
+     * @param[in] stan_funcs_in Stan model specification
+     * @param[in] cpp_out C++ code output stream
+     * @param[in] namespaces Vector of namespace to generate the functions in
+     * @param[in] allow_undefined Permit undefined functions?
+     *
+     * @return <code>false</code> if code could not be generated
+     *    due to syntax error in the functions file;
+     *    <code>true</code> otherwise.
+     */
+    bool compile_functions(std::ostream* msgs,
+                 std::istream& stan_funcs_in,
+                 std::ostream& cpp_out,
+                 const std::vector<std::string>& namespaces,
+                 const bool allow_undefined = false) {
+      program prog;
+
+      //TODO(martincerny) the model_name below probably should not be a constant
+      //but it seems to have no impact on the generated .hpp file
+      bool parsed_ok = parse(msgs, stan_funcs_in,
+                             "functions_only_model", 
+                             prog, allow_undefined);
+      if (!parsed_ok)
+        return false;  // syntax error in program
+        
+      //TODO(martincerny) raise error or warning when other blocks than 
+      //functions are present
+      generate_standalone_functions(prog, namespaces, cpp_out);
+      return true;
+    }
+
+
+  }
+}
+#endif

--- a/src/stan/lang/generator/generate_function.hpp
+++ b/src/stan/lang/generator/generate_function.hpp
@@ -26,14 +26,19 @@ namespace stan {
      * @param[in] fun function AST object
      * @param[in, out] out output stream to which function definition
      * is written
+     * @param[in] rcpp_export if true, comments to enable export for RCpp
+     * are generated
      */
     void generate_function(const function_decl_def& fun,
-                           std::ostream& out) {
+                           std::ostream& out, bool rcpp_export = false) {
       bool is_rng = ends_with("_rng", fun.name_);
       bool is_lp = ends_with("_lp", fun.name_);
       bool is_pf = ends_with("_log", fun.name_)
         || ends_with("_lpdf", fun.name_) || ends_with("_lpmf", fun.name_);
       std::string scalar_t_name = fun_scalar_type(fun, is_lp);
+
+      if (rcpp_export)
+        out << "// [[Rcpp::export]]" << EOL;
 
       generate_function_template_parameters(fun, is_rng, is_lp, is_pf, out);
       generate_function_inline_return_type(fun, scalar_t_name, 0, out);

--- a/src/stan/lang/generator/generate_function_arguments.hpp
+++ b/src/stan/lang/generator/generate_function_arguments.hpp
@@ -26,11 +26,14 @@ namespace stan {
      * @param[in] double_only do not do any templating and make all arguments
      * based on the standard double type
      * @param[in] rng_type set a type of the rng argument in _rng functions
+     * @param[in] parameter_defaults if true, default values for the standard
+     * parameters (now only pstream__) will be generated
      */
     void generate_function_arguments(const function_decl_def& fun, bool is_rng,
                                      bool is_lp, bool is_log, std::ostream& o,
                                      bool double_only = false,
-                                     std::string rng_type = "RNG") {
+                                     std::string rng_type = "RNG",
+                                     bool parameter_defaults = false) {
       o << "(";
       for (size_t i = 0; i < fun.arg_decls_.size(); ++i) {
         std::string template_type_i;
@@ -59,13 +62,12 @@ namespace stan {
       }
       if (is_rng || is_lp || fun.arg_decls_.size() > 0)
         o << ", ";
-      o << "std::ostream* pstream__";
 
-      // Generate a default pstream value, but only if this is not a forward
-      // declaration
-      if (!fun.body_.is_no_op_statement()) {
+      o << "std::ostream* pstream__";
+      if (parameter_defaults) {
         o << " = 0";
       }
+
       o << ")";
     }
 

--- a/src/stan/lang/generator/generate_function_arguments.hpp
+++ b/src/stan/lang/generator/generate_function_arguments.hpp
@@ -28,7 +28,7 @@ namespace stan {
      * @param[in] rng_type set a type of the rng argument in _rng functions
      */
     void generate_function_arguments(const function_decl_def& fun, bool is_rng,
-                                     bool is_lp, bool is_log, std::ostream& o, 
+                                     bool is_lp, bool is_log, std::ostream& o,
                                      bool double_only = false,
                                      std::string rng_type = "RNG") {
       o << "(";
@@ -48,9 +48,9 @@ namespace stan {
       }
       if ((is_rng || is_lp) && fun.arg_decls_.size() > 0)
         o << ", ";
-      if (is_rng)
+      if (is_rng) {
         o << rng_type << "& base_rng__";
-      else if (is_lp) {
+      } else if (is_lp) {
         if (double_only) {
           o << "double& lp__, stan::math::accumulator<double>& lp_accum__";
         } else {

--- a/src/stan/lang/generator/generate_function_arguments.hpp
+++ b/src/stan/lang/generator/generate_function_arguments.hpp
@@ -59,7 +59,7 @@ namespace stan {
       }
       if (is_rng || is_lp || fun.arg_decls_.size() > 0)
         o << ", ";
-      o << "std::ostream* pstream__";
+      o << "std::ostream* pstream__ = 0";
       o << ")";
     }
 

--- a/src/stan/lang/generator/generate_function_arguments.hpp
+++ b/src/stan/lang/generator/generate_function_arguments.hpp
@@ -59,7 +59,13 @@ namespace stan {
       }
       if (is_rng || is_lp || fun.arg_decls_.size() > 0)
         o << ", ";
-      o << "std::ostream* pstream__ = 0";
+      o << "std::ostream* pstream__";
+
+      // Generate a default pstream value, but only if this is not a forward
+      // declaration
+      if (!fun.body_.is_no_op_statement()) {
+        o << " = 0";
+      }
       o << ")";
     }
 

--- a/src/stan/lang/generator/generate_function_arguments.hpp
+++ b/src/stan/lang/generator/generate_function_arguments.hpp
@@ -23,13 +23,22 @@ namespace stan {
      * accumulator
      * @param[in] is_log true if function is log probability function
      * @param[in,out] o stream for generating
+     * @param[in] double_only do not do any templating and make all arguments
+     * based on the standard double type
+     * @param[in] rng_type set a type of the rng argument in _rng functions
      */
     void generate_function_arguments(const function_decl_def& fun, bool is_rng,
-                                     bool is_lp, bool is_log, std::ostream& o) {
+                                     bool is_lp, bool is_log, std::ostream& o, 
+                                     bool double_only = false,
+                                     std::string rng_type = "RNG") {
       o << "(";
       for (size_t i = 0; i < fun.arg_decls_.size(); ++i) {
-        std::string template_type_i
-          = "T" + boost::lexical_cast<std::string>(i) + "__";
+        std::string template_type_i;
+        if (double_only) {
+          template_type_i = "double";
+        } else {
+          template_type_i = "T" + boost::lexical_cast<std::string>(i) + "__";
+        }
         generate_arg_decl(true, true, fun.arg_decls_[i], template_type_i, o);
         if (i + 1 < fun.arg_decls_.size()) {
           o << "," << EOL << INDENT;
@@ -40,9 +49,14 @@ namespace stan {
       if ((is_rng || is_lp) && fun.arg_decls_.size() > 0)
         o << ", ";
       if (is_rng)
-        o << "RNG& base_rng__";
-      else if (is_lp)
-        o << "T_lp__& lp__, T_lp_accum__& lp_accum__";
+        o << rng_type << "& base_rng__";
+      else if (is_lp) {
+        if (double_only) {
+          o << "double& lp__, stan::math::accumulator<double>& lp_accum__";
+        } else {
+          o << "T_lp__& lp__, T_lp_accum__& lp_accum__";
+        }
+      }
       if (is_rng || is_lp || fun.arg_decls_.size() > 0)
         o << ", ";
       o << "std::ostream* pstream__";

--- a/src/stan/lang/generator/generate_function_instantiation.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation.hpp
@@ -1,0 +1,57 @@
+#ifndef STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_HPP
+#define STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_HPP
+
+#include <stan/lang/ast.hpp>
+#include <stan/lang/generator/constants.hpp>
+#include <stan/lang/generator/generate_function_inline_return_type.hpp>
+#include <stan/lang/generator/generate_function_instantiation_body.hpp>
+#include <stan/lang/generator/generate_function_instantiation_name.hpp>
+#include <ostream>
+#include <string>
+
+namespace stan {
+  namespace lang {
+
+    /**
+     * Generate a non-variable (double only) instantiation of  specified 
+     * function and optionally its default for propto=false 
+     * for functions ending in _log.
+     *
+     * Exact behavior differs for unmarked functions, and functions
+     * ending in one of "_rng", "_lp", or "_log".
+     *
+     * @param[in] fun function AST object
+     * @param[in, out] out output stream to which function definition
+     * is written
+     */
+    void generate_function_instantiation(const function_decl_def& fun,
+                           std::ostream& out) {
+
+      // Do not generate anything for forward decalrations
+      if (fun.body_.is_no_op_statement()) {
+        return;
+      }                             
+
+      bool is_rng = ends_with("_rng", fun.name_);
+      bool is_lp = ends_with("_lp", fun.name_);
+      bool is_pf = ends_with("_log", fun.name_)
+        || ends_with("_lpdf", fun.name_) || ends_with("_lpmf", fun.name_);
+
+      // scalar type is always double for instantiations
+      std::string scalar_t_name = "double";
+      std::string rng_class = "boost::ecuyer1988";
+
+      generate_function_inline_return_type(fun, scalar_t_name, 0, out);
+      generate_function_instantiation_name(fun, out);
+      generate_function_arguments(
+        fun, is_rng, is_lp, is_pf, out, true /*no templates*/, rng_class);
+
+      generate_function_instantiation_body(
+        fun, is_rng, is_lp, is_pf, rng_class, out);
+
+      out << EOL;
+    }
+
+  }
+}
+#endif

--- a/src/stan/lang/generator/generate_function_instantiation.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation.hpp
@@ -31,6 +31,12 @@ namespace stan {
         return;
       }
 
+      //Functions that have only int args were not templated in the first place
+      //=> they are already instantiated
+      if(has_only_int_args(fun)) {
+        return;
+      }
+
       bool is_rng = ends_with("_rng", fun.name_);
       bool is_lp = ends_with("_lp", fun.name_);
       bool is_pf = ends_with("_log", fun.name_)

--- a/src/stan/lang/generator/generate_function_instantiation.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation.hpp
@@ -53,7 +53,8 @@ namespace stan {
       generate_function_inline_return_type(fun, scalar_t_name, 0, out);
       generate_function_instantiation_name(fun, out);
       generate_function_arguments(
-        fun, is_rng, is_lp, is_pf, out, true /*no templates*/, rng_class);
+        fun, is_rng, is_lp, is_pf, out, true /*no templates*/, rng_class,
+        true /*parameter_defaults*/);
 
       generate_function_instantiation_body(
         fun, is_rng, is_lp, is_pf, rng_class, out);

--- a/src/stan/lang/generator/generate_function_instantiation.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation.hpp
@@ -6,6 +6,8 @@
 #include <stan/lang/generator/generate_function_inline_return_type.hpp>
 #include <stan/lang/generator/generate_function_instantiation_body.hpp>
 #include <stan/lang/generator/generate_function_instantiation_name.hpp>
+#include <stan/lang/generator/generate_function_arguments.hpp>
+#include <stan/lang/generator/has_only_int_args.hpp>
 #include <ostream>
 #include <string>
 

--- a/src/stan/lang/generator/generate_function_instantiation.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation.hpp
@@ -48,6 +48,8 @@ namespace stan {
       std::string scalar_t_name = "double";
       std::string rng_class = "boost::ecuyer1988";
 
+      out << "// [[Rcpp::export]]" << EOL;
+
       generate_function_inline_return_type(fun, scalar_t_name, 0, out);
       generate_function_instantiation_name(fun, out);
       generate_function_arguments(

--- a/src/stan/lang/generator/generate_function_instantiation.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation.hpp
@@ -31,9 +31,9 @@ namespace stan {
         return;
       }
 
-      //Functions that have only int args were not templated in the first place
-      //=> they are already instantiated
-      if(has_only_int_args(fun)) {
+      // Functions that have only int args were not templated in the first place
+      // => they are already instantiated
+      if (has_only_int_args(fun)) {
         return;
       }
 

--- a/src/stan/lang/generator/generate_function_instantiation.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation.hpp
@@ -26,11 +26,10 @@ namespace stan {
      */
     void generate_function_instantiation(const function_decl_def& fun,
                            std::ostream& out) {
-
       // Do not generate anything for forward decalrations
       if (fun.body_.is_no_op_statement()) {
         return;
-      }                             
+      }
 
       bool is_rng = ends_with("_rng", fun.name_);
       bool is_lp = ends_with("_lp", fun.name_);

--- a/src/stan/lang/generator/generate_function_instantiation_body.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation_body.hpp
@@ -6,6 +6,7 @@
 #include <stan/lang/generator/generate_function_instantiation_template_parameters.hpp>
 #include <ostream>
 #include <vector>
+#include <string>
 
 namespace stan {
   namespace lang {
@@ -25,8 +26,8 @@ namespace stan {
      * @param[in] is_log true if function is log probability function
      * @param[in,out] o stream for generating
      */
-    void generate_function_instantiation_body(const function_decl_def& fun, 
-                                    bool is_rng, bool is_lp, bool is_log, 
+    void generate_function_instantiation_body(const function_decl_def& fun,
+                                    bool is_rng, bool is_lp, bool is_log,
                                     const std::string& rng_class,
                                     std::ostream& o) {
       o << "{" << EOL;
@@ -36,8 +37,8 @@ namespace stan {
       }
       generate_function_name(fun, o);
       generate_function_instantiation_template_parameters(
-        fun, is_rng, is_lp, is_log, rng_class, o); 
-        
+        fun, is_rng, is_lp, is_log, rng_class, o);
+
       o << "(";
       for (size_t arg_i = 0; arg_i < fun.arg_decls_.size(); ++arg_i) {
         o << fun.arg_decls_[arg_i].name_;
@@ -54,7 +55,7 @@ namespace stan {
       if (is_rng || is_lp || fun.arg_decls_.size() > 0)
         o << ", ";
       o << "pstream__";
-      
+
       o << ");" << EOL;
       o << "}" << EOL;
     }

--- a/src/stan/lang/generator/generate_function_instantiation_body.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation_body.hpp
@@ -33,7 +33,7 @@ namespace stan {
                                     const std::string& rng_class,
                                     std::ostream& o) {
       o << "{" << EOL;
-      o << "\t";
+      o << "  ";
       if (!fun.return_type_.is_void()) {
         o << "return ";
       }

--- a/src/stan/lang/generator/generate_function_instantiation_body.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation_body.hpp
@@ -1,0 +1,65 @@
+#ifndef STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_BODY_HPP
+#define STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_BODY_HPP
+
+#include <stan/lang/ast.hpp>
+#include <stan/lang/generator/generate_function_name.hpp>
+#include <stan/lang/generator/generate_function_instantiation_template_parameters.hpp>
+#include <ostream>
+#include <vector>
+
+namespace stan {
+  namespace lang {
+
+    /**
+     * Generate the body for a function instantiation (e.g., the 
+     * call to the templated function with all templated arguments based on 
+     * double).
+     * Requires precalculated flags for whether it is an RNG, uses the log
+     * density accumulator or is a probability function, to the
+     * specified stream.
+     *
+     * @param[in] fun function declaration
+     * @param[in] is_rng true if function is an RNG
+     * @param[in] is_lp true if function accesses log density
+     * accumulator
+     * @param[in] is_log true if function is log probability function
+     * @param[in,out] o stream for generating
+     */
+    void generate_function_instantiation_body(const function_decl_def& fun, 
+                                    bool is_rng, bool is_lp, bool is_log, 
+                                    const std::string& rng_class,
+                                    std::ostream& o) {
+      o << "{" << EOL;
+      o << "\t";
+      if (!fun.return_type_.is_void()) {
+        o << "return ";
+      }
+      generate_function_name(fun, o);
+      generate_function_instantiation_template_parameters(
+        fun, is_rng, is_lp, is_log, rng_class, o); 
+        
+      o << "(";
+      for (size_t arg_i = 0; arg_i < fun.arg_decls_.size(); ++arg_i) {
+        o << fun.arg_decls_[arg_i].name_;
+        if (arg_i + 1 < fun.arg_decls_.size()) {
+          o << ", ";
+        }
+      }
+      if ((is_rng || is_lp) && fun.arg_decls_.size() > 0)
+        o << ", ";
+      if (is_rng)
+        o << "base_rng__";
+      else if (is_lp)
+          o << "lp__, lp_accum__";
+      if (is_rng || is_lp || fun.arg_decls_.size() > 0)
+        o << ", ";
+      o << "pstream__";
+      
+      o << ");" << EOL;
+      o << "}" << EOL;
+    }
+  }
+}
+
+
+#endif

--- a/src/stan/lang/generator/generate_function_instantiation_body.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation_body.hpp
@@ -24,6 +24,8 @@ namespace stan {
      * @param[in] is_lp true if function accesses log density
      * accumulator
      * @param[in] is_log true if function is log probability function
+     * @param[in] rng_class class of the RNG being used (required by xxx_rng 
+     * functions)
      * @param[in,out] o stream for generating
      */
     void generate_function_instantiation_body(const function_decl_def& fun,

--- a/src/stan/lang/generator/generate_function_instantiation_name.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation_name.hpp
@@ -19,7 +19,7 @@ namespace stan {
      */
     void generate_function_instantiation_name(const function_decl_def& fun,
                            std::ostream& out) {
-      out << fun.name_ << "__double_only";
+      out << fun.name_;
     }
 
   }

--- a/src/stan/lang/generator/generate_function_instantiation_name.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation_name.hpp
@@ -19,7 +19,7 @@ namespace stan {
      */
     void generate_function_instantiation_name(const function_decl_def& fun,
                            std::ostream& out) {
-      out << fun.name_ << "__double_only"; 
+      out << fun.name_ << "__double_only";
     }
 
   }

--- a/src/stan/lang/generator/generate_function_instantiation_name.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation_name.hpp
@@ -1,0 +1,27 @@
+#ifndef STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_NAME_HPP
+#define STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_NAME_HPP
+
+#include <stan/lang/ast.hpp>
+#include <stan/lang/generator/constants.hpp>
+#include <ostream>
+#include <string>
+
+namespace stan {
+  namespace lang {
+
+    /**
+     * Generate a name for a non-variable (double only) instantiation of
+     * specified function
+
+     * @param[in] fun function AST object
+     * @param[in, out] out output stream to which function definition
+     * is written
+     */
+    void generate_function_instantiation_name(const function_decl_def& fun,
+                           std::ostream& out) {
+      out << fun.name_ << "__double_only"; 
+    }
+
+  }
+}
+#endif

--- a/src/stan/lang/generator/generate_function_instantiation_template_parameters.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation_template_parameters.hpp
@@ -1,9 +1,13 @@
-#ifndef STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_TEMPLATE_PARAMETERS_HPP
-#define STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_TEMPLATE_PARAMETERS_HPP
+#ifndef \
+STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_TEMPLATE_PARAMETERS_HPP
+#define \
+STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_TEMPLATE_PARAMETERS_HPP
 
 #include <stan/lang/ast.hpp>
 #include <stan/lang/generator/constants.hpp>
 #include <ostream>
+#include <string>
+#include <vector>
 
 namespace stan {
   namespace lang {
@@ -21,14 +25,14 @@ namespace stan {
     void generate_function_instantiation_template_parameters(
                                               const function_decl_def& fun,
                                               bool is_rng, bool is_lp,
-                                              bool is_log, 
+                                              bool is_log,
                                               const std::string& rng_type,
                                               std::ostream& out) {
       std::vector<std::string> type_params;
       type_params.reserve(fun.arg_decls_.size());
 
       if (is_log) {
-        std::string propto_value = "false"; 
+        std::string propto_value = "false";
         type_params.push_back(propto_value);
       }
 
@@ -46,11 +50,10 @@ namespace stan {
         type_params.push_back("stan::math::accumulator<double> ");
       }
 
-
       if (!type_params.empty()) {
         out << "<";
         for (size_t param_i = 0; param_i < type_params.size(); ++param_i) {
-          if(param_i > 0) 
+          if (param_i > 0)
             out << ", ";
           out << type_params[param_i];
         }

--- a/src/stan/lang/generator/generate_function_instantiation_template_parameters.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation_template_parameters.hpp
@@ -1,0 +1,63 @@
+#ifndef STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_TEMPLATE_PARAMETERS_HPP
+#define STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATION_TEMPLATE_PARAMETERS_HPP
+
+#include <stan/lang/ast.hpp>
+#include <stan/lang/generator/constants.hpp>
+#include <ostream>
+
+namespace stan {
+  namespace lang {
+
+    /**
+     * Generate the concrete template parameters for function instantiation.
+     *
+     * @param[in] fun function declaration
+     * @param[in] is_rng true if function is a random number generator
+     * @param[in] is_lp true if function accesses log density
+     * accumulator
+     * @param[in] is_log true if function is a probability function
+     * @param[in] out stream for generating
+     */
+    void generate_function_instantiation_template_parameters(
+                                              const function_decl_def& fun,
+                                              bool is_rng, bool is_lp,
+                                              bool is_log, 
+                                              const std::string& rng_type,
+                                              std::ostream& out) {
+      std::vector<std::string> type_params;
+      type_params.reserve(fun.arg_decls_.size());
+
+      if (is_log) {
+        std::string propto_value = "false"; 
+        type_params.push_back(propto_value);
+      }
+
+      for (size_t i = 0; i < fun.arg_decls_.size(); ++i) {
+        // no template parameter for int-based args
+        if (fun.arg_decls_[i].arg_type_.base_type_ != INT_T) {
+          type_params.push_back("double");
+        }
+      }
+      if (is_rng) {
+        type_params.push_back(rng_type);
+      } else if (is_lp) {
+        type_params.push_back("double");
+        // the trailing space after '>' is necessary to compile
+        type_params.push_back("stan::math::accumulator<double> ");
+      }
+
+
+      if (!type_params.empty()) {
+        out << "<";
+        for (size_t param_i = 0; param_i < type_params.size(); ++param_i) {
+          if(param_i > 0) 
+            out << ", ";
+          out << type_params[param_i];
+        }
+        out << ">";
+      }
+    }
+
+  }
+}
+#endif

--- a/src/stan/lang/generator/generate_function_instantiation_template_parameters.hpp
+++ b/src/stan/lang/generator/generate_function_instantiation_template_parameters.hpp
@@ -20,13 +20,15 @@ namespace stan {
      * @param[in] is_lp true if function accesses log density
      * accumulator
      * @param[in] is_log true if function is a probability function
+     * @param[in] rng_class class of the RNG being used (required by xxx_rng 
+     * functions)
      * @param[in] out stream for generating
      */
     void generate_function_instantiation_template_parameters(
                                               const function_decl_def& fun,
                                               bool is_rng, bool is_lp,
                                               bool is_log,
-                                              const std::string& rng_type,
+                                              const std::string& rng_class,
                                               std::ostream& out) {
       std::vector<std::string> type_params;
       type_params.reserve(fun.arg_decls_.size());
@@ -43,7 +45,7 @@ namespace stan {
         }
       }
       if (is_rng) {
-        type_params.push_back(rng_type);
+        type_params.push_back(rng_class);
       } else if (is_lp) {
         type_params.push_back("double");
         // the trailing space after '>' is necessary to compile

--- a/src/stan/lang/generator/generate_function_instantiations.hpp
+++ b/src/stan/lang/generator/generate_function_instantiations.hpp
@@ -1,0 +1,29 @@
+#ifndef STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATONS_HPP
+#define STAN_LANG_GENERATOR_GENERATE_FUNCTION_INSTANTIATONS_HPP
+
+#include <stan/lang/ast.hpp>
+#include <stan/lang/generator/generate_function_instantiation.hpp>
+#include <ostream>
+#include <vector>
+
+namespace stan {
+  namespace lang {
+
+    /**
+     * Generate instantiations of templated functions with non-variable 
+     * parametersfor standalone generation of functions.
+     *
+     * @param[in] funs sequence of function declarations and
+     * definitions
+     * @param[in,out] o stream for generating
+     */
+    void generate_function_instantiations(
+           const std::vector<function_decl_def>& funs, std::ostream& o) {
+      for (size_t i = 0; i < funs.size(); ++i) {
+        generate_function_instantiation(funs[i], o);
+      }
+    }
+
+  }
+}
+#endif

--- a/src/stan/lang/generator/generate_functions.hpp
+++ b/src/stan/lang/generator/generate_functions.hpp
@@ -18,11 +18,13 @@ namespace stan {
      * @param[in] funs sequence of function declarations and
      * definitions
      * @param[in,out] o stream for generating
+     * @param[in] rcpp_export if true, comments to enable export for RCpp
+     * are generated
      */
     void generate_functions(const std::vector<function_decl_def>& funs,
-                            std::ostream& o) {
+                            std::ostream& o, bool rcpp_export = false) {
       for (size_t i = 0; i < funs.size(); ++i) {
-        generate_function(funs[i], o);
+        generate_function(funs[i], o, rcpp_export);
         generate_function_functor(funs[i], o);
       }
     }

--- a/src/stan/lang/generator/generate_rng_rcpp_helper.hpp
+++ b/src/stan/lang/generator/generate_rng_rcpp_helper.hpp
@@ -17,7 +17,7 @@ namespace stan {
     void generate_rng_rcpp_helper(std::ostream& o) {
       o << "// [[Rcpp::export]]" << EOL;
       o << "boost::ecuyer1988 __create_rng(int seed) {" << EOL;
-      o << "\treturn(boost::ecuyer1988(seed));" << EOL;
+      o << "  return(boost::ecuyer1988(seed));" << EOL;
       o << "}" << EOL << EOL;
     }
 

--- a/src/stan/lang/generator/generate_rng_rcpp_helper.hpp
+++ b/src/stan/lang/generator/generate_rng_rcpp_helper.hpp
@@ -1,8 +1,8 @@
 #ifndef STAN_LANG_GENERATOR_GENERATE_RNG_RCPP_HELPER_HPP
 #define STAN_LANG_GENERATOR_GENERATE_RNG_RCPP_HELPER_HPP
 
-#include <ostream>
 #include <stan/lang/generator/constants.hpp>
+#include <ostream>
 
 namespace stan {
   namespace lang {
@@ -16,7 +16,7 @@ namespace stan {
      */
     void generate_rng_rcpp_helper(std::ostream& o) {
       o << "// [[Rcpp::export]]" << EOL;
-      o << "boost::ecuyer1988 __create_rng(int seed) {" << EOL; 
+      o << "boost::ecuyer1988 __create_rng(int seed) {" << EOL;
       o << "\treturn(boost::ecuyer1988(seed));" << EOL;
       o << "}" << EOL << EOL;
     }

--- a/src/stan/lang/generator/generate_rng_rcpp_helper.hpp
+++ b/src/stan/lang/generator/generate_rng_rcpp_helper.hpp
@@ -1,0 +1,26 @@
+#ifndef STAN_LANG_GENERATOR_GENERATE_RNG_RCPP_HELPER_HPP
+#define STAN_LANG_GENERATOR_GENERATE_RNG_RCPP_HELPER_HPP
+
+#include <ostream>
+#include <stan/lang/generator/constants.hpp>
+
+namespace stan {
+  namespace lang {
+
+   /**
+     * Generate a helper function to export RNG instances to RCpp.
+     * This should match the default RNG chosen in 
+     * generate_function_instantiation()
+     *
+     * @param[in] o output stream
+     */
+    void generate_rng_rcpp_helper(std::ostream& o) {
+      o << "// [[Rcpp::export]]" << EOL;
+      o << "boost::ecuyer1988 __create_rng(int seed) {" << EOL; 
+      o << "\treturn(boost::ecuyer1988(seed));" << EOL;
+      o << "}" << EOL << EOL;
+    }
+
+  }
+}
+#endif

--- a/src/stan/lang/generator/generate_standalone_functions.hpp
+++ b/src/stan/lang/generator/generate_standalone_functions.hpp
@@ -46,7 +46,7 @@ namespace stan {
 
       generate_usings_standalone_functions(o);
 
-      generate_rng_rcpp_helper(o);      
+      generate_rng_rcpp_helper(o);
 
       generate_typedefs(o);
       generate_functions(prog.function_decl_defs_, o, true /*rcpp_export*/);

--- a/src/stan/lang/generator/generate_standalone_functions.hpp
+++ b/src/stan/lang/generator/generate_standalone_functions.hpp
@@ -1,0 +1,59 @@
+#ifndef STAN_LANG_GENERATOR_GENERATE_STANDALONE_FUNCTIONS_HPP
+#define STAN_LANG_GENERATOR_GENERATE_STANDALONE_FUNCTIONS_HPP
+
+#include <stan/lang/ast.hpp>
+#include <stan/lang/generator/generate_functions.hpp>
+#include <stan/lang/generator/generate_globals.hpp>
+#include <stan/lang/generator/generate_includes.hpp>
+#include <stan/lang/generator/generate_typedefs.hpp>
+#include <stan/lang/generator/generate_usings.hpp>
+#include <stan/lang/generator/generate_version_comment.hpp>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace stan {
+  namespace lang {
+
+    /**
+     * Generae the C++ code for standalone functions, generating it
+     * in the namespace provided,
+     * writing to the specified stream.
+     *
+     * @param[in] prog program from which to generate
+     * @param[in] namespaces namespace to generate the functions in
+     * @param[in,out] o stream for generating
+     */
+    void generate_standalone_functions(
+           const program& prog, 
+           const std::vector<std::string>& namespaces,
+           std::ostream& o) {
+      generate_version_comment(o);
+      
+      //TODO(martincerny) try to reduce the includes that are necessary
+      generate_includes(o);
+
+      //generate namespace starts
+      for(size_t namespace_i = 0; 
+          namespace_i < namespaces.size(); ++namespace_i) {
+        o << "namespace " << namespaces[namespace_i] << " { ";
+      }
+      o << std::endl;
+
+      generate_usings(o);
+      generate_typedefs(o);
+      generate_globals(o);
+      generate_functions(prog.function_decl_defs_, o);
+
+      //generate namespace ends
+      for(size_t namespace_i = 0; 
+          namespace_i < namespaces.size(); ++namespace_i) {
+        o << " } ";
+      }
+      o << std::endl;
+      
+    }
+
+  }
+}
+#endif

--- a/src/stan/lang/generator/generate_standalone_functions.hpp
+++ b/src/stan/lang/generator/generate_standalone_functions.hpp
@@ -25,16 +25,16 @@ namespace stan {
      * @param[in,out] o stream for generating
      */
     void generate_standalone_functions(
-           const program& prog, 
+           const program& prog,
            const std::vector<std::string>& namespaces,
            std::ostream& o) {
       generate_version_comment(o);
-      
-      //TODO(martincerny) try to reduce the includes that are necessary
+
+      // TODO(martincerny) try to reduce the includes that are necessary
       generate_includes(o);
 
-      //generate namespace starts
-      for(size_t namespace_i = 0; 
+      // generate namespace starts
+      for (size_t namespace_i = 0;
           namespace_i < namespaces.size(); ++namespace_i) {
         o << "namespace " << namespaces[namespace_i] << " { ";
       }
@@ -45,13 +45,12 @@ namespace stan {
       generate_globals(o);
       generate_functions(prog.function_decl_defs_, o);
 
-      //generate namespace ends
-      for(size_t namespace_i = 0; 
+      // generate namespace ends
+      for (size_t namespace_i = 0;
           namespace_i < namespaces.size(); ++namespace_i) {
         o << " } ";
       }
       o << std::endl;
-      
     }
 
   }

--- a/src/stan/lang/generator/generate_standalone_functions.hpp
+++ b/src/stan/lang/generator/generate_standalone_functions.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/lang/ast.hpp>
 #include <stan/lang/generator/generate_functions.hpp>
+#include <stan/lang/generator/generate_function_instantiations.hpp>
 #include <stan/lang/generator/generate_includes.hpp>
 #include <stan/lang/generator/generate_typedefs.hpp>
 #include <stan/lang/generator/generate_usings_standalone_functions.hpp>
@@ -44,6 +45,7 @@ namespace stan {
 
       generate_typedefs(o);
       generate_functions(prog.function_decl_defs_, o);
+      generate_function_instantiations(prog.function_decl_defs_, o);
 
       // generate namespace ends
       for (size_t namespace_i = 0;

--- a/src/stan/lang/generator/generate_standalone_functions.hpp
+++ b/src/stan/lang/generator/generate_standalone_functions.hpp
@@ -8,6 +8,7 @@
 #include <stan/lang/generator/generate_typedefs.hpp>
 #include <stan/lang/generator/generate_usings_standalone_functions.hpp>
 #include <stan/lang/generator/generate_version_comment.hpp>
+#include <stan/lang/generator/generate_rng_rcpp_helper.hpp>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -30,6 +31,8 @@ namespace stan {
            std::ostream& o) {
       generate_version_comment(o);
 
+      o << "// [[Rcpp::depends(rstan)]]" << EOL;
+
       // TODO(martincerny) try to reduce the includes that are necessary
       generate_include("stan/model/standalone_functions_header.hpp", o);
       o << EOL;
@@ -43,8 +46,10 @@ namespace stan {
 
       generate_usings_standalone_functions(o);
 
+      generate_rng_rcpp_helper(o);      
+
       generate_typedefs(o);
-      generate_functions(prog.function_decl_defs_, o);
+      generate_functions(prog.function_decl_defs_, o, true /*rcpp_export*/);
       generate_function_instantiations(prog.function_decl_defs_, o);
 
       // generate namespace ends

--- a/src/stan/lang/generator/generate_standalone_functions.hpp
+++ b/src/stan/lang/generator/generate_standalone_functions.hpp
@@ -3,10 +3,9 @@
 
 #include <stan/lang/ast.hpp>
 #include <stan/lang/generator/generate_functions.hpp>
-#include <stan/lang/generator/generate_globals.hpp>
 #include <stan/lang/generator/generate_includes.hpp>
 #include <stan/lang/generator/generate_typedefs.hpp>
-#include <stan/lang/generator/generate_usings.hpp>
+#include <stan/lang/generator/generate_usings_standalone_functions.hpp>
 #include <stan/lang/generator/generate_version_comment.hpp>
 #include <ostream>
 #include <string>
@@ -31,18 +30,19 @@ namespace stan {
       generate_version_comment(o);
 
       // TODO(martincerny) try to reduce the includes that are necessary
-      generate_includes(o);
+      generate_include("stan/model/standalone_functions_header.hpp", o);
+      o << EOL;
 
       // generate namespace starts
       for (size_t namespace_i = 0;
           namespace_i < namespaces.size(); ++namespace_i) {
         o << "namespace " << namespaces[namespace_i] << " { ";
       }
-      o << std::endl;
+      o << EOL;
 
-      generate_usings(o);
+      generate_usings_standalone_functions(o);
+
       generate_typedefs(o);
-      generate_globals(o);
       generate_functions(prog.function_decl_defs_, o);
 
       // generate namespace ends
@@ -50,7 +50,7 @@ namespace stan {
           namespace_i < namespaces.size(); ++namespace_i) {
         o << " } ";
       }
-      o << std::endl;
+      o << EOL;
     }
 
   }

--- a/src/stan/lang/generator/generate_usings_standalone_functions.hpp
+++ b/src/stan/lang/generator/generate_usings_standalone_functions.hpp
@@ -1,0 +1,30 @@
+#ifndef STAN_LANG_GENERATOR_GENERATE_USINGS_STANDALONE_FUNCTIONS_HPP
+#define STAN_LANG_GENERATOR_GENERATE_USINGS_STANDALONE_FUNCTIONS_HPP
+
+#include <stan/lang/ast.hpp>
+#include <stan/lang/generator/constants.hpp>
+#include <stan/lang/generator/generate_using.hpp>
+#include <stan/lang/generator/generate_using_namespace.hpp>
+#include <ostream>
+
+namespace stan {
+  namespace lang {
+
+    /**
+     * Generate the using statements for a Stan standalone functions file.
+     *
+     * @param[in,out] o stream for generating
+     */
+    void generate_usings_standalone_functions(std::ostream& o) {
+      generate_using("std::istream", o);
+      generate_using("std::string", o);
+      generate_using("std::stringstream", o);
+      generate_using("std::vector", o);
+      generate_using("stan::math::lgamma", o);
+      generate_using_namespace("stan::math", o);
+      o << EOL;
+    }
+
+  }
+}
+#endif

--- a/src/stan/model/standalone_functions_header.hpp
+++ b/src/stan/model/standalone_functions_header.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/math.hpp>
 
-
+#include <boost/random/additive_combine.hpp>
 #include <stan/lang/rethrow_located.hpp>
 
 #include <cmath>

--- a/src/stan/model/standalone_functions_header.hpp
+++ b/src/stan/model/standalone_functions_header.hpp
@@ -1,0 +1,18 @@
+#ifndef STAN_MODEL_STANDALONE_FUNCTIONS_HEADER_HPP
+#define STAN_MODEL_STANDALONE_FUNCTIONS_HEADER_HPP
+
+#include <stan/math.hpp>
+
+
+#include <stan/lang/rethrow_located.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#endif

--- a/src/test/test-models/README.txt
+++ b/src/test/test-models/README.txt
@@ -7,3 +7,5 @@ good: parsed and code generated without a main, *included* (not
 
 bad: not parsed; put ill-formed models here to test error messages.
 
+good-standalone-functions: same as good, but only for files to be 
+      compiled as standalone functions.

--- a/src/test/test-models/good-standalone-functions/basic.stanfuncs
+++ b/src/test/test-models/good-standalone-functions/basic.stanfuncs
@@ -1,0 +1,14 @@
+//Test compilation of a file that only has functions block
+functions {
+    real my_log1p_exp(real x) {
+        return log1p_exp(x);
+    }
+	
+  
+	vector my_vector_mul_by_5(vector x)
+	{
+		vector[num_elements(x)] result = x * 5.0;
+		return result;
+	}
+}
+

--- a/src/test/test-models/good-standalone-functions/integrate.stanfuncs
+++ b/src/test/test-models/good-standalone-functions/integrate.stanfuncs
@@ -1,0 +1,27 @@
+functions {
+
+  vector integrand(vector x) {
+    return exp(-square(x));
+  }
+
+  real[] integrand_ode(real r, real[] f, real[] theta, real[] x_r, int[] x_i) {
+    real df_dx[1];
+    real x = logit(r);
+    df_dx[1] = exp(-square(x)) * 1/(r * (1-r));
+    return(df_dx);
+  }
+
+  real ode_integrate() {
+    int x_i[0];
+    // ok:
+    //return(integrate_ode_rk45(integrand_ode, rep_array(0.0, 1),
+    //1E-5, rep_array(1.0-1E-5, 1), rep_array(0.0, 0), rep_array(0.0,
+    //0), x_i)[1,1]);
+    // not ok
+    return(integrate_ode_bdf(integrand_ode, rep_array(0.0, 1), 1E-5, rep_array(1.0-1E-5, 1), rep_array(0.0, 0), rep_array(0.0, 0), x_i)[1,1]);
+  }
+
+}
+data {
+}
+model {}

--- a/src/test/test-models/good-standalone-functions/special_functions.stanfuncs
+++ b/src/test/test-models/good-standalone-functions/special_functions.stanfuncs
@@ -1,0 +1,14 @@
+//Testing functions ending in _log, _lp and _rng
+functions {
+  void test_lp(real a) {
+    a ~ normal(0, 1);
+  }
+
+  real test_rng(real a) {
+    return normal_rng(a, 1);
+  }
+
+  real test_lpdf(real a, real b) {
+    return normal_lpdf(a | b, 1);
+  }  
+}

--- a/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
+++ b/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
@@ -16,7 +16,7 @@ void expect_no_errors(std::ostringstream& error_stream) {
 
 TEST(lang_parser, functions_standalone_instantiate_double_basic) {
   std::ostringstream error_stream;
-  EXPECT_EQ(basic_functions::my_log1p_exp__double_only(5, &error_stream), log1p_exp(5)) 
+  EXPECT_EQ(basic_functions::my_log1p_exp(5, &error_stream), log1p_exp(5)) 
     << "Problem instantiating a real -> real function from standalone compilation.";
   expect_no_errors(error_stream);
 
@@ -24,7 +24,7 @@ TEST(lang_parser, functions_standalone_instantiate_double_basic) {
   my_vec[0] = 0.1;
   my_vec[1] = 0.2;
   my_vec[2] = 15.786;
-  EXPECT_EQ(basic_functions::my_vector_mul_by_5__double_only(my_vec, &error_stream), 
+  EXPECT_EQ(basic_functions::my_vector_mul_by_5(my_vec, &error_stream), 
     multiply(my_vec,5.0))  
       << "Problem instantiating a vector -> vector function from standalone compilation.";
   expect_no_errors(error_stream);
@@ -36,13 +36,13 @@ TEST(lang_parser, functions_standalone_instantiate_double_special) {
   boost::ecuyer1988 rng;
   std::ostringstream error_stream;
 
-  special_functions_functions::test_lp__double_only(1.0, lp, lp_accum, &error_stream);
+  special_functions_functions::test_lp(1.0, lp, lp_accum, &error_stream);
   expect_no_errors(error_stream);
 
-  special_functions_functions::test_rng__double_only(1.1, rng, &error_stream);
+  special_functions_functions::test_rng(1.1, rng, &error_stream);
   expect_no_errors(error_stream);
 
-  special_functions_functions::test_lpdf__double_only(1.5, 6, &error_stream);
+  special_functions_functions::test_lpdf(1.5, 6, &error_stream);
   expect_no_errors(error_stream);
 }
 

--- a/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
+++ b/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+#include <sstream>
+#include <test/test-models/good-standalone-functions/basic.hpp>
+
+using namespace stan::math;
+
+void expect_no_errors(const std::ostringstream& error_stream) {
+  EXPECT_TRUE(error_stream.str().empty());  
+}
+
+TEST(lang_parser, functions_standalone_instantiate_double) {
+  std::ostringstream error_stream;
+  EXPECT_EQ(basic_functions::my_log1p_exp(5, &error_stream), log1p_exp(5)) 
+    << "Problem instantiating a real -> real function from standalone compilation.";
+  expect_no_errors(error_stream);
+
+  basic_functions::vector_d my_vec(3);
+  my_vec[0] = 0.1;
+  my_vec[1] = 0.2;
+  my_vec[2] = 15.786;
+  EXPECT_EQ(basic_functions::my_vector_mul_by_5(my_vec, &error_stream), 
+    multiply(my_vec,5.0))  
+      << "Problem instantiating a vector -> vector function from standalone compilation.";
+  expect_no_errors(error_stream);
+}
+

--- a/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
+++ b/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
@@ -1,16 +1,22 @@
 #include <gtest/gtest.h>
 #include <sstream>
 #include <test/test-models/good-standalone-functions/basic.hpp>
+#include <test/test-models/good-standalone-functions/special_functions.hpp>
 
 using namespace stan::math;
 
-void expect_no_errors(const std::ostringstream& error_stream) {
-  EXPECT_TRUE(error_stream.str().empty());  
+/**
+ * Tests that the error stream is empty and resets the error stream.
+ */
+void expect_no_errors(std::ostringstream& error_stream) {
+  EXPECT_TRUE(error_stream.str().empty()) << "Unexpected evaluation error: " << error_stream.str();  
+  error_stream.str("");
+  error_stream.clear();
 }
 
-TEST(lang_parser, functions_standalone_instantiate_double) {
+TEST(lang_parser, functions_standalone_instantiate_double_basic) {
   std::ostringstream error_stream;
-  EXPECT_EQ(basic_functions::my_log1p_exp(5, &error_stream), log1p_exp(5)) 
+  EXPECT_EQ(basic_functions::my_log1p_exp__double_only(5, &error_stream), log1p_exp(5)) 
     << "Problem instantiating a real -> real function from standalone compilation.";
   expect_no_errors(error_stream);
 
@@ -18,9 +24,25 @@ TEST(lang_parser, functions_standalone_instantiate_double) {
   my_vec[0] = 0.1;
   my_vec[1] = 0.2;
   my_vec[2] = 15.786;
-  EXPECT_EQ(basic_functions::my_vector_mul_by_5(my_vec, &error_stream), 
+  EXPECT_EQ(basic_functions::my_vector_mul_by_5__double_only(my_vec, &error_stream), 
     multiply(my_vec,5.0))  
       << "Problem instantiating a vector -> vector function from standalone compilation.";
+  expect_no_errors(error_stream);
+}
+
+TEST(lang_parser, functions_standalone_instantiate_double_special) {
+  double lp = 0.1;
+  stan::math::accumulator<double> lp_accum;
+  boost::ecuyer1988 rng;
+  std::ostringstream error_stream;
+
+  special_functions_functions::test_lp__double_only(1.0, lp, lp_accum, &error_stream);
+  expect_no_errors(error_stream);
+
+  special_functions_functions::test_rng__double_only(1.1, rng, &error_stream);
+  expect_no_errors(error_stream);
+
+  special_functions_functions::test_lpdf__double_only(1.5, 6, &error_stream);
   expect_no_errors(error_stream);
 }
 

--- a/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
+++ b/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <test/test-models/good-standalone-functions/basic.hpp>
 #include <test/test-models/good-standalone-functions/special_functions.hpp>
+#include <test/test-models/good-standalone-functions/integrate.hpp>
 
 using namespace stan::math;
 
@@ -43,6 +44,14 @@ TEST(lang_parser, functions_standalone_instantiate_double_special) {
   expect_no_errors(error_stream);
 
   special_functions_functions::test_lpdf(1.5, 6, &error_stream);
+  expect_no_errors(error_stream);
+}
+
+TEST(lang_parser, functions_standalone_instantiate_numerical_integration) {
+  std::ostringstream error_stream;
+
+  //I am not interested in the results, just that the functions run
+  integrate_functions::ode_integrate(&error_stream);
   expect_no_errors(error_stream);
 }
 

--- a/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
+++ b/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
@@ -34,7 +34,7 @@ TEST(lang_parser, functions_standalone_instantiate_double_basic) {
 TEST(lang_parser, functions_standalone_instantiate_double_special) {
   double lp = 0.1;
   stan::math::accumulator<double> lp_accum;
-  boost::ecuyer1988 rng;
+  boost::ecuyer1988 rng = special_functions_functions::__create_rng(123456);
   std::ostringstream error_stream;
 
   special_functions_functions::test_lp(1.0, lp, lp_accum, &error_stream);

--- a/src/test/unit/lang/parser/functions_standalone_test.cpp
+++ b/src/test/unit/lang/parser/functions_standalone_test.cpp
@@ -3,9 +3,12 @@
 
 TEST(lang_parser, functions_standalone_parsable) {
   test_parsable_standalone_functions("basic");
+  test_parsable_standalone_functions("special_functions");
 }
 
-// TODO(martincerny) check that the -namespace argument is used and enforced
-// correctly
+// TODO(martincerny) test forward function declarations
+
+// TODO(martincerny) check that the -namespace argument to stanc 
+// is used and enforced correctly
 
 

--- a/src/test/unit/lang/parser/functions_standalone_test.cpp
+++ b/src/test/unit/lang/parser/functions_standalone_test.cpp
@@ -2,9 +2,10 @@
 #include <test/unit/lang/utility.hpp>
 
 TEST(lang_parser, functions_standalone_parsable) {
-  //test_parsable("functions-standalone");
-
-  //TODO(martincerny) check that the -namespace argument is used and enforced
-  //correctly
+  test_parsable_standalone_functions("basic");
 }
+
+// TODO(martincerny) check that the -namespace argument is used and enforced
+// correctly
+
 

--- a/src/test/unit/lang/parser/functions_standalone_test.cpp
+++ b/src/test/unit/lang/parser/functions_standalone_test.cpp
@@ -2,7 +2,7 @@
 #include <test/unit/lang/utility.hpp>
 
 TEST(lang_parser, functions_standalone_parsable) {
-  test_parsable("functions-standalone");
+  //test_parsable("functions-standalone");
 
   //TODO(martincerny) check that the -namespace argument is used and enforced
   //correctly

--- a/src/test/unit/lang/parser/functions_standalone_test.cpp
+++ b/src/test/unit/lang/parser/functions_standalone_test.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+#include <test/unit/lang/utility.hpp>
+
+TEST(lang_parser, functions_standalone_parsable) {
+  test_parsable("functions-standalone");
+
+  //TODO(martincerny) check that the -namespace argument is used and enforced
+  //correctly
+}
+

--- a/src/test/unit/lang/parser_generator_test.cpp
+++ b/src/test/unit/lang/parser_generator_test.cpp
@@ -55,7 +55,7 @@ void test_pg_count(const std::string& program_name,
 
 TEST(unitLang, simpleTest) {
   test_pg("user-function-struct-const", 
-          "operator()(const T0__& x, std::ostream* pstream__ = 0) const {");
+          "operator()(const T0__& x, std::ostream* pstream__) const {");
 }     
              
 TEST(unitLang, odeTest) {

--- a/src/test/unit/lang/parser_generator_test.cpp
+++ b/src/test/unit/lang/parser_generator_test.cpp
@@ -55,7 +55,7 @@ void test_pg_count(const std::string& program_name,
 
 TEST(unitLang, simpleTest) {
   test_pg("user-function-struct-const", 
-          "operator()(const T0__& x, std::ostream* pstream__) const {");
+          "operator()(const T0__& x, std::ostream* pstream__ = 0) const {");
 }     
              
 TEST(unitLang, odeTest) {

--- a/src/test/unit/lang/utility.hpp
+++ b/src/test/unit/lang/utility.hpp
@@ -54,6 +54,9 @@ bool is_parsable(const std::string& file_name,
                  bool allow_undefined = false) {
   stan::lang::program prog;
   std::ifstream fs(file_name.c_str());
+  if (!fs.good()) {
+    throw std::invalid_argument("Could not read model file: " + file_name);
+  }
   std::string model_name = file_name_to_model_name(file_name);
   bool parsable
     = stan::lang::parse(msgs, fs, model_name, prog, allow_undefined);
@@ -69,12 +72,13 @@ bool is_parsable(const std::string& file_name,
  */
 bool is_parsable_folder(const std::string& model_name,
                         const std::string folder = "good",
-                        std::ostream* msgs = 0) {
+                        std::ostream* msgs = 0,
+                        const std::string extension = ".stan") {
   std::string path("src/test/test-models/");
   path += folder;
   path += "/";
   path += model_name;
-  path += ".stan";
+  path += extension;
   return is_parsable(path, msgs, false);
 }
 
@@ -87,6 +91,19 @@ void test_parsable(const std::string& model_name) {
   {
     SCOPED_TRACE("parsing: " + model_name);
     EXPECT_TRUE(is_parsable_folder(model_name, "good"));
+  }
+}
+
+/** test that file with standalone functions with specified name in folder 
+ * "good-standalone-functions" parses without throwing an exception
+ *
+ * @param model_name Name of model to parse
+ */
+void test_parsable_standalone_functions(const std::string& model_name) {
+  {
+    SCOPED_TRACE("parsing standalone functions: " + model_name);
+    EXPECT_TRUE(is_parsable_folder(model_name, "good-standalone-functions", 
+                  0, ".stanfuncs"));
   }
 }
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Add support for standalone function compilation. See #2267. 

There are a lot of outstanding questions about whether this is the right way to implement it. I am copying those from #2267, as they seem to got lost there:

1) The decision to choose mode of compilation (functions only / model) by file extension and the choice of the ```.stanfuncs``` extension are both important and should be discussed by the core team (there could be a need for more compilation modes in the future, especially with regards to #2224).
    - My reasoning behind this decision was: 
      - The mode of compilation should be deducible from the file to be compiled alone and should not require the user to check some external configuration/build/... file. This is good for both reading code and editor support.
       - Deciding what to do with a file based on its extension is a common practice, in particular it is what gcc does.
2) I did some changes/refactoring to some very core files and to the test infrastructure to avoid duplicating code, but I felt very uncomfortable making the changes without supervision from someone who understands the project better.
3) Test functions files now reside in ```test/test-models/good-standalone-functions``` - is this a reasonable place in the tree? (an obvious alternative would be ```test/test-standalone-functions/good```)
    - Note that I cannot put ```.stanfuncs``` files simply in  ```test/test-models/good``` because it is then impossible to distinguish the resulting ```.hpp``` files from each other (and I don't think ```.stanfuncs``` should produce something like ```.hpp-funcs```)
4) I had trouble with the 80 char limit, I don't like some of the indents / line breaks it forced me to do, but I couldn't find a better way - could you please check that the code reads nice and is aligned with what others write? (e.g. the two-line ```for``` cycle in ```stanc_helper.hpp``` line 293).
5) When compiling standalone functions, it is definitely necessary to check whether other blocks are contained in the input file. I see two possible ways of doing this - what would you prefer?
    1) keep the default parser and check whether the members of ```stan::lang::program``` are all empty except ```function_decl_defs_``` (requires maintanence when new types of program blocks are introduced or when the ```program``` struct changes)
    2) create a specific parser variant that only recognizes the functions block (would require maintanance when the parser structure changes and a specific parser for other compilation modes would have to be created as well)
6) Should ```compile_functions()``` give a warning or error when other blocks are present?

#### Intended Effect
Add .stanfuncs as a possible source file extension that then results in compiling a file with instantiations of all templated functions.

#### How to Verify
.stanfuncs files are compiled as part of test build, also tests in ```src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp``` and ```src/test/unit/lang/parser/functions_standalone_test.cpp```

#### Side Effects
Touched a lot of core files, please verify it is OK.

#### Documentation
Is rudimentary and pending approval of the core design.

#### Reviewer Suggestions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
