### PR TITLE
integrate_ode_adams in Stan

### DIFF
--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1626,10 +1626,10 @@ namespace stan {
       const {
       error_msgs << "Warning: the integrate_ode() function is deprecated"
              << " in the Stan language; use the following functions"
-             << " instead."
-             << "  integrate_ode_rk45() [non-stiff]"
-             << "  integrate_ode_adams() [non-stiff]"
-             << " integrate_ode_bdf() [stiff]."
+             << " instead.\n"
+             << " integrate_ode_rk45() [explicit, order 5, for non-stiff problems]\n"
+             << " integrate_ode_adams() [implicit, up to order 12, for non-stiff problems]\n"
+             << " integrate_ode_bdf() [implicit, up to order 5, for stiff problems]."
              << std::endl;
     }
     boost::phoenix::function<deprecated_integrate_ode>

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1625,8 +1625,11 @@ namespace stan {
     void deprecated_integrate_ode::operator()(std::ostream& error_msgs)
       const {
       error_msgs << "Warning: the integrate_ode() function is deprecated"
-             << " in the Stan language; use integrate_ode_rk45() [non-stiff]"
-             << " or integrate_ode_bdf() [stiff] instead."
+             << " in the Stan language; use the following functions"
+             << " instead."
+             << "  integrate_ode_rk45() [non-stiff]"
+             << "  integrate_ode_adams() [non-stiff]"
+             << " integrate_ode_bdf() [stiff]."
              << std::endl;
     }
     boost::phoenix::function<deprecated_integrate_ode>

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1627,9 +1627,12 @@ namespace stan {
       error_msgs << "Warning: the integrate_ode() function is deprecated"
              << " in the Stan language; use the following functions"
              << " instead.\n"
-             << " integrate_ode_rk45() [explicit, order 5, for non-stiff problems]\n"
-             << " integrate_ode_adams() [implicit, up to order 12, for non-stiff problems]\n"
-             << " integrate_ode_bdf() [implicit, up to order 5, for stiff problems]."
+             << " integrate_ode_rk45()"
+             << " [explicit, order 5, for non-stiff problems]\n"
+             << " integrate_ode_adams()"
+             << " [implicit, up to order 12, for non-stiff problems]\n"
+             << " integrate_ode_bdf()"
+             << " [implicit, up to order 5, for stiff problems]."
              << std::endl;
     }
     boost::phoenix::function<deprecated_integrate_ode>

--- a/src/stan/lang/grammars/term_grammar_def.hpp
+++ b/src/stan/lang/grammars/term_grammar_def.hpp
@@ -177,7 +177,8 @@ namespace stan {
       integrate_ode_control_r.name("expression");
       integrate_ode_control_r
         %= ( (string("integrate_ode_rk45") >> no_skip[!char_("a-zA-Z0-9_")])
-             | (string("integrate_ode_bdf") >> no_skip[!char_("a-zA-Z0-9_")]) )
+             | (string("integrate_ode_bdf") >> no_skip[!char_("a-zA-Z0-9_")])
+             | (string("integrate_ode_adams") >> no_skip[!char_("a-zA-Z0-9_")]) )
         >> lit('(')              // >> allows backtracking to non-control
         >> identifier_r          // 1) system function name (function only)
         >> lit(',')
@@ -207,6 +208,7 @@ namespace stan {
       integrate_ode_r
         %= ( (string("integrate_ode_rk45") >> no_skip[!char_("a-zA-Z0-9_")])
              | (string("integrate_ode_bdf") >> no_skip[!char_("a-zA-Z0-9_")])
+             | (string("integrate_ode_adams") >> no_skip[!char_("a-zA-Z0-9_")])
              | (string("integrate_ode") >> no_skip[!char_("a-zA-Z0-9_")])
                [deprecated_integrate_ode_f(boost::phoenix::ref(error_msgs_))] )
         > lit('(')

--- a/src/stan/lang/grammars/term_grammar_def.hpp
+++ b/src/stan/lang/grammars/term_grammar_def.hpp
@@ -178,7 +178,7 @@ namespace stan {
       integrate_ode_control_r
         %= ( (string("integrate_ode_rk45") >> no_skip[!char_("a-zA-Z0-9_")])
              | (string("integrate_ode_bdf") >> no_skip[!char_("a-zA-Z0-9_")])
-             | (string("integrate_ode_adams") >> no_skip[!char_("a-zA-Z0-9_")]) )
+             | (string("integrate_ode_adams") >> no_skip[!char_("a-zA-Z0-9_")]))
         >> lit('(')              // >> allows backtracking to non-control
         >> identifier_r          // 1) system function name (function only)
         >> lit(',')

--- a/src/test/test-models/bad/ode/adams/bad_adams_control_function_return.stan
+++ b/src/test/test-models/bad/ode/adams/bad_adams_control_function_return.stan
@@ -1,0 +1,16 @@
+functions{
+  real twoCptModelODE(real t,
+                      real[] x,
+                      real[] parms,
+                      real[] rdata,
+                      int[] idata){
+    real dxdt[2];
+    return dxdt[2];
+  }
+}
+model {
+  real x[2, 2]
+    = integrate_ode_adams(twoCptModelODE,
+                        {1, 1.3}, 1.0, { 2.2, 3 }, { 1.0 }, { 1.0 }, { 2 },
+                        10, 10, 10);
+}

--- a/src/test/test-models/bad/ode/adams/bad_control_function_return.stan
+++ b/src/test/test-models/bad/ode/adams/bad_control_function_return.stan
@@ -1,0 +1,16 @@
+functions{
+  real twoCptModelODE(real t,
+                      real[] x,
+                      real[] parms,
+                      real[] rdata,
+                      int[] idata){
+    real dxdt[2];
+    return dxdt[2];
+  }
+}
+model {
+  real x[2, 2]
+    = integrate_ode_adams(twoCptModelODE,
+                        {1, 1.3}, 1.0, { 2.2, 3 }, { 1.0 }, { 1.0 }, { 2 },
+                        10, 10, 10);
+}

--- a/src/test/test-models/bad/ode/adams/bad_fun_type.stan
+++ b/src/test/test-models/bad/ode/adams/bad_fun_type.stan
@@ -1,0 +1,39 @@
+functions {
+  real[] harm_osc_ode(real[] t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real t0;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,2];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_fun_type_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_fun_type_control.stan
@@ -1,0 +1,39 @@
+functions {
+  real[] harm_osc_ode(real[] t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real t0;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,2];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_t0_var_type.stan
+++ b/src/test/test-models/bad/ode/adams/bad_t0_var_type.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+}
+parameters {
+  real theta[1];
+  real t0;
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_t0_var_type_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_t0_var_type_control.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+}
+parameters {
+  real theta[1];
+  real t0;
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_t_type.stan
+++ b/src/test/test-models/bad/ode/adams/bad_t_type.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  matrix[2,3] t0;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_t_type_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_t_type_control.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  matrix[2,3] t0;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_theta_type.stan
+++ b/src/test/test-models/bad/ode/adams/bad_theta_type.stan
@@ -1,0 +1,39 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real t0;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,2];
+}
+parameters {
+  real theta[2,1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_theta_type_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_theta_type_control.stan
@@ -1,0 +1,39 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real t0;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,2];
+}
+parameters {
+  real theta[2,1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_ts_type.stan
+++ b/src/test/test-models/bad/ode/adams/bad_ts_type.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real t0;
+  real ts[10,2];
+  real x[1];   
+  int x_int[0];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_ts_type_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_ts_type_control.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real t0;
+  real ts[10,2];
+  real x[1];   
+  int x_int[0];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_ts_var_type.stan
+++ b/src/test/test-models/bad/ode/adams/bad_ts_var_type.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real x[1];   
+  int x_int[0];
+  real t0;
+}
+parameters {
+  real theta[1];
+  real ts[10];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_ts_var_type_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_ts_var_type_control.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real x[1];   
+  int x_int[0];
+  real t0;
+}
+parameters {
+  real theta[1];
+  real ts[10];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_x_int_type.stan
+++ b/src/test/test-models/bad/ode/adams/bad_x_int_type.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real t0;
+  real ts[10];
+  real x[1];   
+  int x_int[4,5];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_x_int_type_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_x_int_type_control.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real t0;
+  real ts[10];
+  real x[1];   
+  int x_int[4,5];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_x_type.stan
+++ b/src/test/test-models/bad/ode/adams/bad_x_type.stan
@@ -1,0 +1,39 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real t0;
+  real ts[10];
+  vector[3] x[1];   
+  int x_int[0];
+  real y[10,2];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_x_type_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_x_type_control.stan
@@ -1,0 +1,39 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real t0;
+  real ts[10];
+  vector[3] x[1];   
+  int x_int[0];
+  real y[10,2];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_x_var_type.stan
+++ b/src/test/test-models/bad/ode/adams/bad_x_var_type.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real ts[10];
+  int x_int[0];
+  real t0;
+}
+parameters {
+  real x[1];   
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_x_var_type_adams_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_x_var_type_adams_control.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real ts[10];
+  int x_int[0];
+  real t0;
+}
+parameters {
+  real x[1];   
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_x_var_type_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_x_var_type_control.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2];
+  real ts[10];
+  int x_int[0];
+  real t0;
+}
+parameters {
+  real x[1];   
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_bdf(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_y_type.stan
+++ b/src/test/test-models/bad/ode/adams/bad_y_type.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2,3];
+  real t0;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/ode/adams/bad_y_type_control.stan
+++ b/src/test/test-models/bad/ode/adams/bad_y_type_control.stan
@@ -1,0 +1,38 @@
+functions {
+  real[] harm_osc_ode(real t,
+                      real[] y,         // state
+                      real[] theta,     // parameters
+                      real[] x,         // data
+                      int[] x_int) {    // integer data
+    real dydt[2];
+    dydt[1] <- x[1] * y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  real y0[2,3];
+  real t0;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,2];
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                     y0,            // initial state
+                     t0,            // initial time
+                     ts,            // solution times
+                     theta,         // parameters
+                     x,             // data
+                     x_int, 0.01, 0.01, 10);        // integer data
+  
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/good/integrate_ode_adams.stan
+++ b/src/test/test-models/good/integrate_ode_adams.stan
@@ -25,12 +25,10 @@ parameters {
 }
 model {
   real y_hat[T,2];
-  y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_d, x, x_int);
   y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_p, x, x_int);
   y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_d, x, x_int);
   y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_p, x, x_int);
 
-  y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_d, x, x_int, 1e-10, 1e-10, 1e8);
   y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_p, x, x_int, 1e-10, 1e-10, 1e8);
   y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_d, x, x_int, 1e-10, 1e-10, 1e8);
   y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_p, x, x_int, 1e-10, 1e-10, 1e8);

