### PR TITLE
fix Backus-Naur form gramma of print and reject

### DIFF
--- a/src/docs/stan-reference/appendices.tex
+++ b/src/docs/stan-reference/appendices.tex
@@ -715,8 +715,8 @@ atomic_statement_body
    | 'target' '+=' expression
    | 'break'
    | 'continue'
-   | 'print' '(' (expression | string_literal)* ')'
-   | 'reject' '(' (expression | string_literal)* ')'
+   | 'print' '(' (expression | string_literal)% ',' ')'
+   | 'reject' '(' (expression | string_literal)% ',' ')'
    | 'return' expression
    | ''
 


### PR DESCRIPTION
#### Summary
Reference (manual) only.

The old grammar would contain `print("Hallo " "world!")`  but not `print("Hello ", "world!")`  while only the latter is actually accepted by stan. Should be a comment in #2336 . sorry, next time.

#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below


#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
