### PR TITLE
missing semicolon in manual

### DIFF
--- a/src/docs/stan-reference/examples.tex
+++ b/src/docs/stan-reference/examples.tex
@@ -1557,7 +1557,7 @@ with the vectorized form:
   {
     vector[N] x_beta_jj;
     for (n in 1:N)
-      x_beta_jj[n] = x[n] * beta[jj[n]]
+      x_beta_jj[n] = x[n] * beta[jj[n]];
     y ~ normal(x_beta_jj, sigma);
   }
 \end{stancode}


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`

Not needed because this is just a doc change?

- [x] Declare copyright holder and open-source license: see below

#### Summary

Typo fix.

#### Intended Effect

Make example code from manual compile.

#### How to Verify

I was trying the example from the manual and editing the Stan file in RStudio which checks the syntax whenever I save. Here's before the edit.

```r
rstan:::rstudio_stanc("center-param.stan")
#> SYNTAX ERROR, MESSAGE(S) FROM PARSER:
#>   
#>   
#>   ERROR at line 33
#> 
#> 31:        for (n in 1:N)
#>   32:          x_beta_jj[n] = x[n] * beta[jj[n]]
#> 33:        y ~ normal(x_beta_jj, sigma);
#> ^
#>   34:      }
#> 
#> PARSER EXPECTED: ";"
#> Error in stanc(model_code = paste(program, collapse = "\n"), model_name = model_cppname,  : 
#>   failed to parse Stan model 'center-param' due to the above error.
```

Here's after.

```r
rstan:::rstudio_stanc("center-param.stan")
#> center-param.stan is syntactically correct.
```

#### Side Effects

#### Documentation

#### Reviewer Suggestions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Tristan Mahr

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
