### PR TITLE
expose DAE to stan

### DIFF
--- a/src/stan/lang/ast.hpp
+++ b/src/stan/lang/ast.hpp
@@ -120,6 +120,7 @@
 #include <stan/lang/ast/node/increment_log_prob_statement.hpp>
 #include <stan/lang/ast/node/index_op.hpp>
 #include <stan/lang/ast/node/index_op_sliced.hpp>
+#include <stan/lang/ast/node/integrate_dae.hpp>
 #include <stan/lang/ast/node/integrate_ode.hpp>
 #include <stan/lang/ast/node/integrate_ode_control.hpp>
 #include <stan/lang/ast/node/int_literal.hpp>

--- a/src/stan/lang/ast/fun/expression_bare_type_vis.hpp
+++ b/src/stan/lang/ast/fun/expression_bare_type_vis.hpp
@@ -9,6 +9,7 @@
 #include <stan/lang/ast/node/row_vector_expr.hpp>
 #include <stan/lang/ast/node/variable.hpp>
 #include <stan/lang/ast/node/fun.hpp>
+#include <stan/lang/ast/node/integrate_dae.hpp>
 #include <stan/lang/ast/node/integrate_ode.hpp>
 #include <stan/lang/ast/node/integrate_ode_control.hpp>
 #include <stan/lang/ast/node/algebra_solver.hpp>
@@ -86,6 +87,13 @@ struct expression_bare_type_vis : public boost::static_visitor<bare_expr_type> {
    * @return bare expression type
    */
   bare_expr_type operator()(const fun& e) const;
+
+  /**
+   * Return the bare_expr_type corresponding to this expression
+   *
+   * @return bare expression type
+   */
+  bare_expr_type operator()(const integrate_dae& e) const;
 
   /**
    * Return the bare_expr_type corresponding to this expression

--- a/src/stan/lang/ast/fun/expression_bare_type_vis_def.hpp
+++ b/src/stan/lang/ast/fun/expression_bare_type_vis_def.hpp
@@ -44,6 +44,12 @@ bare_expr_type expression_bare_type_vis::operator()(const fun& e) const {
 }
 
 bare_expr_type expression_bare_type_vis::operator()(
+    const integrate_dae& e) const {
+  return bare_array_type(
+      bare_expr_type(bare_array_type(bare_expr_type(double_type()))));
+}
+  
+bare_expr_type expression_bare_type_vis::operator()(
     const integrate_ode& e) const {
   return bare_array_type(
       bare_expr_type(bare_array_type(bare_expr_type(double_type()))));

--- a/src/stan/lang/ast/fun/expression_bare_type_vis_def.hpp
+++ b/src/stan/lang/ast/fun/expression_bare_type_vis_def.hpp
@@ -48,7 +48,7 @@ bare_expr_type expression_bare_type_vis::operator()(
   return bare_array_type(
       bare_expr_type(bare_array_type(bare_expr_type(double_type()))));
 }
-  
+
 bare_expr_type expression_bare_type_vis::operator()(
     const integrate_ode& e) const {
   return bare_array_type(

--- a/src/stan/lang/ast/fun/has_non_param_var_vis.hpp
+++ b/src/stan/lang/ast/fun/has_non_param_var_vis.hpp
@@ -91,6 +91,15 @@ namespace stan {
        * @param[in] e expression
        * @return true if contains a variable not declared as a parameter
        */
+      bool operator()(const integrate_dae& e) const;
+
+      /**
+       * Return true if the specified expression contains a variable
+       * not declared as a parameter.
+       *
+       * @param[in] e expression
+       * @return true if contains a variable not declared as a parameter
+       */
       bool operator()(const integrate_ode& e) const;
 
       /**

--- a/src/stan/lang/ast/fun/has_non_param_var_vis_def.hpp
+++ b/src/stan/lang/ast/fun/has_non_param_var_vis_def.hpp
@@ -84,7 +84,7 @@ namespace stan {
       // if any vars, return true because integration will be nonlinear
       return boost::apply_visitor(*this, e.theta_.expr_);
     }
-    
+
     bool has_non_param_var_vis::operator()(const integrate_ode& e) const {
       // if any vars, return true because integration will be nonlinear
       return boost::apply_visitor(*this, e.y0_.expr_)

--- a/src/stan/lang/ast/fun/has_non_param_var_vis_def.hpp
+++ b/src/stan/lang/ast/fun/has_non_param_var_vis_def.hpp
@@ -80,6 +80,11 @@ namespace stan {
       return var_scope.tpar();
     }
 
+    bool has_non_param_var_vis::operator()(const integrate_dae& e) const {
+      // if any vars, return true because integration will be nonlinear
+      return boost::apply_visitor(*this, e.theta_.expr_);
+    }
+    
     bool has_non_param_var_vis::operator()(const integrate_ode& e) const {
       // if any vars, return true because integration will be nonlinear
       return boost::apply_visitor(*this, e.y0_.expr_)

--- a/src/stan/lang/ast/fun/has_var_vis.hpp
+++ b/src/stan/lang/ast/fun/has_var_vis.hpp
@@ -109,7 +109,7 @@ namespace stan {
        * @return true if expression contains a non-data variable
        */
       bool operator()(const integrate_dae& e) const;
-      
+
       /**
        * Return true if the specified expression contains a non-data
        * variable.

--- a/src/stan/lang/ast/fun/has_var_vis.hpp
+++ b/src/stan/lang/ast/fun/has_var_vis.hpp
@@ -15,6 +15,7 @@ namespace stan {
     struct row_vector_expr;
     struct variable;
     struct fun;
+    struct integrate_dae;
     struct integrate_ode;
     struct integrate_ode_control;
     struct algebra_solver;
@@ -100,6 +101,15 @@ namespace stan {
        */
       bool operator()(const variable& e) const;
 
+      /**
+       * Return true if the specified expression contains a non-data
+       * variable.
+       *
+       * @param e expression
+       * @return true if expression contains a non-data variable
+       */
+      bool operator()(const integrate_dae& e) const;
+      
       /**
        * Return true if the specified expression contains a non-data
        * variable.

--- a/src/stan/lang/ast/fun/has_var_vis_def.hpp
+++ b/src/stan/lang/ast/fun/has_var_vis_def.hpp
@@ -51,6 +51,11 @@ bool has_var_vis::operator()(const fun& e) const {
   return false;
 }
 
+bool has_var_vis::operator()(const integrate_dae& e) const {
+  // only theta may contain vars
+  return boost::apply_visitor(*this, e.theta_.expr_);
+}
+
 bool has_var_vis::operator()(const integrate_ode& e) const {
   // only init state and params may contain vars
   return boost::apply_visitor(*this, e.y0_.expr_)

--- a/src/stan/lang/ast/fun/is_nil_vis.hpp
+++ b/src/stan/lang/ast/fun/is_nil_vis.hpp
@@ -14,6 +14,7 @@ namespace stan {
     struct row_vector_expr;
     struct variable;
     struct fun;
+    struct integrate_dae;
     struct integrate_ode;
     struct integrate_ode_control;
     struct algebra_solver;
@@ -38,6 +39,7 @@ namespace stan {
       bool operator()(const row_vector_expr& x) const;  // NOLINT
       bool operator()(const variable& x) const;  // NOLINT(runtime/explicit)
       bool operator()(const fun& x) const;  // NOLINT(runtime/explicit)
+      bool operator()(const integrate_dae& x) const;  // NOLINT
       bool operator()(const integrate_ode& x) const;  // NOLINT
       bool operator()(const integrate_ode_control& x) const;  // NOLINT
       bool operator()(const algebra_solver& x) const;  // NOLINT

--- a/src/stan/lang/ast/fun/is_nil_vis_def.hpp
+++ b/src/stan/lang/ast/fun/is_nil_vis_def.hpp
@@ -38,6 +38,10 @@ namespace stan {
       return false;
     }
 
+    bool is_nil_vis::operator()(const integrate_dae& /* x */) const {
+      return false;
+    }
+
     bool is_nil_vis::operator()(const integrate_ode& /* x */) const {
       return false;
     }

