### PR TITLE
expose qr_thin_{Q,R}

### DIFF
--- a/src/docs/stan-reference/examples.tex
+++ b/src/docs/stan-reference/examples.tex
@@ -165,11 +165,11 @@ $x$ is a $N \times K$ matrix, and $\beta$ is a $K$-vector of coefficients.
 Presuming $N \geq K$, we can exploit the fact that any design matrix, $x$
 can be decomposed using the thin QR decomposition into an orthogonal matrix
 $Q$ and an upper-triangular matrix $R$, i.e. $x = Q R$. See \ref{QR-decomposition}
-for more information on the QR decomposition but note that \code{qr\_Q} and
-\code{qr\_R} implement the fat QR decomposition so here we thin it by including
-only $K$ columns in $Q$ and $K$ rows in $R$. Also, in practice, it is best to
-write $x = Q^\ast R^\ast$ where $Q^\ast = Q \times \sqrt{n - 1}$ and
-$R^\ast = \frac{1}{\sqrt{n - 1}} R$. Thus, we can equivalently write
+for more information on the thin QR decomposition. Note that the columns of $x$
+should each have a mean of zero and no constant column. Also, in practice, it 
+is best to write $x = Q^\ast R^\ast$ where $Q^\ast = Q \times s$
+and $R^\ast = \frac{1}{s} R$, where $s$ is some scale factor such as
+$\sqrt{N - 1.0}$ or $R_{K,K}$. Thus, we can equivalently write
 $\eta = x \beta = Q R \beta = Q^\ast R^\ast \beta$. If we let
 $\theta = R^\ast \beta$, then we have $\eta = Q^\ast \theta$ and
 $\beta = R^{\ast^{-1}} \theta$. In that case, the previous Stan program becomes
@@ -178,17 +178,15 @@ $\beta = R^{\ast^{-1}} \theta$. In that case, the previous Stan program becomes
 data {
   int<lower=0> N;   // number of data items
   int<lower=0> K;   // number of predictors
-  matrix[N, K] x;   // predictor matrix
+  matrix[N, K] x;   // predictor matrix with centered columns!
   vector[N] y;      // outcome vector
 }
 transformed data {
-  matrix[N, K] Q_ast;
-  matrix[K, K] R_ast;
-  matrix[K, K] R_ast_inverse;
-  // thin and scale the QR decomposition
-  Q_ast = qr_Q(x)[, 1:K] * sqrt(N - 1);
-  R_ast = qr_R(x)[1:K, ] / sqrt(N - 1);
-  R_ast_inverse = inverse(R_ast);
+  matrix[K, K] R = qr_thin_R(x);
+  real s = sqrt(N - 1.0); // or N or R[K, K] or another number
+  matrix[K, K] R_ast = R / s;
+  matrix[N, K] Q_ast = qr_thin_Q(x) * s;
+  matrix[K, K] R_ast_inverse = inverse(R_ast);
 }
 parameters {
   real alpha;           // intercept
@@ -197,10 +195,10 @@ parameters {
 }
 model {
   y ~ normal(Q_ast * theta + alpha, sigma);  // likelihood
+  // priors
 }
 generated quantities {
-  vector[K] beta;
-  beta = R_ast_inverse * theta; // coefficients on x
+  vector[K] beta = R_ast_inverse * theta; // coefficients on x
 }
 \end{stancode}
 %
@@ -219,20 +217,19 @@ reasoning is threefold:
   of $x$ generally do not. Thus, a Hamiltonian Monte Carlo algorithm
   can move around the parameter space with a smaller number of larger
   steps
-\item Since the covariance matrix for the columns of $Q\ast$ is an
-  identity matrix, $\theta$ typically has a reasonable scale if the
+\item Since the covariance matrix for the columns of $Q\ast$ is proportional
+  to an identity matrix, $\theta$ typically has a reasonable scale if the
   units of $y$ are also reasonable. This also helps HMC move
   efficiently without compromising numerical accuracy.
 \end{enumerate}
 %
 Consequently, this QR reparameterization is recommended for linear and
 generalized linear models in Stan whenever $K > 1$ and you do not have
-an informative prior on the \emph{location} of $\beta$. It can also be
-worthwhile to subtract the mean from each column of $x$ before
-obtaining the QR decomposition, which does not affect the posterior
-distribution of $\theta$ or $\beta$ but does affect $\alpha$ and
-allows you to interpret $\alpha$ as the expectation of $y$ in a linear
-model.
+an informative prior on the \emph{location} of $\beta$. Subtracting the 
+mean from each column of $x$ before obtaining the QR decomposition, does 
+not affect the posterior distribution of $\theta$ or $\beta$ but does 
+affect $\alpha$ and allows you to interpret $\alpha$ as the expectation of 
+$y$ in a linear model for an average observation.
 
 \section{Priors for Coefficients and Scales}\label{regression-priors.section}
 

--- a/src/docs/stan-reference/functions.tex
+++ b/src/docs/stan-reference/functions.tex
@@ -3119,6 +3119,15 @@ eigenvalues of 0).
 
 \begin{description}
 %
