### PR TITLE
added stan::math:: qualifier to abs in generator

### DIFF
--- a/src/stan/lang/ast/node/fun_def.hpp
+++ b/src/stan/lang/ast/node/fun_def.hpp
@@ -11,7 +11,7 @@ namespace stan {
     fun::fun() { }
 
     fun::fun(const std::string& name, const std::vector<expression>& args)
-      : name_(name), args_(args) { }
+      : name_(name), original_name_(name), args_(args) { }
 
   }
 }

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -78,7 +78,7 @@ namespace stan {
           qualify(f);
       else if (f.args_.size() == 2
                && (f.name_ == "fdim" || f.name_ == "fmax" || f.name_ == "fmin"
-                   || f.name_ == "hypot" ))
+                   || f.name_ == "hypot"))
         qualify(f);
       else if (f.args_.size() == 3 && f.name_ == "fma")
         qualify(f);

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -39,7 +39,7 @@ namespace stan {
 
     /**
      * Add qualifier "stan::math::" to nullary functions defined in
-     * the Stan language and to unary <code>abs<code>.  Sets original
+     * the Stan language and to unary `abs`.  Sets original
      * name of specified function to name and add "stan::math::"
      * namespace qualifier to name.
      *

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -27,8 +27,8 @@ namespace stan {
   namespace lang {
 
     /**
-     * Set original name of specified function to name and add
-     * "stan::math::" namespace qualifier to name.
+     * Set `original_name_` of specified function to `name_` then
+     * adds `stan::math::` namespace qualifier to `name_`.
      *
      * @param[in, out] f Function to qualify.
      */
@@ -38,45 +38,48 @@ namespace stan {
     }
 
     /**
-     * Add qualifier "stan::math::" to nullary functions defined in
-     * the Stan language and to unary `abs`.  Sets original
-     * name of specified function to name and add "stan::math::"
-     * namespace qualifier to name.
+     * Add namespace qualifier `stan::math::` to function names in order to
+     * avoid ambiguities for nullary functions in the Stan language which
+     * are also defined in `cmath.h` via call to function `qualify`.
      *
      * @param[in, out] f Function to qualify.
      */
     void qualify_builtins(fun& f) {
-      if ((f.args_.size() == 1 && f.name_ == "abs")
-          || (f.args_.size() > 0
-              && (f.name_ == "e" || f.name_ == "pi"
-                  || f.name_ == "log2" || f.name_ == "log10"
-                  || f.name_ == "sqrt2" || f.name_ == "not_a_number"
-                  || f.name_ == "positive_infinity"
-                  || f.name_ == "negative_infinity"
-                  || f.name_ == "machine_precision")))
+      if (f.args_.size() == 0
+          && (f.name_ == "e" || f.name_ == "pi"
+              || f.name_ == "log2" || f.name_ == "log10"
+              || f.name_ == "sqrt2" || f.name_ == "not_a_number"
+              || f.name_ == "positive_infinity"
+              || f.name_ == "negative_infinity"
+              || f.name_ == "machine_precision"))
           qualify(f);
     }
 
     /**
-     * Add namespace qualifier stan::math:: to specify Stan versions
-     * of functions to avoid ambiguities with versions defined in
-     * math.h in the top-level namespace.  Sets original name of
-     * specified function to name and add <code>stan::math::</code>
-     * namespace qualifier to name.
+     * Add namespace qualifier `stan::math::` to function names in order to
+     * avoid ambiguities for unary functions which are also defined in `cmath.h`
+     * via call to function `qualify`.
      *
      * @param[in, out] f Function to qualify.
      */
     void qualify_cpp11_builtins(fun& f) {
       if (f.args_.size() == 1
-          && (f.name_ == "acosh"|| f.name_ == "asinh" || f.name_ == "atanh"
-              || f.name_ == "exp2" || f.name_ == "expm1" || f.name_ == "log1p"
-              || f.name_ == "log2" || f.name_ == "cbrt" || f.name_ == "erf"
-              || f.name_ == "erfc" || f.name_ == "tgamma" || f.name_ == "lgamma"
-              || f.name_ == "round" || f.name_ == "trunc"))
+          && (f.name_ == "abs" || f.name_ == "acos"|| f.name_ == "acosh"
+              || f.name_ == "asin"|| f.name_ == "asinh" || f.name_ == "atan"
+              || f.name_ == "atan2" || f.name_ == "atanh" || f.name_ == "cbrt"
+              || f.name_ == "ciel" || f.name_ == "cos"|| f.name_ == "cosh"
+              || f.name_ == "erf" || f.name_ == "erfc" || f.name_ == "exp"
+              || f.name_ == "exp2" || f.name_ == "expm1" || f.name_ == "fabs"
+              || f.name_ == "floor" || f.name_ == "lgamma" || f.name_ == "log"
+              || f.name_ == "log1p" || f.name_ == "log2" || f.name_ == "log10"
+              || f.name_ == "round" || f.name_ == "sin" || f.name_ == "sinh"
+              || f.name_ == "sqrt" || f.name_ == "tan" || f.name_ == "tanh"
+              || f.name_ == "tgamma" || f.name_ == "trunc"))
           qualify(f);
       else if (f.args_.size() == 2
                && (f.name_ == "fdim" || f.name_ == "fmax" || f.name_ == "fmin"
-                   || f.name_ == "hypot"))
+                   || f.name_ == "fmod" || f.name_ == "hypot" ||
+                   f.name_ == "pow"))
         qualify(f);
       else if (f.args_.size() == 3 && f.name_ == "fma")
         qualify(f);
