### PR TITLE
Bugfix/2346 standalone functions for rstan

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -284,6 +284,12 @@ src/test/unit/variational/eta_adapt_small_test.cpp:src/test/test-models/good/var
 ##
 test/integration/compile_models$(EXE) : $(patsubst %.stan,%.hpp-test,$(shell find src/test/test-models/good -type f -name '*.stan'))
 
+## 
+# Same trick as above for models, but for standalone functions, using 
+# "src/test/test-models/good-standalone-functions/*.stanfuncs"
+##
+test/integration/compile_standalone_functions$(EXE) : $(patsubst %.stanfuncs,%.hpp-test,$(shell find src/test/test-models/good-standalone-functions -type f -name '*.stanfuncs'))
+
 
 test_name = $(shell echo $(1) | sed 's,_[0-9]\{5\},_test.hpp,g')
 

--- a/src/stan/lang/generator/generate_function.hpp
+++ b/src/stan/lang/generator/generate_function.hpp
@@ -37,7 +37,7 @@ namespace stan {
         || ends_with("_lpdf", fun.name_) || ends_with("_lpmf", fun.name_);
       std::string scalar_t_name = fun_scalar_type(fun, is_lp);
 
-      if (rcpp_export && has_only_int_args(fun) 
+      if (rcpp_export && has_only_int_args(fun)
         && !fun.body_.is_no_op_statement())
           out << "// [[Rcpp::export]]" << EOL;
 

--- a/src/stan/lang/generator/generate_function.hpp
+++ b/src/stan/lang/generator/generate_function.hpp
@@ -27,7 +27,7 @@ namespace stan {
      * @param[in, out] out output stream to which function definition
      * is written
      * @param[in] rcpp_export if true, comments to enable export for RCpp
-     * are generated
+     * are generated (for non-templated functions only)
      */
     void generate_function(const function_decl_def& fun,
                            std::ostream& out, bool rcpp_export = false) {
@@ -37,8 +37,9 @@ namespace stan {
         || ends_with("_lpdf", fun.name_) || ends_with("_lpmf", fun.name_);
       std::string scalar_t_name = fun_scalar_type(fun, is_lp);
 
-      if (rcpp_export)
-        out << "// [[Rcpp::export]]" << EOL;
+      if (rcpp_export && has_only_int_args(fun) 
+        && !fun.body_.is_no_op_statement())
+          out << "// [[Rcpp::export]]" << EOL;
 
       generate_function_template_parameters(fun, is_rng, is_lp, is_pf, out);
       generate_function_inline_return_type(fun, scalar_t_name, 0, out);

--- a/src/stan/lang/generator/generate_functions.hpp
+++ b/src/stan/lang/generator/generate_functions.hpp
@@ -19,7 +19,7 @@ namespace stan {
      * definitions
      * @param[in,out] o stream for generating
      * @param[in] rcpp_export if true, comments to enable export for RCpp
-     * are generated
+     * are generated (for non-templated functions only)
      */
     void generate_functions(const std::vector<function_decl_def>& funs,
                             std::ostream& o, bool rcpp_export = false) {

--- a/src/stan/lang/generator/generate_usings_standalone_functions.hpp
+++ b/src/stan/lang/generator/generate_usings_standalone_functions.hpp
@@ -20,7 +20,6 @@ namespace stan {
       generate_using("std::string", o);
       generate_using("std::stringstream", o);
       generate_using("std::vector", o);
-      generate_using("stan::math::lgamma", o);
       generate_using_namespace("stan::math", o);
       o << EOL;
     }

--- a/src/test/integration/compile_standalone_functions_test.cpp
+++ b/src/test/integration/compile_standalone_functions_test.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+TEST(lang,compile_standalone_functions) {
+  SUCCEED() 
+    << "Standalone function compilation done through makefile dependencies." 
+    << std::endl
+    << "Should have compiled: "
+    << "src/test/test-models/good-standalone-functions/*.stanfuncs";
+}

--- a/src/test/test-models/good-standalone-functions/basic.stanfuncs
+++ b/src/test/test-models/good-standalone-functions/basic.stanfuncs
@@ -10,5 +10,9 @@ functions {
 		vector[num_elements(x)] result = x * 5.0;
 		return result;
 	}
+
+	int int_only_multiplication(int a, int b) {
+		return a*b;
+	}
 }
 

--- a/src/test/test-models/good-standalone-functions/lgamma.stanfuncs
+++ b/src/test/test-models/good-standalone-functions/lgamma.stanfuncs
@@ -1,0 +1,7 @@
+//Test that lgamma works once we removed the using
+functions {
+    real test_lgamma(real x) {
+        return lgamma(x);
+    }
+}
+

--- a/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
+++ b/src/test/unit/lang/parser/functions_standalone_instantiate_test.cpp
@@ -29,6 +29,11 @@ TEST(lang_parser, functions_standalone_instantiate_double_basic) {
     multiply(my_vec,5.0))  
       << "Problem instantiating a vector -> vector function from standalone compilation.";
   expect_no_errors(error_stream);
+
+  EXPECT_EQ(basic_functions::int_only_multiplication(3, 8, &error_stream), 
+    3 * 8)  
+      << "Problem instantiating an int-only function from standalone compilation.";
+  expect_no_errors(error_stream);
 }
 
 TEST(lang_parser, functions_standalone_instantiate_double_special) {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
With respect to #2346 - fix problems in standalone function compilation that block integration with RStan.

#### Intended Effect
RCpp export only for non-templated functions, removed using of lgamma.

#### How to Verify
Test with RStan :-) For the lgamma, a new test checking whether lgamma compiles in a standalone func has been added.

#### Side Effects
Hopefully none.

#### Documentation
N/A

#### Reviewer Suggestions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Martin Černý / Institute of Microbiology of the Czech Academy of Sciences

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
