### PR TITLE
Update manual and function signatures for ordered logistic/probit

### DIFF
--- a/src/docs/stan-reference/distributions.tex
+++ b/src/docs/stan-reference/distributions.tex
@@ -691,8 +691,74 @@ $\mbox{logit}^{-1}(\infty) = 1$.
     \farg{k} given linear predictor \farg{eta} and cutpoints
     \farg{c}.}
 %
+  \fitem{real}{ordered\_logistic\_lpmf}{ints \farg{k} \textbar\ vector \farg{eta},
+    vector \farg{c}}{The log ordered logistic probability mass of
+    \farg{k} given linear predictors \farg{eta}, all sharing the same cutpoints
+    \farg{c}.}
+%
+  \fitem{real}{ordered\_logistic\_lpmf}{ints \farg{k} \textbar\ vector \farg{eta},
+    vectors \farg{c}}{The log ordered logistic probability mass of
+    \farg{k} given linear predictors \farg{eta}, each with different cutpoints
+    \farg{c}.}
 \fitem{int}{ordered\_logistic\_rng}{real \farg{eta}, vector \farg{c}}{Generate
   an ordered logistic variate with linear predictor \farg{eta} and cutpoints
+    \farg{c}; may only be used in generated quantities block}
+\end{description}
+
+\section{Ordered Probit Distribution}
+
+\subsubsection{Probability Mass Function}
+
+If $K \in \nats$ with $K > 2$, $c \in \reals^{K-1}$ such that $c_k <
+c_{k+1}$ for $k \in \setlist{1,\ldots,K-2}$, and $\eta \in \reals$, then for $k \in
+\setlist{1,\ldots,K}$,
+\[
+\distro{OrderedProbit}(k|\eta,c)
+=
+\left\{
+\begin{array}{ll}
+1 - \Phi(\eta - c_1) & \mbox{if } k = 1,
+\\[4pt]
+\Phi(\eta - c_{k-1}) - \Phi(\eta -
+c_{k})
+
+& \mbox{if } 1 < k < K, \mbox{and}
+\\[4pt]
+\Phi(\eta - c_{K-1}) - 0
+& \mbox{if } k = K.
+\end{array}
+\right.
+\]
+%
+The $k=K$ case is written with the redundant subtraction of zero to
+illustrate the parallelism of the cases; the $k=1$ and $k=K$ edge
+cases can be subsumed into the general definition by setting $c_0 =
+-\infty$ and $c_K = +\infty$ with $\Phi(-\infty) = 0$ and
+$\Phi(\infty) = 1$.
+
+\pitemdisc{k}{ordered\_probit}{eta, c}
+
+
+\subsubsection{Stan Functions}
+
+\begin{description}
+  \fitem{real}{ordered\_probit\_lpmf}{int \farg{k} \textbar\ real \farg{eta},
+    vector \farg{c}}{The log ordered probit probability mass of
+    \farg{k} given linear predictor \farg{eta} and cutpoints
+    \farg{c}.}
+%
+  \fitem{real}{ordered\_probit\_lpmf}{ints \farg{k} \textbar\ vector \farg{eta},
+    vector \farg{c}}{The log ordered probit probability mass of
+    \farg{k} given linear predictors \farg{eta}, all sharing the same cutpoints
+    \farg{c}.}
+%
+  \fitem{real}{ordered\_probit\_lpmf}{ints \farg{k} \textbar\ vector \farg{eta},
+    vectors \farg{c}}{The log ordered probit probability mass of
+    \farg{k} given linear predictors \farg{eta}, each with different cutpoints
+    \farg{c}.}
+%
+\fitem{int}{ordered\_probit\_rng}{real \farg{eta}, vector \farg{c}}{Generate
+  an ordered probit variate with linear predictor \farg{eta} and cutpoints
     \farg{c}; may only be used in generated quantities block}
 \end{description}
 

--- a/src/docs/stan-reference/distributions.tex
+++ b/src/docs/stan-reference/distributions.tex
@@ -686,20 +686,10 @@ $\mbox{logit}^{-1}(\infty) = 1$.
 \subsubsection{Stan Functions}
 
 \begin{description}
-  \fitem{real}{ordered\_logistic\_lpmf}{int \farg{k} \textbar\ real \farg{eta},
-    vector \farg{c}}{The log ordered logistic probability mass of
-    \farg{k} given linear predictor \farg{eta} and cutpoints
-    \farg{c}.}
-%
-  \fitem{real}{ordered\_logistic\_lpmf}{ints \farg{k} \textbar\ vector \farg{eta},
-    vector \farg{c}}{The log ordered logistic probability mass of
-    \farg{k} given linear predictors \farg{eta}, all sharing the same cutpoints
-    \farg{c}.}
-%
   \fitem{real}{ordered\_logistic\_lpmf}{ints \farg{k} \textbar\ vector \farg{eta},
     vectors \farg{c}}{The log ordered logistic probability mass of
-    \farg{k} given linear predictors \farg{eta}, each with different cutpoints
-    \farg{c}.}
+    \farg{k} given linear predictors \farg{eta}, and cutpoints \farg{c}.}
+
 \fitem{int}{ordered\_logistic\_rng}{real \farg{eta}, vector \farg{c}}{Generate
   an ordered logistic variate with linear predictor \farg{eta} and cutpoints
     \farg{c}; may only be used in generated quantities block}