--- a/src/stan/lang/ast/fun/var_occurs_vis.hpp
+++ b/src/stan/lang/ast/fun/var_occurs_vis.hpp
@@ -15,6 +15,7 @@ namespace stan {
     struct row_vector_expr;
     struct variable;
     struct fun;
+    struct integrate_dae;
     struct integrate_ode;
     struct integrate_ode_control;
     struct algebra_solver;
@@ -110,6 +111,15 @@ namespace stan {
        */
       bool operator()(const fun& e) const;
 
+      /**
+       * Return true if the variable occurs in the specified
+       * expression.
+       *
+       * @param[in] e expression
+       * @return true if the variable occurs in the arguments
+       */
+      bool operator()(const integrate_dae& e) const;
+      
       /**
        * Return true if the variable occurs in the specified
        * expression.

--- a/src/stan/lang/ast/fun/var_occurs_vis.hpp
+++ b/src/stan/lang/ast/fun/var_occurs_vis.hpp
@@ -119,7 +119,7 @@ namespace stan {
        * @return true if the variable occurs in the arguments
        */
       bool operator()(const integrate_dae& e) const;
-      
+
       /**
        * Return true if the variable occurs in the specified
        * expression.

--- a/src/stan/lang/ast/fun/var_occurs_vis_def.hpp
+++ b/src/stan/lang/ast/fun/var_occurs_vis_def.hpp
@@ -55,6 +55,10 @@ namespace stan {
       return false;
     }
 
+    bool var_occurs_vis::operator()(const integrate_dae& e) const {
+      return false;  // no refs persist out of integrate_dae() call
+    }
+    
     bool var_occurs_vis::operator()(const integrate_ode& e) const {
       return false;  // no refs persist out of integrate_ode() call
     }

--- a/src/stan/lang/ast/fun/var_occurs_vis_def.hpp
+++ b/src/stan/lang/ast/fun/var_occurs_vis_def.hpp
@@ -58,7 +58,7 @@ namespace stan {
     bool var_occurs_vis::operator()(const integrate_dae& e) const {
       return false;  // no refs persist out of integrate_dae() call
     }
-    
+
     bool var_occurs_vis::operator()(const integrate_ode& e) const {
       return false;  // no refs persist out of integrate_ode() call
     }

--- a/src/stan/lang/ast/fun/write_expression_vis.hpp
+++ b/src/stan/lang/ast/fun/write_expression_vis.hpp
@@ -9,6 +9,7 @@
 #include <stan/lang/ast/node/row_vector_expr.hpp>
 #include <stan/lang/ast/node/variable.hpp>
 #include <stan/lang/ast/node/fun.hpp>
+#include <stan/lang/ast/node/integrate_dae.hpp>
 #include <stan/lang/ast/node/integrate_ode.hpp>
 #include <stan/lang/ast/node/integrate_ode_control.hpp>
 #include <stan/lang/ast/node/algebra_solver.hpp>
@@ -74,6 +75,11 @@ struct write_expression_vis : public boost::static_visitor<std::string> {
    * Return string representation for expression.
    */
   std::string operator()(const fun& e) const;
+
+  /**
+   * Return string representation for expression.
+   */
+  std::string operator()(const integrate_dae& e) const;
 
   /**
    * Return string representation for expression.

--- a/src/stan/lang/ast/fun/write_expression_vis_def.hpp
+++ b/src/stan/lang/ast/fun/write_expression_vis_def.hpp
@@ -79,6 +79,18 @@ std::string write_expression_vis::operator()(const fun& e) const {
   return ss.str();
 }
 
+std::string write_expression_vis::operator()(const integrate_dae& e) const {
+  std::stringstream ss;
+  ss << e.integration_function_name_ << "(" << e.system_function_name_ << ", "
+     << e.yy0_.to_string() << ", "
+     << e.yp0_.to_string() << ", "
+     << e.t0_.to_string() << ", "
+     << e.ts_.to_string() << ", " << e.x_.to_string() << ", "
+     << e.x_int_.to_string() << ", " << e.rel_tol_.to_string() << ", "
+     << e.abs_tol_.to_string() << ", " << e.max_num_steps_.to_string() << ")";
+  return ss.str();
+}
+
 std::string write_expression_vis::operator()(const integrate_ode& e) const {
   std::stringstream ss;
   ss << e.integration_function_name_ << "(" << e.system_function_name_ << ", "

--- a/src/stan/lang/ast/node/expression.hpp
+++ b/src/stan/lang/ast/node/expression.hpp
@@ -19,6 +19,7 @@ namespace stan {
     struct row_vector_expr;
     struct variable;
     struct fun;
+    struct integrate_dae;
     struct integrate_ode;
     struct integrate_ode_control;
     struct algebra_solver;
@@ -39,6 +40,7 @@ namespace stan {
                              boost::recursive_wrapper<row_vector_expr>,
                              boost::recursive_wrapper<variable>,
                              boost::recursive_wrapper<fun>,
+                             boost::recursive_wrapper<integrate_dae>,
                              boost::recursive_wrapper<integrate_ode>,
                              boost::recursive_wrapper<integrate_ode_control>,
                              boost::recursive_wrapper<algebra_solver>,
@@ -62,6 +64,7 @@ namespace stan {
       expression(const row_vector_expr& expr);  // NOLINT(runtime/explicit)
       expression(const variable& expr);  // NOLINT(runtime/explicit)
       expression(const fun& expr);  // NOLINT(runtime/explicit)
+      expression(const integrate_dae& expr);  // NOLINT(runtime/explicit)
       expression(const integrate_ode& expr);  // NOLINT(runtime/explicit)
       expression(const integrate_ode_control& expr);  // NOLINT
       expression(const algebra_solver& expr);  // NOLINT(runtime/explicit)

--- a/src/stan/lang/ast/node/expression_def.hpp
+++ b/src/stan/lang/ast/node/expression_def.hpp
@@ -32,6 +32,8 @@ namespace stan {
 
     expression::expression(const variable& expr) : expr_(expr) { }
 
+    expression::expression(const integrate_dae& expr) : expr_(expr) { }
+
     expression::expression(const integrate_ode& expr) : expr_(expr) { }
 
     expression::expression(const integrate_ode_control& expr) : expr_(expr) { }

--- a/src/stan/lang/ast/node/integrate_dae.hpp
+++ b/src/stan/lang/ast/node/integrate_dae.hpp
@@ -1,0 +1,115 @@
+#ifndef STAN_LANG_AST_NODE_INTEGRATE_DAE_HPP
+#define STAN_LANG_AST_NODE_INTEGRATE_DAE_HPP
+
+#include <stan/lang/ast/node/expression.hpp>
+#include <string>
+
+namespace stan {
+  namespace lang {
+
+    struct expression;
+
+    /**
+     * Structure for a DAE integration statement with control
+     * parameters for the integrator.
+     */
+    struct integrate_dae {
+      /**
+       * The name of the integrator.
+       */
+      std::string integration_function_name_;
+
+      /**
+       * Name of the DAE system.
+       */
+      std::string system_function_name_;
+
+      /**
+       * Initial state (array of real).
+       */
+      expression yy0_;
+
+      /**
+       * Initial derivative state (array of real).
+       */
+      expression yp0_;
+
+      /**
+       * Initial time (real).
+       */
+      expression t0_;
+
+      /**
+       * Solution times (array of real).
+       */
+      expression ts_;
+
+      /**
+       * Parameters (array of real).
+       */
+      expression theta_;
+
+      /**
+       * Real-valued data (array of real).
+       */
+      expression x_;
+
+      /**
+       * Integer-valued data (array of int).
+       */
+      expression x_int_;  // integer data
+
+      /**
+       * Relative tolerance (real).
+       */
+      expression rel_tol_;
+
+      /**
+       * Absolute tolerance (real).
+       */
+      expression abs_tol_;
+
+      /**
+       * Maximum number of steps (integer).
+       */
+      expression max_num_steps_;
+
+      /**
+       * Construct a default DAE integrator object.
+       */
+      integrate_dae();
+
+      /**
+       * Construt an DAE integrator with the
+       * specified values.
+       *
+       * @param integration_function_name name of integrator
+       * @param system_function_name name of DAE system
+       * @param yy0 initial state
+       * @param yp0 initial derivative state
+       * @param t0 initial time
+       * @param ts solution times
+       * @param theta parameters
+       * @param x real-valued data
+       * @param x_int integer-valued data
+       * @param rel_tol relative tolerance of integrator
+       * @param abs_tol absolute tolerance of integrator
+       * @param max_steps max steps in integrator
+       */
+      integrate_dae(const std::string& integration_function_name,
+                    const std::string& system_function_name,
+                    const expression& yy0,
+                    const expression& yp0,
+                    const expression& t0,
+                    const expression& ts,
+                    const expression& theta,
+                    const expression& x,
+                    const expression& x_int,
+                    const expression& rel_tol,
+                    const expression& abs_tol,
+                    const expression& max_steps);
+    };
+
+  }
+}
+#endif

