### PR TITLE
feature/2539: matrix_exp_multiply & scale_matrix_exp_multiply

### DIFF
--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -666,6 +666,7 @@ for (const auto& t : all_vector_types) {
  }
 add_nullary("machine_precision");
 add("matrix_exp", expr_type(matrix_type()), expr_type(matrix_type()));
+add("matrix_exp", expr_type(matrix_type()), expr_type(matrix_type()), expr_type(matrix_type()), expr_type(double_type()));
 add("max", expr_type(int_type()), expr_type(int_type(), 1));
 add("max", expr_type(double_type()), expr_type(double_type(), 1));
 add("max", expr_type(double_type()), expr_type(vector_type()));

--- a/src/test/test-models/good/function-signatures/math/matrix/matrix_exp.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/matrix_exp.stan
@@ -1,20 +1,29 @@
 data {
   int d_int;
+  int d_col_b;
   matrix[d_int,d_int] d_matrix;
+  real d_t;
+  matrix[d_int,d_col_b] d_matrix_b;
 }
 transformed data {
   matrix[d_int,d_int] transformed_data_matrix;
   transformed_data_matrix = matrix_exp(d_matrix);
+  transformed_data_matrix = matrix_exp(d_matrix, d_matrix_b, d_t);
 }
 parameters {
   real y_p;
   matrix[d_int,d_int] p_matrix;
+  real p_t;
+  matrix[d_int,d_col_b] p_matrix_b;
 }
 transformed parameters {
   matrix[d_int,d_int] transformed_param_matrix;
-        
   transformed_param_matrix = matrix_exp(p_matrix);
-  transformed_param_matrix = matrix_exp(d_matrix);
+  transformed_param_matrix = matrix_exp(d_matrix, p_matrix_b, p_t);
+  transformed_param_matrix = matrix_exp(d_matrix, d_matrix_b, p_t);
+  transformed_param_matrix = matrix_exp(p_matrix, p_matrix_b, p_t);
+  transformed_param_matrix = matrix_exp(p_matrix, d_matrix_b, p_t);
+  transformed_param_matrix = matrix_exp(p_matrix, d_matrix_b, d_t);
 }
 model {
   y_p ~ normal(0,1);


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Expose `matrix_exp_action` by overloading `matrix_exp` in Stan

#### Intended Effect
Allow in Stan
```Stan
matrix_exp(matrix A, matrix B, real t)
```
to calculate `exp(At)B`.

#### How to Verify
Function signature test

#### Side Effects
n/a
#### Documentation
To be added with doc of `matrix_exp`.

#### Copyright and Licensing
Metrum Research Group, LLC

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
