### PR TITLE
Feature/2412 arg2 rising falling factorial

### DIFF
--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -363,7 +363,8 @@ for (size_t i = 0; i < vector_types.size(); ++i) {
 }
 add_unary("exponential_rng");
 add_unary_vectorized("fabs");
-add_binary("falling_factorial");
+add("falling_factorial", expr_type(double_type()), expr_type(double_type()), expr_type(int_type()));
+add("falling_factorial", expr_type(int_type()), expr_type(int_type()), expr_type(int_type()));
 add_binary("fdim");
 add_unary_vectorized("floor");
 add_ternary("fma");
@@ -917,7 +918,8 @@ add("rep_matrix", expr_type(matrix_type()), expr_type(vector_type()), expr_type(
 add("rep_matrix", expr_type(matrix_type()), expr_type(row_vector_type()), expr_type(int_type()));
 add("rep_row_vector", expr_type(row_vector_type()), expr_type(double_type()), expr_type(int_type()));
 add("rep_vector", expr_type(vector_type()), expr_type(double_type()), expr_type(int_type()));
-add_binary("rising_factorial");
+add("rising_factorial", expr_type(double_type()), expr_type(double_type()), expr_type(int_type()));
+add("rising_factorial", expr_type(int_type()), expr_type(int_type()), expr_type(int_type()));
 add_unary_vectorized("round");
 add("row", expr_type(row_vector_type()), expr_type(matrix_type()), expr_type(int_type()));
 add("rows", expr_type(int_type()), expr_type(vector_type()));

--- a/src/test/test-models/bad/function-signatures/falling_factorial.stan
+++ b/src/test/test-models/bad/function-signatures/falling_factorial.stan
@@ -1,0 +1,10 @@
+data { 
+  real d_real;
+  real r_real;
+}
+transformed data {
+  real transformed_data_real;
+  transformed_data_real <- falling_factorial(d_real, r_real);
+}
+
+  

--- a/src/test/test-models/bad/function-signatures/rising_factorial.stan
+++ b/src/test/test-models/bad/function-signatures/rising_factorial.stan
@@ -1,0 +1,8 @@
+data { 
+  real d_real;
+  real r_real;
+}
+transformed parameters {
+  real transformed_param_real;
+  transformed_param_real <-  rising_factorial(d_real, r_real);
+}

--- a/src/test/test-models/good/function-signatures/math/functions/falling_factorial.stan
+++ b/src/test/test-models/good/function-signatures/math/functions/falling_factorial.stan
@@ -2,15 +2,11 @@ data {
   int d_int;
   int r_int;
   real d_real;
-  real r_real;
   
 }
 transformed data {
-  int transformed_data_int;
   real transformed_data_real;
 
-  transformed_data_real <- falling_factorial(d_real, r_real);
-  transformed_data_real <- falling_factorial(d_int, r_real);
   transformed_data_real <- falling_factorial(d_real, d_int);
   transformed_data_real <- falling_factorial(r_int, d_int);
 }
@@ -21,19 +17,11 @@ parameters {
 transformed parameters {
   real transformed_param_real;
 
-  transformed_param_real <-  falling_factorial(d_real, r_real);
-  transformed_param_real <-  falling_factorial(d_int , r_real);
   transformed_param_real <-  falling_factorial(d_real, d_int);
   transformed_param_real <-  falling_factorial(r_int, d_int);
-
-  transformed_param_real <-  falling_factorial(r_int, p_real);
-  transformed_param_real <-  falling_factorial(r_real,p_real);
-  transformed_param_real <-  falling_factorial(p_real,p_real);
-  transformed_param_real <-  falling_factorial(p_real,r_int);
-  transformed_param_real <-  falling_factorial(p_real,r_real);
+  transformed_param_real <-  falling_factorial(p_real,d_int);
 }
 model {  
   y_p ~ normal(0,1);
 }
-
   

--- a/src/test/test-models/good/function-signatures/math/functions/rising_factorial.stan
+++ b/src/test/test-models/good/function-signatures/math/functions/rising_factorial.stan
@@ -2,14 +2,10 @@ data {
   int d_int;
   int r_int;
   real d_real;
-  real r_real;
 }
 transformed data {
-  int transformed_data_int;
   real transformed_data_real;
 
-  transformed_data_real <- rising_factorial(d_real, r_real);
-  transformed_data_real <- rising_factorial(d_int, r_real);
   transformed_data_real <- rising_factorial(d_real, d_int);
   transformed_data_real <- rising_factorial(r_int, d_int);
 }
@@ -20,16 +16,9 @@ parameters {
 transformed parameters {
   real transformed_param_real;
 
-  transformed_param_real <-  rising_factorial(d_real, r_real);
-  transformed_param_real <-  rising_factorial(d_int , r_real);
   transformed_param_real <-  rising_factorial(d_real, d_int);
   transformed_param_real <-  rising_factorial(r_int, d_int);
-
-  transformed_param_real <-  rising_factorial(r_int, p_real);
-  transformed_param_real <-  rising_factorial(r_real,p_real);
-  transformed_param_real <-  rising_factorial(p_real,p_real);
   transformed_param_real <-  rising_factorial(p_real,r_int);
-  transformed_param_real <-  rising_factorial(p_real,r_real);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/unit/lang/parser/function_sig_errors_test.cpp
+++ b/src/test/unit/lang/parser/function_sig_errors_test.cpp
@@ -1,4 +1,6 @@
 #include <gtest/gtest.h>
+#include <exception>
+#include <stdexcept>
 #include <test/unit/lang/utility.hpp>
 
 TEST(langParser, functionSigErrorsFunUnknown) {
@@ -27,3 +29,9 @@ TEST(langParser, functionSigErrorsMultiDef) {
   test_throws("multi_fun",
               "Function already defined, name=foo");
 }
+TEST(langParser, functionSigErrorsFactorial) {
+  EXPECT_THROW(is_parsable("src/test/test-models/bad/function-signatures/math/functions/falling_factorial.stan"),
+                           std::invalid_argument);
+  EXPECT_THROW(is_parsable("src/test/test-models/bad/function-signatures/math/functions/rising_factorial.stan"),
+                           std::invalid_argument);
+}  

--- a/src/test/unit/lang/parser/function_sig_errors_test.cpp
+++ b/src/test/unit/lang/parser/function_sig_errors_test.cpp
@@ -30,8 +30,8 @@ TEST(langParser, functionSigErrorsMultiDef) {
               "Function already defined, name=foo");
 }
 TEST(langParser, functionSigErrorsFactorial) {
-  EXPECT_THROW(is_parsable("src/test/test-models/bad/function-signatures/math/functions/falling_factorial.stan"),
+  EXPECT_THROW(is_parsable("src/test/test-models/bad/function-signatures/falling_factorial.stan"),
                            std::invalid_argument);
-  EXPECT_THROW(is_parsable("src/test/test-models/bad/function-signatures/math/functions/rising_factorial.stan"),
+  EXPECT_THROW(is_parsable("src/test/test-models/bad/function-signatures/rising_factorial.stan"),
                            std::invalid_argument);
 }  


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Change parser and so that functions `rising_factorial` and `falling_factorial` require 2nd arg to be an int.

#### Intended Effect
change Stan in advance of merging update to mathlib.

#### How to Verify
unit tests.

#### Side Effects

#### Documentation
(assuming mathlib PR addresses manual issues)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
