### PR TITLE
generalize boost version check in ADVI tests

### DIFF
--- a/src/test/unit/variational/eta_adapt_small_test.cpp
+++ b/src/test/unit/variational/eta_adapt_small_test.cpp
@@ -62,7 +62,7 @@ TEST_F(eta_adapt_small_test, eta_should_be_small) {
   stan::variational::normal_fullrank fullrank_init =
     stan::variational::normal_fullrank(cont_params_);
 
-#if BOOST_VERSION > 106400
+#if BOOST_VERSION >= 106400
   EXPECT_EQ(0.1, advi_meanfield_->adapt_eta(meanfield_init, 1000, logger));
   EXPECT_EQ(0.1, advi_fullrank_->adapt_eta(fullrank_init, 1000, logger));
 #else

--- a/src/test/unit/variational/eta_adapt_small_test.cpp
+++ b/src/test/unit/variational/eta_adapt_small_test.cpp
@@ -62,7 +62,7 @@ TEST_F(eta_adapt_small_test, eta_should_be_small) {
   stan::variational::normal_fullrank fullrank_init =
     stan::variational::normal_fullrank(cont_params_);
 
-#if BOOST_VERSION == 106400
+#if BOOST_VERSION > 106400
   EXPECT_EQ(0.1, advi_meanfield_->adapt_eta(meanfield_init, 1000, logger));
   EXPECT_EQ(0.1, advi_fullrank_->adapt_eta(fullrank_init, 1000, logger));
 #else


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit` (just for changed file)
- [x] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary

Just waht issue #2446 says---generalize test for Boost by replacing `==` with `>` in `ifdef`.

#### Intended Effect

Allow us to upgrade Boost.  The PR for that in `stan-dev/math` is currently blocked:

https://github.com/stan-dev/math/pull/700

#### How to Verify

usual unit tests

#### Side Effects

no

#### Documentation

n/a

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)