@@ -742,20 +732,9 @@ $\Phi(\infty) = 1$.
 \subsubsection{Stan Functions}
 
 \begin{description}
-  \fitem{real}{ordered\_probit\_lpmf}{int \farg{k} \textbar\ real \farg{eta},
-    vector \farg{c}}{The log ordered probit probability mass of
-    \farg{k} given linear predictor \farg{eta} and cutpoints
-    \farg{c}.}
-%
-  \fitem{real}{ordered\_probit\_lpmf}{ints \farg{k} \textbar\ vector \farg{eta},
-    vector \farg{c}}{The log ordered probit probability mass of
-    \farg{k} given linear predictors \farg{eta}, all sharing the same cutpoints
-    \farg{c}.}
-%
   \fitem{real}{ordered\_probit\_lpmf}{ints \farg{k} \textbar\ vector \farg{eta},
     vectors \farg{c}}{The log ordered probit probability mass of
-    \farg{k} given linear predictors \farg{eta}, each with different cutpoints
-    \farg{c}.}
+    \farg{k} given linear predictors \farg{eta}, and cutpoints \farg{c}.}
 %
 \fitem{int}{ordered\_probit\_rng}{real \farg{eta}, vector \farg{c}}{Generate
   an ordered probit variate with linear predictor \farg{eta} and cutpoints

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -785,8 +785,19 @@ for (size_t i=1; i < 10; i++) {
   add("num_elements", expr_type(int_type()), expr_type(vector_type(), i));
 }
 add("ordered_logistic_log", expr_type(double_type()), expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
+add("ordered_logistic_log", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type()));
+add("ordered_logistic_log", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type(), 1));
 add("ordered_logistic_lpmf", expr_type(double_type()), expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
+add("ordered_logistic_lpmf", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type()));
+add("ordered_logistic_lpmf", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type(), 1));
 add("ordered_logistic_rng", expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
+add("ordered_probit_log", expr_type(double_type()), expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
+add("ordered_probit_log", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type()));
+add("ordered_probit_log", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type(), 1));
+add("ordered_probit_lpmf", expr_type(double_type()), expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
+add("ordered_probit_lpmf", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type()));
+add("ordered_probit_lpmf", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type(), 1));
+add("ordered_probit_rng", expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
 add_binary("owens_t");
 for (size_t i = 0; i < vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -784,20 +784,37 @@ for (size_t i=1; i < 10; i++) {
   add("num_elements", expr_type(int_type()), expr_type(row_vector_type(), i));
   add("num_elements", expr_type(int_type()), expr_type(vector_type(), i));
 }
-add("ordered_logistic_log", expr_type(double_type()), expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
-add("ordered_logistic_log", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type()));
-add("ordered_logistic_log", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type(), 1));
-add("ordered_logistic_lpmf", expr_type(double_type()), expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
-add("ordered_logistic_lpmf", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type()));
-add("ordered_logistic_lpmf", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type(), 1));
-add("ordered_logistic_rng", expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
-add("ordered_probit_log", expr_type(double_type()), expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
-add("ordered_probit_log", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type()));
-add("ordered_probit_log", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type(), 1));
-add("ordered_probit_lpmf", expr_type(double_type()), expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
-add("ordered_probit_lpmf", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type()));
-add("ordered_probit_lpmf", expr_type(double_type()), expr_type(int_type(), 1), expr_type(vector_type()), expr_type(vector_type(), 1));
-add("ordered_probit_rng", expr_type(int_type()), expr_type(double_type()), expr_type(vector_type()));
+add("ordered_logistic_log", expr_type(double_type()), expr_type(int_type()),
+    expr_type(double_type()), expr_type(vector_type()));
+for (size_t i = 0; i < 2; ++i) {
+  add("ordered_logistic_log", expr_type(double_type()),
+      expr_type(int_type(), 1), expr_type(vector_type()),
+      expr_type(vector_type(), i));
+}
+add("ordered_logistic_lpmf", expr_type(double_type()), expr_type(int_type()),
+    expr_type(double_type()), expr_type(vector_type()));
+for (size_t i = 0; i < 2; ++i) {
+  add("ordered_logistic_lpmf", expr_type(double_type()),
+      expr_type(int_type(), 1), expr_type(vector_type()),
+      expr_type(vector_type(), i));
+}
+add("ordered_logistic_rng", expr_type(int_type()), expr_type(double_type()),
+    expr_type(vector_type()));
+add("ordered_probit_log", expr_type(double_type()), expr_type(int_type()),
+    expr_type(double_type()), expr_type(vector_type()));
+for (size_t i = 0; i < 2; ++i) {
+  add("ordered_probit_log", expr_type(double_type()),
+      expr_type(int_type(), 1), expr_type(vector_type()),
+      expr_type(vector_type(), i));
+}
+add("ordered_probit_lpmf", expr_type(double_type()), expr_type(int_type()),
+    expr_type(double_type()), expr_type(vector_type()));
+for (size_t i = 0; i < 2; ++i) {
+  add("ordered_probit_lpmf", expr_type(double_type()), expr_type(int_type(), 1),
+      expr_type(vector_type()), expr_type(vector_type(), i));
+}
+add("ordered_probit_rng", expr_type(int_type()), expr_type(double_type()),
+    expr_type(vector_type()));
 add_binary("owens_t");
 for (size_t i = 0; i < vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {

--- a/src/test/test-models/good/function-signatures/distributions/multivariate/discrete/ordered_logistic/ordered_logistic_log.stan
+++ b/src/test/test-models/good/function-signatures/distributions/multivariate/discrete/ordered_logistic/ordered_logistic_log.stan
@@ -1,16 +1,21 @@
 data { 
   int d_int;
   real d_real;
+  int d_int_array[d_int];
   vector[d_int] d_vector;
+  vector[d_int] d_vector_array[d_int];
 }
 transformed data {
   real transformed_data_real;
 
   transformed_data_real <- ordered_logistic_log(d_int, d_real, d_vector);
+  transformed_data_real <- ordered_logistic_log(d_int_array, d_vector, d_vector);
+  transformed_data_real <- ordered_logistic_log(d_int_array, d_vector, d_vector_array);
 }
 parameters {
   real p_real;
   vector[d_int] p_vector;
+  vector[d_int] p_vector_array[d_int];
 
   real y_p;
 }
@@ -18,9 +23,20 @@ transformed parameters {
   real transformed_param_real;
 
   transformed_param_real <- ordered_logistic_log(d_int, d_real, d_vector);
+  transformed_param_real <- ordered_logistic_log(d_int_array, d_vector, d_vector);
+  transformed_param_real <- ordered_logistic_log(d_int_array, d_vector, d_vector_array);
+
   transformed_param_real <- ordered_logistic_log(d_int, p_real, d_vector);
+  transformed_param_real <- ordered_logistic_log(d_int_array, p_vector, d_vector);
+  transformed_param_real <- ordered_logistic_log(d_int_array, p_vector, d_vector_array);
+
   transformed_param_real <- ordered_logistic_log(d_int, d_real, p_vector);
+  transformed_param_real <- ordered_logistic_log(d_int_array, d_vector, p_vector);
+  transformed_param_real <- ordered_logistic_log(d_int_array, d_vector, p_vector_array);
+
   transformed_param_real <- ordered_logistic_log(d_int, p_real, p_vector);
+  transformed_param_real <- ordered_logistic_log(d_int_array, p_vector, p_vector);
+  transformed_param_real <- ordered_logistic_log(d_int_array, p_vector, p_vector_array);
 }
 model {  
   y_p ~ normal(0,1);

--- a/src/test/test-models/good/function-signatures/distributions/multivariate/discrete/ordered_probit/ordered_probit_log.stan
+++ b/src/test/test-models/good/function-signatures/distributions/multivariate/discrete/ordered_probit/ordered_probit_log.stan
@@ -1,0 +1,43 @@
+data { 
+  int d_int;
+  real d_real;
+  int d_int_array[d_int];
+  vector[d_int] d_vector;
+  vector[d_int] d_vector_array[d_int];
+}
+transformed data {
+  real transformed_data_real;
+
+  transformed_data_real <- ordered_probit_log(d_int, d_real, d_vector);
+  transformed_data_real <- ordered_probit_log(d_int_array, d_vector, d_vector);
+  transformed_data_real <- ordered_probit_log(d_int_array, d_vector, d_vector_array);
+}
+parameters {
+  real p_real;
+  vector[d_int] p_vector;
+  vector[d_int] p_vector_array[d_int];
+
+  real y_p;
+}
+transformed parameters {
+  real transformed_param_real;
+
+  transformed_param_real <- ordered_probit_log(d_int, d_real, d_vector);
+  transformed_param_real <- ordered_probit_log(d_int_array, d_vector, d_vector);
+  transformed_param_real <- ordered_probit_log(d_int_array, d_vector, d_vector_array);
+
+  transformed_param_real <- ordered_probit_log(d_int, p_real, d_vector);
+  transformed_param_real <- ordered_probit_log(d_int_array, p_vector, d_vector);
+  transformed_param_real <- ordered_probit_log(d_int_array, p_vector, d_vector_array);
+
+  transformed_param_real <- ordered_probit_log(d_int, d_real, p_vector);
+  transformed_param_real <- ordered_probit_log(d_int_array, d_vector, p_vector);
+  transformed_param_real <- ordered_probit_log(d_int_array, d_vector, p_vector_array);
+
+  transformed_param_real <- ordered_probit_log(d_int, p_real, p_vector);
+  transformed_param_real <- ordered_probit_log(d_int_array, p_vector, p_vector);
+  transformed_param_real <- ordered_probit_log(d_int_array, p_vector, p_vector_array);
+}
+model {  
+  y_p ~ normal(0,1);
+}

--- a/src/test/unit/lang/parser/distribution_functions_test.cpp
+++ b/src/test/unit/lang/parser/distribution_functions_test.cpp
@@ -227,6 +227,10 @@ TEST(lang_parser, ordered_logistic_distribution_function_signatures) {
   test_parsable("function-signatures/distributions/multivariate/discrete/ordered_logistic/ordered_logistic_log");
 }
 
+TEST(lang_parser, ordered_probit_distribution_function_signatures) {
+  test_parsable("function-signatures/distributions/multivariate/discrete/ordered_probit/ordered_probit_log");
+}
+
 TEST(lang_parser, dirichlet_distribution_function_signatures) {
   test_parsable("function-signatures/distributions/multivariate/continuous/dirichlet_log");
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Update the manual, function signatures, and tests for the vectorised ordered logistic and probit distributions introduced in math prs: stan-dev/math/pull/638 stan-dev/math/pull/645

#### Intended Effect
Allow usage of ordered logistic and probit distributions in stan

#### How to Verify
Visually inspect

#### Side Effects
N/A

#### Documentation
Included in PR

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
