### PR TITLE
Bugfix/2344 undef bool member

### DIFF
--- a/src/stan/io/json/json_data_handler.hpp
+++ b/src/stan/io/json/json_data_handler.hpp
@@ -93,14 +93,14 @@ namespace stan {
        *
        * <b>Warning:</b> This method does not close the input stream.
        *
-       * @param vars_r - name-value map for real-valued variables
-       * @param vars_i - name-value map for int-valued variables
+       * @param vars_r name-value map for real-valued variables
+       * @param vars_i name-value map for int-valued variables
        */
-      json_data_handler(vars_map_r& vars_r, vars_map_i& vars_i) :
-        json_handler(), vars_r_(vars_r), vars_i_(vars_i),
-        key_(), values_r_(), values_i_(),
-        dims_(), dims_verify_(), dims_unknown_(),
-        dim_idx_(), dim_last_(), is_int_() {
+      json_data_handler(vars_map_r& vars_r, vars_map_i& vars_i)
+        : json_handler(), vars_r_(vars_r), vars_i_(vars_i),
+          key_(), values_r_(), values_i_(),
+          dims_(), dims_verify_(), dims_unknown_(),
+          dim_idx_(0), dim_last_(0), is_int_(true) {
       }
 
       void start_text() {

--- a/src/stan/lang/ast/node/conditional_op_def.hpp
+++ b/src/stan/lang/ast/node/conditional_op_def.hpp
@@ -6,7 +6,8 @@
 namespace stan {
   namespace lang {
 
-    conditional_op::conditional_op() { }
+    conditional_op::conditional_op()
+      : has_var_(false) { }
 
     conditional_op::conditional_op(const expression& cond,
                                    const expression& true_val,

--- a/src/stan/lang/ast/node/conditional_op_def.hpp
+++ b/src/stan/lang/ast/node/conditional_op_def.hpp
@@ -11,11 +11,10 @@ namespace stan {
     conditional_op::conditional_op(const expression& cond,
                                    const expression& true_val,
                                    const expression& false_val)
-      : cond_(cond),
-        true_val_(true_val),
-        false_val_(false_val),
+      : cond_(cond), true_val_(true_val), false_val_(false_val),
         type_(promote_primitive(true_val.expression_type(),
-                                false_val.expression_type())) {
+                                false_val.expression_type())),
+        has_var_(false), scope_() {
     }
 
   }

--- a/src/stan/lang/ast/node/matrix_expr_def.hpp
+++ b/src/stan/lang/ast/node/matrix_expr_def.hpp
@@ -7,8 +7,8 @@
 namespace stan {
   namespace lang {
 
-    matrix_expr::matrix_expr() : args_(), has_var_(false),
-                                 matrix_expr_scope_() { }
+    matrix_expr::matrix_expr()
+      : args_(), has_var_(false), matrix_expr_scope_() { }
 
     matrix_expr::matrix_expr(const std::vector<expression>& args)
       : args_(args), has_var_(false), matrix_expr_scope_() { }

--- a/src/stan/lang/ast/node/row_vector_expr_def.hpp
+++ b/src/stan/lang/ast/node/row_vector_expr_def.hpp
@@ -7,8 +7,8 @@
 namespace stan {
   namespace lang {
 
-    row_vector_expr::row_vector_expr() : args_(), has_var_(false),
-                                         row_vector_expr_scope_() { }
+    row_vector_expr::row_vector_expr()
+      : args_(), has_var_(false), row_vector_expr_scope_() { }
 
     row_vector_expr::row_vector_expr(const std::vector<expression>& args)
       : args_(args), has_var_(false), row_vector_expr_scope_() { }

--- a/src/stan/lang/ast/node/sample_def.hpp
+++ b/src/stan/lang/ast/node/sample_def.hpp
@@ -7,10 +7,10 @@ namespace stan {
   namespace lang {
 
 
-    sample::sample() { }
+    sample::sample() : is_discrete_(false) { }
 
     sample::sample(expression& e, distribution& dist)
-        : expr_(e), dist_(dist) { }
+      : expr_(e), dist_(dist), is_discrete_(false) { }
 
     bool sample::is_ill_formed() const {
         return expr_.expression_type().is_ill_formed()

--- a/src/stan/lang/ast/scope.hpp
+++ b/src/stan/lang/ast/scope.hpp
@@ -38,8 +38,7 @@ namespace stan {
        *
        * @param program_block enclosing program block
        */
-      scope(const
-                 origin_block& program_block);   // NOLINT(runtime/explicit)
+      scope(const origin_block& program_block);   // NOLINT(runtime/explicit)
 
       /**
        * Construct scope for a variable in specified outer program block,

--- a/src/stan/lang/ast/scope_def.hpp
+++ b/src/stan/lang/ast/scope_def.hpp
@@ -7,14 +7,13 @@
 namespace stan {
   namespace lang {
 
-    scope::scope()
-      : program_block_(model_name_origin), is_local_(false) { }
+    scope::scope() : program_block_(model_name_origin), is_local_(false) { }
 
     scope::scope(const origin_block& program_block)
       : program_block_(program_block), is_local_(false) { }
 
     scope::scope(const origin_block& program_block,
-                           const bool& is_local)
+                 const bool& is_local)
       : program_block_(program_block), is_local_(is_local) { }
 
 

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -24,10 +24,10 @@ namespace stan {
       base_nuts(const Model& model, BaseRNG& rng)
         : base_hmc<Model, Hamiltonian, Integrator, BaseRNG>(model, rng),
           depth_(0), max_depth_(5), max_deltaH_(1000),
-          n_leapfrog_(0), divergent_(0), energy_(0) {
+          n_leapfrog_(0), divergent_(false), energy_(0) {
       }
 
-      /** 
+      /**
        * specialized constructor for specified diag mass matrix
        */
       base_nuts(const Model& model, BaseRNG& rng,
@@ -35,10 +35,10 @@ namespace stan {
         : base_hmc<Model, Hamiltonian, Integrator, BaseRNG>(model, rng,
                                                             inv_e_metric),
           depth_(0), max_depth_(5), max_deltaH_(1000),
-          n_leapfrog_(0), divergent_(0), energy_(0) {
+          n_leapfrog_(0), divergent_(false), energy_(0) {
       }
 
-      /** 
+      /**
        * specialized constructor for specified dense mass matrix
        */
       base_nuts(const Model& model, BaseRNG& rng,
@@ -46,7 +46,7 @@ namespace stan {
         : base_hmc<Model, Hamiltonian, Integrator, BaseRNG>(model, rng,
                                                             inv_e_metric),
         depth_(0), max_depth_(5), max_deltaH_(1000),
-        n_leapfrog_(0), divergent_(0), energy_(0) {
+        n_leapfrog_(0), divergent_(false), energy_(0) {
       }
 
       ~base_nuts() {}

--- a/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
@@ -24,6 +24,9 @@ namespace stan {
       int n_tree;
       double sum_prob;
       bool criterion;
+
+      // just to guarantee bool initializes to valid value
+      nuts_util() : criterion(false) { }
     };
 
     // The No-U-Turn Sampler (NUTS) with the

--- a/src/test/unit/io/json/json_data_handler_test.cpp
+++ b/src/test/unit/io/json/json_data_handler_test.cpp
@@ -12,7 +12,7 @@ void test_rtl_2_ltr(size_t idx_rtl,
   stan::json::vars_map_r vars_r;
   stan::json::vars_map_i vars_i;
   stan::json::json_data_handler handler(vars_r, vars_i);
-  EXPECT_TRUE(handler.is_int_ == 0 || handler.is_int_ == 1);
+
   size_t idx = handler.convert_offset_rtl_2_ltr(idx_rtl,dims);
   EXPECT_EQ(idx, idx_ltr);
 }

--- a/src/test/unit/io/json/json_data_handler_test.cpp
+++ b/src/test/unit/io/json/json_data_handler_test.cpp
@@ -6,17 +6,18 @@
 #include <stan/io/json/json_handler.hpp>
 #include <stan/io/json/json_parser.hpp>
 
-void test_rtl_2_ltr(size_t idx_rtl, 
+void test_rtl_2_ltr(size_t idx_rtl,
                     size_t idx_ltr,
                     const std::vector<size_t>& dims) {
   stan::json::vars_map_r vars_r;
   stan::json::vars_map_i vars_i;
   stan::json::json_data_handler handler(vars_r, vars_i);
+  EXPECT_TRUE(handler.is_int_ == 0 || handler.is_int_ == 1);
   size_t idx = handler.convert_offset_rtl_2_ltr(idx_rtl,dims);
   EXPECT_EQ(idx, idx_ltr);
 }
 
-void test_exception(size_t idx_rtl, 
+void test_exception(size_t idx_rtl,
                     const std::string& exception_text,
                     const std::vector<size_t>& dims) {
   stan::json::vars_map_r vars_r;

--- a/src/test/unit/lang/ast_test.cpp
+++ b/src/test/unit/lang/ast_test.cpp
@@ -835,7 +835,44 @@ TEST(StanLangAstFun, is_nonempty) {
   EXPECT_TRUE(is_nonempty("  \r\n \n 1  \n"));
 }
 
+template <typename T>
+void expect_has_var_bool(const T& x) {
+  EXPECT_TRUE(x.has_var_ == 0 || x.has_var_ == 1);
+}
 
+
+TEST(StanLangAst, ConditionalOp) {
+  expect_has_var_bool(stan::lang::conditional_op());
+
+  stan::lang::expression e = int_literal(3);
+  expect_has_var_bool(stan::lang::conditional_op(e, e, e));
+}
+
+TEST(StanLangAst, RowVectorExpr) {
+  expect_has_var_bool(stan::lang::row_vector_expr());
+}
+
+TEST(StanLangAst, MatrixExpr) {
+  expect_has_var_bool(stan::lang::matrix_expr());
+}
+
+TEST(StanLangAst, Sample) {
+  stan::lang::sample s;
+  EXPECT_TRUE(s.is_discrete_ == true || s.is_discrete_ == false);
+
+  stan::lang::expression e = int_literal(3);
+  stan::lang::distribution d;
+  stan::lang::sample s2(e, d);
+  EXPECT_TRUE(s2.is_discrete_ == true || s2.is_discrete_ == false);
+}
+
+TEST(StanLangAst, Scope) {
+  stan::lang::scope s;
+  EXPECT_TRUE(s.is_local() == true || s.is_local() == false);
+
+  stan::lang::scope s2(stan::lang::data_origin);
+  EXPECT_TRUE(s2.is_local() == true || s2.is_local() == false);
+}
 
 
 

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -110,6 +110,8 @@ TEST(McmcNutsBaseNuts, set_max_depth_test) {
   stan::mcmc::mock_model model(q.size());
   stan::mcmc::mock_nuts sampler(model, base_rng);
 
+  EXPECT_TRUE(sampler.divergent_ == true || sampler.divergent_ == false);
+
   int old_max_depth = 1;
   sampler.set_max_depth(old_max_depth);
   EXPECT_EQ(old_max_depth, sampler.get_max_depth());

--- a/src/test/unit/mcmc/hmc/nuts_classic/base_nuts_classic_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts_classic/base_nuts_classic_test.cpp
@@ -95,6 +95,8 @@ TEST(McmcNutsBaseNutsClassic, set_max_depth) {
   stan::mcmc::mock_model model(q.size());
   stan::mcmc::mock_nuts_classic sampler(model, base_rng);
 
+  EXPECT_TRUE(sampler.divergent_ == true || sampler.divergent_ == false);
+
   int old_max_depth = 1;
   sampler.set_max_depth(old_max_depth);
   EXPECT_EQ(old_max_depth, sampler.get_max_depth());


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Make sure all `bool` member variables will be instantiated as `true` or `false`.

#### Intended Effect

Stop picky compilers from griping.

#### How to Verify

Behavior's not changing here as the were never intended to be used uninstantiated.  The members that are now being configured are private and not accessible through the API.

#### Side Effects

No.

#### Tests

Unit tests for accessible `bool` values.

#### Documentation

n/a

#### Reviewer Suggestions

anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
