### PR TITLE
resolve hessian() in mcmc and model, fixes #2321

### DIFF
--- a/src/stan/model/hessian.hpp
+++ b/src/stan/model/hessian.hpp
@@ -15,8 +15,9 @@ namespace stan {
                  Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_f,
                  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& hess_f,
                  std::ostream* msgs = 0) {
-      stan::math::hessian(model_functional<M>(model, msgs),
-                          x, f, grad_f, hess_f);
+      stan::math::hessian<model_functional<M> >(model_functional<M>(model,
+                                                                    msgs),
+                                                x, f, grad_f, hess_f);
     }
 
   }

--- a/src/stan/model/model_functional.hpp
+++ b/src/stan/model/model_functional.hpp
@@ -17,8 +17,10 @@ namespace stan {
         : model(m), o(out) {}
 
       template <typename T>
-      T operator()(Eigen::Matrix<T, Eigen::Dynamic, 1>& x) const {
-        return model.template log_prob<true, true, T>(x, o);
+      T operator()(const Eigen::Matrix<T, Eigen::Dynamic, 1>& x) const {
+        // log_prob() requires non-const but doesn't modify its argument
+        return model.template
+          log_prob<true, true, T>(const_cast<Eigen::Matrix<T, -1, 1>& >(x), o);
       }
     };
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Resolve `hessian()` to call O(N) reverse-mode version.


#### Intended Effect

It was previously calling the O(N^2) forward-mode version because of const conflict instantiating reverse mode.

#### How to Verify

Tests still pass.  The resolution is guaranteed because of the functor type as the template parameter, which is only available for the reverse-mode Hessian calculation.

#### Side Effects

It'll be faster.

#### Documentation

n/a

#### Reviewer Suggestions

@betanalpha @syclik 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
