### PR TITLE
Use nullptr instead of 0

### DIFF
--- a/src/stan/lang/generator/generate_function_arguments.hpp
+++ b/src/stan/lang/generator/generate_function_arguments.hpp
@@ -5,6 +5,7 @@
 #include <stan/lang/generator/constants.hpp>
 #include <stan/lang/generator/generate_arg_decl.hpp>
 #include <boost/lexical_cast.hpp>
+#include <cstddef>
 #include <ostream>
 #include <string>
 
@@ -65,7 +66,7 @@ namespace stan {
 
       o << "std::ostream* pstream__";
       if (parameter_defaults) {
-        o << " = 0";
+        o << " = nullptr";
       }
 
       o << ")";


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary

Change the default argument of `pstream__` from 0 to `nullptr` now that we are using C++11

#### Intended Effect

Make it easier to call `rstan::expose_stan_functions`

#### How to Verify

Call `rstan::expose_stan_functions` on a Stan program with a user-defined Stan function using the for-2.18 branch

#### Side Effects

None

#### Documentation

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
