### PR TITLE
Bugfix/2416 qualify local xformed data vars as data

### DIFF
--- a/src/stan/lang/ast/fun/has_var_vis_def.hpp
+++ b/src/stan/lang/ast/fun/has_var_vis_def.hpp
@@ -47,7 +47,7 @@ namespace stan {
     bool has_var_vis::operator()(const variable& e) const {
       scope var_scope = var_map_.get_scope(e.name_);
       return var_scope.par_or_tpar()
-        || (var_scope.is_local() && !e.type_.base_type_.is_int_type());
+        || (var_scope.local_allows_var() && !e.type_.base_type_.is_int_type());
     }
 
     bool has_var_vis::operator()(const fun& e) const {

--- a/src/stan/lang/ast/scope.hpp
+++ b/src/stan/lang/ast/scope.hpp
@@ -66,6 +66,15 @@ namespace stan {
       bool is_local() const;
 
       /**
+       * Flags local scopes which permit parameter variables,
+       * i.e., program block can't be transformed data or
+       * generated quantities program blocks.
+       *
+       * @return true for local parameter origin block types
+       */
+      bool local_allows_var() const;
+
+      /**
        * Flags scopes where parameter variables are declared,
        * i.e., top-level of parameter or transformed parameter block.
        *

--- a/src/stan/lang/ast/scope.hpp
+++ b/src/stan/lang/ast/scope.hpp
@@ -66,9 +66,10 @@ namespace stan {
       bool is_local() const;
 
       /**
-       * Flags local scopes which permit parameter variables,
-       * i.e., program block can't be transformed data or
-       * generated quantities program blocks.
+       * Flags local scopes which permit parameter variables.
+       * Allows local blocks in functions, transfromed parameter,
+       * and model blocks; disallows local blocks in transformed data
+       * and generated quantities program blocks.
        *
        * @return true for local parameter origin block types
        */

--- a/src/stan/lang/ast/scope_def.hpp
+++ b/src/stan/lang/ast/scope_def.hpp
@@ -26,9 +26,9 @@ namespace stan {
     }
 
     bool scope::local_allows_var() const {
-      return is_local_ &&
-        !(program_block_ == transformed_data_origin
-          || program_block_ == derived_origin);
+      return is_local_
+        && program_block_ != transformed_data_origin
+        && program_block_ != derived_origin;
     }
 
     bool scope::par_or_tpar() const {

--- a/src/stan/lang/ast/scope_def.hpp
+++ b/src/stan/lang/ast/scope_def.hpp
@@ -25,6 +25,12 @@ namespace stan {
       return is_local_;
     }
 
+    bool scope::local_allows_var() const {
+      return is_local_ &&
+        !(program_block_ == transformed_data_origin
+          || program_block_ == derived_origin);
+    }
+
     bool scope::par_or_tpar() const {
       return !is_local_
         && (program_block_ == parameter_origin

--- a/src/stan/lang/ast/sigs/function_arg_type.hpp
+++ b/src/stan/lang/ast/sigs/function_arg_type.hpp
@@ -60,7 +60,7 @@ namespace stan {
       /**
        * Return true if the `expr_type` of the specified
        * `function_arg_type` is not equal to the
-       * `expr_type` of this `function_arg_type</
+       * `expr_type` of this `function_arg_type`.
        * Ignore status of bool `data_only_`.
        *
        * @param fa_type other function argument type.

--- a/src/test/test-models/good/parser-generator/data_qualifier_scope_xformed_data.stan
+++ b/src/test/test-models/good/parser-generator/data_qualifier_scope_xformed_data.stan
@@ -1,0 +1,19 @@
+functions {
+  vector target(vector y, vector theta, real[] x_r, int[] x_i) {
+    vector[2] deltas;
+    deltas[1] = y[1] - theta[1] - x_r[1];
+    return deltas;
+  }
+}
+
+transformed data {
+  vector[1] y;
+  {
+    vector[1] y_guess = [1]';
+    vector[1] theta = [1]';
+    real x_r[0] = {1.0};
+    int x_i[0];
+
+    y = algebra_solver(tail_delta, y_guess, theta, x_r, x_i);
+  }
+}

--- a/src/test/test-models/good/parser-generator/data_qualifier_scope_xformed_data.stan
+++ b/src/test/test-models/good/parser-generator/data_qualifier_scope_xformed_data.stan
@@ -14,6 +14,6 @@ transformed data {
     real x_r[0] = {1.0};
     int x_i[0];
 
-    y = algebra_solver(tail_delta, y_guess, theta, x_r, x_i);
+    y = algebra_solver(target, y_guess, theta, x_r, x_i);
   }
 }

--- a/src/test/test-models/good/parser-generator/data_qualifier_scope_xformed_data.stan
+++ b/src/test/test-models/good/parser-generator/data_qualifier_scope_xformed_data.stan
@@ -7,13 +7,22 @@ functions {
 }
 
 transformed data {
-  vector[1] y;
+  vector[1] td_y;
   {
-    vector[1] y_guess = [1]';
-    vector[1] theta = [1]';
-    real x_r[0] = {1.0};
-    int x_i[0];
-
-    y = algebra_solver(target, y_guess, theta, x_r, x_i);
+    vector[1] td_y_guess = [1]';
+    vector[1] td_theta = [1]';
+    real td_x_r[0] = {1.0};
+    int td_x_i[0];
+    td_y = algebra_solver(target, td_y_guess, td_theta, td_x_r, td_x_i);
+  }
+}
+generated quantities {
+  vector[1] gq_y;
+  {
+    vector[1] gq_y_guess = [1]';
+    vector[1] gq_theta = [1]';
+    real gq_x_r[0] = {1.0};
+    int gq_x_i[0];
+    gq_y = algebra_solver(target, gq_y_guess, gq_theta, gq_x_r, gq_x_i);
   }
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
see issue #2417 

#### Intended Effect
allow calls to algebraic solver using local vars as data vars.

#### How to Verify
added test model `src/test/test-models/good/parser-generator/data_qualifier_scope_xformed_data.hpp-test`

#### Side Effects
none

#### Documentation
na

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)