### PR TITLE
update makefile to use sundials instead cvodes lib

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -24,9 +24,9 @@ test/%.o : src/test/%_test.cpp
 ##
 # Rule for building a test executable
 ##
-test/%$(EXE) : test/%.o $(LIBGTEST) $(LIBCVODES)
+test/%$(EXE) : test/%.o $(LIBGTEST) $(LIBSUNDIALS)
 	@mkdir -p $(dir $@)
-	$(LINK.cc) -O$O $(GTEST_MAIN) $< $(GTEST_CXXFLAGS) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS) $(LIBCVODES)
+	$(LINK.cc) -O$O $(GTEST_MAIN) $< $(GTEST_CXXFLAGS) $(OUTPUT_OPTION) $(LIBGTEST) $(LDLIBS) $(LIBSUNDIALS)
 
 
 ##


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Per stan-dev/math#779 the cvodes and idas libs are replaced by sundials. PR stan-dev/math#832 makes this update for the makefile of math lib. Similar changes need to be made for the makefile of cmdstan, rstan, etc. It suffices to replace LIBCVODES in makefile with LIBSUNDIALS.

#### How to Verify
Successful make of projects utilizing sundials functionalities.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Metrum Research Group, LLC


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
