### PR TITLE
Feature 2539 matrix exp mult

### DIFF
--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -674,6 +674,7 @@ for (const auto& t : all_vector_types) {
  }
 add_nullary("machine_precision");
 add("matrix_exp", expr_type(matrix_type()), expr_type(matrix_type()));
+add("matrix_exp_multiply", expr_type(matrix_type()), expr_type(matrix_type()), expr_type(matrix_type()));
 add("max", expr_type(int_type()), expr_type(int_type(), 1));
 add("max", expr_type(double_type()), expr_type(double_type(), 1));
 add("max", expr_type(double_type()), expr_type(vector_type()));
@@ -1040,6 +1041,7 @@ add("rows_dot_product", expr_type(vector_type()), expr_type(matrix_type()), expr
 add("rows_dot_self", expr_type(vector_type()), expr_type(vector_type()));
 add("rows_dot_self", expr_type(vector_type()), expr_type(row_vector_type()));
 add("rows_dot_self", expr_type(vector_type()), expr_type(matrix_type()));
+add("scale_matrix_exp_multiply", expr_type(matrix_type()), expr_type(double_type()), expr_type(matrix_type()), expr_type(matrix_type()));
 for (size_t i = 0; i < vector_types.size(); ++i) {
   for (size_t j = 0; j < vector_types.size(); ++j) {
     for (size_t k = 0; k < vector_types.size(); ++k) {

--- a/src/test/test-models/good/function-signatures/math/matrix/matrix_exp_multiply.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/matrix_exp_multiply.stan
@@ -1,0 +1,25 @@
+data {
+  int d_int;
+  int d_col;
+  matrix[d_int,d_int] d_matrix_a;
+  matrix[d_int,d_col] d_matrix_b;
+}
+transformed data {
+  matrix[d_int,d_col] transformed_data_matrix;
+  transformed_data_matrix = matrix_exp_multiply(d_matrix_a, d_matrix_b);
+}
+parameters {
+  real y_p;
+  matrix[d_int,d_int] p_matrix_a;
+  matrix[d_int,d_col] p_matrix_b;
+}
+transformed parameters {
+  matrix[d_int,d_col] transformed_param_matrix;
+        
+  transformed_param_matrix = matrix_exp_multiply(p_matrix_a, p_matrix_b);
+  transformed_param_matrix = matrix_exp_multiply(p_matrix_a, d_matrix_b);
+  transformed_param_matrix = matrix_exp_multiply(d_matrix_a, p_matrix_b);
+}
+model {
+  y_p ~ normal(0,1);
+}

--- a/src/test/test-models/good/function-signatures/math/matrix/scale_matrix_exp_multiply.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/scale_matrix_exp_multiply.stan
@@ -1,0 +1,30 @@
+data {
+  int d_int;
+  int d_col;
+  real d_t;
+  matrix[d_int,d_int] d_matrix_a;
+  matrix[d_int,d_col] d_matrix_b;
+}
+transformed data {
+  matrix[d_int,d_col] transformed_data_matrix;
+  transformed_data_matrix = scale_matrix_exp_multiply(d_t, d_matrix_a, d_matrix_b);
+}
+parameters {
+  real y_p;
+  real p_t;
+  matrix[d_int,d_int] p_matrix_a;
+  matrix[d_int,d_col] p_matrix_b;
+}
+transformed parameters {
+  matrix[d_int,d_col] transformed_param_matrix;
+        
+  transformed_param_matrix = scale_matrix_exp_multiply(d_t, p_matrix_a, p_matrix_b);
+  transformed_param_matrix = scale_matrix_exp_multiply(d_t, p_matrix_a, d_matrix_b);
+  transformed_param_matrix = scale_matrix_exp_multiply(d_t, d_matrix_a, p_matrix_b);
+  transformed_param_matrix = scale_matrix_exp_multiply(p_t, p_matrix_a, p_matrix_b);
+  transformed_param_matrix = scale_matrix_exp_multiply(p_t, p_matrix_a, d_matrix_b);
+  transformed_param_matrix = scale_matrix_exp_multiply(p_t, d_matrix_a, p_matrix_b);
+}
+model {
+  y_p ~ normal(0,1);
+}

--- a/src/test/test-models/good/function-signatures/math/matrix/scale_matrix_exp_multiply.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/scale_matrix_exp_multiply.stan
@@ -11,7 +11,6 @@ transformed data {
 }
 parameters {
   real y_p;
-  real p_t;
   matrix[d_int,d_int] p_matrix_a;
   matrix[d_int,d_col] p_matrix_b;
 }
@@ -21,9 +20,6 @@ transformed parameters {
   transformed_param_matrix = scale_matrix_exp_multiply(d_t, p_matrix_a, p_matrix_b);
   transformed_param_matrix = scale_matrix_exp_multiply(d_t, p_matrix_a, d_matrix_b);
   transformed_param_matrix = scale_matrix_exp_multiply(d_t, d_matrix_a, p_matrix_b);
-  transformed_param_matrix = scale_matrix_exp_multiply(p_t, p_matrix_a, p_matrix_b);
-  transformed_param_matrix = scale_matrix_exp_multiply(p_t, p_matrix_a, d_matrix_b);
-  transformed_param_matrix = scale_matrix_exp_multiply(p_t, d_matrix_a, p_matrix_b);
 }
 model {
   y_p ~ normal(0,1);

--- a/src/test/unit/lang/parser/matrix_functions_test.cpp
+++ b/src/test/unit/lang/parser/matrix_functions_test.cpp
@@ -163,6 +163,10 @@ TEST(lang_parser, matrix_exp_matrix_function_signatures) {
     test_parsable("function-signatures/math/matrix/matrix_exp");
 }
 
+TEST(lang_parser, matrix_exp_multiply_matrix_function_signatures) {
+    test_parsable("function-signatures/math/matrix/matrix_exp_multiply");
+}
+
 TEST(lang_parser, max_matrix_function_signatures) {
   test_parsable("function-signatures/math/matrix/max");
 }
@@ -257,6 +261,10 @@ TEST(lang_parser, rows_dot_product_matrix_function_signatures) {
 
 TEST(lang_parser, rows_dot_self_matrix_function_signatures) {
   test_parsable("function-signatures/math/matrix/rows_dot_self");
+}
+
+TEST(lang_parser, scale_matrix_exp_multiply_matrix_function_signatures) {
+    test_parsable("function-signatures/math/matrix/scale_matrix_exp_multiply");
 }
 
 TEST(lang_parser, singular_values_matrix_function_signatures) {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
This PR address #2539, allowing
```Stan
matrix_exp_multiply(matrix A, matrix B);
scale_matrix_exp_multiply(real t, matrix A, matrix B);
```
in Stan language.

#### Intended Effect
```Stan
matrix_exp_multiply(matrix A, matrix B);
scale_matrix_exp_multiply(real t, matrix A, matrix B);
```
for `exp(A)B` and `exp(tA)B`, respectively.

#### How to Verify
unit tests

#### Side Effects
n/a

#### Documentation
#2547
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Metrum Research Group, LLC


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
