### PR TITLE
Fixing the integration variable

### DIFF
--- a/src/docs/stan-reference/distributions.tex
+++ b/src/docs/stan-reference/distributions.tex
@@ -118,7 +118,7 @@ F_Y(y)
 \ = \
 \mbox{Pr}[Y < y]
 \ = \
-\int_{-\infty}^y p(y \, | \, \theta) \ \mathrm{d}\theta.
+\int_{-\infty}^y p(y \, | \, \theta) \ \mathrm{d}y.
 \]
 The complementary cumulative distribution function (CCDF) is defined
 as


### PR DESCRIPTION
In the definition of the Cumulative Distribution Functions the integration variable was incorrectly defined as $\theta$ instead of $y%.
