### PR TITLE
gcc exhausts Travis memory if run in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
       env:
         - MATRIX_EVAL="CXX=g++-4.9"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
-          PARALLEL=2
+          PARALLEL=1
     - <<: *linux_gcc
       env:
         - MATRIX_EVAL="CXX=g++-4.9"


### PR DESCRIPTION
Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
