### PR TITLE
Work around Windows Jenkins failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,6 +96,7 @@ pipeline {
             }
         }
         stage('Tests') {
+            failFast true
             parallel {
                 stage('Windows Unit') {
                     agent { label 'windows' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def setup(String pr) {
     """
     if (pr != '')  {
         prNumber = pr.tokenize('-').last()
-        script += """ 
+        script += """
             cd lib/stan_math
             git fetch https://github.com/stan-dev/math +refs/pull/${prNumber}/merge:refs/remotes/origin/pr/${prNumber}/merge
             git checkout refs/remotes/origin/pr/${prNumber}/merge
@@ -100,22 +100,24 @@ pipeline {
                 stage('Windows Unit') {
                     agent { label 'windows' }
                     steps {
-                        unstash 'StanSetup'
+                        checkout scm
+                        bat setup(params.math_pr)
                         setupCC(false)
                         runTestsWin("src/test/unit")
                     }
                     post { always { deleteDir() } }
                 }
-                stage('Windows Headers') { 
+                stage('Windows Headers') {
                     agent { label 'windows' }
                     steps {
-                        unstash 'StanSetup'
+                        checkout scm
+                        bat setup(params.math_pr)
                         setupCC()
                         bat "make -j${env.PARALLEL} test-headers"
                     }
                     post { always { deleteDir() } }
                 }
-                stage('Unit') { 
+                stage('Unit') {
                     agent any
                     steps {
                         unstash 'StanSetup'
@@ -126,7 +128,7 @@ pipeline {
                 }
                 stage('Integration') {
                     agent any
-                    steps { 
+                    steps {
                         unstash 'StanSetup'
                         setupCC()
                         runTests("src/test/integration", separateMakeStep=false)
@@ -151,7 +153,7 @@ pipeline {
                 sh """
                     ./runTests.py -j${env.PARALLEL} src/test/performance
                     cd test/performance
-                    RScript ../../src/test/performance/plot_performance.R 
+                    RScript ../../src/test/performance/plot_performance.R
                 """
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,11 @@ def runTestsWin(String testPath) {
     finally { junit 'test/**/*.xml' }
 }
 
+def deleteDirWin() {
+    bat "attrib -r -s /s /d"
+    deleteDir()
+}
+
 pipeline {
     agent none
     parameters {
@@ -101,22 +106,24 @@ pipeline {
                 stage('Windows Unit') {
                     agent { label 'windows' }
                     steps {
+                        deleteDirWin()
                         checkout scm
                         bat setup(params.math_pr)
                         setupCC(false)
                         runTestsWin("src/test/unit")
                     }
-                    post { always { deleteDir() } }
+                    post { always { deleteDirWin() } }
                 }
                 stage('Windows Headers') {
                     agent { label 'windows' }
                     steps {
+                        deleteDirWin()
                         checkout scm
                         bat setup(params.math_pr)
                         setupCC()
                         bat "make -j${env.PARALLEL} test-headers"
                     }
-                    post { always { deleteDir() } }
+                    post { always { deleteDirWin() } }
                 }
                 stage('Unit') {
                     agent any

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,14 +101,12 @@ pipeline {
             }
         }
         stage('Tests') {
-            failFast true
             parallel {
                 stage('Windows Unit') {
                     agent { label 'windows' }
                     steps {
                         deleteDirWin()
-                        checkout scm
-                        bat setup(params.math_pr)
+                        unstash 'StanSetup'
                         setupCC(false)
                         runTestsWin("src/test/unit")
                     }
@@ -118,8 +116,7 @@ pipeline {
                     agent { label 'windows' }
                     steps {
                         deleteDirWin()
-                        checkout scm
-                        bat setup(params.math_pr)
+                        unstash 'StanSetup'
                         setupCC()
                         bat "make -j${env.PARALLEL} test-headers"
                     }

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -54,7 +54,7 @@
 class performance : public ::testing::Test {
 public:
   static void SetUpTestCase() {
-    N = 100;
+    N = 1;
     seconds_per_run.resize(N);
     last_draws_per_run.resize(N);
     matches_tagged_version = false;

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -54,7 +54,7 @@
 class performance : public ::testing::Test {
 public:
   static void SetUpTestCase() {
-    N = 1;
+    N = 100;
     seconds_per_run.resize(N);
     last_draws_per_run.resize(N);
     matches_tagged_version = false;


### PR DESCRIPTION
After a Jenkins master reboot a couple of days ago, the Jenkins Windows agent started being unable to delete its own workspace, showing messages like the one pasted below. These are often attributed to things like search indexing or anti-virus locking random files, but these are not the issue as reported by Unlocker (and the fact that the machine seems to have neither of these). For some reason, running `attrib` to remove the read-only and system attributes on the workspace before performing a delete or unstash seems to work. So here we are.

```

java.nio.file.AccessDeniedException: C:\Jenkins2\workspace\Stan_develop-3CVGV42HAM7J3BLI3M44PCR6M52FN6ZQ65IEZ6TOSHJURSBO2PPA\src\test\test-models\bad\read_only
	at sun.nio.fs.WindowsException.translateToIOException(Unknown Source)
	at sun.nio.fs.WindowsException.rethrowAsIOException(Unknown Source)
	at sun.nio.fs.WindowsException.rethrowAsIOException(Unknown Source)
	at sun.nio.fs.WindowsFileSystemProvider.implDelete(Unknown Source)
	at sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(Unknown Source)
	at java.nio.file.Files.deleteIfExists(Unknown Source)
	at hudson.Util.tryOnceDeleteFile(Util.java:297)
	at hudson.Util.deleteFile(Util.java:253)
Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to JNLP4-connect connection from gelman-group-win.stat.columbia.edu/128.59.76.64:50229
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1737)
		at hudson.remoting.UserResponse.retrieve(UserRequest.java:313)
		at hudson.remoting.Channel.call(Channel.java:952)
		at hudson.FilePath.act(FilePath.java:998)
		at hudson.FilePath.act(FilePath.java:987)
		at hudson.FilePath.deleteRecursive(FilePath.java:1192)
		at org.jenkinsci.plugins.workflow.steps.DeleteDirStep$Execution.run(DeleteDirStep.java:77)
		at org.jenkinsci.plugins.workflow.steps.DeleteDirStep$Execution.run(DeleteDirStep.java:69)
		at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1$1.call(SynchronousNonBlockingStepExecution.java:49)
		at hudson.security.ACL.impersonate(ACL.java:290)
		at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1.run(SynchronousNonBlockingStepExecution.java:46)
		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
		at java.util.concurrent.FutureTask.run(FutureTask.java:266)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
		at java.lang.Thread.run(Thread.java:748)
Caused: java.io.IOException: Unable to delete 'C:\Jenkins2\workspace\Stan_develop-3CVGV42HAM7J3BLI3M44PCR6M52FN6ZQ65IEZ6TOSHJURSBO2PPA\src\test\test-models\bad\read_only'. Tried 3 times (of a maximum of 3) waiting 0.1 sec between attempts.
	at hudson.Util.deleteFile(Util.java:258)
	at hudson.FilePath.deleteRecursive(FilePath.java:1225)
	at hudson.FilePath.deleteContentsRecursive(FilePath.java:1234)
	at hudson.FilePath.deleteRecursive(FilePath.java:1216)
	at hudson.FilePath.deleteContentsRecursive(FilePath.java:1234)
	at hudson.FilePath.deleteRecursive(FilePath.java:1216)
	at hudson.FilePath.deleteContentsRecursive(FilePath.java:1234)
	at hudson.FilePath.deleteRecursive(FilePath.java:1216)
	at hudson.FilePath.deleteContentsRecursive(FilePath.java:1234)
	at hudson.FilePath.deleteRecursive(FilePath.java:1216)
	at hudson.FilePath.deleteContentsRecursive(FilePath.java:1234)
	at hudson.FilePath.deleteRecursive(FilePath.java:1216)
	at hudson.FilePath.access$1100(FilePath.java:208)
	at hudson.FilePath$13.invoke(FilePath.java:1195)
	at hudson.FilePath$13.invoke(FilePath.java:1192)
	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:2816)
	at hudson.remoting.UserRequest.perform(UserRequest.java:210)
	at hudson.remoting.UserRequest.perform(UserRequest.java:53)
	at hudson.remoting.Request$2.run(Request.java:364)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at java.util.concurrent.FutureTask.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at hudson.remoting.Engine$1$1.run(Engine.java:94)
	at java.lang.Thread.run(Unknown Source)
Also:   java.nio.file.AccessDeniedException: C:\Jenkins2\workspace\Stan_develop-3CVGV42HAM7J3BLI3M44PCR6M52FN6ZQ65IEZ6TOSHJURSBO2PPA\src\test\test-models\bad\stanc_helper.stan
		at sun.nio.fs.WindowsException.translateToIOException(Unknown Source)
		at sun.nio.fs.WindowsException.rethrowAsIOException(Unknown Source)
		at sun.nio.fs.WindowsException.rethrowAsIOException(Unknown Source)
		at sun.nio.fs.WindowsFileSystemProvider.newByteChannel(Unknown Source)
		at java.nio.file.spi.FileSystemProvider.newOutputStream(Unknown Source)
		at java.nio.file.Files.newOutputStream(Unknown Source)
		at hudson.util.IOUtils.copy(IOUtils.java:42)
		at hudson.FilePath.readFromTar(FilePath.java:2363)
	Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to JNLP4-connect connection from gelman-group-win.stat.columbia.edu/128.59.76.64:50229
			at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1737)
			at hudson.remoting.UserResponse.retrieve(UserRequest.java:313)
			at hudson.remoting.Channel.call(Channel.java:952)
			at hudson.FilePath.act(FilePath.java:998)
			at hudson.FilePath.act(FilePath.java:987)
			at hudson.FilePath.untar(FilePath.java:540)
			at org.jenkinsci.plugins.workflow.flow.StashManager.unstash(StashManager.java:129)
			at org.jenkinsci.plugins.workflow.support.steps.stash.UnstashStep$Execution.run(UnstashStep.java:74)
			at org.jenkinsci.plugins.workflow.support.steps.stash.UnstashStep$Execution.run(UnstashStep.java:61)
			at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1$1.call(SynchronousNonBlockingStepExecution.java:49)
			at hudson.security.ACL.impersonate(ACL.java:290)
			at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1.run(SynchronousNonBlockingStepExecution.java:46)
			at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
			at java.util.concurrent.FutureTask.run(FutureTask.java:266)
			at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
			at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
			at java.lang.Thread.run(Thread.java:748)
	Caused: java.io.IOException: Failed to extract StanSetup.tar.gz
		at hudson.FilePath.readFromTar(FilePath.java:2373)
		at hudson.FilePath.access$400(FilePath.java:208)
		at hudson.FilePath$4.invoke(FilePath.java:542)
		at hudson.FilePath$4.invoke(FilePath.java:540)
		at hudson.FilePath$FileCallableWrapper.call(FilePath.java:2816)
		at hudson.remoting.UserRequest.perform(UserRequest.java:210)
		at hudson.remoting.UserRequest.perform(UserRequest.java:53)
		at hudson.remoting.Request$2.run(Request.java:364)
		at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
		at java.util.concurrent.FutureTask.run(Unknown Source)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
		at hudson.remoting.Engine$1$1.run(Engine.java:94)
		at java.lang.Thread.run(Unknown Source)
	Caused: java.io.IOException: remote file operation failed: C:\Jenkins2\workspace\Stan_develop-3CVGV42HAM7J3BLI3M44PCR6M52FN6ZQ65IEZ6TOSHJURSBO2PPA at hudson.remoting.Channel@47c318f0:JNLP4-connect connection from gelman-group-win.stat.columbia.edu/128.59.76.64:50229
		at hudson.FilePath.act(FilePath.java:1005)
		at hudson.FilePath.act(FilePath.java:987)
		at hudson.FilePath.untar(FilePath.java:540)
		at org.jenkinsci.plugins.workflow.flow.StashManager.unstash(StashManager.java:129)
		at org.jenkinsci.plugins.workflow.support.steps.stash.UnstashStep$Execution.run(UnstashStep.java:74)
		at org.jenkinsci.plugins.workflow.support.steps.stash.UnstashStep$Execution.run(UnstashStep.java:61)
Caused: java.io.IOException: remote file operation failed: C:\Jenkins2\workspace\Stan_develop-3CVGV42HAM7J3BLI3M44PCR6M52FN6ZQ65IEZ6TOSHJURSBO2PPA at hudson.remoting.Channel@47c318f0:JNLP4-connect connection from gelman-group-win.stat.columbia.edu/128.59.76.64:50229
	at hudson.FilePath.act(FilePath.java:1005)
	at hudson.FilePath.act(FilePath.java:987)
	at hudson.FilePath.deleteRecursive(FilePath.java:1192)
	at org.jenkinsci.plugins.workflow.steps.DeleteDirStep$Execution.run(DeleteDirStep.java:77)
	at org.jenkinsci.plugins.workflow.steps.DeleteDirStep$Execution.run(DeleteDirStep.java:69)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1$1.call(SynchronousNonBlockingStepExecution.java:49)
	at hudson.security.ACL.impersonate(ACL.java:290)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1.run(SynchronousNonBlockingStepExecution.java:46)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Finished: FAILURE
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