@@ -1929,6 +1932,7 @@ namespace stan {
         || deprecate_suffix("_log",
              "'_lpdf' for density functions or '_lpmf' for mass functions",
              fun, error_msgs);
+
 
       // add stan::math:: qualifier for built-in nullary and math.h
       qualify_builtins(fun);

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1987,7 +1987,7 @@ namespace stan {
         }
       }
 
-      if (fun.name_ == "abs"
+      if (fun.name_ == "stan::math::abs"
           && fun.args_.size() > 0
           && fun.args_[0].expression_type().is_primitive_double()) {
         error_msgs << "Warning: Function abs(real) is deprecated"

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -35,21 +35,18 @@ namespace stan {
      * @param[in, out] f Function to qualify.
      */
     void qualify_builtins(fun& f) {
-      if (f.name_ == "max" || f.name_ == "min") {
-        if (f.args_.size() == 2) {
-          if (f.args_[0].expression_type().is_primitive_int()
-              && f.args_[1].expression_type().is_primitive_int()) {
-            f.name_ = "std::" + f.name_;
-            return;
-          }
-        }
+      if ((f.name_ == "max" || f.name_ == "min")
+          && f.args_.size() == 2
+          && f.args_[0].expression_type().is_primitive_int()
+          && f.args_[1].expression_type().is_primitive_int()) {
+        f.name_ = "std::" + f.name_;
+        return;
       }
-
-      if (f.name_ == "ceil") {
-        if (f.args_[0].expression_type().is_primitive_int()) {
-          f.name_ = "std::" + f.name_;
-          return;
-        }
+      
+      if (f.name_ == "ceil" 
+          && f.args_[0].expression_type().is_primitive_int()) {
+        f.name_ = "std::" + f.name_;
+        return;
       }
 
       if ((f.args_.size() == 0

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -67,7 +67,7 @@ namespace stan {
           && (f.name_ == "abs" || f.name_ == "acos"|| f.name_ == "acosh"
               || f.name_ == "asin"|| f.name_ == "asinh" || f.name_ == "atan"
               || f.name_ == "atan2" || f.name_ == "atanh" || f.name_ == "cbrt"
-              || f.name_ == "ciel" || f.name_ == "cos"|| f.name_ == "cosh"
+              || f.name_ == "cos"|| f.name_ == "cosh"
               || f.name_ == "erf" || f.name_ == "erfc" || f.name_ == "exp"
               || f.name_ == "exp2" || f.name_ == "expm1" || f.name_ == "fabs"
               || f.name_ == "floor" || f.name_ == "lgamma" || f.name_ == "log"
@@ -78,8 +78,7 @@ namespace stan {
           qualify(f);
       else if (f.args_.size() == 2
                && (f.name_ == "fdim" || f.name_ == "fmax" || f.name_ == "fmin"
-                   || f.name_ == "fmod" || f.name_ == "hypot" ||
-                   f.name_ == "pow"))
+                   || f.name_ == "hypot" ))
         qualify(f);
       else if (f.args_.size() == 3 && f.name_ == "fma")
         qualify(f);

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -35,19 +35,19 @@ namespace stan {
      * @param[in, out] f Function to qualify.
      */
     void qualify_builtins(fun& f) {
-      if (fun.name_ == "max" || fun.name_ == "min") {
-        if (fun.args_.size() == 2) {
-          if (fun.args_[0].expression_type().is_primitive_int()
-              && fun.args_[1].expression_type().is_primitive_int()) {
-            fun.name_ = "std::" + fun.name_;
+      if (f.name_ == "max" || f.name_ == "min") {
+        if (f.args_.size() == 2) {
+          if (f.args_[0].expression_type().is_primitive_int()
+              && f.args_[1].expression_type().is_primitive_int()) {
+            f.name_ = "std::" + f.name_;
             return;
           }
         }
       }
 
-      if (fun.name_ == "ceil") {
-        if (fun.args_[0].expression_type().is_primitive_int()) {
-          fun.name_ = "std::" + fun.name_;
+      if (f.name_ == "ceil") {
+        if (f.args_[0].expression_type().is_primitive_int()) {
+          f.name_ = "std::" + f.name_;
           return;
         }
       }

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -42,8 +42,8 @@ namespace stan {
         f.name_ = "std::" + f.name_;
         return;
       }
-      
-      if (f.name_ == "ceil" 
+
+      if (f.name_ == "ceil"
           && f.args_[0].expression_type().is_primitive_int()) {
         f.name_ = "std::" + f.name_;
         return;

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -43,14 +43,17 @@ namespace stan {
                || f.name_ == "machine_precision"))
           ||  (f.args_.size() == 1
                && (f.name_ == "abs" || f.name_ == "acos"|| f.name_ == "acosh"
-                   || f.name_ == "asin"|| f.name_ == "asinh" || f.name_ == "atan"
-                   || f.name_ == "atan2" || f.name_ == "atanh" || f.name_ == "cbrt"
+                   || f.name_ == "asin"|| f.name_ == "asinh"
+                   || f.name_ == "atan" || f.name_ == "atan2"
+                   || f.name_ == "atanh" || f.name_ == "cbrt"
                    || f.name_ == "ceil" || f.name_ == "cos"|| f.name_ == "cosh"
                    || f.name_ == "erf" || f.name_ == "erfc" || f.name_ == "exp"
-                   || f.name_ == "exp2" || f.name_ == "expm1" || f.name_ == "fabs"
-                   || f.name_ == "floor" || f.name_ == "lgamma" || f.name_ == "log"
-                   || f.name_ == "log1p" || f.name_ == "log2" || f.name_ == "log10"
-                   || f.name_ == "round" || f.name_ == "sin" || f.name_ == "sinh"
+                   || f.name_ == "exp2" || f.name_ == "expm1"
+                   || f.name_ == "fabs" || f.name_ == "floor"
+                   || f.name_ == "lgamma" || f.name_ == "log"
+                   || f.name_ == "log1p" || f.name_ == "log2"
+                   || f.name_ == "log10" || f.name_ == "round"
+                   || f.name_ == "sin" || f.name_ == "sinh"
                    || f.name_ == "sqrt" || f.name_ == "tan" || f.name_ == "tanh"
                    || f.name_ == "tgamma" || f.name_ == "trunc"))
           || (f.args_.size() == 2

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -39,8 +39,9 @@ namespace stan {
 
     /**
      * Add qualifier "stan::math::" to nullary functions defined in
-     * the Stan language.  Sets original name of specified function to
-     * name and add "stan::math::" namespace qualifier to name.
+     * the Stan language and to unary <code>abs<code>.  Sets original
+     * name of specified function to name and add "stan::math::"
+     * namespace qualifier to name.
      *
      * @param[in, out] f Function to qualify.
      */
@@ -49,7 +50,8 @@ namespace stan {
       if (f.name_ == "e" || f.name_ == "pi" || f.name_ == "log2"
           || f.name_ == "log10" || f.name_ == "sqrt2"
           || f.name_ == "not_a_number" || f.name_ == "positive_infinity"
-          || f.name_ == "negative_infinity" || f.name_ == "machine_precision")
+          || f.name_ == "negative_infinity" || f.name_ == "machine_precision"
+          || f.name_ == "abs")
         qualify(f);
     }
 

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -46,13 +46,15 @@ namespace stan {
      * @param[in, out] f Function to qualify.
      */
     void qualify_builtins(fun& f) {
-      if (f.args_.size() > 0) return;
-      if (f.name_ == "e" || f.name_ == "pi" || f.name_ == "log2"
-          || f.name_ == "log10" || f.name_ == "sqrt2"
-          || f.name_ == "not_a_number" || f.name_ == "positive_infinity"
-          || f.name_ == "negative_infinity" || f.name_ == "machine_precision"
-          || f.name_ == "abs")
-        qualify(f);
+      if ((f.args_.size() == 1 && f.name_ == "abs")
+          || (f.args_.size() > 0
+              && (f.name_ == "e" || f.name_ == "pi"
+                  || f.name_ == "log2" || f.name_ == "log10"
+                  || f.name_ == "sqrt2" || f.name_ == "not_a_number"
+                  || f.name_ == "positive_infinity"
+                  || f.name_ == "negative_infinity"
+                  || f.name_ == "machine_precision")))
+          qualify(f);
     }
 
     /**

--- a/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
@@ -148,9 +148,9 @@ namespace stan {
           if (this->rand_uniform_() < accept_prob)
             z_sample = z_propose;
 
-            // Break if exhaustion criterion is satisfied
-            if (std::fabs(ave) < x_delta_)
-              break;
+          // Break if exhaustion criterion is satisfied
+          if (std::fabs(ave) < x_delta_)
+            break;
         }
 
         this->n_leapfrog_ = n_leapfrog;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add `stan::math::` qualifier to `abs` in C++ code generated for a Stan program.

#### Intended Effect

Remove ambiguity in g++.

#### How to Verify

Passes unit tests on integration server.

#### Side Effects

No.

#### Documentation

n/a

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
