### PR TITLE
Fix typo in default filename for compile

### DIFF
--- a/src/stan/lang/compile_functions.hpp
+++ b/src/stan/lang/compile_functions.hpp
@@ -34,7 +34,7 @@ namespace stan {
                            std::ostream& cpp_out,
                            const std::vector<std::string>& namespaces,
                            const bool allow_undefined = false,
-                           const std::string& filename = "unkown file name",
+                           const std::string& filename = "unknown file name",
                            const std::vector<std::string>& include_paths
                            = std::vector<std::string>()) {
       io::program_reader reader(stan_funcs_in, filename, include_paths);

--- a/src/stan/lang/compiler.hpp
+++ b/src/stan/lang/compiler.hpp
@@ -34,7 +34,7 @@ namespace stan {
      */
     bool compile(std::ostream* msgs, std::istream& in, std::ostream& out,
                  const std::string& name, const bool allow_undefined = false,
-                 const std::string& filename = "unkown file name",
+                 const std::string& filename = "unknown file name",
                  const std::vector<std::string>& include_paths
                   = std::vector<std::string>()) {
       io::program_reader reader(in, filename, include_paths);


### PR DESCRIPTION
Fixes typo.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
