### PR TITLE
add default argument to reader

### DIFF
--- a/src/stan/lang/rethrow_located.hpp
+++ b/src/stan/lang/rethrow_located.hpp
@@ -87,7 +87,8 @@ namespace stan {
      * @param[in] reader trace of how program was included from files
      */
     inline void rethrow_located(const std::exception& e, int line,
-                                const io::program_reader& reader) {
+                                const io::program_reader& reader = 
+                                  stan::io::program_reader()) {
       using std::bad_alloc;          // -> exception
       using std::bad_cast;           // -> exception
       using std::bad_exception;      // -> exception

--- a/src/stan/lang/rethrow_located.hpp
+++ b/src/stan/lang/rethrow_located.hpp
@@ -87,7 +87,7 @@ namespace stan {
      * @param[in] reader trace of how program was included from files
      */
     inline void rethrow_located(const std::exception& e, int line,
-                                const io::program_reader& reader = 
+                                const io::program_reader& reader =
                                   stan::io::program_reader()) {
       using std::bad_alloc;          // -> exception
       using std::bad_cast;           // -> exception


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary

Add trivial default argument to `reader` in `rethrow_located`

#### Intended Effect

Allow ancient Stan code to keep working when I update StanHeaders

#### How to Verify

I have been doing this in StanHeaders and it is fine.

#### Side Effects

Closes #2509 

#### Documentation

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