--- a/src/test/test-models/good/integrate_ode_adams.stan
+++ b/src/test/test-models/good/integrate_ode_adams.stan
@@ -1,0 +1,49 @@
+functions {
+  real[] sho(real t,
+             real[] y,
+             real[] theta,
+             real[] x,
+             int[] x_int) {
+    real dydt[2];
+    dydt[1] = y[2];
+    dydt[2] = -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+data {
+  int<lower=1> T;
+  real y0_d[2];
+  real t0;
+  real ts[T];
+  real theta_d[1];
+  real x[0];
+  int x_int[0];
+}
+parameters {
+  real y0_p[2];
+  real theta_p[1];
+}
+model {
+  real y_hat[T,2];
+  y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_d, x, x_int);
+  y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_p, x, x_int);
+  y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_d, x, x_int);
+  y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_p, x, x_int);
+
+  y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_d, x, x_int, 1e-10, 1e-10, 1e8);
+  y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_p, x, x_int, 1e-10, 1e-10, 1e8);
+  y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_d, x, x_int, 1e-10, 1e-10, 1e8);
+  y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_p, x, x_int, 1e-10, 1e-10, 1e8);
+}
+generated quantities {
+  real y_hat[T,2];
+  y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_d, x, x_int);
+  y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_p, x, x_int);
+  y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_d, x, x_int);
+  y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_p, x, x_int);
+
+  y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_d, x, x_int, 1e-10, 1e-10, 1e8);
+  y_hat = integrate_ode_adams(sho, y0_d, t0, ts, theta_p, x, x_int, 1e-10, 1e-10, 1e8);
+  y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_d, x, x_int, 1e-10, 1e-10, 1e8);
+  y_hat = integrate_ode_adams(sho, y0_p, t0, ts, theta_p, x, x_int, 1e-10, 1e-10, 1e8);
+}

