### PR TITLE
replace 1/2 in example code with 0.5

### DIFF
--- a/src/docs/stan-reference/examples.tex
+++ b/src/docs/stan-reference/examples.tex
@@ -6986,7 +6986,7 @@ transformed data {
   for (i in 1:(N - 1)) {
     K[i,i] = 1 + 0.1;
     for (j in (i + 1):N) {
-      K[i, j] = exp(-1/2 * pow(x[i] - x[j], 2));
+      K[i, j] = exp(-0.5 * square(x[i] - x[j]));
       K[j, i] = K[i, j];
     }
   }
@@ -7398,14 +7398,12 @@ functions {
                             real delta) {
     int N = size(x);
     matrix[N, N] K;
-    real inv_half = -1/2;
     real sq_alpha = square(alpha);
     for (i in 1:(N - 1)) {
       K[i,i] = sq_alpha + delta;
       for (j in (i + 1):N) {
         K[i, j] = sq_alpha
-                      * exp(inv_half
-                            * dot_self((x[i] - x[j]) ./ rho));
+                      * exp(-0.5 * dot_self((x[i] - x[j]) ./ rho));
         K[j, i] = K[i, j];
       }
     }


### PR DESCRIPTION
1/2 get rounded due to integer division

#### Submisison Checklist
Changes only made to .tex file

- [NA] Run unit tests: `./runTests.py src/test/unit`
- [NA] Run cpplint: `make cpplint`
- [NA] Declare copyright holder and open-source license: see below

#### Summary
Fix bugs in example code in manual

#### Reviewer Suggestions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