+\fitem{matrix}{qr\_thin\_Q}{matrix \farg{A}}{
+The orthogonal matrix in the thin QR decomposition of \farg{A}, which
+implies that the resulting matrix is the same dimensions as as \farg{A}}
+%
+\fitem{matrix}{qr\_thin\_R}{matrix \farg{A}}{
+  The upper triangular matrix in the thin QR decomposition of \farg{A},
+  which implies that the resulting matrix has the same dimensions as
+  \farg{A} has columns}
+%
 \fitem{matrix}{qr\_Q}{matrix \farg{A}}{
 The orthogonal matrix in the fat QR decomposition of \farg{A}, which
 implies that the resulting matrix is square with the same number of
@@ -3131,15 +3140,21 @@ rows as \farg{A}}
 %
 \end{description}
 %
+The thin QR decomposition is generally preferable and will consume much
+less memory when the input matrix is large than will the fat QR 
+decomposition. Both versions of the decomposition represent the input
+matrix as
+\[
+A = Q \, R.
+\]
 Multiplying a column of an orthogonal matrix by $-1$ still results in
 an orthogonal matrix, and you can multiply the corresponding row of
 the upper trapezoidal matrix by $-1$ without changing the product. Thus,
 Stan adopts the normalization that the diagonal elements of the upper
 trapezoidal matrix are strictly positive and the columns of the
-orthogonal matrix are reflected if necessary. The input matrix $A$ need
-not be square but must have at least as many rows as it has columns.
-Also, this QR decomposition algorithm does not utilize pivoting and
-thus is fast but may be numerically unstable.
+orthogonal matrix are reflected if necessary. Also, these QR 
+decomposition algorithms do not utilize pivoting and thus may be 
+numerically unstable on input matrices that have less than full rank.
 
 \subsubsection{Cholesky Decomposition}
 

--- a/src/docs/stan-reference/functions.tex
+++ b/src/docs/stan-reference/functions.tex
@@ -3121,12 +3121,12 @@ eigenvalues of 0).
 %
 \fitem{matrix}{qr\_thin\_Q}{matrix \farg{A}}{
 The orthogonal matrix in the thin QR decomposition of \farg{A}, which
-implies that the resulting matrix is the same dimensions as as \farg{A}}
+implies that the resulting matrix has the same dimensions as \farg{A}}
 %
 \fitem{matrix}{qr\_thin\_R}{matrix \farg{A}}{
   The upper triangular matrix in the thin QR decomposition of \farg{A},
-  which implies that the resulting matrix has the same dimensions as
-  \farg{A} has columns}
+  which implies that the resulting matrix is square with the same
+  number of columns as \farg{A}}
 %
 \fitem{matrix}{qr\_Q}{matrix \farg{A}}{
 The orthogonal matrix in the fat QR decomposition of \farg{A}, which
@@ -3136,7 +3136,7 @@ rows as \farg{A}}
 \fitem{matrix}{qr\_R}{matrix \farg{A}}{
   The upper trapezoidal matrix in the fat QR decomposition of \farg{A},
   which implies that the resulting matrix will be square with the same 
-  dimensions as \farg{A}}
+  number of rows as \farg{A}}
 %
 \end{description}
 %

--- a/src/docs/stan-reference/functions.tex
+++ b/src/docs/stan-reference/functions.tex
@@ -3135,13 +3135,13 @@ rows as \farg{A}}
 %
 \fitem{matrix}{qr\_R}{matrix \farg{A}}{
   The upper trapezoidal matrix in the fat QR decomposition of \farg{A},
-  which implies that the resulting matrix has the same dimensions as
-  \farg{A}}
+  which implies that the resulting matrix will be square with the same 
+  dimensions as \farg{A}}
 %
 \end{description}
 %