--- a/src/test/test-models/good/ode_good.stan
+++ b/src/test/test-models/good/ode_good.stan
@@ -45,6 +45,13 @@ transformed parameters {
                              theta,         // parameters
                              x,             // data
                              x_int);        // integer data
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                               y0,            // initial state
+                               t0,            // initial time
+                               ts,            // solution times
+                               theta,         // parameters
+                               x,             // data
+                               x_int);        // integer data
   y_hat <- integrate_ode_rk45(harm_osc_ode,  // system
                               y0,            // initial state
                               t0,            // initial time
@@ -59,6 +66,13 @@ transformed parameters {
                              theta,         // parameters
                              x,             // data
                              x_int, 0.01, 0.01, 10); // integer data
+  y_hat <- integrate_ode_adams(harm_osc_ode,  // system
+                               y0,            // initial state
+                               t0,            // initial time
+                               ts,            // solution times
+                               theta,         // parameters
+                               x,             // data
+                               x_int, 0.01, 0.01, 10); // integer data
   
 }
 model {

--- a/src/test/test-models/good/parser-generator/ode_control.stan
+++ b/src/test/test-models/good/parser-generator/ode_control.stan
@@ -24,15 +24,18 @@ transformed data {
 model {
 }
 generated quantities {
-  real y_hat[T,2];
+  real y_hat[T,3];
   y_hat <- integrate_ode_rk45(sho, y0, t0, ts, theta, x, x_int,
                               1e-10, 1e-10, 1e6);
   y_hat <- integrate_ode_bdf(sho, y0, t0, ts, theta, x, x_int,
+                             1e-10, 1e-10, 1e6);
+  y_hat <- integrate_ode_adams(sho, y0, t0, ts, theta, x, x_int,
                              1e-10, 1e-10, 1e6);
 
   // add measurement error
   for (t in 1:T) {
     y_hat[t,1] <- y_hat[t,1] + normal_rng(0,0.1);
     y_hat[t,2] <- y_hat[t,2] + normal_rng(0,0.1);
+    y_hat[t,3] <- y_hat[t,3] + normal_rng(0,0.1);
   }
 }

--- a/src/test/unit/lang/parser/integrate_ode_deprecation_test.cpp
+++ b/src/test/unit/lang/parser/integrate_ode_deprecation_test.cpp
@@ -4,6 +4,8 @@
 TEST(langParser, integrate_ode_deprecation) {
   test_warning("integrate_ode_deprecation",
                "the integrate_ode() function is deprecated in the"
-               " Stan language; use integrate_ode_rk45() [non-stiff]"
-               " or integrate_ode_bdf() [stiff] instead.");
+               " Stan language; use the following functions instead."
+               "  integrate_ode_rk45() [non-stiff]"
+               "  integrate_ode_adams() [non-stiff]"
+               "  integrate_ode_bdf() [stiff].");
 }

--- a/src/test/unit/lang/parser/integrate_ode_deprecation_test.cpp
+++ b/src/test/unit/lang/parser/integrate_ode_deprecation_test.cpp
@@ -4,8 +4,8 @@
 TEST(langParser, integrate_ode_deprecation) {
   test_warning("integrate_ode_deprecation",
                "the integrate_ode() function is deprecated in the"
-               " Stan language; use the following functions instead."
-               "  integrate_ode_rk45() [non-stiff]"
-               "  integrate_ode_adams() [non-stiff]"
-               "  integrate_ode_bdf() [stiff].");
+               " Stan language; use the following functions instead.\n"
+               " integrate_ode_rk45() [explicit, order 5, for non-stiff problems]\n"
+               " integrate_ode_adams() [implicit, up to order 12, for non-stiff problems]\n"
+               " integrate_ode_bdf() [implicit, up to order 5, for stiff problems].");
 }

