### PR TITLE
Feature/issue 2467 expose bernoullig logit rng

### DIFF
--- a/src/docs/functions/distributions.tex
+++ b/src/docs/functions/distributions.tex
@@ -417,9 +417,11 @@ If $\alpha \in \reals$, then for $c \in \setlist{0,1}$,
 \end{description}
 %
 \begin{description}
-\fitem{int}{bernoulli\_logit\_rng}{real \farg{alpha}}{Generate a Bernoulli
-  variate with chance of success $\mbox{logit}^{-1}(\alpha)$; may only be used in
-  generated quantities block}
+  \fitem{R}{bernoulli\_logit\_rng}{reals \farg{alpha}}{Generate a
+    Bernoulli variate with chance of success
+    $\mbox{logit}^{-1}(\alpha)$; may only be used in generated
+    quantities block.  For a description of argument and return types,
+    see \refsection{prng-vectorization}.}
 \end{description}
 
 
@@ -488,11 +490,11 @@ Suppose $N \in \nats$ and $\theta \in [0,1]$, and $n \in
 \end{description}
 %
 \begin{description}
-\fitem{R}{binomial\_rng}{ints \farg{N}, reals \farg{theta}}{Generate a binomial
-  variate with \farg{N} trials and chance of success \farg{theta}; may only be used in
-  generated quantities block.  For a description of argument and
-  return types, see \refsection{prng-vectorization}.
-}
+  \fitem{R}{binomial\_rng}{ints \farg{N}, reals \farg{theta}}{Generate
+    a binomial variate with \farg{N} trials and chance of success
+    \farg{theta}; may only be used in generated quantities block.  For
+    a description of argument and return types, see
+    \refsection{prng-vectorization}.  }
 \end{description}
 
 

--- a/src/stan/lang/function_signatures.h
+++ b/src/stan/lang/function_signatures.h
@@ -77,7 +77,9 @@ for (size_t i = 0; i < int_vector_types.size(); ++i)
 for (const auto& t : all_vector_types) {
   add("bernoulli_rng", rng_return_type<int_type>(t), t);
  }
-add("bernoulli_logit_rng", expr_type(int_type()), expr_type(double_type()));
+for (const auto& t : all_vector_types) {
+  add("bernoulli_logit_rng", rng_return_type<int_type>(t), t);
+ }
 for (size_t i = 0; i < int_vector_types.size(); ++i)
   for (size_t j = 0; j < vector_types.size(); ++j) {
     add("bernoulli_logit_log", expr_type(double_type()), int_vector_types[i],

--- a/src/test/test-models/good/function-signatures/distributions/rngs.stan
+++ b/src/test/test-models/good/function-signatures/distributions/rngs.stan
@@ -23,7 +23,12 @@ generated quantities {
   int N[3];
 
   n = bernoulli_logit_rng(0.0);
-  
+  N = bernoulli_logit_rng(alpha);
+  N = bernoulli_logit_rng(nu);
+  N = bernoulli_logit_rng(ns);
+  N = bernoulli_logit_rng(u);
+  n = bernoulli_logit_rng(3);
+
   N = binomial_rng(ns, alpha);
   N = binomial_rng(ns, nu);
   N = binomial_rng(ns, ns);


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

Passed the following: `make clean && ./runTests.py -j3 src/test/unit/lang/`

#### Summary

Expose vectorized `bernoulli_logit_rng` following https://github.com/stan-dev/math/pull/932 in a continued effort to fulfill https://github.com/stan-dev/stan/issues/2467.

#### Intended Effect

As above, with documentation to support it.

#### How to Verify

Test with `make clean && ./runTests.py -j3 src/test/unit/lang/`.

#### Side Effects

None intended.

#### Documentation

Added in `src/docs/functions/distributions.tex`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

California State University, Chico

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
