### PR TITLE
Use the correct syntax to disable implicit makefile rules

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@
 help:
 
 ## Disable implicit rules.
-SUFIXES:
+.SUFFIXES:
 
 ##
 # Users should only need to set these three variables for use.


### PR DESCRIPTION
See https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html
for reference.

This change massively reduces the number of steps run by make:

$ make -d | wc -l
5556

$ make -d | wc -l
411

#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

The makefile line that is supposed to disable implicit rules is not correct, so implicit rules are actually not disabled, but are check at each make invocation.

#### Intended Effect

By using .SUFFIXES (spelled correctly, see link to documentation), the number of rules checked is reduced as desired.

#### How to Verify

Compare the output of `make -d` before and after patch.

#### Side Effects

None.

#### Documentation

None necessary.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Marco Colombo, University of Edinburgh


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
