### PR TITLE
Add workaround for empty params in Jenkins job triggering

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,8 @@ def deleteDirWin() {
     deleteDir()
 }
 
+String cmdstan_pr() { params.cmdstan_pr ?: "downstream_tests" }
+
 pipeline {
     agent none
     parameters {
@@ -127,9 +129,9 @@ pipeline {
         stage('Upstream CmdStan tests') {
             when { expression { env.BRANCH_NAME ==~ /PR-\d+/ } }
             steps {
-                build(job: "CmdStan/${params.cmdstan_pr}",
+                build(job: "CmdStan/${cmdstan_pr()}",
                       parameters: [string(name: 'stan_pr', value: env.BRANCH_NAME),
-                                    string(name: 'math_pr', value: params.math_pr)])
+                                   string(name: 'math_pr', value: params.math_pr)])
             }
         }
         stage('Performance') {


### PR DESCRIPTION
This will be sort of a moot point once we move to a monorepo, but..

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
