### PR TITLE
Bugfix/2612 parser msg unknown variable

### DIFF
--- a/src/stan/lang/grammars/semantic_actions.hpp
+++ b/src/stan/lang/grammars/semantic_actions.hpp
@@ -416,9 +416,9 @@ namespace stan {
     validate_void_return_allowed_f;
 
     // called from: statement_grammar
-    struct set_lhs_var_assgn : public phoenix_functor_quinary {
+    struct set_lhs_var_assgn : public phoenix_functor_quaternary {
       void operator()(assgn& a, const std::string& name, bool& pass,
-                      const variable_map& vm, std::ostream& error_msgs) const;
+                      const variable_map& vm) const;
     };
     extern boost::phoenix::function<set_lhs_var_assgn>
     set_lhs_var_assgn_f;

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1015,10 +1015,9 @@ namespace stan {
 
 
     void set_lhs_var_assgn::operator()(assgn& a, const std::string& name,
-                                       bool& pass, const variable_map& vm,
-                                       std::ostream& error_msgs) const {
+                                       bool& pass, const variable_map& vm)
+      const {
       if (!vm.exists(name)) {
-        error_msgs << "Unknown variable: " << name << std::endl;
         pass = false;
         return;
       }

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -288,8 +288,7 @@ namespace stan {
       assgn_r.name("assignment statement");
       assgn_r
         %= identifier_r[set_lhs_var_assgn_f(_val, _1, _pass,
-                                            boost::phoenix::ref(var_map_),
-                                            boost::phoenix::ref(error_msgs_))]
+                                            boost::phoenix::ref(var_map_))]
         >> opt_idxs_r(_r1)
         >> assignment_operator_r
         >> (eps[validate_lhs_var_assgn_f(_val, _r1, _pass,

--- a/src/test/test-models/good/fun_as_lhs_sampling.stan
+++ b/src/test/test-models/good/fun_as_lhs_sampling.stan
@@ -1,0 +1,9 @@
+// programs to tickle bug 2612
+// sampling stmts w/ function calls
+
+transformed data {
+  matrix[2,2] M = rep_matrix(0, 2, 2);
+}
+model {
+  to_vector(M) ~ normal(0, 1);
+}

--- a/src/test/test-models/good/fun_as_stmt.stan
+++ b/src/test/test-models/good/fun_as_stmt.stan
@@ -1,0 +1,9 @@
+// programs to tickle bug 2612
+functions {
+  void foo_lp() {
+    // does nothing
+  }
+}
+model {
+  foo_lp();
+}

--- a/src/test/unit/lang/parser/functions_on_lhs_test.cpp
+++ b/src/test/unit/lang/parser/functions_on_lhs_test.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include <fstream>
+#include <istream>
+#include <sstream>
+#include <exception>
+#include <stdexcept>
+#include <test/unit/lang/utility.hpp>
+
+TEST(stmtGrammar, fun_as_lhs_sampling) {
+  test_parsable("fun_as_lhs_sampling");
+  std::string foo = test_parse_msgs("fun_as_lhs_sampling");
+  EXPECT_EQ("",foo);
+}
+
+TEST(stmtGrammar, fun_as_stmt) {
+  test_parsable("fun_as_stmt");
+  std::string foo = test_parse_msgs("fun_as_stmt");
+  EXPECT_EQ("",foo);
+}
+

--- a/src/test/unit/lang/utility.hpp
+++ b/src/test/unit/lang/utility.hpp
@@ -104,6 +104,19 @@ void test_parsable(const std::string& model_name) {
   SUCCEED();
 }
 
+/** test that model with specified name in folder "good"
+ *  parses without throwing an exception
+ *
+ * @param model_name Name of model to parse
+ */
+std::string test_parse_msgs(const std::string& model_name) {
+  bool result;
+  std::stringstream msgs;
+  SCOPED_TRACE("parsing: " + model_name);
+  result = is_parsable_folder(model_name, "good", &msgs);
+  return msgs.str();
+}
+
 /** test that file with standalone functions with specified name in folder
  * "good-standalone-functions" parses without throwing an exception
  *


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Fixes bug introduced by PR #2555 which causes parser to output spurious error message "Unknown variable" for statements consisting of just a function call or sampling statements which have a function call on the left-hand side.

#### Intended Effect
All syntactically valid programs should compile without error messages.

#### How to Verify
Added test models and unit test to unit test suite.

#### Side Effects
None

#### Documentation
N/A
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University




By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)