### PR TITLE
Use CircleCI to build the manual

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.0
+jobs:
+  docs:
+    docker:
+      - image: 0xcaff/bookdown
+    steps:
+      - checkout
+      - run: make doc
+      - store_artifacts:
+          path: doc
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   docs:
     docker:
-      - image: 0xcaff/bookdown
+      - image: seantalts/bookdown
     steps:
       - checkout
       - run: make doc

--- a/.circleci/doc-docker/Dockerfile
+++ b/.circleci/doc-docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM drmike/r-bookdown
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  latexmk \
+  git \
+  ssh \
+  texlive-latex-recommended \
+  texlive-latex-extra \
+  lmodern

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
             }
         }
         stage('Linting & Doc checks') {
-            agent { label 'linux' }
+            agent any
             steps {
                 script {
                     retry(3) { checkout scm }
@@ -80,14 +80,12 @@ pipeline {
                     parallel(
                         CppLint: { sh "make cpplint" },
                         API_docs: { sh 'make doxygen' },
-                        Manuals: { sh "make doc" },
                     )
                 }
             }
             post {
                 always {
                     warnings consoleParsers: [[parserName: 'CppLint']], canRunOnFailed: true
-                    warnings consoleParsers: [[parserName: 'math-dependencies']], canRunOnFailed: true
                     deleteDir()
                 }
             }


### PR DESCRIPTION
This removes our dependency on a properly configured Linux box, switching to a public docker image (Dockerfile included in PR). CircleCI will also publish the manual as HTML: https://26-80548827-gh.circle-artifacts.com/0/root/project/doc/reference-manual/index.html


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Sean Talts

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
