### PR TITLE
Add new log_mix signatures and unit tests

### DIFF
--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -584,6 +584,14 @@ add("log_determinant", expr_type(double_type()), expr_type(matrix_type()));
 add_binary("log_diff_exp");
 add_binary("log_falling_factorial");
 add_ternary("log_mix");
+for (size_t i = 1; i < vector_types.size(); ++i) {
+  add("log_mix", expr_type(double_type()), vector_types[i], expr_type(double_type(), 1));
+  for (size_t j = 0; j < 2; ++j) {
+    for (size_t k = 2; k < 4; ++k) {
+      add("log_mix", expr_type(double_type()), vector_types[i], expr_type(base_types[k], j));
+    }
+  }
+}
 add_binary("log_rising_factorial");
 add_unary_vectorized("log_inv_logit");
 add("log_softmax", expr_type(vector_type()), expr_type(vector_type()));

--- a/src/test/test-models/good/function-signatures/math/functions/log_mix.stan
+++ b/src/test/test-models/good/function-signatures/math/functions/log_mix.stan
@@ -1,45 +1,135 @@
-data { 
+data {
+  int N;
+  int M;
   real d_real_theta;
+  real d_real_theta_arr[N];
+  vector[N] d_vec_theta;
+  row_vector[N] d_rowvec_theta;
   real d_real_lam_1;
   real d_real_lam_2;
+  real d_real_lam_arr[N];
+  vector[N] d_vec_lam;
+  row_vector[N] d_rowvec_lam;
+  vector[N] d_vec_lam_arr[M];
+  row_vector[N] d_rowvec_lam_arr[M];
   real y_p;
 }
 transformed data {
   real transformed_data_real;
  
-  transformed_data_real <- log_mix(d_real_theta,
+  transformed_data_real = log_mix(d_real_theta,
                                          d_real_lam_1,
                                          d_real_lam_1);
+
+  transformed_data_real = log_mix(d_real_theta_arr,d_real_lam_arr);
+  transformed_data_real = log_mix(d_real_theta_arr,d_vec_lam);
+  transformed_data_real = log_mix(d_real_theta_arr,d_rowvec_lam);
+  transformed_data_real = log_mix(d_real_theta_arr,d_vec_lam_arr);
+  transformed_data_real = log_mix(d_real_theta_arr,d_rowvec_lam_arr);
+
+  transformed_data_real = log_mix(d_vec_theta,d_real_lam_arr);
+  transformed_data_real = log_mix(d_vec_theta,d_vec_lam);
+  transformed_data_real = log_mix(d_vec_theta,d_rowvec_lam);
+  transformed_data_real = log_mix(d_vec_theta,d_vec_lam_arr);
+  transformed_data_real = log_mix(d_vec_theta,d_rowvec_lam_arr);
+
+  transformed_data_real = log_mix(d_rowvec_theta,d_real_lam_arr);
+  transformed_data_real = log_mix(d_rowvec_theta,d_vec_lam);
+  transformed_data_real = log_mix(d_rowvec_theta,d_rowvec_lam);
+  transformed_data_real = log_mix(d_rowvec_theta,d_vec_lam_arr);
+  transformed_data_real = log_mix(d_rowvec_theta,d_rowvec_lam_arr);
 }
 parameters {
   real p_real_theta;
+  real p_real_theta_arr[N];
+  vector[N] p_vec_theta;
+  row_vector[N] p_rowvec_theta;
   real p_real_lam_1;
   real p_real_lam_2;
+  real p_real_lam_arr[N];
+  vector[N] p_vec_lam;
+  row_vector[N] p_rowvec_lam;
+  vector[N] p_vec_lam_arr[M];
+  row_vector[N] p_rowvec_lam_arr[M];
 }
 transformed parameters {
   real transformed_param_real;
 
-  transformed_param_real <- log_mix(p_real_theta,
+  transformed_param_real = log_mix(p_real_theta,
                                     p_real_lam_1,
                                     d_real_lam_1);
-  transformed_param_real <- log_mix(p_real_theta,
+  transformed_param_real = log_mix(p_real_theta,
                                     d_real_lam_1,
                                     p_real_lam_1);
-  transformed_param_real <- log_mix(p_real_theta,
+  transformed_param_real = log_mix(p_real_theta,
                                     d_real_lam_1,
                                     d_real_lam_1);
-  transformed_param_real <- log_mix(d_real_theta,
+  transformed_param_real = log_mix(d_real_theta,
                                     p_real_lam_1,
                                     p_real_lam_1);
-  transformed_param_real <- log_mix(d_real_theta,
+  transformed_param_real = log_mix(d_real_theta,
                                     p_real_lam_1,
                                     d_real_lam_1);
-  transformed_param_real <- log_mix(d_real_theta,
+  transformed_param_real = log_mix(d_real_theta,
                                     d_real_lam_1,
                                     p_real_lam_1);
-  transformed_param_real <- log_mix(p_real_theta,
+  transformed_param_real = log_mix(p_real_theta,
                                     p_real_lam_1,
                                     p_real_lam_1);
+
+  transformed_param_real = log_mix(d_real_theta_arr,p_real_lam_arr);
+  transformed_param_real = log_mix(d_real_theta_arr,p_vec_lam);
+  transformed_param_real = log_mix(d_real_theta_arr,p_rowvec_lam);
+  transformed_param_real = log_mix(d_real_theta_arr,p_vec_lam_arr);
+  transformed_param_real = log_mix(d_real_theta_arr,p_rowvec_lam_arr);
+
+  transformed_param_real = log_mix(p_real_theta_arr,d_real_lam_arr);
+  transformed_param_real = log_mix(p_real_theta_arr,d_vec_lam);
+  transformed_param_real = log_mix(p_real_theta_arr,d_rowvec_lam);
+  transformed_param_real = log_mix(p_real_theta_arr,d_vec_lam_arr);
+  transformed_param_real = log_mix(p_real_theta_arr,d_rowvec_lam_arr);
+
+  transformed_param_real = log_mix(p_real_theta_arr,p_real_lam_arr);
+  transformed_param_real = log_mix(p_real_theta_arr,p_vec_lam);
+  transformed_param_real = log_mix(p_real_theta_arr,p_rowvec_lam);
+  transformed_param_real = log_mix(p_real_theta_arr,p_vec_lam_arr);
+  transformed_param_real = log_mix(p_real_theta_arr,p_rowvec_lam_arr);
+
+  transformed_param_real = log_mix(d_vec_theta,p_real_lam_arr);
+  transformed_param_real = log_mix(d_vec_theta,p_vec_lam);
+  transformed_param_real = log_mix(d_vec_theta,p_rowvec_lam);
+  transformed_param_real = log_mix(d_vec_theta,p_vec_lam_arr);
+  transformed_param_real = log_mix(d_vec_theta,p_rowvec_lam_arr);
+
+  transformed_param_real = log_mix(p_vec_theta,d_real_lam_arr);
+  transformed_param_real = log_mix(p_vec_theta,d_vec_lam);
+  transformed_param_real = log_mix(p_vec_theta,d_rowvec_lam);
+  transformed_param_real = log_mix(p_vec_theta,d_vec_lam_arr);
+  transformed_param_real = log_mix(p_vec_theta,d_rowvec_lam_arr);
+
+  transformed_param_real = log_mix(p_vec_theta,p_real_lam_arr);
+  transformed_param_real = log_mix(p_vec_theta,p_vec_lam);
+  transformed_param_real = log_mix(p_vec_theta,p_rowvec_lam);
+  transformed_param_real = log_mix(p_vec_theta,p_vec_lam_arr);
+  transformed_param_real = log_mix(p_vec_theta,p_rowvec_lam_arr);
+
+  transformed_param_real = log_mix(d_rowvec_theta,p_real_lam_arr);
+  transformed_param_real = log_mix(d_rowvec_theta,p_vec_lam);
+  transformed_param_real = log_mix(d_rowvec_theta,p_rowvec_lam);
+  transformed_param_real = log_mix(d_rowvec_theta,p_vec_lam_arr);
+  transformed_param_real = log_mix(d_rowvec_theta,p_rowvec_lam_arr);
+
+  transformed_param_real = log_mix(p_rowvec_theta,d_real_lam_arr);
+  transformed_param_real = log_mix(p_rowvec_theta,d_vec_lam);
+  transformed_param_real = log_mix(p_rowvec_theta,d_rowvec_lam);
+  transformed_param_real = log_mix(p_rowvec_theta,d_vec_lam_arr);
+  transformed_param_real = log_mix(p_rowvec_theta,d_rowvec_lam_arr);
+
+  transformed_param_real = log_mix(p_rowvec_theta,p_real_lam_arr);
+  transformed_param_real = log_mix(p_rowvec_theta,p_vec_lam);
+  transformed_param_real = log_mix(p_rowvec_theta,p_rowvec_lam);
+  transformed_param_real = log_mix(p_rowvec_theta,p_vec_lam_arr);
+  transformed_param_real = log_mix(p_rowvec_theta,p_rowvec_lam_arr);
 }
 model {  
   y_p ~ normal(0,1);


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Adds function signatures and instantiation tests for the extended log_mix functions added in stan-dev/math#664 and stan-dev/math#751

The new signatures are:
```
Available argument signatures for log_mix:

  log_mix(real, real, real)
  log_mix(real[], real[])
  log_mix(real[], vector)
  log_mix(real[], row vector)
  log_mix(real[], vector[])
  log_mix(real[], row vector[])
  log_mix(vector, real[])
  log_mix(vector, vector)
  log_mix(vector, row vector)
  log_mix(vector, vector[])
  log_mix(vector, row vector[])
  log_mix(row vector, real[])
  log_mix(row vector, vector)
  log_mix(row vector, row vector)
  log_mix(row vector, vector[])
  log_mix(row vector, row vector[])

```
#### Intended Effect
Expose the new functions for use in Stan

#### How to Verify
Instantiation tests for new signatures have been added to the test for the current (ternary) signature

#### Side Effects
N/A

#### Documentation
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