--- a/src/test/unit/lang/parser/ode_test.cpp
+++ b/src/test/unit/lang/parser/ode_test.cpp
@@ -119,3 +119,49 @@ TEST(lang_parser, integrate_ode_bdf_control_bad) {
   test_throws("ode/bad_x_var_type_bdf_control",
       "sixth argument to integrate_ode_bdf (real data) must be data only");
 }
+
+TEST(lang_parser, integrate_ode_adams_bad) {
+  test_throws("ode/adams/bad_adams_control_function_return",
+      "first argument to integrate_ode_adams must be the name of a function with signature");
+  test_throws("ode/adams/bad_fun_type",
+      "first argument to integrate_ode_adams must be the name of a function with signature");
+  test_throws("ode/adams/bad_y_type",
+              "second argument to integrate_ode_adams must have type real[]");
+  test_throws("ode/adams/bad_t_type",
+          "third argument to integrate_ode_adams must have type real or int");
+  test_throws("ode/adams/bad_ts_type",
+              "fourth argument to integrate_ode_adams must have type real[]");
+  test_throws("ode/adams/bad_theta_type",
+              "fifth argument to integrate_ode_adams must have type real[]");
+  test_throws("ode/adams/bad_x_type",
+              "sixth argument to integrate_ode_adams must have type real[]");
+  test_throws("ode/adams/bad_x_int_type",
+              "seventh argument to integrate_ode_adams must have type int[]");
+  test_throws("ode/adams/bad_t0_var_type",
+      "third argument to integrate_ode_adams (initial times) must be data only");
+  test_throws("ode/adams/bad_x_var_type",
+      "sixth argument to integrate_ode_adams (real data) must be data only");
+}
+
+TEST(lang_parser, integrate_ode_adams_control_bad) {
+  test_throws("ode/adams/bad_fun_type_control",
+      "first argument to integrate_ode_adams must be the name of a function with signature");
+  test_throws("ode/adams/bad_y_type_control",
+              "second argument to integrate_ode_adams must have type real[]");
+  test_throws("ode/adams/bad_t_type_control",
+          "third argument to integrate_ode_adams must have type real or int");
+  test_throws("ode/adams/bad_ts_type_control",
+              "fourth argument to integrate_ode_adams must have type real[]");
+  test_throws("ode/adams/bad_theta_type_control",
+              "fifth argument to integrate_ode_adams must have type real[]");
+  test_throws("ode/adams/bad_x_type_control",
+              "sixth argument to integrate_ode_adams must have type real[]");
+  test_throws("ode/adams/bad_x_int_type_control",
+              "seventh argument to integrate_ode_adams must have type int[]");
+  test_throws("ode/adams/bad_t0_var_type_control",
+      "third argument to integrate_ode_adams (initial times) must be data only");
+  test_throws("ode/adams/bad_ts_var_type_control",
+    "fourth argument to integrate_ode_adams (solution times) must be data only");
+  test_throws("ode/adams/bad_x_var_type_adams_control",
+      "sixth argument to integrate_ode_adams (real data) must be data only");
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
With https://github.com/stan-dev/math/issues/734 we are ready to provde Adams-Moulton integrator to Stan language. The process is identical to `rk45` and `bdf` integrators, as the function signature as well as ODE functor signature remain the same.

#### Intended Effect
Support `integrate_ode_adams` function as the third ODE solver in Stan.

#### How to Verify
Unit tests and model tests.

#### Side Effects
n/a

#### Documentation

#### Copyright and Licensing
Metrum Research Group, LLC

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
