### PR TITLE
Sampling is able to initialize when there is an exception in transformed parrameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ stan.kdev4
 
 # local make include
 /make/local
+
+*.gch

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -13,202 +13,202 @@
 #include <vector>
 
 namespace stan {
-  namespace services {
-    namespace util {
+namespace services {
+namespace util {
 
-      /**
-       * Returns a valid initial value of the parameters of the model
-       * on the unconstrained scale.
-       *
-       * For identical inputs (model, init, rng, init_radius), this
-       * function will produce the same initialization.
-       *
-       * Initialization first tries to use the provided
-       * <code>stan::io::var_context</code>, then it will generate
-       * random uniform values from -init_radius to +init_radius for missing
-       * parameters.
-       *
-       * When the <code>var_context</code> provides all variables or
-       * the init_radius is 0, this function will only evaluate the
-       * log probability of the model with the unconstrained
-       * parameters once to see if it's valid.
-       *
-       * When at least some of the initialization is random, it will
-       * randomly initialize until it finds a set of unconstrained
-       * parameters that are valid or it hits <code>MAX_INIT_TRIES =
-       * 100</code> (hard-coded).
-       *
-       * Valid initialization is defined as a finite, non-NaN value
-       * for the evaluation of the log probability and all its
-       * gradients.
-       *
-       * @param[in] model the model
-       * @param[in] init a var_context with initial values
-       * @param[in,out] rng random number generator
-       * @param[in] init_radius the radius for generating random values.
-       *   A value of 0 indicates that the unconstrained parameters (not
-       *   provided by init) should be initialized with 0.
-       * @param[in] print_timing indicates whether a timing message should
-       *   be printed to the logger
-       * @param[in,out] logger logger for messages
-       * @param[in,out] init_writer init writer (on the unconstrained scale)
-       * @throws exception passed through from the model if the model has a
-       *   fatal error (not a std::domain_error)
-       * @throws std::domain_error if the model can not be initialized and
-       *   the model does not have a fatal error (only allows for
-       *   std::domain_error)
-       * @return valid unconstrained parameters for the model
-       */
-      template <class Model, class RNG>
-      std::vector<double> initialize(Model& model,
-                                     stan::io::var_context& init,
-                                     RNG& rng,
-                                     double init_radius,
-                                     bool print_timing,
-                                     stan::callbacks::logger& logger,
-                                     stan::callbacks::writer&
-                                     init_writer) {
-        std::vector<double> unconstrained;
-        std::vector<int> disc_vector;
+/**
+ * Returns a valid initial value of the parameters of the model
+ * on the unconstrained scale.
+ *
+ * For identical inputs (model, init, rng, init_radius), this
+ * function will produce the same initialization.
+ *
+ * Initialization first tries to use the provided
+ * <code>stan::io::var_context</code>, then it will generate
+ * random uniform values from -init_radius to +init_radius for missing
+ * parameters.
+ *
+ * When the <code>var_context</code> provides all variables or
+ * the init_radius is 0, this function will only evaluate the
+ * log probability of the model with the unconstrained
+ * parameters once to see if it's valid.
+ *
+ * When at least some of the initialization is random, it will
+ * randomly initialize until it finds a set of unconstrained
+ * parameters that are valid or it hits <code>MAX_INIT_TRIES =
+ * 100</code> (hard-coded).
+ *
+ * Valid initialization is defined as a finite, non-NaN value
+ * for the evaluation of the log probability and all its
+ * gradients.
+ *
+ * @param[in] model the model
+ * @param[in] init a var_context with initial values
+ * @param[in,out] rng random number generator
+ * @param[in] init_radius the radius for generating random values.
+ *   A value of 0 indicates that the unconstrained parameters (not
+ *   provided by init) should be initialized with 0.
+ * @param[in] print_timing indicates whether a timing message should
+ *   be printed to the logger
+ * @param[in,out] logger logger for messages
+ * @param[in,out] init_writer init writer (on the unconstrained scale)
+ * @throws exception passed through from the model if the model has a
+ *   fatal error (not a std::domain_error)
+ * @throws std::domain_error if the model can not be initialized and
+ *   the model does not have a fatal error (only allows for
+ *   std::domain_error)
+ * @return valid unconstrained parameters for the model
+ */
+template <class Model, class RNG>
+std::vector<double> initialize(Model& model,
+                               stan::io::var_context& init,
+                               RNG& rng,
+                               double init_radius,
+                               bool print_timing,
+                               stan::callbacks::logger& logger,
+                               stan::callbacks::writer&
+                               init_writer) {
+  std::vector<double> unconstrained;
+  std::vector<int> disc_vector;
 
-        bool is_fully_initialized = true;
-        bool any_initialized = false;
-        std::vector<std::string> param_names;
-        model.get_param_names(param_names);
-        for (size_t n = 0; n < param_names.size(); n++) {
-          is_fully_initialized &= init.contains_r(param_names[n]);
-          any_initialized |= init.contains_r(param_names[n]);
-        }
-
-        bool init_zero = init_radius <= std::numeric_limits<double>::min();
-
-        int MAX_INIT_TRIES = is_fully_initialized || init_zero ? 1 : 100;
-        int num_init_tries = 0;
-        for (; num_init_tries < MAX_INIT_TRIES; num_init_tries++) {
-          stan::io::random_var_context
-            random_context(model, rng, init_radius, init_zero);
-
-          if (!any_initialized) {
-            unconstrained = random_context.get_unconstrained();
-          } else {
-            stan::io::chained_var_context context(init, random_context);
-
-            std::stringstream msg;
-            try {
-              model.transform_inits(context,
-                                    disc_vector,
-                                    unconstrained,
-                                    &msg);
-            } catch (const std::exception& e) {
-              if (msg.str().length() > 0)
-                logger.info(msg);
-              logger.info(e.what());
-              throw;
-            }
-            if (msg.str().length() > 0)
-              logger.info(msg);
-          }
-          double log_prob(0);
-          std::stringstream msg;
-          try {
-            log_prob = model.template log_prob<false, true>
-              (unconstrained, disc_vector, &msg);
-            if (msg.str().length() > 0)
-              logger.info(msg);
-          } catch (std::domain_error& e) {
-            if (msg.str().length() > 0)
-              logger.info(msg);
-            logger.info("Rejecting initial value:");
-            logger.info("  Error evaluating the log probability"
-                        " at the initial value.");
-            logger.info(e.what());
-            continue;
-          } catch (std::exception& e) {
-            if (msg.str().length() > 0)
-              logger.info(msg);
-            logger.info("Unrecoverable error evaluating the log probability"
-                        " at the initial value.");
-            logger.info(e.what());
-            throw;
-          }
-          if (!boost::math::isfinite(log_prob)) {
-            logger.info("Rejecting initial value:");
-            logger.info("  Log probability evaluates to log(0),"
-                        " i.e. negative infinity.");
-            logger.info("  Stan can't start sampling from this"
-                        " initial value.");
-            continue;
-          }
-          std::stringstream log_prob_msg;
-          std::vector<double> gradient;
-          bool gradient_ok = true;
-          clock_t start_check = clock();
-          try {
-            log_prob = stan::model::log_prob_grad<true, true>
-              (model, unconstrained, disc_vector,
-               gradient, &log_prob_msg);
-          } catch (const std::exception& e) {
-            if (log_prob_msg.str().length() > 0)
-              logger.info(log_prob_msg);
-            logger.info(e.what());
-            throw;
-          }
-          clock_t end_check = clock();
-          double deltaT = static_cast<double>(end_check - start_check)
-            / CLOCKS_PER_SEC;
-          if (log_prob_msg.str().length() > 0)
-            logger.info(log_prob_msg);
-
-          for (size_t i = 0; i < gradient.size(); ++i) {
-            if (gradient_ok && !boost::math::isfinite(gradient[i])) {
-              logger.info("Rejecting initial value:");
-              logger.info("  Gradient evaluated at the initial value"
-                          " is not finite.");
-              logger.info("  Stan can't start sampling from this"
-                          " initial value.");
-              gradient_ok = false;
-            }
-          }
-          if (gradient_ok && print_timing) {
-            logger.info("");
-            std::stringstream msg1;
-            msg1 << "Gradient evaluation took " << deltaT << " seconds";
-            logger.info(msg1);
-
-            std::stringstream msg2;
-            msg2 << "1000 transitions using 10 leapfrog steps"
-                 << " per transition would take"
-                 << " " << 1e4 * deltaT << " seconds.";
-            logger.info(msg2);
-
-            logger.info("Adjust your expectations accordingly!");
-            logger.info("");
-            logger.info("");
-          }
-          if (gradient_ok)
-            break;
-        }
-
-        if (num_init_tries == MAX_INIT_TRIES) {
-          if (!is_fully_initialized && !init_zero) {
-            logger.info("");
-            std::stringstream msg;
-            msg << "Initialization between (-" << init_radius
-                << ", " << init_radius << ") failed after"
-                << " " << MAX_INIT_TRIES <<  " attempts. ";
-            logger.info(msg);
-            logger.info(" Try specifying initial values,"
-                        " reducing ranges of constrained values,"
-                        " or reparameterizing the model.");
-          }
-          throw std::domain_error("Initialization failed.");
-        }
-
-        init_writer(unconstrained);
-        return unconstrained;
-      }
-
-    }
+  bool is_fully_initialized = true;
+  bool any_initialized = false;
+  std::vector<std::string> param_names;
+  model.get_param_names(param_names);
+  for (size_t n = 0; n < param_names.size(); n++) {
+    is_fully_initialized &= init.contains_r(param_names[n]);
+    any_initialized |= init.contains_r(param_names[n]);
   }
+
+  bool init_zero = init_radius <= std::numeric_limits<double>::min();
+
+  int MAX_INIT_TRIES = is_fully_initialized || init_zero ? 1 : 100;
+  int num_init_tries = 0;
+  for (; num_init_tries < MAX_INIT_TRIES; num_init_tries++) {
+    stan::io::random_var_context
+        random_context(model, rng, init_radius, init_zero);
+
+    if (!any_initialized) {
+      unconstrained = random_context.get_unconstrained();
+    } else {
+      stan::io::chained_var_context context(init, random_context);
+
+      std::stringstream msg;
+      try {
+        model.transform_inits(context,
+                              disc_vector,
+                              unconstrained,
+                              &msg);
+      } catch (const std::exception& e) {
+        if (msg.str().length() > 0)
+          logger.info(msg);
+        logger.info(e.what());
+        throw;
+      }
+      if (msg.str().length() > 0)
+        logger.info(msg);
+    }
+    double log_prob(0);
+    std::stringstream msg;
+    try {
+      log_prob = model.template log_prob<false, true>
+                 (unconstrained, disc_vector, &msg);
+      if (msg.str().length() > 0)
+        logger.info(msg);
+    } catch (std::domain_error& e) {
+      if (msg.str().length() > 0)
+        logger.info(msg);
+      logger.info("Rejecting initial value:");
+      logger.info("  Error evaluating the log probability"
+                  " at the initial value.");
+      logger.info(e.what());
+      continue;
+    } catch (std::exception& e) {
+      if (msg.str().length() > 0)
+        logger.info(msg);
+      logger.info("Unrecoverable error evaluating the log probability"
+                  " at the initial value.");
+      logger.info(e.what());
+      throw;
+    }
+    if (!boost::math::isfinite(log_prob)) {
+      logger.info("Rejecting initial value:");
+      logger.info("  Log probability evaluates to log(0),"
+                  " i.e. negative infinity.");
+      logger.info("  Stan can't start sampling from this"
+                  " initial value.");
+      continue;
+    }
+    std::stringstream log_prob_msg;
+    std::vector<double> gradient;
+    bool gradient_ok = true;
+    clock_t start_check = clock();
+    try {
+      log_prob = stan::model::log_prob_grad<true, true>
+                 (model, unconstrained, disc_vector,
+                  gradient, &log_prob_msg);
+    } catch (const std::exception& e) {
+      if (log_prob_msg.str().length() > 0)
+        logger.info(log_prob_msg);
+      logger.info(e.what());
+      throw;
+    }
+    clock_t end_check = clock();
+    double deltaT = static_cast<double>(end_check - start_check)
+                    / CLOCKS_PER_SEC;
+    if (log_prob_msg.str().length() > 0)
+      logger.info(log_prob_msg);
+
+    for (size_t i = 0; i < gradient.size(); ++i) {
+      if (gradient_ok && !boost::math::isfinite(gradient[i])) {
+        logger.info("Rejecting initial value:");
+        logger.info("  Gradient evaluated at the initial value"
+                    " is not finite.");
+        logger.info("  Stan can't start sampling from this"
+                    " initial value.");
+        gradient_ok = false;
+      }
+    }
+    if (gradient_ok && print_timing) {
+      logger.info("");
+      std::stringstream msg1;
+      msg1 << "Gradient evaluation took " << deltaT << " seconds";
+      logger.info(msg1);
+
+      std::stringstream msg2;
+      msg2 << "1000 transitions using 10 leapfrog steps"
+           << " per transition would take"
+           << " " << 1e4 * deltaT << " seconds.";
+      logger.info(msg2);
+
+      logger.info("Adjust your expectations accordingly!");
+      logger.info("");
+      logger.info("");
+    }
+    if (gradient_ok)
+      break;
+  }
+
+  if (num_init_tries == MAX_INIT_TRIES) {
+    if (!is_fully_initialized && !init_zero) {
+      logger.info("");
+      std::stringstream msg;
+      msg << "Initialization between (-" << init_radius
+          << ", " << init_radius << ") failed after"
+          << " " << MAX_INIT_TRIES <<  " attempts. ";
+      logger.info(msg);
+      logger.info(" Try specifying initial values,"
+                  " reducing ranges of constrained values,"
+                  " or reparameterizing the model.");
+    }
+    throw std::domain_error("Initialization failed.");
+  }
+
+  init_writer(unconstrained);
+  return unconstrained;
+}
+
+}
+}
 }
 #endif

--- a/src/test/unit/io/random_var_context_test.cpp
+++ b/src/test/unit/io/random_var_context_test.cpp
@@ -4,17 +4,107 @@
 #include <boost/random/additive_combine.hpp>  // L'Ecuyer RNG
 #include <boost/random/uniform_real_distribution.hpp>
 #include <test/test-models/good/services/test_lp.hpp>
+#include <test/unit/util.hpp>
+
+namespace test {
+// mock_throwing_model_in_write_array throws exception in the write_array()
+// method
+class mock_throwing_model_in_write_array: public stan::model::prob_grad {
+ public:
+
+  mock_throwing_model_in_write_array():
+      stan::model::prob_grad(1),
+      templated_log_prob_calls(0),
+      transform_inits_calls(0),
+      write_array_calls(0),
+      log_prob_return_value(0.0) { }
+
+  void reset() {
+    templated_log_prob_calls = 0;
+    transform_inits_calls = 0;
+    write_array_calls = 0;
+    log_prob_return_value = 0.0;
+  }
+
+  template <bool propto__, bool jacobian__, typename T__>
+  T__ log_prob(std::vector<T__>& params_r__,
+               std::vector<int>& params_i__,
+               std::ostream* pstream__ = 0) const {
+    ++templated_log_prob_calls;
+    return log_prob_return_value;
+  }
+
+  void transform_inits(const stan::io::var_context& context__,
+                       std::vector<int>& params_i__,
+                       std::vector<double>& params_r__,
+                       std::ostream* pstream__) const {
+    ++transform_inits_calls;
+    for (size_t n = 0; n < params_r__.size(); ++n) {
+      params_r__[n] = n;
+    }
+  }
+
+  void get_dims(std::vector<std::vector<size_t> >& dimss__) const {
+    dimss__.resize(0);
+    std::vector<size_t> scalar_dim;
+    dimss__.push_back(scalar_dim);
+  }
+
+  void constrained_param_names(std::vector<std::string>& param_names__,
+                               bool include_tparams__ = true,
+                               bool include_gqs__ = true) const {
+    param_names__.push_back("theta");
+  }
+
+  void get_param_names(std::vector<std::string>& names) const {
+    constrained_param_names(names);
+  }
+
+  void unconstrained_param_names(std::vector<std::string>& param_names__,
+                                 bool include_tparams__ = true,
+                                 bool include_gqs__ = true) const {
+    param_names__.clear();
+    for (size_t n = 0; n < num_params_r__; ++n) {
+      std::stringstream param_name;
+      param_name << "param_" << n;
+      param_names__.push_back(param_name.str());
+    }
+  }
+  template <typename RNG>
+  void write_array(RNG& base_rng__,
+                   std::vector<double>& params_r__,
+                   std::vector<int>& params_i__,
+                   std::vector<double>& vars__,
+                   bool include_tparams__ = true,
+                   bool include_gqs__ = true,
+                   std::ostream* pstream__ = 0) const {
+    ++write_array_calls;
+    throw std::domain_error("throwing within write_array");
+    vars__.resize(0);
+    for (size_t i = 0; i < params_r__.size(); ++i)
+      vars__.push_back(params_r__[i]);
+  }
+
+  mutable int templated_log_prob_calls;
+  mutable int transform_inits_calls;
+  mutable int write_array_calls;
+  double log_prob_return_value;
+};
+}
+
 
 class random_var_context : public testing::Test {
-public:
+ public:
   random_var_context()
-    : empty_context(),
-      model(empty_context, static_cast<std::stringstream*>(0)),
-      rng(0) { }
+      : empty_context(),
+        model(empty_context, static_cast<std::stringstream*>(0)),
+        rng(0),
+        throwing_model() { }
 
   stan::io::empty_var_context empty_context;
   stan_model model;
   boost::ecuyer1988 rng;
+  test::mock_throwing_model_in_write_array throwing_model;  
 };
 
 TEST_F(random_var_context, contains_r) {
@@ -80,4 +170,10 @@ TEST_F(random_var_context, names_i) {
   std::vector<std::string> names_i;
   EXPECT_NO_THROW(context.names_i(names_i));
   EXPECT_EQ(0, names_i.size());
+}
+
+TEST_F(random_var_context, construct) {
+  EXPECT_THROW_MSG(stan::io::random_var_context(throwing_model, rng, 2, false),
+                   std::domain_error,
+                   "throwing within write_array");
 }

--- a/src/test/unit/services/util/initialize_test.cpp
+++ b/src/test/unit/services/util/initialize_test.cpp
@@ -11,11 +11,11 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 
 class ServicesUtilInitialize : public testing::Test {
-public:
+ public:
   ServicesUtilInitialize()
-    : model(empty_context, 12345, &model_ss),
-      message(message_ss),
-      rng(stan::services::util::create_rng(0, 1)) {}
+      : model(empty_context, 12345, &model_ss),
+        message(message_ss),
+        rng(stan::services::util::create_rng(0, 1)) {}
 
   stan_model model;
   stan::io::empty_var_context empty_context;
@@ -36,7 +36,7 @@ TEST_F(ServicesUtilInitialize, radius_zero__print_false) {
                                             init_radius, print_timing,
                                             logger, init);
   ASSERT_EQ(model.num_params_r(), params.size())
-    << "2 parameters";
+      << "2 parameters";
   EXPECT_FLOAT_EQ(0, params[0]);
   EXPECT_FLOAT_EQ(0, params[1]);
 
@@ -56,7 +56,7 @@ TEST_F(ServicesUtilInitialize, radius_zero__print_true) {
                                             init_radius, print_timing,
                                             logger, init);
   ASSERT_EQ(model.num_params_r(), params.size())
-    << "2 parameters";
+      << "2 parameters";
   EXPECT_FLOAT_EQ(0, params[0]);
   EXPECT_FLOAT_EQ(0, params[1]);
 
@@ -78,7 +78,7 @@ TEST_F(ServicesUtilInitialize, radius_two__print_false) {
                                             init_radius, print_timing,
                                             logger, init);
   ASSERT_EQ(model.num_params_r(), params.size())
-    << "2 parameters";
+      << "2 parameters";
   EXPECT_GT(params[0], -init_radius);
   EXPECT_LT(params[0], init_radius);
   EXPECT_GT(params[1], -init_radius);
@@ -100,7 +100,7 @@ TEST_F(ServicesUtilInitialize, radius_two__print_true) {
                                             init_radius, print_timing,
                                             logger, init);
   ASSERT_EQ(model.num_params_r(), params.size())
-    << "2 parameters";
+      << "2 parameters";
   EXPECT_GT(params[0], -init_radius);
   EXPECT_LT(params[0], init_radius);
   EXPECT_GT(params[1], -init_radius);
@@ -136,7 +136,7 @@ TEST_F(ServicesUtilInitialize, full_init__print_false) {
                                             init_radius, print_timing,
                                             logger, init);
   ASSERT_EQ(model.num_params_r(), params.size())
-    << "2 parameters";
+      << "2 parameters";
   EXPECT_FLOAT_EQ(1.5, params[0]);
   EXPECT_FLOAT_EQ(-0.5, params[1]);
 
@@ -168,7 +168,7 @@ TEST_F(ServicesUtilInitialize, full_init__print_true) {
                                             init_radius, print_timing,
                                             logger, init);
   ASSERT_EQ(model.num_params_r(), params.size())
-    << "2 parameters";
+      << "2 parameters";
   EXPECT_FLOAT_EQ(1.5, params[0]);
   EXPECT_FLOAT_EQ(-0.5, params[1]);
 
@@ -182,88 +182,89 @@ TEST_F(ServicesUtilInitialize, full_init__print_true) {
 }
 
 namespace test {
-  // Mock Throwing Model throws exception
-  class mock_throwing_model: public stan::model::prob_grad {
-  public:
+// Mock Throwing Model throws exception
+class mock_throwing_model: public stan::model::prob_grad {
+ public:
 
-    mock_throwing_model():
+  mock_throwing_model():
       stan::model::prob_grad(1),
       templated_log_prob_calls(0),
       transform_inits_calls(0),
       write_array_calls(0),
       log_prob_return_value(0.0) { }
 
-    void reset() {
-      templated_log_prob_calls = 0;
-      transform_inits_calls = 0;
-      write_array_calls = 0;
-      log_prob_return_value = 0.0;
-    }
+  void reset() {
+    templated_log_prob_calls = 0;
+    transform_inits_calls = 0;
+    write_array_calls = 0;
+    log_prob_return_value = 0.0;
+  }
 
-    template <bool propto__, bool jacobian__, typename T__>
-    T__ log_prob(std::vector<T__>& params_r__,
-                 std::vector<int>& params_i__,
-                 std::ostream* pstream__ = 0) const {
-      ++templated_log_prob_calls;
-      throw std::domain_error("throwing within log_prob");
-      return log_prob_return_value;
-    }
+  template <bool propto__, bool jacobian__, typename T__>
+  T__ log_prob(std::vector<T__>& params_r__,
+               std::vector<int>& params_i__,
+               std::ostream* pstream__ = 0) const {
+    ++templated_log_prob_calls;
+    throw std::domain_error("throwing within log_prob");
+    return log_prob_return_value;
+  }
 
-    void transform_inits(const stan::io::var_context& context__,
-                         std::vector<int>& params_i__,
-                         std::vector<double>& params_r__,
-                         std::ostream* pstream__) const {
-      ++transform_inits_calls;
-      for (size_t n = 0; n < params_r__.size(); ++n) {
-        params_r__[n] = n;
-      }
+  void transform_inits(const stan::io::var_context& context__,
+                       std::vector<int>& params_i__,
+                       std::vector<double>& params_r__,
+                       std::ostream* pstream__) const {
+    ++transform_inits_calls;
+    for (size_t n = 0; n < params_r__.size(); ++n) {
+      params_r__[n] = n;
     }
+  }
 
-    void get_dims(std::vector<std::vector<size_t> >& dimss__) const {
-      dimss__.resize(0);
-      std::vector<size_t> scalar_dim;
-      dimss__.push_back(scalar_dim);
-    }
+  void get_dims(std::vector<std::vector<size_t> >& dimss__) const {
+    dimss__.resize(0);
+    std::vector<size_t> scalar_dim;
+    dimss__.push_back(scalar_dim);
+  }
 
-    void constrained_param_names(std::vector<std::string>& param_names__,
+  void constrained_param_names(std::vector<std::string>& param_names__,
+                               bool include_tparams__ = true,
+                               bool include_gqs__ = true) const {
+    param_names__.push_back("theta");
+  }
+
+  void get_param_names(std::vector<std::string>& names) const {
+    constrained_param_names(names);
+  }
+
+  void unconstrained_param_names(std::vector<std::string>& param_names__,
                                  bool include_tparams__ = true,
                                  bool include_gqs__ = true) const {
-      param_names__.push_back("theta");
+    param_names__.clear();
+    for (size_t n = 0; n < num_params_r__; ++n) {
+      std::stringstream param_name;
+      param_name << "param_" << n;
+      param_names__.push_back(param_name.str());
     }
+  }
+  template <typename RNG>
+  void write_array(RNG& base_rng__,
+                   std::vector<double>& params_r__,
+                   std::vector<int>& params_i__,
+                   std::vector<double>& vars__,
+                   bool include_tparams__ = true,
+                   bool include_gqs__ = true,
+                   std::ostream* pstream__ = 0) const {
+    ++write_array_calls;
+    vars__.resize(0);
+    for (size_t i = 0; i < params_r__.size(); ++i)
+      vars__.push_back(params_r__[i]);
+  }
 
-    void get_param_names(std::vector<std::string>& names) const {
-      constrained_param_names(names);
-    }
+  mutable int templated_log_prob_calls;
+  mutable int transform_inits_calls;
+  mutable int write_array_calls;
+  double log_prob_return_value;
+};
 
-    void unconstrained_param_names(std::vector<std::string>& param_names__,
-                                   bool include_tparams__ = true,
-                                   bool include_gqs__ = true) const {
-      param_names__.clear();
-      for (size_t n = 0; n < num_params_r__; ++n) {
-        std::stringstream param_name;
-        param_name << "param_" << n;
-        param_names__.push_back(param_name.str());
-      }
-    }
-    template <typename RNG>
-    void write_array(RNG& base_rng__,
-                     std::vector<double>& params_r__,
-                     std::vector<int>& params_i__,
-                     std::vector<double>& vars__,
-                     bool include_tparams__ = true,
-                     bool include_gqs__ = true,
-                     std::ostream* pstream__ = 0) const {
-      ++write_array_calls;
-      vars__.resize(0);
-      for (size_t i = 0; i < params_r__.size(); ++i)
-        vars__.push_back(params_r__[i]);
-    }
-
-    mutable int templated_log_prob_calls;
-    mutable int transform_inits_calls;
-    mutable int write_array_calls;
-    double log_prob_return_value;
-  };
 }
 
 TEST_F(ServicesUtilInitialize, model_throws__radius_zero) {
@@ -322,88 +323,88 @@ TEST_F(ServicesUtilInitialize, model_throws__full_init) {
 
 
 namespace test {
-  // Mock Throwing Model throws exception
-  class mock_error_model: public stan::model::prob_grad {
-  public:
+// Mock Throwing Model throws exception
+class mock_error_model: public stan::model::prob_grad {
+ public:
 
-    mock_error_model():
+  mock_error_model():
       stan::model::prob_grad(1),
       templated_log_prob_calls(0),
       transform_inits_calls(0),
       write_array_calls(0),
       log_prob_return_value(0.0) { }
 
-    void reset() {
-      templated_log_prob_calls = 0;
-      transform_inits_calls = 0;
-      write_array_calls = 0;
-      log_prob_return_value = 0.0;
-    }
+  void reset() {
+    templated_log_prob_calls = 0;
+    transform_inits_calls = 0;
+    write_array_calls = 0;
+    log_prob_return_value = 0.0;
+  }
 
-    template <bool propto__, bool jacobian__, typename T__>
-    T__ log_prob(std::vector<T__>& params_r__,
-                 std::vector<int>& params_i__,
-                 std::ostream* pstream__ = 0) const {
-      ++templated_log_prob_calls;
-      throw std::out_of_range("out_of_range error in log_prob");
-      return log_prob_return_value;
-    }
+  template <bool propto__, bool jacobian__, typename T__>
+  T__ log_prob(std::vector<T__>& params_r__,
+               std::vector<int>& params_i__,
+               std::ostream* pstream__ = 0) const {
+    ++templated_log_prob_calls;
+    throw std::out_of_range("out_of_range error in log_prob");
+    return log_prob_return_value;
+  }
 
-    void transform_inits(const stan::io::var_context& context__,
-                         std::vector<int>& params_i__,
-                         std::vector<double>& params_r__,
-                         std::ostream* pstream__) const {
-      ++transform_inits_calls;
-      for (size_t n = 0; n < params_r__.size(); ++n) {
-        params_r__[n] = n;
-      }
+  void transform_inits(const stan::io::var_context& context__,
+                       std::vector<int>& params_i__,
+                       std::vector<double>& params_r__,
+                       std::ostream* pstream__) const {
+    ++transform_inits_calls;
+    for (size_t n = 0; n < params_r__.size(); ++n) {
+      params_r__[n] = n;
     }
+  }
 
-    void get_dims(std::vector<std::vector<size_t> >& dimss__) const {
-      dimss__.resize(0);
-      std::vector<size_t> scalar_dim;
-      dimss__.push_back(scalar_dim);
-    }
+  void get_dims(std::vector<std::vector<size_t> >& dimss__) const {
+    dimss__.resize(0);
+    std::vector<size_t> scalar_dim;
+    dimss__.push_back(scalar_dim);
+  }
 
-    void constrained_param_names(std::vector<std::string>& param_names__,
+  void constrained_param_names(std::vector<std::string>& param_names__,
+                               bool include_tparams__ = true,
+                               bool include_gqs__ = true) const {
+    param_names__.push_back("theta");
+  }
+
+  void get_param_names(std::vector<std::string>& names) const {
+    constrained_param_names(names);
+  }
+
+  void unconstrained_param_names(std::vector<std::string>& param_names__,
                                  bool include_tparams__ = true,
                                  bool include_gqs__ = true) const {
-      param_names__.push_back("theta");
+    param_names__.clear();
+    for (size_t n = 0; n < num_params_r__; ++n) {
+      std::stringstream param_name;
+      param_name << "param_" << n;
+      param_names__.push_back(param_name.str());
     }
+  }
+  template <typename RNG>
+  void write_array(RNG& base_rng__,
+                   std::vector<double>& params_r__,
+                   std::vector<int>& params_i__,
+                   std::vector<double>& vars__,
+                   bool include_tparams__ = true,
+                   bool include_gqs__ = true,
+                   std::ostream* pstream__ = 0) const {
+    ++write_array_calls;
+    vars__.resize(0);
+    for (size_t i = 0; i < params_r__.size(); ++i)
+      vars__.push_back(params_r__[i]);
+  }
 
-    void get_param_names(std::vector<std::string>& names) const {
-      constrained_param_names(names);
-    }
-
-    void unconstrained_param_names(std::vector<std::string>& param_names__,
-                                   bool include_tparams__ = true,
-                                   bool include_gqs__ = true) const {
-      param_names__.clear();
-      for (size_t n = 0; n < num_params_r__; ++n) {
-        std::stringstream param_name;
-        param_name << "param_" << n;
-        param_names__.push_back(param_name.str());
-      }
-    }
-    template <typename RNG>
-    void write_array(RNG& base_rng__,
-                     std::vector<double>& params_r__,
-                     std::vector<int>& params_i__,
-                     std::vector<double>& vars__,
-                     bool include_tparams__ = true,
-                     bool include_gqs__ = true,
-                     std::ostream* pstream__ = 0) const {
-      ++write_array_calls;
-      vars__.resize(0);
-      for (size_t i = 0; i < params_r__.size(); ++i)
-        vars__.push_back(params_r__[i]);
-    }
-
-    mutable int templated_log_prob_calls;
-    mutable int transform_inits_calls;
-    mutable int write_array_calls;
-    double log_prob_return_value;
-  };
+  mutable int templated_log_prob_calls;
+  mutable int transform_inits_calls;
+  mutable int write_array_calls;
+  double log_prob_return_value;
+};
 }
 
 
@@ -462,4 +463,144 @@ TEST_F(ServicesUtilInitialize, model_errors__full_init) {
   EXPECT_EQ(2, logger.call_count());
   EXPECT_EQ(2, logger.call_count_info());
   EXPECT_EQ(1, logger.find_info("out_of_range error in log_prob"));
+}
+
+namespace test {
+// mock_throwing_model_in_write_array throws exception in the write_array()
+// method
+class mock_throwing_model_in_write_array: public stan::model::prob_grad {
+ public:
+
+  mock_throwing_model_in_write_array():
+      stan::model::prob_grad(1),
+      templated_log_prob_calls(0),
+      transform_inits_calls(0),
+      write_array_calls(0),
+      log_prob_return_value(0.0) { }
+
+  void reset() {
+    templated_log_prob_calls = 0;
+    transform_inits_calls = 0;
+    write_array_calls = 0;
+    log_prob_return_value = 0.0;
+  }
+
+  template <bool propto__, bool jacobian__, typename T__>
+  T__ log_prob(std::vector<T__>& params_r__,
+               std::vector<int>& params_i__,
+               std::ostream* pstream__ = 0) const {
+    ++templated_log_prob_calls;
+    return log_prob_return_value;
+  }
+
+  void transform_inits(const stan::io::var_context& context__,
+                       std::vector<int>& params_i__,
+                       std::vector<double>& params_r__,
+                       std::ostream* pstream__) const {
+    ++transform_inits_calls;
+    for (size_t n = 0; n < params_r__.size(); ++n) {
+      params_r__[n] = n;
+    }
+  }
+
+  void get_dims(std::vector<std::vector<size_t> >& dimss__) const {
+    dimss__.resize(0);
+    std::vector<size_t> scalar_dim;
+    dimss__.push_back(scalar_dim);
+  }
+
+  void constrained_param_names(std::vector<std::string>& param_names__,
+                               bool include_tparams__ = true,
+                               bool include_gqs__ = true) const {
+    param_names__.push_back("theta");
+  }
+
+  void get_param_names(std::vector<std::string>& names) const {
+    constrained_param_names(names);
+  }
+
+  void unconstrained_param_names(std::vector<std::string>& param_names__,
+                                 bool include_tparams__ = true,
+                                 bool include_gqs__ = true) const {
+    param_names__.clear();
+    for (size_t n = 0; n < num_params_r__; ++n) {
+      std::stringstream param_name;
+      param_name << "param_" << n;
+      param_names__.push_back(param_name.str());
+    }
+  }
+  template <typename RNG>
+  void write_array(RNG& base_rng__,
+                   std::vector<double>& params_r__,
+                   std::vector<int>& params_i__,
+                   std::vector<double>& vars__,
+                   bool include_tparams__ = true,
+                   bool include_gqs__ = true,
+                   std::ostream* pstream__ = 0) const {
+    ++write_array_calls;
+    throw std::domain_error("throwing within write_array");
+    vars__.resize(0);
+    for (size_t i = 0; i < params_r__.size(); ++i)
+      vars__.push_back(params_r__[i]);
+  }
+
+  mutable int templated_log_prob_calls;
+  mutable int transform_inits_calls;
+  mutable int write_array_calls;
+  double log_prob_return_value;
+};
+}
+
+TEST_F(ServicesUtilInitialize, model_throws_in_write_array__radius_zero) {
+  test::mock_throwing_model_in_write_array throwing_model;
+
+  double init_radius = 0;
+  bool print_timing = false;
+  EXPECT_THROW(stan::services::util::initialize(throwing_model, empty_context, rng,
+                                                init_radius, print_timing,
+                                                logger, init),
+               std::domain_error);
+
+  EXPECT_EQ(3, logger.call_count());
+  EXPECT_EQ(3, logger.call_count_info());
+  EXPECT_EQ(1, logger.find_info("throwing within write_array"));
+}
+
+TEST_F(ServicesUtilInitialize, model_throws_in_write_array__radius_two) {
+  test::mock_throwing_model_in_write_array throwing_model;
+
+  double init_radius = 2;
+  bool print_timing = false;
+  EXPECT_THROW(stan::services::util::initialize(throwing_model, empty_context, rng,
+                                                init_radius, print_timing,
+                                                logger, init),
+               std::domain_error);
+  EXPECT_EQ(303, logger.call_count());
+  EXPECT_EQ(303, logger.call_count_info());
+  EXPECT_EQ(100, logger.find_info("throwing within write_array"));
+}
+
+TEST_F(ServicesUtilInitialize, model_throws_in_write_array__full_init) {
+  std::vector<std::string> names_r;
+  std::vector<double> values_r;
+  std::vector<std::vector<size_t> > dim_r;
+  names_r.push_back("y");
+  values_r.push_back(6.35149);   // 1.5 unconstrained: -10 + 20 * inv.logit(1.5)
+  values_r.push_back(-2.449187); // -0.5 unconstrained
+  std::vector<size_t> d;
+  d.push_back(2);
+  dim_r.push_back(d);
+  stan::io::array_var_context init_context(names_r, values_r, dim_r);
+
+  test::mock_throwing_model_in_write_array throwing_model;
+
+  double init_radius = 2;
+  bool print_timing = false;
+  EXPECT_THROW(stan::services::util::initialize(throwing_model, init_context, rng,
+                                                init_radius, print_timing,
+                                                logger, init),
+               std::domain_error);
+  EXPECT_EQ(303, logger.call_count());
+  EXPECT_EQ(303, logger.call_count_info());
+  EXPECT_EQ(100, logger.find_info("throwing within write_array"));
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This pull request allows initialization of a Stan program to continue when there's a violation of constraints in the transformed parameters block (or a `reject()` statement). This fixes #2562, reverting behavior to pre-v2.17.

#### Intended Effect

This is meant to make running Stan easier. When there's an exception thrown, the initialization procedure treats that as a bad starting point and retries.

#### How to Verify

There are updated tests in `src/test/unit/services/util/initialize_test.cpp`. In the new tests, there is a mock model that throws in the `write_array()` method of the model, which is where the transformed parameters are validated. The new tests make sure that the initialization is retried 100 times.

#### Side Effects

Some additional things in the pull request:
- updated .gitignore for *.gch (precompiled headers)
- added new test to `random_var_context_test.cpp` to verify that `random_var_context` will now be constructed in a bad state.

#### Documentation

None needed. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Generable

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
