### PR TITLE
end of symbol for algebra_solver, map_rect, fixes #2502

### DIFF
--- a/src/stan/lang/grammars/term_grammar_def.hpp
+++ b/src/stan/lang/grammars/term_grammar_def.hpp
@@ -255,6 +255,7 @@ namespace stan {
       algebra_solver_r.name("expression");
       algebra_solver_r
         %= lit("algebra_solver")
+        >> no_skip[!char_("a-zA-Z0-9_")]
         > lit('(')
         > identifier_r          // 1) system function name (function only)
         > lit(',')
@@ -272,6 +273,7 @@ namespace stan {
       map_rect_r.name("map_rect");
       map_rect_r
           %= lit("map_rect")
+          >> no_skip[!char_("a-zA-Z0-9_")]
           > lit('(')
           > identifier_r          // 1) mapped function name
           > lit(',')

--- a/src/stan/lang/grammars/term_grammar_def.hpp
+++ b/src/stan/lang/grammars/term_grammar_def.hpp
@@ -254,8 +254,7 @@ namespace stan {
 
       algebra_solver_r.name("expression");
       algebra_solver_r
-        %= lit("algebra_solver")
-        >> no_skip[!char_("a-zA-Z0-9_")]
+        %= (lit("algebra_solver") >> no_skip[!char_("a-zA-Z0-9_")])
         > lit('(')
         > identifier_r          // 1) system function name (function only)
         > lit(',')
@@ -272,8 +271,7 @@ namespace stan {
 
       map_rect_r.name("map_rect");
       map_rect_r
-          %= lit("map_rect")
-          >> no_skip[!char_("a-zA-Z0-9_")]
+          %= (lit("map_rect") >> no_skip[!char_("a-zA-Z0-9_")])
           > lit('(')
           > identifier_r          // 1) mapped function name
           > lit(',')

--- a/src/test/test-models/good/algebra_solver_good.stan
+++ b/src/test/test-models/good/algebra_solver_good.stan
@@ -1,8 +1,11 @@
 functions {
-  vector algebra_system (vector x,
-                         vector y,
-                         real[] dat,
-                         int[] dat_int) {
+  real algebra_solverfake(real x) {
+    return 2 * x;
+  }
+  vector algebra_system(vector x,
+                        vector y,
+                        real[] dat,
+                        int[] dat_int) {
     vector[2] f_x;
     f_x[1] = x[1] - y[1];
     f_x[2] = x[2] - y[2];
@@ -33,11 +36,12 @@ parameters {
 }
 
 transformed parameters {
+  real abc_tp = algebra_solverfake(2.9);
   vector[2] theta_p;
-  
+
   theta_p = algebra_solver(algebra_system, x, y, dat, dat_int);
   theta_p = algebra_solver(algebra_system, x, y, dat, dat_int, 0.01, 0.01, 10);
-  
+
   theta_p = algebra_solver(algebra_system, x, y_p, dat, dat_int);
   theta_p = algebra_solver(algebra_system, x, y_p, dat, dat_int, 0.01, 0.01, 10);
 
@@ -46,6 +50,8 @@ transformed parameters {
 
   theta_p = algebra_solver(algebra_system, x_p, y_p, dat, dat_int);
   theta_p = algebra_solver(algebra_system, x_p, y_p, dat, dat_int, 0.01, 0.01, 10);
+
+
 }
 
 model {

--- a/src/test/test-models/good/map_rect.stan
+++ b/src/test/test-models/good/map_rect.stan
@@ -3,6 +3,9 @@ functions {
              real[] data_r, int[] data_i) {
     return [1, 2, 3]';
   }
+  real map_rectfake(real x) {
+    return 2 * x;
+  }
 }
 data {
   vector[3] shared_params_d;
@@ -15,6 +18,9 @@ parameters {
   vector[3] job_params_p[3];
 }
 transformed parameters {
+  real abc1_p = 3;
+  real abc2_p = map_rectfake(abc1_p);
+  real abc3_p = map_rectfake(12);
   vector[3] y_hat_tp1
       = map_rect(foo, shared_params_p, job_params_d, data_r, data_i);
   vector[3] y_hat_tp2
@@ -22,7 +28,12 @@ transformed parameters {
   vector[3] y_hat_tp3
       = map_rect(foo, shared_params_p, job_params_d, data_r, data_i);
 }
+model {
+  real abc_m = map_rectfake(abc1_p);
+}
 generated quantities {
+  real abc1_gq = map_rectfake(12);
+  real abc2_gq = map_rectfake(abc1_p);
   vector[3] y_hat_gq
       = map_rect(foo, shared_params_d, job_params_d, data_r, data_i);
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add condition to `algebra_solver` and `map_rect` to allow symbols that use them as prefixes.  This is just a nofollow statement before the expectation in the grammar.

#### Intended Effect

Allow the grammar to handle prefixes properly.

#### How to Verify

Added unit tests for both cases.

#### Side Effects

No.

#### Documentation

Now matches doc.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