--- a/src/stan/lang/ast/node/integrate_dae_def.hpp
+++ b/src/stan/lang/ast/node/integrate_dae_def.hpp
@@ -1,0 +1,31 @@
+#ifndef STAN_LANG_AST_NODE_INTEGRATE_DAE_DEF_HPP
+#define STAN_LANG_AST_NODE_INTEGRATE_DAE_DEF_HPP
+
+#include <stan/lang/ast.hpp>
+#include <string>
+
+namespace stan {
+  namespace lang {
+
+    integrate_dae::integrate_dae() { }
+
+    integrate_dae::integrate_dae(
+                           const std::string& integration_function_name,
+                           const std::string& system_function_name,
+                           const expression& yy0,
+                           const expression& yp0,
+                           const expression& t0,
+                           const expression& ts, const expression& theta,
+                           const expression& x, const expression& x_int,
+                           const expression& rel_tol, const expression& abs_tol,
+                           const expression& max_num_steps)
+      : integration_function_name_(integration_function_name),
+        system_function_name_(system_function_name),
+        yy0_(yy0), yp0_(yp0),
+        t0_(t0), ts_(ts), theta_(theta), x_(x), x_int_(x_int),
+        rel_tol_(rel_tol), abs_tol_(abs_tol), max_num_steps_(max_num_steps) {
+    }
+
+  }
+}
+#endif

