### PR TITLE
Increase precision in the output of the ELBO values.

### DIFF
--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -366,7 +366,7 @@ namespace stan {
 
         logger.info("Begin stochastic gradient ascent.");
         logger.info("  iter"
-                    "       ELBO"
+                    "             ELBO"
                     "   delta_ELBO_mean"
                     "   delta_ELBO_med"
                     "   notes ");
@@ -411,7 +411,7 @@ namespace stan {
             ss << "  "
                << std::setw(4) << iter_counter
                << "  "
-               << std::right << std::setw(9) << std::setprecision(1)
+               << std::setw(15) << std::fixed << std::setprecision(3)
                << elbo
                << "  "
                << std::setw(16) << std::fixed << std::setprecision(3)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

The display of the evidence lower bound is not precise enough, being limited to 1 significant digit. To be able to use those quantities to compare different models, more significant digits should be presented in the output (see also this discussion https://github.com/stan-dev/rstan/issues/272).

This is a sample of the current output:

```
Begin stochastic gradient ascent.
  iter       ELBO   delta_ELBO_mean   delta_ELBO_med   notes 
   100     -4e+07             1.000            1.000
   200     -2e+07             0.966            1.000
   300     -2e+06             4.786            1.000
   400     -1e+06             3.630            1.000
   500     -1e+05             5.368            1.000
```

#### Intended Effect

This is how the output looks with the patch:

```
Begin stochastic gradient ascent.
  iter             ELBO   delta_ELBO_mean   delta_ELBO_med   notes 
   100    -26605721.221             1.000            1.000
   200     -5190865.107             2.563            4.125
   300      -989986.035             3.123            4.125
   400      -511750.168             2.576            4.125
   500       -98946.446             2.895            4.125
```

#### Side Effects

None.

#### Documentation

No documentation changes necessary, unless a sample output is presented anywhere (there's none in the Stan manual).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Marco Colombo, University of Edinburgh


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
