### PR TITLE
Update expected values for performance test

### DIFF
--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -108,31 +108,31 @@ TEST_F(performance, values_from_tagged_version) {
     << "last tagged version, 2.17.0, had " << N_values << " elements";
 
   std::vector<double> first_run = last_draws_per_run[0];
-  EXPECT_FLOAT_EQ(-65.7658, first_run[0])
+  EXPECT_FLOAT_EQ(-65.781998, first_run[0])
     << "lp__: index 0";
 
-  EXPECT_FLOAT_EQ(0.944063, first_run[1])
+  EXPECT_FLOAT_EQ(1.0, first_run[1])
     << "accept_stat__: index 1";
 
-  EXPECT_FLOAT_EQ(0.76857001, first_run[2])
+  EXPECT_FLOAT_EQ(0.76853198, first_run[2])
     << "stepsize__: index 2";
 
   EXPECT_FLOAT_EQ(2, first_run[3])
     << "treedepth__: index 3";
 
-  EXPECT_FLOAT_EQ(3, first_run[4])
+  EXPECT_FLOAT_EQ(7, first_run[4])
     << "n_leapfrog__: index 4";
 
   EXPECT_FLOAT_EQ(0, first_run[5])
     << "divergent__: index 5";
 
-  EXPECT_FLOAT_EQ(65.779, first_run[6])
+  EXPECT_FLOAT_EQ(66.6695, first_run[6])
     << "energy__: index 6";
 
-  EXPECT_FLOAT_EQ(1.37067, first_run[7])
+  EXPECT_FLOAT_EQ(1.55186, first_run[7])
     << "beta.1: index 7";
 
-  EXPECT_FLOAT_EQ(-0.771606, first_run[8])
+  EXPECT_FLOAT_EQ(-0.52400702, first_run[8])
     << "beta.2: index 8";
 
   matches_tagged_version = !HasNonfatalFailure();


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
New parameterisation of inv_logit (math pull stan-dev/math#889) to avoid underflow causes the logistic performance test to return slightly different values (as a result of no longer underflowing).

#### Intended Effect
Allow new parameterisation to pass,

#### How to Verify
N/A

#### Side Effects
N/A

#### Documentation
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