-The thin QR decomposition is generally preferable and will consume much
-less memory when the input matrix is large than will the fat QR 
+The thin QR decomposition is always preferable because it will consume
+much less memory when the input matrix is large than will the fat QR 
 decomposition. Both versions of the decomposition represent the input
 matrix as
 \[

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -332,6 +332,8 @@ add("eigenvalues_sym", expr_type(vector_type()), expr_type(matrix_type()));
 add("eigenvectors_sym", expr_type(matrix_type()), expr_type(matrix_type()));
 add("qr_Q", expr_type(matrix_type()), expr_type(matrix_type()));
 add("qr_R", expr_type(matrix_type()), expr_type(matrix_type()));
+add("qr_thin_Q", expr_type(matrix_type()), expr_type(matrix_type()));
+add("qr_thin_R", expr_type(matrix_type()), expr_type(matrix_type()));
 add("elt_divide", expr_type(vector_type()), expr_type(vector_type()), expr_type(vector_type()));
 add("elt_divide", expr_type(row_vector_type()), expr_type(row_vector_type()), expr_type(row_vector_type()));
 add("elt_divide", expr_type(matrix_type()), expr_type(matrix_type()), expr_type(matrix_type()));

--- a/src/test/test-models/good/function-signatures/math/matrix/qr_thin_Q.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/qr_thin_Q.stan
@@ -1,0 +1,23 @@
+data { 
+  int d_int;
+  matrix[d_int,d_int] d_matrix;
+}
+
+transformed data {
+  matrix[d_int,d_int] transformed_data_matrix;
+
+  transformed_data_matrix <- qr_thin_Q(d_matrix);
+}
+parameters {
+  real y_p;
+  matrix[d_int,d_int] p_matrix;
+}
+transformed parameters {
+  matrix[d_int,d_int] transformed_param_matrix;
+
+  transformed_param_matrix <- qr_thin_Q(d_matrix);
+  transformed_param_matrix <- qr_thin_Q(p_matrix);
+}
+model {  
+  y_p ~ normal(0,1);
+}

--- a/src/test/test-models/good/function-signatures/math/matrix/qr_thin_R.stan
+++ b/src/test/test-models/good/function-signatures/math/matrix/qr_thin_R.stan
@@ -1,0 +1,23 @@
+data { 
+  int d_int;
+  matrix[d_int,d_int] d_matrix;
+}
+
+transformed data {
+  matrix[d_int,d_int] transformed_data_matrix;
+
+  transformed_data_matrix <- qr_thin_R(d_matrix);
+}
+parameters {
+  real y_p;
+  matrix[d_int,d_int] p_matrix;
+}
+transformed parameters {
+  matrix[d_int,d_int] transformed_param_matrix;
+
+  transformed_param_matrix <- qr_thin_R(d_matrix);
+  transformed_param_matrix <- qr_thin_R(p_matrix);
+}
+model {  
+  y_p ~ normal(0,1);
+}

--- a/src/test/unit/lang/parser/matrix_functions_test.cpp
+++ b/src/test/unit/lang/parser/matrix_functions_test.cpp
@@ -215,6 +215,14 @@ TEST(lang_parser, qr_R_matrix_function_signatures) {
   test_parsable("function-signatures/math/matrix/qr_R");
 }
 
+TEST(lang_parser, qr_thin_Q_matrix_function_signatures) {
+  test_parsable("function-signatures/math/matrix/qr_thin_Q");
+}
+
+TEST(lang_parser, qr_thin_R_matrix_function_signatures) {
+  test_parsable("function-signatures/math/matrix/qr_thin_R");
+}
+
 TEST(lang_parser, quad_form_matrix_function_signatures) {
   test_parsable("function-signatures/math/matrix/quad_form");
 }


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py src/test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary

Expose `qr_thin_Q()` and `qr_thin_R()` to the Stan language

#### Intended Effect

Allow users to use `qr_thin_Q()` and `qr_thin_R()`.

Fixes #2560 .

#### How to Verify

Run tests under `src/test/test-models/good/function-signatures/math/matrix/`

#### Side Effects

Uses less RAM than fat QR decomposition

#### Documentation

Yes

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
