### PR TITLE
Change parser messages to avoid word "Warning" - use "Info" instead

### DIFF
--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -99,7 +99,7 @@ namespace stan {
       if (f.name_ != old_name) return false;
       f.original_name_ = f.name_;
       f.name_ = new_name;
-      msgs << "Warning: Function name '" << old_name << "' is deprecated"
+      msgs << "Info: Function name '" << old_name << "' is deprecated"
            << " and will be removed in a later release; please replace"
            << " with '" << new_name << "'" << std::endl;
       return true;
@@ -109,7 +109,7 @@ namespace stan {
                           const std::string& replacement, fun& f,
                           std::ostream& msgs) {
       if (!ends_with(deprecated_suffix, f.name_)) return false;
-      msgs << "Warning: Deprecated function '" << f.name_ << "';"
+      msgs << "Info: Deprecated function '" << f.name_ << "';"
            << " please replace suffix '" << deprecated_suffix
            << "' with " << replacement << std::endl;
       return true;
@@ -941,7 +941,7 @@ namespace stan {
     void deprecate_old_assignment_op::operator()(std::string& op,
                                                  std::ostream& error_msgs)
       const {
-      error_msgs << "Warning (non-fatal): assignment operator <- deprecated"
+      error_msgs << "Info: assignment operator <- deprecated"
                  << " in the Stan language;"
                  << " use = instead."
                  << std::endl;
@@ -1047,7 +1047,7 @@ namespace stan {
         }
         if (a.lhs_var_occurs_on_rhs()) {
           // this only requires a warning --- a deep copy will be made
-          error_msgs << "Warning: left-hand side variable"
+          error_msgs << "Info: left-hand side variable"
                      << " (name=" << name << ")"
                      << " occurs on right-hand side of assignment, causing"
                      << " inefficient deep copy to avoid aliasing."
@@ -1178,7 +1178,7 @@ namespace stan {
       }
 
       if (internal_function_name == "lkj_cov_log") {
-        error_msgs << "Warning: the lkj_cov_log() sampling distribution"
+        error_msgs << "Info: the lkj_cov_log() sampling distribution"
                    << " is deprecated.  It will be removed in Stan 3."
                    << std::endl
                    << "Code LKJ covariance in terms of an lkj_corr()"
@@ -1195,7 +1195,7 @@ namespace stan {
       }
       // test for LHS not being purely a variable
       if (has_non_param_var(s.expr_, var_map)) {
-        error_msgs << "Warning (non-fatal):"
+        error_msgs << "Info:"
                    << std::endl
                    << "Left-hand side of sampling statement (~) may contain a"
                    << " non-linear transform of a parameter or local variable."
@@ -1501,7 +1501,7 @@ namespace stan {
 
     void deprecate_increment_log_prob::operator()(
                                        std::stringstream& error_msgs) const {
-      error_msgs << "Warning (non-fatal): increment_log_prob(...);"
+      error_msgs << "Info: increment_log_prob(...);"
                  << " is deprecated and will be removed in the future."
                  << std::endl
                  << "  Use target += ...; instead."
@@ -1568,7 +1568,7 @@ namespace stan {
 
     void deprecated_integrate_ode::operator()(std::ostream& error_msgs)
       const {
-      error_msgs << "Warning: the integrate_ode() function is deprecated"
+      error_msgs << "Info: the integrate_ode() function is deprecated"
              << " in the Stan language; use the following functions"
              << " instead.\n"
              << " integrate_ode_rk45()"
@@ -1981,7 +1981,7 @@ namespace stan {
                                         const variable_map& var_map,
                                         std::ostream& error_msgs) const {
       if (fun.name_ == "get_lp")
-        error_msgs << "Warning (non-fatal): get_lp() function deprecated."
+        error_msgs << "Info: get_lp() function deprecated."
                    << std::endl
                    << "  It will be removed in a future release."
                    << std::endl
@@ -2077,7 +2077,7 @@ namespace stan {
       if (fun.name_ == "abs"
           && fun.args_.size() > 0
           && fun.args_[0].expression_type().is_primitive_double()) {
-        error_msgs << "Warning: Function abs(real) is deprecated"
+        error_msgs << "Info: Function abs(real) is deprecated"
                    << " in the Stan language."
                    << std::endl
                    << "         It will be removed in a future release."
@@ -2087,7 +2087,7 @@ namespace stan {
       }
 
       if (fun.name_ == "lkj_cov_log") {
-        error_msgs << "Warning: the lkj_cov_log() function"
+        error_msgs << "Info: the lkj_cov_log() function"
                    << " is deprecated.  It will be removed in Stan 3."
                    << std::endl
                    << "Code LKJ covariance in terms of an lkj_corr()"
@@ -2097,7 +2097,7 @@ namespace stan {
       }
 
       if (fun.name_ == "if_else") {
-        error_msgs << "Warning (non-fatal): the if_else() function"
+        error_msgs << "Info: the if_else() function"
                    << " is deprecated.  "
                    << "Use the conditional operator '?:' instead."
                    << std::endl;
@@ -2277,7 +2277,7 @@ namespace stan {
       if (expr1.expression_type().is_primitive_int()
           && expr2.expression_type().is_primitive_int()) {
         // result might be assigned to real - generate warning
-        error_msgs << "Warning: integer division"
+        error_msgs << "Info: integer division"
                    << " implicitly rounds to integer."
                    << " Found int division: ";
         generate_expression(expr1.expr_, user_facing, error_msgs);
@@ -2489,7 +2489,7 @@ namespace stan {
         pass = false;
         return;
       } else if (name == std::string("params_r__")) {
-        error_msgs << std::endl << "Warning:" << std::endl
+        error_msgs << std::endl << "Info:" << std::endl
                    << "  Direct access to params_r__ yields an inconsistent"
                    << " statistical model in isolation and no guarantee is"
                    << " made that this model will yield valid inferences."
@@ -3229,7 +3229,7 @@ namespace stan {
     boost::phoenix::function<trace> trace_f;
 
     void deprecate_pound_comment::operator()(std::ostream& error_msgs) const {
-      error_msgs << "Warning (non-fatal): Comments beginning with #"
+      error_msgs << "Info: Comments beginning with #"
                  << " are deprecated.  Please use // in place of #"
                  << " for line comments." << std::endl;
     }

--- a/src/test/unit/lang/parser/assignment_test.cpp
+++ b/src/test/unit/lang/parser/assignment_test.cpp
@@ -26,7 +26,7 @@ TEST(lang_parser, mat_assign_function_signatures) {
 TEST(lang_parser, new_assign) {
   test_parsable("assignment-new");
   test_warning("assignment-old",
-               "Warning (non-fatal): assignment operator <- deprecated"
+               "Info: assignment operator <- deprecated"
                " in the Stan language;"
                " use = instead.");
 

--- a/src/test/unit/lang/parser/expression_grammar_test.cpp
+++ b/src/test/unit/lang/parser/expression_grammar_test.cpp
@@ -8,7 +8,7 @@ TEST(langParserExpressionGrammarDef, intDivUserFacing) {
 
 TEST(langParserExpressionGrammarDef, absDeprecate) {
   test_warning("abs-deprecate",
-               "Warning: Function abs(real) is deprecated in the Stan language.");
+               "Info: Function abs(real) is deprecated in the Stan language.");
 }
 
 TEST(langParserExpressionGrammarDef, conditionalOp) {

--- a/src/test/unit/lang/parser/if_else_deprecation_test.cpp
+++ b/src/test/unit/lang/parser/if_else_deprecation_test.cpp
@@ -3,5 +3,5 @@
 
 TEST(langParser, if_elseDeprecationFunction) {
   test_warning("function-signatures/math/functions/if_else",
-               "Warning (non-fatal): the if_else() function is deprecated.");
+               "Info: the if_else() function is deprecated.");
 }

--- a/src/test/unit/lang/parser/lkj_cov_deprecation_test.cpp
+++ b/src/test/unit/lang/parser/lkj_cov_deprecation_test.cpp
@@ -3,9 +3,9 @@
 
 TEST(langParser, lkjCovDeprecationSampling) {
   test_warning("lkj_cov_deprecation1",
-               "Warning: the lkj_cov_log() sampling distribution is deprecated.");
+               "Info: the lkj_cov_log() sampling distribution is deprecated.");
 }
 TEST(langParser, lkjCovDeprecationFunction) {
   test_warning("lkj_cov_deprecation2",
-               "Warning: the lkj_cov_log() function is deprecated.");
+               "Info: the lkj_cov_log() function is deprecated.");
 }

--- a/src/test/unit/lang/parser/replace_log_funs_test.cpp
+++ b/src/test/unit/lang/parser/replace_log_funs_test.cpp
@@ -6,24 +6,24 @@ TEST(langParser, funsNewLSyntax) {
 }
 TEST(langParser, deprecateOldLogFuns) {
   test_warning("old-log-funs",
-               "Warning: Function name 'multiply_log' is deprecated"
+               "Info: Function name 'multiply_log' is deprecated"
                " and will be removed in a later release; please"
                " replace with 'lmultiply'");
   test_warning("old-log-funs",
-               "Warning: Function name 'binomial_coefficient_log' is"
+               "Info: Function name 'binomial_coefficient_log' is"
                " deprecated and will be removed in a later release;"
                " please replace with 'lchoose'");
 }
 TEST(langParser, deprecateOldProbLogFuns) {
   test_warning("deprecate-old-prob-funs",
-               "Warning: Deprecated function 'normal_log'; please replace"
+               "Info: Deprecated function 'normal_log'; please replace"
                " suffix '_log' with '_lpdf' for density functions"
                " or '_lpmf' for mass functions");
   test_warning("deprecate-old-prob-funs",
-               "Warning: Deprecated function 'normal_cdf_log'; please"
+               "Info: Deprecated function 'normal_cdf_log'; please"
                " replace suffix '_cdf_log' with '_lcdf'");
   test_warning("deprecate-old-prob-funs",
-               "Warning: Deprecated function 'normal_ccdf_log'; please"
+               "Info: Deprecated function 'normal_ccdf_log'; please"
                " replace suffix '_ccdf_log' with '_lccdf'");
 }
 TEST(langParser, newProbFunSuffixes) {

--- a/src/test/unit/lang/parser/statement_grammar_test.cpp
+++ b/src/test/unit/lang/parser/statement_grammar_test.cpp
@@ -44,7 +44,7 @@ TEST(langParserStatementGrammar, targetReserved) {
 
 TEST(langParserStatementGrammar, deprecateIncrementLogProb) {
   test_warning("deprecate-increment-log-prob",
-               "Warning (non-fatal): increment_log_prob(...);"
+               "Info: increment_log_prob(...);"
                " is deprecated and will be removed in the future.");
   test_warning("deprecate-increment-log-prob",
                "  Use target += ...; instead.");
@@ -110,7 +110,7 @@ TEST(langParserStatementGrammar, useCdfWithSamplingNotation) {
 
 TEST(langParserStatementGrammar, targetFunGetLpDeprecated) {
   test_warning("get-lp-deprecate", 
-               "Warning (non-fatal): get_lp() function deprecated.");
+               "Info: get_lp() function deprecated.");
   test_warning("get-lp-deprecate", 
                "  It will be removed in a future release.");
   test_warning("get-lp-deprecate", 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Changed messages from parser so that messages prefaced with "Warning" and "Warning (non-fatal)" are now prefaced with "Info" instead.

#### Intended Effect
see issue #2608 

#### How to Verify
unit tests stan/lang/parser

#### Side Effects
N/A

#### Documentation
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
