### PR TITLE
Feature/issue 2462 effective_sample_size interface for rstan/pystan

### DIFF
--- a/src/test/unit/mcmc/chains_test.cpp
+++ b/src/test/unit/mcmc/chains_test.cpp
@@ -18,7 +18,7 @@ public:
     epil1_stream.open("src/test/unit/mcmc/test_csv_files/epil.1.csv");
     epil2_stream.open("src/test/unit/mcmc/test_csv_files/epil.2.csv");
   }
-  
+
   void TearDown() {
     blocker1_stream.close();
     blocker2_stream.close();
@@ -38,8 +38,8 @@ TEST_F(McmcChains, constructor) {
   EXPECT_EQ(blocker1.header.size(), chains1.num_params());
   for (int i = 0; i < blocker1.header.size(); i++)
     EXPECT_EQ(blocker1.header(i), chains1.param_name(i));
-  
-  
+
+
   // construct with stan_csv
   stan::mcmc::chains<> chains2(blocker1);
   EXPECT_EQ(1, chains2.num_chains());
@@ -55,14 +55,14 @@ TEST_F(McmcChains, add) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   // construct with Eigen::Vector
   stan::mcmc::chains<> chains(blocker1.header);
   EXPECT_EQ(0, chains.num_chains());
   EXPECT_EQ(0, chains.num_samples());
 
   Eigen::RowVectorXd theta = blocker1.samples.row(0);
-  EXPECT_NO_THROW(chains.add(1, theta)) 
+  EXPECT_NO_THROW(chains.add(1, theta))
     << "adding a single sample to a new chain";
   EXPECT_EQ(2, chains.num_chains());
   EXPECT_EQ(0, chains.num_samples(0));
@@ -70,7 +70,7 @@ TEST_F(McmcChains, add) {
   EXPECT_EQ(1, chains.num_samples());
 
   theta = blocker1.samples.row(1);
-  EXPECT_NO_THROW(chains.add(1, theta)) 
+  EXPECT_NO_THROW(chains.add(1, theta))
     << "adding a single sample to an existing chain";
   EXPECT_EQ(2, chains.num_chains());
   EXPECT_EQ(0, chains.num_samples(0));
@@ -178,9 +178,9 @@ TEST_F(McmcChains, blocker1_num_chains) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
-  
+
   EXPECT_EQ(1, chains.num_chains());
 }
 
@@ -188,9 +188,9 @@ TEST_F(McmcChains, blocker1_num_samples) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
-  
+
   EXPECT_EQ(1000, chains.num_samples());
 }
 
@@ -198,9 +198,9 @@ TEST_F(McmcChains, blocker2_num_samples) {
   std::stringstream out;
   stan::io::stan_csv blocker2 = stan::io::stan_csv_reader::parse(blocker2_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker2);
-  
+
   EXPECT_EQ(1000, chains.num_samples());
 }
 
@@ -209,10 +209,10 @@ TEST_F(McmcChains, blocker_num_samples) {
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   stan::io::stan_csv blocker2 = stan::io::stan_csv_reader::parse(blocker2_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
   chains.add(blocker2);
-  
+
   EXPECT_EQ(2000, chains.num_samples());
   EXPECT_EQ(1000, chains.num_samples(0));
   EXPECT_EQ(1000, chains.num_samples(1));
@@ -223,7 +223,7 @@ TEST_F(McmcChains, blocker1_param_names) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
   ASSERT_EQ(blocker1.header.size(), chains.num_params());
   ASSERT_EQ(blocker1.header.size(), chains.param_names().size());
@@ -235,7 +235,7 @@ TEST_F(McmcChains, blocker1_param_name) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
   ASSERT_EQ(blocker1.header.size(), chains.num_params());
   for (int i = 0; i < blocker1.header.size(); i++) {
@@ -246,7 +246,7 @@ TEST_F(McmcChains, blocker1_index) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
   ASSERT_EQ(blocker1.header.size(), chains.num_params());
   for (int i = 0; i < blocker1.header.size(); i++)
@@ -256,7 +256,7 @@ TEST_F(McmcChains, blocker1_warmup) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
 
   ASSERT_EQ(1, chains.warmup().size());
@@ -273,7 +273,7 @@ TEST_F(McmcChains, blocker1_warmup) {
   ASSERT_EQ(1, chains.warmup().size());
   EXPECT_EQ(100, chains.warmup()(0));
   EXPECT_EQ(100, chains.warmup(0));
- 
+
   chains.add(blocker1);
   ASSERT_EQ(2, chains.warmup().size());
   EXPECT_EQ(100, chains.warmup()(0));
@@ -302,7 +302,7 @@ TEST_F(McmcChains, blocker_mean) {
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   stan::io::stan_csv blocker2 = stan::io::stan_csv_reader::parse(blocker2_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
 
   Eigen::VectorXd means1 = blocker1.samples.colwise().mean();
@@ -355,9 +355,9 @@ TEST_F(McmcChains, blocker_sd) {
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   stan::io::stan_csv blocker2 = stan::io::stan_csv_reader::parse(blocker2_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
-  
+
   using std::sqrt;
   for (int j = 0; j < chains.num_params(); j++) {
     ASSERT_NEAR(sd(blocker1.samples.col(j)), chains.sd(0,j), 1e-8)
@@ -375,14 +375,14 @@ TEST_F(McmcChains, blocker_sd) {
     ASSERT_NEAR(sd(x), chains.sd(j), 1e-8)
       << "2: param sd. index: " << j;
   }
-  
+
   chains.set_warmup(500);
   for (int j = 0; j < chains.num_params(); j++) {
     Eigen::VectorXd x1(500), x2(500), x(1000);
     x1 << blocker1.samples.col(j).bottomRows(500);
     x2 << blocker2.samples.col(j).bottomRows(500);
     x << x1, x2;
-    
+
     ASSERT_NEAR(sd(x1), chains.sd(0,j), 1e-8)
       << "3: chain sd 1 with warmup";
     ASSERT_NEAR(sd(x2), chains.sd(1,j), 1e-8)
@@ -413,9 +413,9 @@ TEST_F(McmcChains, blocker_variance) {
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   stan::io::stan_csv blocker2 = stan::io::stan_csv_reader::parse(blocker2_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
-  
+
   using std::sqrt;
   for (int j = 0; j < chains.num_params(); j++) {
     ASSERT_NEAR(variance(blocker1.samples.col(j)), chains.variance(0,j), 1e-8)
@@ -433,14 +433,14 @@ TEST_F(McmcChains, blocker_variance) {
     ASSERT_NEAR(variance(x), chains.variance(j), 1e-8)
       << "2: param variance. index: " << j;
   }
-  
+
   chains.set_warmup(500);
   for (int j = 0; j < chains.num_params(); j++) {
     Eigen::VectorXd x1(500), x2(500), x(1000);
     x1 << blocker1.samples.col(j).bottomRows(500);
     x2 << blocker2.samples.col(j).bottomRows(500);
     x << x1, x2;
-    
+
     ASSERT_NEAR(variance(x1), chains.variance(0,j), 1e-8)
       << "3: chain variance 1 with warmup";
     ASSERT_NEAR(variance(x2), chains.variance(1,j), 1e-8)
@@ -472,10 +472,10 @@ TEST_F(McmcChains, blocker_covariance) {
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   stan::io::stan_csv blocker2 = stan::io::stan_csv_reader::parse(blocker2_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
   chains.add(blocker2);
-  
+
   int n = 0;
   for (int i = 0; i < chains.num_params(); i++) {
     for (int j = i; j < chains.num_params(); j++) {
@@ -490,11 +490,11 @@ TEST_F(McmcChains, blocker_covariance) {
 
   x << x1, y1;
   y << x2, y2;
-      
+
   double cov1 = covariance(x1, x2);
   double cov2 = covariance(y1, y2);
   double cov = covariance(x, y);
-      
+
   ASSERT_NEAR(cov1, chains.covariance(0,i,j), 1e-8);
   ASSERT_NEAR(cov2, chains.covariance(1,i,j), 1e-8);
   ASSERT_NEAR(cov, chains.covariance(i,j), 1e-8);
@@ -518,10 +518,10 @@ TEST_F(McmcChains, blocker_correlation) {
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   stan::io::stan_csv blocker2 = stan::io::stan_csv_reader::parse(blocker2_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
   chains.add(blocker2);
-  
+
   int n = 0;
   for (int i = 0; i < chains.num_params(); i++) {
     for (int j = i; j < chains.num_params(); j++) {
@@ -536,7 +536,7 @@ TEST_F(McmcChains, blocker_correlation) {
 
   x << x1, y1;
   y << x2, y2;
-      
+
 
   double cov1 = covariance(x1, x2);
   double cov2 = covariance(y1, y2);
@@ -552,7 +552,7 @@ TEST_F(McmcChains, blocker_correlation) {
     corr2 = cov2 / sd(y1) / sd(y2);
   if (std::fabs(cov) > 1e-8)
     corr = cov / sd(x) / sd(y);
-    
+
   ASSERT_NEAR(corr1, chains.correlation(0,i,j), 1e-8)
     << "(" << i << ", " << j << ")";
   ASSERT_NEAR(corr2, chains.correlation(1,i,j), 1e-8)
@@ -566,7 +566,7 @@ TEST_F(McmcChains, blocker_correlation) {
     << "(" << i << ", " << j << ")";
   ASSERT_NEAR(corr, chains.correlation(j,i), 1e-8)
     << "(" << i << ", " << j << ")";
-  
+
   std::string name1 = chains.param_name(i);
   std::string name2 = chains.param_name(j);
   ASSERT_FLOAT_EQ(chains.correlation(0,i,j), chains.correlation(0,name1,name2));
@@ -581,11 +581,11 @@ TEST_F(McmcChains, blocker_quantile) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
-  
+
   int index = 5;
-  
+
   // R's quantile function
   EXPECT_NEAR(0.00241709, chains.quantile(0,index,0.1), 1e-2);
   EXPECT_NEAR(0.00348311, chains.quantile(0,index,0.2), 1e-2);
@@ -596,7 +596,7 @@ TEST_F(McmcChains, blocker_quantile) {
   EXPECT_NEAR(0.0131629, chains.quantile(0,index,0.7), 1e-2);
   EXPECT_NEAR(0.0185874, chains.quantile(0,index,0.8), 1e-2);
   EXPECT_NEAR(0.0263824, chains.quantile(0,index,0.9), 1e-2);
-  
+
   EXPECT_NEAR(0.00241709, chains.quantile(index,0.1), 1e-2);
   EXPECT_NEAR(0.00348311, chains.quantile(index,0.2), 1e-2);
   EXPECT_NEAR(0.00477931, chains.quantile(index,0.3), 1e-2);
@@ -609,11 +609,11 @@ TEST_F(McmcChains, blocker_quantile) {
 
   std::string name = chains.param_name(index);
   EXPECT_FLOAT_EQ(chains.quantile(0,index,0.1), chains.quantile(0,name,0.1));
-  EXPECT_FLOAT_EQ(chains.quantile(0,index,0.3), chains.quantile(0,name,0.3));  
+  EXPECT_FLOAT_EQ(chains.quantile(0,index,0.3), chains.quantile(0,name,0.3));
   EXPECT_FLOAT_EQ(chains.quantile(0,index,0.5), chains.quantile(0,name,0.5));
 
   EXPECT_FLOAT_EQ(chains.quantile(index,0.2), chains.quantile(name,0.2));
-  EXPECT_FLOAT_EQ(chains.quantile(index,0.4), chains.quantile(name,0.4));  
+  EXPECT_FLOAT_EQ(chains.quantile(index,0.4), chains.quantile(name,0.4));
   EXPECT_FLOAT_EQ(chains.quantile(index,0.6), chains.quantile(name,0.6));
 }
 
@@ -621,16 +621,16 @@ TEST_F(McmcChains, blocker_quantiles) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
-  
+
   int index = 5;
 
   Eigen::VectorXd probs(9);
   probs << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9;
-  
+
   Eigen::VectorXd quantiles;
-  
+
   quantiles = chains.quantiles(0,index,probs);
   // R's quantile function
   ASSERT_EQ(9, quantiles.size());
@@ -662,7 +662,7 @@ TEST_F(McmcChains, blocker_quantiles) {
   Eigen::VectorXd quantiles_by_name;
   quantiles = chains.quantiles(0,index,probs);
   quantiles_by_name = chains.quantiles(0,name,probs);
-  
+
   ASSERT_EQ(quantiles.size(), quantiles_by_name.size());
   for (int i = 0; i < quantiles.size(); i++) {
     EXPECT_FLOAT_EQ(quantiles(i), quantiles_by_name(i));
@@ -670,7 +670,7 @@ TEST_F(McmcChains, blocker_quantiles) {
 
   quantiles = chains.quantiles(index,probs);
   quantiles_by_name = chains.quantiles(name,probs);
-  
+
   ASSERT_EQ(quantiles.size(), quantiles_by_name.size());
   for (int i = 0; i < quantiles.size(); i++) {
     EXPECT_FLOAT_EQ(quantiles(i), quantiles_by_name(i));
@@ -681,11 +681,11 @@ TEST_F(McmcChains, blocker_central_interval) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
-  
+
   int index = 5;
-  
+
   Eigen::Vector2d interval;
 
   interval = chains.central_interval(0,index,0.6);
@@ -716,11 +716,11 @@ TEST_F(McmcChains, blocker_autocorrelation) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
   Eigen::VectorXd ac;
   EXPECT_NO_THROW(ac = chains.autocorrelation(0,5));
-  
+
   EXPECT_NEAR(1, ac[0], 0.01);
   EXPECT_NEAR(0.529912, ac[1], 0.01);
   EXPECT_NEAR(0.406604, ac[2], 0.01);
@@ -765,11 +765,11 @@ TEST_F(McmcChains, blocker_autocovariance) {
   std::stringstream out;
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
   Eigen::VectorXd ac;
   EXPECT_NO_THROW(ac = chains.autocovariance(0,5));
-  
+
   EXPECT_NEAR(0.000150861, ac[0], 0.01);
   EXPECT_NEAR(7.99431e-05, ac[1], 0.01);
   EXPECT_NEAR(6.13408e-05, ac[2], 0.01);
@@ -816,7 +816,7 @@ TEST_F(McmcChains,blocker_effective_sample_size) {
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   stan::io::stan_csv blocker2 = stan::io::stan_csv_reader::parse(blocker2_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
   chains.add(blocker2);
 
@@ -836,13 +836,19 @@ TEST_F(McmcChains,blocker_effective_sample_size) {
 
   for (int index = 4; index < chains.num_params(); index++) {
     ASSERT_NEAR(n_eff(index - 4), chains.effective_sample_size(index), 1.0)
-      << "n_effective for index: " << index << ", parameter: " 
+      << "n_effective for index: " << index << ", parameter: "
+      << chains.param_name(index);
+  }
+
+  for (int index = 4; index < chains.num_params(); index++) {
+    ASSERT_NEAR(n_eff(index - 4), chains.effective_sample_size_new(index), 1.0)
+      << "n_effective for index: " << index << ", parameter: "
       << chains.param_name(index);
   }
 
   for (int index = 0; index < chains.num_params(); index++) {
     std::string name = chains.param_name(index);
-    ASSERT_EQ(chains.effective_sample_size(index), 
+    ASSERT_EQ(chains.effective_sample_size(index),
         chains.effective_sample_size(name));
   }
 }
@@ -852,12 +858,12 @@ TEST_F(McmcChains,blocker_split_potential_scale_reduction) {
   stan::io::stan_csv blocker1 = stan::io::stan_csv_reader::parse(blocker1_stream, &out);
   stan::io::stan_csv blocker2 = stan::io::stan_csv_reader::parse(blocker2_stream, &out);
   EXPECT_EQ("", out.str());
-  
+
   stan::mcmc::chains<> chains(blocker1);
   chains.add(blocker2);
-  
+
   Eigen::VectorXd rhat(48);
-  rhat << 
+  rhat <<
     1.00718,1.00473,0.999203,1.00061,1.00378,
     1.01031,1.00173,1.0045,1.00111,1.00337,
     1.00546,1.00105,1.00558,1.00463,1.00534,
@@ -871,13 +877,13 @@ TEST_F(McmcChains,blocker_split_potential_scale_reduction) {
 
   for (int index = 4; index < chains.num_params(); index++) {
     ASSERT_NEAR(rhat(index - 4), chains.split_potential_scale_reduction(index), 1e-4)
-      << "rhat for index: " << index << ", parameter: " 
+      << "rhat for index: " << index << ", parameter: "
       << chains.param_name(index);
   }
 
   for (int index = 0; index < chains.num_params(); index++) {
     std::string name = chains.param_name(index);
-    ASSERT_EQ(chains.split_potential_scale_reduction(index), 
+    ASSERT_EQ(chains.split_potential_scale_reduction(index),
         chains.split_potential_scale_reduction(name));
   }
 


### PR DESCRIPTION
… old effective_sample_size to new stan-dev/math autocovariance fns

#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add new interface to effective_sample_size for RStan and PyStan.

Replace https://github.com/stan-dev/stan/pull/2477

#### Intended Effect

New interface.

#### How to Verify

make clean && ./runTests.py -j2 src/test/unit/mcmc/chains_test.cpp

#### Side Effects

None intended.

#### Documentation

Inline as function doc.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

California State University, Chico


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