--- a/src/stan/lang/ast_def.cpp
+++ b/src/stan/lang/ast_def.cpp
@@ -121,6 +121,7 @@
 #include <stan/lang/ast/node/index_op_def.hpp>
 #include <stan/lang/ast/node/index_op_sliced_def.hpp>
 #include <stan/lang/ast/node/int_literal_def.hpp>
+#include <stan/lang/ast/node/integrate_dae_def.hpp>
 #include <stan/lang/ast/node/integrate_ode_def.hpp>
 #include <stan/lang/ast/node/integrate_ode_control_def.hpp>
 #include <stan/lang/ast/node/lb_idx_def.hpp>

--- a/src/stan/lang/generator/expression_visgen.hpp
+++ b/src/stan/lang/generator/expression_visgen.hpp
@@ -139,6 +139,33 @@ namespace stan {
         o_ << ")";
       }
 
+      void operator()(const integrate_dae& fx) const {
+        o_ << "integrate_dae"
+           << "("
+           << fx.system_function_name_
+           << "_functor__(), ";
+        generate_expression(fx.yy0_, NOT_USER_FACING, o_);
+        o_ << ", ";
+        generate_expression(fx.yp0_, NOT_USER_FACING, o_);
+        o_ << ", ";
+        generate_expression(fx.t0_, NOT_USER_FACING, o_);
+        o_ << ", ";
+        generate_expression(fx.ts_, NOT_USER_FACING, o_);
+        o_ << ", ";
+        generate_expression(fx.theta_, user_facing_, o_);
+        o_ << ", ";
+        generate_expression(fx.x_, NOT_USER_FACING, o_);
+        o_ << ", ";
+        generate_expression(fx.x_int_, NOT_USER_FACING, o_);
+        o_ << ", ";
+        generate_expression(fx.rel_tol_, NOT_USER_FACING, o_);
+        o_ << ", ";
+        generate_expression(fx.abs_tol_, NOT_USER_FACING, o_);
+        o_ << ", ";
+        generate_expression(fx.max_num_steps_, NOT_USER_FACING, o_);
+        o_ << ", pstream__)";
+      }
+
       void operator()(const integrate_ode& fx) const {
         o_ << (fx.integration_function_name_ == "integrate_ode"
                ? "integrate_ode_rk45"

--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -559,6 +559,15 @@ namespace stan {
     };
     extern boost::phoenix::function<set_no_op> set_no_op_f;
 
+    // called from: term_grammar
+    struct validate_integrate_dae
+      : public phoenix_functor_quaternary {
+      void operator()(const integrate_dae& dae_fun,
+                      const variable_map& var_map, bool& pass,
+                      std::ostream& error_msgs) const;
+    };
+    extern boost::phoenix::function<validate_integrate_dae>
+    validate_integrate_dae_f;
 
     // called from: term_grammar
     struct deprecated_integrate_ode : phoenix_functor_unary {
@@ -793,6 +802,7 @@ namespace stan {
       bool operator()(const matrix_expr& x) const;
       bool operator()(const row_vector_expr& x) const;
       bool operator()(const variable& x) const;
+      bool operator()(const integrate_dae& x) const;
       bool operator()(const integrate_ode& x) const;
       bool operator()(const integrate_ode_control& x) const;
       bool operator()(const algebra_solver& x) const;

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1545,7 +1545,8 @@ namespace stan {
                                             std::ostream& error_msgs) const {
       pass = true;
       // integrate_dae requires function with signature
-      // (real, data real[ ], data real[ ], real[ ], data real[ ], data int[ ]): real[ ]"      
+      // (real, data real[ ], data real[ ], real[ ],
+      // data real[ ], data int[ ]): real[ ]"
 
       double_type t_double;
       bare_expr_type t_ar_double(bare_array_type(t_double, 1));

--- a/src/stan/lang/grammars/term_grammar.hpp
+++ b/src/stan/lang/grammars/term_grammar.hpp
@@ -86,6 +86,11 @@ namespace stan {
       fun_r;
 
       boost::spirit::qi::rule<Iterator,
+                              integrate_dae(scope),
+                              whitespace_grammar<Iterator> >
+      integrate_dae_r;
+
+      boost::spirit::qi::rule<Iterator,
                               integrate_ode(scope),
                               whitespace_grammar<Iterator> >
       integrate_ode_r;

--- a/src/test/test-models/bad/dae/bad_atol_type.stan
+++ b/src/test/test-models/bad/dae/bad_atol_type.stan
@@ -1,0 +1,53 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  real t;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real atol_bad;
+  real theta[2];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, atol_bad, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_fun_type.stan
+++ b/src/test/test-models/bad/dae/bad_fun_type.stan
@@ -1,0 +1,51 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yp[1] * (r1 - yp[2]);
+    res[2] = yp[2] - yp[2] * (r2 - yp[2] / yp[1] - yp[3]);
+    res[3] = yp[3] * (p * yp[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[3];
+  real yp0[3];
+  real t0;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0,            // initial state
+                        yp0,            // initial derivative
+                        t0,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_max_step_type.stan
+++ b/src/test/test-models/bad/dae/bad_max_step_type.stan
@@ -1,0 +1,53 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  real t;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+  int max_step[3];
+}
+parameters {
+  real theta[2];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, max_step);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_rtol_type.stan
+++ b/src/test/test-models/bad/dae/bad_rtol_type.stan
@@ -1,0 +1,53 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  real t;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real rtol_bad;
+  real theta[2];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        rtol_bad, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_t0_var_type.stan
+++ b/src/test/test-models/bad/dae/bad_t0_var_type.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real t_bad;
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t_bad,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_t_type.stan
+++ b/src/test/test-models/bad/dae/bad_t_type.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  real t_bad[2];
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t_bad,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_theta_type.stan
+++ b/src/test/test-models/bad/dae/bad_theta_type.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  real t[2];
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real theta_bad[2, 1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t,             // initial time
+                        ts,             // solution times
+                        theta_bad,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_ts_type.stan
+++ b/src/test/test-models/bad/dae/bad_ts_type.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  real t;
+  real ts_bad[10,2];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t,             // initial time
+                        ts_bad,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_ts_var_type.stan
+++ b/src/test/test-models/bad/dae/bad_ts_var_type.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+  real t;
+}
+parameters {
+  real ts_bad[10];
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t,             // initial time
+                        ts_bad,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_x_int_type.stan
+++ b/src/test/test-models/bad/dae/bad_x_int_type.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  real t[2];
+  real ts[10];
+  real x[1,3];   
+  int x_int_bad[3,1];
+  real y[10,3];
+}
+parameters {
+  real theta[2];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int_bad,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_x_type.stan
+++ b/src/test/test-models/bad/dae/bad_x_type.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  real t[2];
+  real ts[10];
+  real x_bad[1,3];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real theta[2];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x_bad,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_x_var_type.stan
+++ b/src/test/test-models/bad/dae/bad_x_var_type.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5];
+  real yp0[3];
+  int x_int[0];
+  real y[10,3];
+  real t;
+  real ts[19];
+}
+parameters {
+  real x_bad[10];
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0,            // initial derivative
+                        t,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x_bad,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_yp_type.stan
+++ b/src/test/test-models/bad/dae/bad_yp_type.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[5,2];
+  real yp0_bad[3, 2];
+  real t[2];
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0, // initial state
+                        yp0_bad,            // initial derivative
+                        t,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/bad/dae/bad_yy_type.stan
+++ b/src/test/test-models/bad/dae/bad_yy_type.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0_bad[5,2];
+  real yp0[3];
+  real t[2];
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0_bad, // initial state
+                        yp0,            // initial derivative
+                        t,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/test-models/good/dae_good.stan
+++ b/src/test/test-models/good/dae_good.stan
@@ -1,0 +1,52 @@
+functions {
+  real[] prey_predator_harvest(real t,
+                               real[] yy, // state
+                               real[] yp, // state derivative
+                               real[] theta,  // parameters
+                               real[] x,      // data
+                               int[] x_int) {
+    real res[3];
+    real r1;
+    real r2;
+    real p;
+    r1 = 1.0;
+    r2 = 3.0;
+    p = 2.0;
+
+    res[1] = yp[1] - yy[1] * (r1 - yy[2]);
+    res[2] = yp[2] - yy[2] * (r2 - yy[2] / yy[1] - yy[3]);
+    res[3] = yy[3] * (p * yy[2] - 1.0) - theta[1];
+
+    return res;
+  }
+}
+
+data {
+  real yy0[3];
+  real yp0[3];
+  real t0;
+  real ts[10];
+  real x[1];   
+  int x_int[0];
+  real y[10,3];
+}
+parameters {
+  real theta[1];
+  real<lower=0> sigma;
+}
+transformed parameters {
+  real y_hat[10,3];
+  y_hat = integrate_dae(prey_predator_harvest, // system
+                        yy0,            // initial state
+                        yp0,            // initial derivative
+                        t0,             // initial time
+                        ts,             // solution times
+                        theta,          // parameters
+                        x,              // data
+                        x_int,          // integer data
+                        1.E-3, 1.E-10, 1000);
+}
+model {
+  for (t in 1:10)
+    y[t] ~ normal(y_hat[t], sigma);  // independent normal noise
+}

--- a/src/test/unit/lang/ast/fun/solve_funs_test.cpp
+++ b/src/test/unit/lang/ast/fun/solve_funs_test.cpp
@@ -14,9 +14,74 @@ using stan::lang::bare_expr_type;
 using stan::lang::double_type;
 using stan::lang::expression;
 using stan::lang::int_type;
+using stan::lang::integrate_dae;
 using stan::lang::integrate_ode;
 using stan::lang::vector_type;
 using stan::lang::variable;
+
+TEST(langAst, solveDae) {
+
+  integrate_dae so; // null ctor should work and not raise error
+
+  std::string integration_function_name = "bar";
+  std::string system_function_name = "foo";
+
+  double_type tDouble;
+  double_type tDoubleData(true);
+  int_type tIntData(true);
+
+  variable yy0("yy0_var_name");
+  yy0.set_type(bare_array_type(tDouble, 1));
+
+  variable yp0("yp0_var_name");
+  yp0.set_type(bare_array_type(tDouble, 1));
+
+  variable t0("t0_var_name");
+  t0.set_type(tDouble);
+
+  variable ts("ts_var_name");
+  ts.set_type(bare_array_type(tDoubleData, 1));
+
+  variable theta("theta_var_name");
+  theta.set_type(bare_array_type(tDouble, 1));
+
+  variable x("x_var_name");
+  x.set_type(bare_array_type(tDoubleData, 1));
+
+  variable x_int("x_int_var_name");
+  x_int.set_type(bare_array_type(tIntData, 1));
+
+  variable rtol("rtol_var_name");
+  rtol.set_type(tDouble);
+
+  variable atol("atol_var_name");
+  atol.set_type(tDouble);
+
+  variable max_steps("max_steps_var_name");
+  max_steps.set_type(tIntData);
+
+  // example of instantiation
+  integrate_dae so2(integration_function_name, system_function_name,
+                    yy0, yp0, t0, ts, theta, x, x_int, rtol,
+                    atol, max_steps);
+
+  // dumb test to make sure we at least get the right types back
+  EXPECT_EQ(integration_function_name, so2.integration_function_name_);
+  EXPECT_EQ(system_function_name, so2.system_function_name_);
+  EXPECT_EQ(yy0.type_, so2.yy0_.bare_type());
+  EXPECT_EQ(yp0.type_, so2.yp0_.bare_type());
+  EXPECT_EQ(t0.type_, so2.t0_.bare_type());
+  EXPECT_EQ(ts.type_, so2.ts_.bare_type());
+  EXPECT_EQ(theta.type_, so2.theta_.bare_type());
+  EXPECT_EQ(x.type_, so2.x_.bare_type());
+  EXPECT_EQ(x_int.type_, so2.x_int_.bare_type());
+  EXPECT_EQ(rtol.type_, so2.rel_tol_.bare_type());
+  EXPECT_EQ(atol.type_, so2.abs_tol_.bare_type());
+  EXPECT_EQ(max_steps.type_, so2.max_num_steps_.bare_type());
+
+  expression e2(so2);
+  EXPECT_EQ(bare_expr_type(bare_array_type(tDouble,2)), e2.bare_type());
+}
 
 TEST(langAst, solveOde) {
 

--- a/src/test/unit/lang/ast/node/expression_test.cpp
+++ b/src/test/unit/lang/ast/node/expression_test.cpp
@@ -127,6 +127,65 @@ TEST(astExpression, algebra_solver) {
   EXPECT_TRUE(e1.bare_type().is_vector_type());
 }
 
+TEST(astExpression, integrate_dae) {
+  stan::lang::integrate_dae so; // null ctor should work and not raise error
+
+  std::string integration_function_name = "bar";
+  std::string system_function_name = "foo";
+
+  stan::lang::variable yy0("yy0_var_name");
+  yy0.set_type(stan::lang::bare_array_type(stan::lang::double_type()));
+
+  stan::lang::variable yp0("yp0_var_name");
+  yp0.set_type(stan::lang::bare_array_type(stan::lang::double_type()));
+
+  stan::lang::variable t0("t0_var_name");
+  t0.set_type(stan::lang::double_type());
+
+  stan::lang::variable ts("ts_var_name");
+  ts.set_type(stan::lang::bare_array_type(stan::lang::double_type()));
+
+  stan::lang::variable theta("theta_var_name");
+  theta.set_type(stan::lang::bare_array_type(stan::lang::double_type()));
+
+  stan::lang::variable x("x_var_name");
+  x.set_type(stan::lang::bare_array_type(stan::lang::double_type()));
+
+  stan::lang::variable x_int("x_int_var_name");
+  x_int.set_type(stan::lang::bare_array_type(stan::lang::int_type()));
+
+  stan::lang::variable rtol("rtol_var_name");
+  rtol.set_type(stan::lang::double_type());
+
+  stan::lang::variable atol("atol_var_name");
+  atol.set_type(stan::lang::double_type());
+
+  stan::lang::variable max_steps("max_steps_var_name");
+  max_steps.set_type(stan::lang::int_type());
+
+  // example of instantiation
+  stan::lang::integrate_dae so2(integration_function_name, system_function_name,
+                                yy0, yp0, t0, ts, theta, x, x_int,
+                                rtol, atol, max_steps);
+  // check integrate_ode
+  EXPECT_EQ(integration_function_name, so2.integration_function_name_);
+  EXPECT_EQ(system_function_name, so2.system_function_name_);
+  EXPECT_EQ(yy0.type_, so2.yy0_.bare_type());
+  EXPECT_EQ(yp0.type_, so2.yp0_.bare_type());
+  EXPECT_EQ(t0.type_, so2.t0_.bare_type());
+  EXPECT_EQ(ts.type_, so2.ts_.bare_type());
+  EXPECT_EQ(theta.type_, so2.theta_.bare_type());
+  EXPECT_EQ(x.type_, so2.x_.bare_type());
+  EXPECT_EQ(x_int.type_, so2.x_int_.bare_type());
+  EXPECT_EQ(rtol.type_, so2.rel_tol_.bare_type());
+  EXPECT_EQ(atol.type_, so2.abs_tol_.bare_type());
+  EXPECT_EQ(max_steps.type_, so2.max_num_steps_.bare_type());
+
+  stan::lang::expression e1(so2);
+  // check expression
+  EXPECT_EQ(e1.bare_type().order_id(), "array_array_03_double_type");
+}
+
 // TODO:mitzi need similar test for integrate_ode_control
 TEST(astExpression, integrate_ode) {
   stan::lang::integrate_ode so; // null ctor should work and not raise error

--- a/src/test/unit/lang/generator/generate_expression_test.cpp
+++ b/src/test/unit/lang/generator/generate_expression_test.cpp
@@ -143,6 +143,48 @@ TEST(generateExpression, algebra_solver) {
 }
 
 
+TEST(generateExpression, integrate_dae) {
+  static const bool user_facing = true;
+  std::stringstream msgs;
+
+  stan::lang::integrate_dae so; // null ctor should work and not raise error
+
+  std::string integration_function_name = "integrate_dae";
+  std::string system_function_name = "foo";
+  stan::lang::variable yy0("yy0_var_name");
+  yy0.set_type(stan::lang::bare_array_type(stan::lang::double_type()));
+  stan::lang::variable yp0("yp0_var_name");
+  yp0.set_type(stan::lang::bare_array_type(stan::lang::double_type()));
+  stan::lang::variable t0("t0_var_name");
+  t0.set_type(stan::lang::double_type());
+  stan::lang::variable ts("ts_var_name");
+  ts.set_type(stan::lang::bare_array_type(stan::lang::double_type()));
+  stan::lang::variable theta("theta_var_name");
+  theta.set_type(stan::lang::bare_array_type(stan::lang::double_type()));
+  stan::lang::variable x("x_var_name");
+  x.set_type(stan::lang::bare_array_type(stan::lang::double_type()));
+  stan::lang::variable x_int("x_int_var_name");
+  x_int.set_type(stan::lang::bare_array_type(stan::lang::int_type()));
+  stan::lang::variable rtol("rtol_var_name");
+  rtol.set_type(stan::lang::double_type());
+  stan::lang::variable atol("atol_var_name");
+  atol.set_type(stan::lang::double_type());
+  stan::lang::variable max_steps("max_steps_var_name");
+  max_steps.set_type(stan::lang::int_type());
+
+  stan::lang::integrate_dae so2(integration_function_name, system_function_name,
+                                yy0, yp0, t0, ts, theta, x,
+                                x_int, rtol, atol, max_steps);
+  stan::lang::expression e1(so2);
+
+  generate_expression(e1, user_facing, msgs);
+  EXPECT_EQ(msgs.str(),
+            "integrate_dae(foo_functor__(), yy0_var_name, yp0_var_name, "
+            "t0_var_name, ts_var_name, "
+            "theta_var_name, x_var_name, x_int_var_name, "
+            "rtol_var_name, atol_var_name, max_steps_var_name, pstream__)");
+}
+
 TEST(generateExpression, integrate_ode) {
   static const bool user_facing = true;
   std::stringstream msgs;

--- a/src/test/unit/lang/parser/dae_test.cpp
+++ b/src/test/unit/lang/parser/dae_test.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include <test/unit/lang/utility.hpp>
+
+TEST(lang_parser, integrate_dae_good) {
+  test_parsable("dae_good");
+}
+TEST(lang_parser, integrate_dae_bad) {
+  test_throws("dae/bad_fun_type",
+              "wrong signature ");
+  test_throws("dae/bad_yy_type",
+              "second argument to integrate_dae must");
+  test_throws("dae/bad_yp_type",
+              "third argument to integrate_dae must");
+  test_throws("dae/bad_t_type",
+              "fourth argument to integrate_dae must");
+  test_throws("dae/bad_ts_type",
+              "fifth argument to integrate_dae must");
+  test_throws("dae/bad_theta_type",
+              "sixth argument to integrate_dae must");
+  test_throws("dae/bad_x_type",
+              "seventh argument to integrate_dae must");
+  test_throws("dae/bad_x_int_type",
+              "eighth argument to integrate_dae must");
+  test_throws("dae/bad_rtol_type",
+              "ninth argument to integrate_dae");
+  test_throws("dae/bad_atol_type",
+              "tenth argument to integrate_dae");
+  test_throws("dae/bad_max_step_type",
+              "eleventh argument to integrate_dae");
+
+  // check data-only types
+  test_throws("dae/bad_t0_var_type",
+              "fourth argument to integrate_dae");
+  test_throws("dae/bad_ts_var_type",
+              "fifth argument to integrate_dae");
+  test_throws("dae/bad_x_var_type",
+              "seventh argument to integrate_dae");
+}

--- a/src/test/unit/lang/parser_generator_test.cpp
+++ b/src/test/unit/lang/parser_generator_test.cpp
@@ -58,6 +58,14 @@ TEST(unitLang, simpleTest) {
           "operator()(const T0__& x, std::ostream* pstream__) const {");
 }     
              
+// TEST(unitLang, daeTest) {
+//   std::string expected;
+//   expected = "stan::math::assign(y_hat, "
+//     "integrate_dae(dae_functor__(), yy0, yp0, t0, ts, theta, x, x_int, rtol, atol, max_steps, pstream__));";
+//   test_pg("dae", expected);
+//   test_pg_count("dae", expected, 1);
+// }
+
 TEST(unitLang, odeTest) {
   std::string expected;
   expected = "stan::math::assign(y_hat, "


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
For #2600, exposing `integrate_dae` to Stan lang. 

#### Intended Effect
`integrate_dae` solves a DAE provided through user-function. The user-function requires signature
```stan
(real, data real[ ], data real[ ], real[ ], data real[ ], data int[ ]): real[ ]
```
and `integrate_dae` has signature
```stan
rea[, ] = integrate_dae(F, data real[], data real[], data real, data real[], real[], data real[], data int[], data real, data real, data int)
```
Note that unlike `integrate_ode`, for DAE user must supply control parameters `rel_tol`, `abs_tol`, and `max_num_step`, as they are problem-dependent for DAEs.

#### How to Verify
unit tests.
`dae_good` model should pass parsing. Models in `dae/bad` should trigger error.


#### Documentation
doxygen
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Metrum Research Group, LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
