### PR TITLE
add eol to program strings; fixes #2359

### DIFF
--- a/src/stan/lang/parser.hpp
+++ b/src/stan/lang/parser.hpp
@@ -42,7 +42,7 @@ namespace stan {
 
       std::ostringstream buf;
       buf << in.rdbuf();
-      std::string stan_string = buf.str();
+      std::string stan_string = buf.str() + "\n";
       if (!is_nonempty(stan_string))
         *out << std::endl << "WARNING: empty program" << std::endl;
 

--- a/src/test/test-models/bad/oneline-error.stan
+++ b/src/test/test-models/bad/oneline-error.stan
@@ -1,0 +1,1 @@
+parameters { vector y[10]; } model { }

--- a/src/test/unit/lang/parser/error_messages_test.cpp
+++ b/src/test/unit/lang/parser/error_messages_test.cpp
@@ -2,25 +2,25 @@
 #include <test/unit/lang/utility.hpp>
 
 TEST(LangGrammars,test1) {
-  test_throws("err-open-block", 
+  test_throws("err-open-block",
               "PARSER EXPECTED: \"{");
-  test_throws("err-close-block", 
+  test_throws("err-close-block",
               "PARSER EXPECTED: \"}");
-  test_throws("err-transformed-params", 
+  test_throws("err-transformed-params",
               "PARSER EXPECTED: \"parameters");
-  test_throws("err-expected-model", 
+  test_throws("err-expected-model",
               "PARSER EXPECTED: whitespace to end of file");
-  test_throws("err-expected-generated", 
+  test_throws("err-expected-generated",
               "PARSER EXPECTED: \"quantities");
-  test_throws("err-expected-bracket", 
+  test_throws("err-expected-bracket",
               "PARSER EXPECTED: \"{");
-  test_throws("err-expected-end-of-model", 
+  test_throws("err-expected-end-of-model",
               "PARSER EXPECTED: whitespace to end of file");
-  test_throws("err-second-operand-plus", 
+  test_throws("err-second-operand-plus",
               "PARSER EXPECTED: <expression>");
-  test_throws("err-nested-parens", 
+  test_throws("err-nested-parens",
               "PARSER EXPECTED: <expression>");
-  test_throws("err-nested-parens-close", 
+  test_throws("err-nested-parens-close",
               "PARSER EXPECTED: \")");
   test_throws("err-integrate-ode-comma",
               "PARSER EXPECTED: \",");
@@ -51,7 +51,7 @@ TEST(LangGrammars,test1) {
               "variable \"lijaflj\" does not exist");
   test_throws("err-fun-bare-types-int",
               "comma to indicate more dimensions or ]");
-  test_throws("err-bare-type-close-square", 
+  test_throws("err-bare-type-close-square",
               "comma to indicate more dimensions or ] to end type declaration");
   test_throws("err-close-function-args",
               "PARSER EXPECTED: <argument declaration or close paren");
@@ -65,5 +65,7 @@ TEST(LangGrammars,test1) {
               "variable \"real\" does not exist");
   test_throws("err-double-dims",
               "dimension declaration requires expression denoting integer; found type=real");
+  test_throws("oneline-error",
+              "1: parameters { vector y[10]; } model { }");
 }
- 
+


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Automatically append a newline to every input program string.

#### Intended Effect

Aloow error messages from the final line of a program if there is no end-of-line (`\n`) at the end of the file.

#### How to Verify

Added a new unit test for a one-liner with no end-of-line at end of file.  It fails in existing develop, but passes with this patch.

#### Side Effects

No.

#### Documentation

n/a

#### Reviewer Suggestions

anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
