### PR TITLE
Feature/issue 2474 vi diagnostic

### DIFF
--- a/src/stan/services/experimental/advi/fullrank.hpp
+++ b/src/stan/services/experimental/advi/fullrank.hpp
@@ -69,7 +69,8 @@ namespace stan {
                                logger, init_writer);
 
           std::vector<std::string> names;
-          names.push_back("lp__");
+          names.push_back("log_p");
+          names.push_back("log_q");
           model.constrained_param_names(names, true, true);
           parameter_writer(names);
 

--- a/src/stan/services/experimental/advi/fullrank.hpp
+++ b/src/stan/services/experimental/advi/fullrank.hpp
@@ -69,8 +69,9 @@ namespace stan {
                                logger, init_writer);
 
           std::vector<std::string> names;
-          names.push_back("log_p");
-          names.push_back("log_q");
+          names.push_back("lp__");
+          names.push_back("log_p__");
+          names.push_back("log_q__");
           model.constrained_param_names(names, true, true);
           parameter_writer(names);
 

--- a/src/stan/services/experimental/advi/fullrank.hpp
+++ b/src/stan/services/experimental/advi/fullrank.hpp
@@ -71,7 +71,7 @@ namespace stan {
           std::vector<std::string> names;
           names.push_back("lp__");
           names.push_back("log_p__");
-          names.push_back("log_q__");
+          names.push_back("log_g__");
           model.constrained_param_names(names, true, true);
           parameter_writer(names);
 

--- a/src/stan/services/experimental/advi/meanfield.hpp
+++ b/src/stan/services/experimental/advi/meanfield.hpp
@@ -69,7 +69,9 @@ namespace stan {
                                logger, init_writer);
 
           std::vector<std::string> names;
-          names.push_back("lp__");
+          names.push_back("log_p");
+          names.push_back("log_q");
+
           model.constrained_param_names(names, true, true);
           parameter_writer(names);
 

--- a/src/stan/services/experimental/advi/meanfield.hpp
+++ b/src/stan/services/experimental/advi/meanfield.hpp
@@ -69,9 +69,9 @@ namespace stan {
                                logger, init_writer);
 
           std::vector<std::string> names;
-          names.push_back("log_p");
-          names.push_back("log_q");
-
+          names.push_back("lp__");
+          names.push_back("log_p__");
+          names.push_back("log_q__");
           model.constrained_param_names(names, true, true);
           parameter_writer(names);
 

--- a/src/stan/services/experimental/advi/meanfield.hpp
+++ b/src/stan/services/experimental/advi/meanfield.hpp
@@ -71,7 +71,7 @@ namespace stan {
           std::vector<std::string> names;
           names.push_back("lp__");
           names.push_back("log_p__");
-          names.push_back("log_q__");
+          names.push_back("log_g__");
           model.constrained_param_names(names, true, true);
           parameter_writer(names);
 

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -505,9 +505,9 @@ namespace stan {
                                    tol_rel_obj, max_iterations,
                                    logger, diagnostic_writer);
 
-        // Write mean of posterior approximation on first output line
-        // I suggest removing this so called "posterior mean" block   for it is the dirct transforation of posterior mean (i.e., not the posterior mean of the real parameters).   The mean and sd of real coordinate space will be extracted a few lines below.--Yuling
-            
+        /* Write mean of posterior approximation on first output line.
+           The "posterior mean" block is the dirct transforation of posterior mean 
+           (not the posterior mean of the real parameters). */
         cont_params_ = variational.mean();
         std::vector<double> cont_vector(cont_params_.size());
         for (int i = 0; i < cont_params_.size(); ++i)
@@ -523,7 +523,7 @@ namespace stan {
         values.insert(values.begin(), 0);  //  the first line of log_p
         values.insert(values.begin(), 0);  //  the first line of log_q
         parameter_writer(values);
- 
+
         // Draw more samples from posterior and write on subsequent lines
         logger.info("");
         std::stringstream ss;
@@ -531,10 +531,8 @@ namespace stan {
            << n_posterior_samples_
            << " from the approximate posterior... ";
         logger.info(ss);
-            
-        double log_p=0;
-        double log_q=0;
-            
+        double log_p = 0;
+        double log_q = 0;
         // Draw posterior samples. log_q is the log normal densities.
         for (int n = 0; n < n_posterior_samples_; ++n) {
           variational.sample_lp(rng_, cont_params_, log_q);
@@ -542,7 +540,8 @@ namespace stan {
             cont_vector.at(i) = cont_params_(i);
           }
           std::stringstream msg2;
-          model_.write_array(rng_, cont_vector, disc_vector, values, true, true, &msg2);
+          model_.write_array(rng_, cont_vector, disc_vector,
+                             values, true, true, &msg2);
           //  log_p: Log probability in the unconstrained space
           log_p = model_.template log_prob<false, true>(cont_params_, &msg2);
           if (msg2.str().length() > 0)
@@ -552,7 +551,6 @@ namespace stan {
           parameter_writer(values);
         }
         logger.info("COMPLETED.");
-    
         return stan::services::error_codes::OK;
       }
 

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -523,7 +523,7 @@ namespace stan {
         values.insert(values.begin(), {0, 0, 0});
         parameter_writer(values);
 
-        // Draw more samples from posterior and write on subsequent lines
+        // Draw more from posterior and write on subsequent lines
         logger.info("");
         std::stringstream ss;
         ss << "Drawing a sample of size "
@@ -532,7 +532,7 @@ namespace stan {
         logger.info(ss);
         double log_p = 0;
         double log_g = 0;
-        // Draw posterior samples. log_g is the log normal densities.
+        // Draw posterior sample. log_g is the log normal densities.
         for (int n = 0; n < n_posterior_samples_; ++n) {
           variational.sample_log_g(rng_, cont_params_, log_g);
           for (int i = 0; i < cont_params_.size(); ++i) {

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -506,7 +506,7 @@ namespace stan {
                                    logger, diagnostic_writer);
 
         /* Write mean of posterior approximation on first output line.
-           The "posterior mean" block is the dirct transforation of posterior mean 
+           The "posterior mean" block is the dirct transformation of posterior mean 
            (not the posterior mean of the real parameters). */
         cont_params_ = variational.mean();
         std::vector<double> cont_vector(cont_params_.size());
@@ -520,6 +520,7 @@ namespace stan {
                            true, true, &msg);
         if (msg.str().length() > 0)
           logger.info(msg);
+        values.insert(values.begin(), 0);  // the first line of lp__
         values.insert(values.begin(), 0);  //  the first line of log_p
         values.insert(values.begin(), 0);  //  the first line of log_q
         parameter_writer(values);
@@ -535,7 +536,7 @@ namespace stan {
         double log_q = 0;
         // Draw posterior samples. log_q is the log normal densities.
         for (int n = 0; n < n_posterior_samples_; ++n) {
-          variational.sample_lp(rng_, cont_params_, log_q);
+          variational.sample_lq(rng_, cont_params_, log_q);
           for (int i = 0; i < cont_params_.size(); ++i) {
             cont_vector.at(i) = cont_params_(i);
           }
@@ -546,8 +547,9 @@ namespace stan {
           log_p = model_.template log_prob<false, true>(cont_params_, &msg2);
           if (msg2.str().length() > 0)
             logger.info(msg2);
-          values.insert(values.begin(), log_p);
-          values.insert(values.begin()+1, log_q);
+          values.insert(values.begin(), 0);    // lp__ is an empty column.
+          values.insert(values.begin()+1, log_p);
+          values.insert(values.begin()+2, log_q);
           parameter_writer(values);
         }
         logger.info("COMPLETED.");

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -519,7 +519,7 @@ namespace stan {
         if (msg.str().length() > 0)
           logger.info(msg);
 
-        // The first row of lp_, log_p, and log_q.
+        // The first row of lp_, log_p, and log_g.
         values.insert(values.begin(), {0, 0, 0});
         parameter_writer(values);
 
@@ -531,10 +531,10 @@ namespace stan {
            << " from the approximate posterior... ";
         logger.info(ss);
         double log_p = 0;
-        double log_q = 0;
-        // Draw posterior samples. log_q is the log normal densities.
+        double log_g = 0;
+        // Draw posterior samples. log_g is the log normal densities.
         for (int n = 0; n < n_posterior_samples_; ++n) {
-          variational.sample_log_q(rng_, cont_params_, log_q);
+          variational.sample_log_g(rng_, cont_params_, log_g);
           for (int i = 0; i < cont_params_.size(); ++i) {
             cont_vector.at(i) = cont_params_(i);
           }
@@ -545,8 +545,8 @@ namespace stan {
           log_p = model_.template log_prob<false, true>(cont_params_, &msg2);
           if (msg2.str().length() > 0)
             logger.info(msg2);
-         // Write lp__, log_p, and log_q.
-          values.insert(values.begin(), {0, log_p, log_q});
+         // Write lp__, log_p, and log_g.
+          values.insert(values.begin(), {0, log_p, log_g});
           parameter_writer(values);
         }
         logger.info("COMPLETED.");

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -31,6 +31,8 @@ namespace stan {
       Eigen::VectorXd transform(const Eigen::VectorXd& eta) const;
       template <class BaseRNG>
       void sample(BaseRNG& rng, Eigen::VectorXd& eta) const;
+      template <class BaseRNG>
+      void sample_lp(BaseRNG& rng, Eigen::VectorXd& eta, double& log_q) const;
       template <class M, class BaseRNG>
       void calc_grad(base_family& elbo_grad,
                      M& m,

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -32,8 +32,8 @@ namespace stan {
       template <class BaseRNG>
       void sample(BaseRNG& rng, Eigen::VectorXd& eta) const;
       template <class BaseRNG>
-      void sample_log_q(BaseRNG& rng, Eigen::VectorXd& eta,
-                        double& log_q) const;
+      void sample_log_g(BaseRNG& rng, Eigen::VectorXd& eta,
+                        double& log_g) const;
       template <class M, class BaseRNG>
       void calc_grad(base_family& elbo_grad,
                      M& m,

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -18,7 +18,7 @@ namespace stan {
 
     public:
       // Constructors
-      base_family(size_t dimension)
+      explicit base_family(size_t dimension)
         : dimension_(dimension) {}
 
       /**
@@ -38,9 +38,9 @@ namespace stan {
       base_family operator*=(double scalar);
 
       // Distribution-based operations
-      virtual const Eigen::VectorXd& mean() const {};
-      virtual double entropy() const {};
-      virtual Eigen::VectorXd transform(const Eigen::VectorXd& eta) const {};
+      virtual const Eigen::VectorXd& mean() const {}
+      virtual double entropy() const {}
+      virtual Eigen::VectorXd transform(const Eigen::VectorXd& eta) const {}
       /**
        * Assign a draw from this mean field approximation to the
        * specified vector using the specified random number generator.

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -32,7 +32,8 @@ namespace stan {
       template <class BaseRNG>
       void sample(BaseRNG& rng, Eigen::VectorXd& eta) const;
       template <class BaseRNG>
-      void sample_lq(BaseRNG& rng, Eigen::VectorXd& eta, double& log_q) const;
+      void sample_log_q(BaseRNG& rng, Eigen::VectorXd& eta,
+                        double& log_q) const;
       template <class M, class BaseRNG>
       void calc_grad(base_family& elbo_grad,
                      M& m,

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -32,7 +32,7 @@ namespace stan {
       template <class BaseRNG>
       void sample(BaseRNG& rng, Eigen::VectorXd& eta) const;
       template <class BaseRNG>
-      void sample_lp(BaseRNG& rng, Eigen::VectorXd& eta, double& log_q) const;
+      void sample_lq(BaseRNG& rng, Eigen::VectorXd& eta, double& log_q) const;
       template <class M, class BaseRNG>
       void calc_grad(base_family& elbo_grad,
                      M& m,

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -56,6 +56,16 @@ namespace stan {
       template <class BaseRNG>
       virtual void sample_log_g(BaseRNG& rng, Eigen::VectorXd& eta,
                         double& log_g) const;
+      /**
+       * Compute the log normal density. The constant (d log 2 pi) is dropped. 
+       *
+       * @param[in] eta Vector; dimension has to be the same as the dimension 
+       * of variational q.
+       * @return The log  density in the variational approximation;
+       * The constant term is dropped. 
+       * @throws std::range_error If the index is out of range.
+       */
+      double log_p(const Eigen::VectorXd& eta) const;
       template <class M, class BaseRNG>
       void calc_grad(base_family& elbo_grad,
                      M& m,

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -29,8 +29,30 @@ namespace stan {
       const Eigen::VectorXd& mean() const;
       double entropy() const;
       Eigen::VectorXd transform(const Eigen::VectorXd& eta) const;
+      /**
+       * Assign a draw from this mean field approximation to the
+       * specified vector using the specified random number generator.
+       *
+       * @tparam BaseRNG Class of random number generator.
+       * @param[in] rng Base random number generator.
+       * @param[out] eta Vector to which the draw is assigned; dimension has to be
+       * the same as the dimension of variational q.
+       * @throws std::range_error If the index is out of range.
+       */
       template <class BaseRNG>
       void sample(BaseRNG& rng, Eigen::VectorXd& eta) const;
+      /**
+       * Draw a posterior sample from the normal distribution, 
+       * and return its log normal density. The constant (d log 2 pi) is dropped. 
+       *
+       * @param[in] rng Base random number generator.
+       * @param[out] eta Vector to which the draw is assigned; dimension has to be
+       * the same as the dimension of variational q. eta will be transformed into
+       * variational posteriors.
+       * @param[out] log_g The log  density in the variational approximation;
+       * The constant term is dropped. 
+       * @throws std::range_error If the index is out of range.
+       */
       template <class BaseRNG>
       void sample_log_g(BaseRNG& rng, Eigen::VectorXd& eta,
                         double& log_g) const;

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -40,7 +40,7 @@ namespace stan {
        * @throws std::range_error If the index is out of range.
        */
       template <class BaseRNG>
-      void sample(BaseRNG& rng, Eigen::VectorXd& eta) const;
+      virtual void sample(BaseRNG& rng, Eigen::VectorXd& eta) const;
       /**
        * Draw a posterior sample from the normal distribution, 
        * and return its log normal density. The constant (d log 2 pi) is dropped. 
@@ -54,7 +54,7 @@ namespace stan {
        * @throws std::range_error If the index is out of range.
        */
       template <class BaseRNG>
-      void sample_log_g(BaseRNG& rng, Eigen::VectorXd& eta,
+      virtual void sample_log_g(BaseRNG& rng, Eigen::VectorXd& eta,
                         double& log_g) const;
       template <class M, class BaseRNG>
       void calc_grad(base_family& elbo_grad,

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -40,7 +40,7 @@ namespace stan {
        * @throws std::range_error If the index is out of range.
        */
       template <class BaseRNG>
-      virtual void sample(BaseRNG& rng, Eigen::VectorXd& eta) const;
+      void sample(BaseRNG& rng, Eigen::VectorXd& eta) const;
       /**
        * Draw a posterior sample from the normal distribution, 
        * and return its log normal density. The constant (d log 2 pi) is dropped. 
@@ -54,10 +54,10 @@ namespace stan {
        * @throws std::range_error If the index is out of range.
        */
       template <class BaseRNG>
-      virtual void sample_log_g(BaseRNG& rng, Eigen::VectorXd& eta,
+      void sample_log_g(BaseRNG& rng, Eigen::VectorXd& eta,
                         double& log_g) const;
       /**
-       * Compute the log normal density. The constant (d log 2 pi) is dropped. 
+       * Compute the log normal density. The constant is dropped. 
        *
        * @param[in] eta Vector; dimension has to be the same as the dimension 
        * of variational q.
@@ -65,7 +65,7 @@ namespace stan {
        * The constant term is dropped. 
        * @throws std::range_error If the index is out of range.
        */
-      double log_p(const Eigen::VectorXd& eta) const;
+      double calc_log_g(const Eigen::VectorXd& eta) const;
       template <class M, class BaseRNG>
       void calc_grad(base_family& elbo_grad,
                      M& m,

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -378,6 +378,20 @@ namespace stan {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         eta = transform(eta);
       }
+        
+        /**
+         * New: Draw a posterior sample from a normal distribution, and return the log normal density. Constant (d* log 2 pi) is removed.
+         */
+        template <class BaseRNG>
+        void sample_lp(BaseRNG& rng, Eigen::VectorXd& eta,  double& log_q) const {
+            log_q=0;
+            for (int d = 0; d < dimension_; ++d){
+            eta(d) = stan::math::normal_rng(0, 1, rng);
+            log_q+= stan::math::square(eta(d))*(-0.5)- fabs(L_chol_(d, d));
+            }
+            eta = transform(eta);
+        }
+        
 
       /**
        * Calculates the "blackbox" gradient with respect to BOTH the

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -378,21 +378,21 @@ namespace stan {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         eta = transform(eta);
       }
-        
         /**
          * New: Draw a posterior sample from a normal distribution, and return the log normal density. Constant (d* log 2 pi) is removed.
          */
         template <class BaseRNG>
-        void sample_lp(BaseRNG& rng, Eigen::VectorXd& eta,  double& log_q) const {
-            log_q=0;
-            for (int d = 0; d < dimension_; ++d){
-            eta(d) = stan::math::normal_rng(0, 1, rng);
-            log_q+= stan::math::square(eta(d))*(-0.5)- fabs(L_chol_(d, d));
+        void sample_lp(BaseRNG& rng,
+                       Eigen::VectorXd& eta,
+                       double& log_q)
+        const {
+            log_q = 0;
+            for (int d = 0; d < dimension_; ++d) {
+              eta(d) = stan::math::normal_rng(0, 1, rng);
+              log_q+= stan::math::square(eta(d))*(-0.5)- fabs(L_chol_(d, d));
             }
             eta = transform(eta);
         }
-        
-
       /**
        * Calculates the "blackbox" gradient with respect to BOTH the
        * location vector (mu) and the cholesky factor of the scale

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -380,7 +380,7 @@ namespace stan {
         for (int d = 0; d < dimension_; ++d) {
           eta(d) = stan::math::normal_rng(0, 1, rng);
 	  // The log determinant is computed from the Cholesky factor
-          log_g += stan::math::square(eta(d))*(-0.5) - fabs(L_chol_(d, d));
+          log_g += -stan::math::square(eta(d)) * 0.5 - fabs(L_chol_(d, d));
         }
         eta = transform(eta);
       }

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -380,7 +380,7 @@ namespace stan {
       }
 
       /**
-        * New: Draw a posterior sample from the normal distribution, 
+        * Draw a posterior sample from the normal distribution, 
         * and return its log normal density. The constant (d log 2 pi) is removed. 
         * @param[in] rng Base random number generator.
         * @param[in, out] eta Vector to which the draw is assigned; must

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -375,14 +375,24 @@ namespace stan {
       void sample_log_g(BaseRNG& rng,
 			Eigen::VectorXd& eta,
 			double& log_g) const {
-	// Draw from the approximation and compute the log density
-        log_g = 0;
+	// Draw from the approximation
         for (int d = 0; d < dimension_; ++d) {
           eta(d) = stan::math::normal_rng(0, 1, rng);
-	  // The log determinant is computed from the Cholesky factor
-          log_g += -stan::math::square(eta(d)) * 0.5 - fabs(L_chol_(d, d));
         }
+	// Compute the log density before transformation
+        log_g = log_g(eta);
+	// Transform to real-coordinate space
         eta = transform(eta);
+      }
+      
+      double log_g(Eigen::VectorXd& eta) const {
+	// Compute the log density wrt normal distribution
+        double log_g = 0;
+        for (int d = 0; d < dimension_; ++d) {
+	  // The log determinant is computed from the Cholesky factor
+          log_g += -stan::math::square(eta(d)) * 0.5 - log(L_chol_(d, d));
+        }
+	return log_g;
       }
       
       /**

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -373,27 +373,27 @@ namespace stan {
 
       template <class BaseRNG>
       void sample_log_g(BaseRNG& rng,
-			Eigen::VectorXd& eta,
-			double& log_g) const {
-	// Draw from the approximation
+                        Eigen::VectorXd& eta,
+                        double& log_g) const {
+        // Draw from the approximation
         for (int d = 0; d < dimension_; ++d) {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         }
-	// Compute the log density before transformation
+        // Compute the log density before transformation
         log_g = calc_log_g(eta);
-	// Transform to real-coordinate space
+        // Transform to real-coordinate space
         eta = transform(eta);
       }
-      
+
       double calc_log_g(const Eigen::VectorXd& eta) const {
-	// Compute the log density wrt normal distribution dropping constants
+        // Compute the log density wrt normal distribution dropping constants
         double log_g = 0;
         for (int d = 0; d < dimension_; ++d) {
           log_g += -stan::math::square(eta(d)) * 0.5;
         }
-	return log_g;
+        return log_g;
       }
-      
+
       /**
        * Calculates the "blackbox" gradient with respect to BOTH the
        * location vector (mu) and the cholesky factor of the scale

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -31,6 +31,11 @@ namespace stan {
       Eigen::MatrixXd L_chol_;
 
       /**
+       * Dimensionality of distribution.
+       */
+      const int dimension_;
+
+      /**
        * Raise a domain exception if the specified vector contains
        * not-a-number values.
        *
@@ -83,7 +88,7 @@ namespace stan {
       explicit normal_fullrank(size_t dimension)
       : mu_(Eigen::VectorXd::Zero(dimension)),
         L_chol_(Eigen::MatrixXd::Zero(dimension, dimension)),
-        base_family(dimension) {
+        dimension_(dimension) {
       }
 
 
@@ -97,7 +102,7 @@ namespace stan {
       : mu_(cont_params),
         L_chol_(Eigen::MatrixXd::Identity(cont_params.size(),
                                           cont_params.size())),
-        base_family(cont_params.size()) {
+        dimension_(cont_params.size()) {
       }
 
       /**
@@ -116,11 +121,16 @@ namespace stan {
        */
       normal_fullrank(const Eigen::VectorXd& mu,
                       const Eigen::MatrixXd& L_chol)
-      : mu_(mu), L_chol_(L_chol),  base_family(mu.size()) {
+      : mu_(mu), L_chol_(L_chol),  dimension_(mu.size()) {
         static const char* function = "stan::variational::normal_fullrank";
         validate_mean(function, mu);
         validate_cholesky_factor(function, L_chol);
       }
+
+      /**
+       * Return the dimensionality of the approximation.
+       */
+      int dimension() const { return dimension_; }
 
       /**
        * Return the mean vector.

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -385,17 +385,17 @@ namespace stan {
         * @param[in] rng Base random number generator.
         * @param[in, out] eta Vector to which the draw is assigned; must
         * already be properly sized. eta will be transformed into variational posteriors. 
-        * @param[out] log_q The log density in the full-rank normal approximation.
+        * @param[out] log_g The log density in the full-rank normal approximation.
         * @throws std::range_error If the index is out of range.
         */
       template <class BaseRNG>
-      void sample_log_q(BaseRNG& rng,
+      void sample_log_g(BaseRNG& rng,
                        Eigen::VectorXd& eta,
-                       double& log_q) const {
-        log_q = 0;
+                       double& log_g) const {
+        log_g = 0;
         for (int d = 0; d < dimension_; ++d) {
           eta(d) = stan::math::normal_rng(0, 1, rng);
-          log_q+= stan::math::square(eta(d))*(-0.5)- fabs(L_chol_(d, d));
+          log_g+= stan::math::square(eta(d))*(-0.5)- fabs(L_chol_(d, d));
         }
         eta = transform(eta);
       }

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -381,11 +381,12 @@ namespace stan {
 
       /**
         * Draw a posterior sample from the normal distribution, 
-        * and return its log normal density. The constant (d log 2 pi) is removed. 
+        * and return its log normal density. The constant (d log 2 pi) is dropped. 
         * @param[in] rng Base random number generator.
         * @param[in, out] eta Vector to which the draw is assigned; must
         * already be properly sized. eta will be transformed into variational posteriors. 
         * @param[out] log_g The log density in the full-rank normal approximation.
+        * The constant term is dropped. 
         * @throws std::range_error If the index is out of range.
         */
       template <class BaseRNG>

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -382,7 +382,7 @@ namespace stan {
          * New: Draw a posterior sample from a normal distribution, and return the log normal density. Constant (d* log 2 pi) is removed.
          */
         template <class BaseRNG>
-        void sample_lp(BaseRNG& rng,
+        void sample_lq(BaseRNG& rng,
                        Eigen::VectorXd& eta,
                        double& log_q)
         const {

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -380,12 +380,12 @@ namespace stan {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         }
 	// Compute the log density before transformation
-        log_g = log_g(eta);
+        log_g = calc_log_g(eta);
 	// Transform to real-coordinate space
         eta = transform(eta);
       }
       
-      double log_g(Eigen::VectorXd& eta) const {
+      double calc_log_g(const Eigen::VectorXd& eta) const {
 	// Compute the log density wrt normal distribution dropping constants
         double log_g = 0;
         for (int d = 0; d < dimension_; ++d) {

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -419,7 +419,8 @@ namespace stan {
                         "Dimension of variables in model", cont_params.size());
 
         Eigen::VectorXd mu_grad = Eigen::VectorXd::Zero(dimension());
-        Eigen::MatrixXd L_grad  = Eigen::MatrixXd::Zero(dimension(), dimension());
+        Eigen::MatrixXd L_grad  = Eigen::MatrixXd::Zero(dimension(),
+                                                        dimension());
         double tmp_lp = 0.0;
         Eigen::VectorXd tmp_mu_grad = Eigen::VectorXd::Zero(dimension());
         Eigen::VectorXd eta = Eigen::VectorXd::Zero(dimension());

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -386,11 +386,10 @@ namespace stan {
       }
       
       double log_g(Eigen::VectorXd& eta) const {
-	// Compute the log density wrt normal distribution
+	// Compute the log density wrt normal distribution dropping constants
         double log_g = 0;
         for (int d = 0; d < dimension_; ++d) {
-	  // The log determinant is computed from the Cholesky factor
-          log_g += -stan::math::square(eta(d)) * 0.5 - log(L_chol_(d, d));
+          log_g += -stan::math::square(eta(d)) * 0.5;
         }
 	return log_g;
       }

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -378,21 +378,27 @@ namespace stan {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         eta = transform(eta);
       }
-        /**
-         * New: Draw a posterior sample from a normal distribution, and return the log normal density. Constant (d* log 2 pi) is removed.
-         */
-        template <class BaseRNG>
-        void sample_lq(BaseRNG& rng,
+
+      /**
+        * New: Draw a posterior sample from the normal distribution, 
+        * and return its log normal density. The constant (d log 2 pi) is removed. 
+        * @param[in] rng Base random number generator.
+        * @param[in, out] eta Vector to which the draw is assigned; must
+        * already be properly sized. eta will be transformed into variational posteriors. 
+        * @param[out] log_q The log density in the full-rank normal approximation.
+        * @throws std::range_error If the index is out of range.
+        */
+      template <class BaseRNG>
+      void sample_log_q(BaseRNG& rng,
                        Eigen::VectorXd& eta,
-                       double& log_q)
-        const {
-            log_q = 0;
-            for (int d = 0; d < dimension_; ++d) {
-              eta(d) = stan::math::normal_rng(0, 1, rng);
-              log_q+= stan::math::square(eta(d))*(-0.5)- fabs(L_chol_(d, d));
-            }
-            eta = transform(eta);
+                       double& log_q) const {
+        log_q = 0;
+        for (int d = 0; d < dimension_; ++d) {
+          eta(d) = stan::math::normal_rng(0, 1, rng);
+          log_q+= stan::math::square(eta(d))*(-0.5)- fabs(L_chol_(d, d));
         }
+        eta = transform(eta);
+      }
       /**
        * Calculates the "blackbox" gradient with respect to BOTH the
        * location vector (mu) and the cholesky factor of the scale

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -341,23 +341,26 @@ namespace stan {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         eta = transform(eta);
       }
-        
         /**
-         * New: Draw a posterior sample from a normal distribution, and return the log normal density. Constant (d* log 2 pi) is removed. It is termed log_q because it denotes the approximation density using variational families.
+         * New: Draw a posterior sample from a normal distribution, 
+         and return the log normal density. 
+         Constant (d* log 2 pi) is removed. It changes as a function 
+         of parameters, but not as a fixed posterior sample.
+         It is saved as log_q because ( the approximation density 
+        using variational families)
          */
         template <class BaseRNG>
-        void sample_lp(BaseRNG& rng, Eigen::VectorXd& eta, double& log_q) const {
-            
-            // Draw from standard normal and transform to real-coordinate space
-            log_q=0;
-        for (int d = 0; d < dimension_; ++d){
-                eta(d) = stan::math::normal_rng(0, 1, rng);
-                
-                log_q+= stan::math::square(eta(d))*(-0.5);
-           }
+        void sample_lp(BaseRNG& rng,
+                       Eigen::VectorXd& eta,
+                       double& log_q)
+        const {
+                log_q = 0;
+                for (int d = 0; d < dimension_; ++d) {
+                  eta(d) = stan::math::normal_rng(0, 1, rng);
+                  log_q += stan::math::square(eta(d))*(-0.5);
+                }
             eta = transform(eta);
         }
-    
 
       /**
        * Calculates the "blackbox" gradient with respect to both the

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -341,6 +341,23 @@ namespace stan {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         eta = transform(eta);
       }
+        
+        /**
+         * New: Draw a posterior sample from a normal distribution, and return the log normal density. Constant (d* log 2 pi) is removed. It is termed log_q because it denotes the approximation density using variational families.
+         */
+        template <class BaseRNG>
+        void sample_lp(BaseRNG& rng, Eigen::VectorXd& eta, double& log_q) const {
+            
+            // Draw from standard normal and transform to real-coordinate space
+            log_q=0;
+        for (int d = 0; d < dimension_; ++d){
+                eta(d) = stan::math::normal_rng(0, 1, rng);
+                
+                log_q+= stan::math::square(eta(d))*(-0.5);
+           }
+            eta = transform(eta);
+        }
+    
 
       /**
        * Calculates the "blackbox" gradient with respect to both the

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -341,12 +341,12 @@ namespace stan {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         }
 	// Compute the log density before transformation
-        log_g = log_g(eta);
+        log_g = calc_log_g(eta);
 	// Transform to real-coordinate space
         eta = transform(eta);
       }
       
-      double log_g(Eigen::VectorXd& eta) const {
+      double calc_log_g(const Eigen::VectorXd& eta) const {
 	// Compute the log density wrt normal distribution dropping constants
 	double log_g = 0;
 	for (int d = 0; d < dimension_; ++d) {

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -29,6 +29,11 @@ namespace stan {
        */
       Eigen::VectorXd omega_;
 
+      /**
+       * Dimensionality of distribution.
+       */
+      const int dimension_;
+
     public:
       /**
        * Construct a variational distribution of the specified
@@ -40,7 +45,7 @@ namespace stan {
       explicit normal_meanfield(size_t dimension)
         : mu_(Eigen::VectorXd::Zero(dimension)),
           omega_(Eigen::VectorXd::Zero(dimension)),
-          base_family(dimension) {
+          dimension_(dimension) {
       }
 
       /**
@@ -53,7 +58,7 @@ namespace stan {
       explicit normal_meanfield(const Eigen::VectorXd& cont_params)
         : mu_(cont_params),
           omega_(Eigen::VectorXd::Zero(cont_params.size())),
-          base_family(cont_params.size()) {
+          dimension_(cont_params.size()) {
       }
 
       /**
@@ -68,7 +73,7 @@ namespace stan {
        */
       normal_meanfield(const Eigen::VectorXd& mu,
                        const Eigen::VectorXd& omega)
-        : mu_(mu), omega_(omega), base_family(mu.size()) {
+        : mu_(mu), omega_(omega), dimension_(mu.size()) {
         static const char* function =
           "stan::variational::normal_meanfield";
         stan::math::check_size_match(function,
@@ -77,6 +82,12 @@ namespace stan {
         stan::math::check_not_nan(function, "Mean vector", mu_);
         stan::math::check_not_nan(function, "Log std vector", omega_);
       }
+
+      /**
+       * Return the dimensionality of the approximation.
+       */
+      int dimension() const { return dimension_; }
+
       /**
        * Return the mean vector.
        */

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -352,7 +352,7 @@ namespace stan {
 	for (int d = 0; d < dimension_; ++d) {
 	  log_g += -stan::math::square(eta(d)) * 0.5;
 	}
-	log_g += omega_.sum();
+	log_g += -omega_.sum();
 	return log_g;
       }
 

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -347,19 +347,19 @@ namespace stan {
          * @param[in] rng Base random number generator.
          * @param[in, out] eta Vector to which the draw is assigned; must already
          * be properly sized. eta will be transformed into variational posteriors.
-         * @param[out] log_q The log  density in the mean-field normal approximation;
+         * @param[out] log_g The log  density in the mean-field normal approximation;
          * The constant term is removed. 
          * @throws std::range_error If the index is out of range.
          */
         template <class BaseRNG>
-        void sample_log_q(BaseRNG& rng,
+        void sample_log_g(BaseRNG& rng,
                        Eigen::VectorXd& eta,
-                       double& log_q)
+                       double& log_g)
         const {
-                log_q = 0;
+                log_g = 0;
                 for (int d = 0; d < dimension_; ++d) {
                   eta(d) = stan::math::normal_rng(0, 1, rng);
-                  log_q += stan::math::square(eta(d))*(-0.5);
+                  log_g += stan::math::square(eta(d))*(-0.5);
                 }
             eta = transform(eta);
         }

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -347,12 +347,11 @@ namespace stan {
       }
       
       double log_g(Eigen::VectorXd& eta) const {
-	// Compute the log density with respect to normal distribution
+	// Compute the log density wrt normal distribution dropping constants
 	double log_g = 0;
 	for (int d = 0; d < dimension_; ++d) {
 	  log_g += -stan::math::square(eta(d)) * 0.5;
 	}
-	log_g += -omega_.sum();
 	return log_g;
       }
 

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -324,16 +324,6 @@ namespace stan {
         return eta.array().cwiseProduct(omega_.array().exp()) + mu_.array();
       }
 
-      /**
-       * Assign a draw from this mean field approximation to the
-       * specified vector using the specified random number generator.
-       *
-       * @tparam BaseRNG Class of random number generator.
-       * @param[in] rng Base random number generator.
-       * @param[in,out] eta Vector to which the draw is assigned; must
-       * already be properly sized.
-       * @throws std::range_error If the index is out of range.
-       */
       template <class BaseRNG>
       void sample(BaseRNG& rng, Eigen::VectorXd& eta) const {
         // Draw from standard normal and transform to real-coordinate space
@@ -341,28 +331,19 @@ namespace stan {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         eta = transform(eta);
       }
-        /**
-         * Draw a posterior sample from the normal distribution, 
-         * and return its log normal density. The constant (d log 2 pi) is dropped. 
-         * @param[in] rng Base random number generator.
-         * @param[in, out] eta Vector to which the draw is assigned; must already
-         * be properly sized. eta will be transformed into variational posteriors.
-         * @param[out] log_g The log  density in the mean-field normal approximation;
-         * The constant term is dropped. 
-         * @throws std::range_error If the index is out of range.
-         */
-        template <class BaseRNG>
-        void sample_log_g(BaseRNG& rng,
-                       Eigen::VectorXd& eta,
-                       double& log_g)
-        const {
-                log_g = 0;
-                for (int d = 0; d < dimension_; ++d) {
-                  eta(d) = stan::math::normal_rng(0, 1, rng);
-                  log_g += stan::math::square(eta(d))*(-0.5);
-                }
-            eta = transform(eta);
-        }
+      
+      template <class BaseRNG>
+      void sample_log_g(BaseRNG& rng,
+			Eigen::VectorXd& eta,
+			double& log_g) const {
+	// Draw from the approximation and compute the log density
+	log_g = 0;
+	for (int d = 0; d < dimension_; ++d) {
+	  eta(d) = stan::math::normal_rng(0, 1, rng);
+	  log_g += stan::math::square(eta(d))*(-0.5);
+	}
+	eta = transform(eta);
+      }
 
       /**
        * Calculates the "blackbox" gradient with respect to both the

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -336,13 +336,24 @@ namespace stan {
       void sample_log_g(BaseRNG& rng,
 			Eigen::VectorXd& eta,
 			double& log_g) const {
-	// Draw from the approximation and compute the log density
-	log_g = 0;
+	// Draw from the approximation
+        for (int d = 0; d < dimension_; ++d) {
+          eta(d) = stan::math::normal_rng(0, 1, rng);
+        }
+	// Compute the log density before transformation
+        log_g = log_g(eta);
+	// Transform to real-coordinate space
+        eta = transform(eta);
+      }
+      
+      double log_g(Eigen::VectorXd& eta) const {
+	// Compute the log density with respect to normal distribution
+	double log_g = 0;
 	for (int d = 0; d < dimension_; ++d) {
-	  eta(d) = stan::math::normal_rng(0, 1, rng);
 	  log_g += -stan::math::square(eta(d)) * 0.5;
 	}
-	eta = transform(eta);
+	log_g += omega_.sum();
+	return log_g;
       }
 
       /**

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -346,11 +346,11 @@ namespace stan {
          and return the log normal density. 
          Constant (d* log 2 pi) is removed. It changes as a function 
          of parameters, but not as a fixed posterior sample.
-         It is saved as log_q because ( the approximation density 
-        using variational families)
+         It is saved as log_q (the approximation density 
+        using variational families).
          */
         template <class BaseRNG>
-        void sample_lp(BaseRNG& rng,
+        void sample_lq(BaseRNG& rng,
                        Eigen::VectorXd& eta,
                        double& log_q)
         const {

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -343,12 +343,12 @@ namespace stan {
       }
         /**
          * Draw a posterior sample from the normal distribution, 
-         * and return its log normal density. The constant (d log 2 pi) is removed. 
+         * and return its log normal density. The constant (d log 2 pi) is dropped. 
          * @param[in] rng Base random number generator.
          * @param[in, out] eta Vector to which the draw is assigned; must already
          * be properly sized. eta will be transformed into variational posteriors.
          * @param[out] log_g The log  density in the mean-field normal approximation;
-         * The constant term is removed. 
+         * The constant term is dropped. 
          * @throws std::range_error If the index is out of range.
          */
         template <class BaseRNG>

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -340,7 +340,7 @@ namespace stan {
 	log_g = 0;
 	for (int d = 0; d < dimension_; ++d) {
 	  eta(d) = stan::math::normal_rng(0, 1, rng);
-	  log_g += stan::math::square(eta(d))*(-0.5);
+	  log_g += -stan::math::square(eta(d)) * 0.5;
 	}
 	eta = transform(eta);
       }

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -331,28 +331,28 @@ namespace stan {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         eta = transform(eta);
       }
-      
+
       template <class BaseRNG>
       void sample_log_g(BaseRNG& rng,
-			Eigen::VectorXd& eta,
-			double& log_g) const {
-	// Draw from the approximation
+                        Eigen::VectorXd& eta,
+                        double& log_g) const {
+        // Draw from the approximation
         for (int d = 0; d < dimension_; ++d) {
           eta(d) = stan::math::normal_rng(0, 1, rng);
         }
-	// Compute the log density before transformation
+        // Compute the log density before transformation
         log_g = calc_log_g(eta);
-	// Transform to real-coordinate space
+        // Transform to real-coordinate space
         eta = transform(eta);
       }
-      
+
       double calc_log_g(const Eigen::VectorXd& eta) const {
-	// Compute the log density wrt normal distribution dropping constants
-	double log_g = 0;
-	for (int d = 0; d < dimension_; ++d) {
-	  log_g += -stan::math::square(eta(d)) * 0.5;
-	}
-	return log_g;
+        // Compute the log density wrt normal distribution dropping constants
+        double log_g = 0;
+        for (int d = 0; d < dimension_; ++d) {
+          log_g += -stan::math::square(eta(d)) * 0.5;
+        }
+        return log_g;
       }
 
       /**

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -342,15 +342,17 @@ namespace stan {
         eta = transform(eta);
       }
         /**
-         * New: Draw a posterior sample from a normal distribution, 
-         and return the log normal density. 
-         Constant (d* log 2 pi) is removed. It changes as a function 
-         of parameters, but not as a fixed posterior sample.
-         It is saved as log_q (the approximation density 
-        using variational families).
+         * New: Draw a posterior sample from the normal distribution, 
+         * and return its log normal density. The constant (d log 2 pi) is removed. 
+         * @param[in] rng Base random number generator.
+         * @param[in, out] eta Vector to which the draw is assigned; must already
+         * be properly sized. eta will be transformed into variational posteriors.
+         * @param[out] log_q The log  density in the mean-field normal approximation;
+         * The constant term is removed. 
+         * @throws std::range_error If the index is out of range.
          */
         template <class BaseRNG>
-        void sample_lq(BaseRNG& rng,
+        void sample_log_q(BaseRNG& rng,
                        Eigen::VectorXd& eta,
                        double& log_q)
         const {

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -342,7 +342,7 @@ namespace stan {
         eta = transform(eta);
       }
         /**
-         * New: Draw a posterior sample from the normal distribution, 
+         * Draw a posterior sample from the normal distribution, 
          * and return its log normal density. The constant (d log 2 pi) is removed. 
          * @param[in] rng Base random number generator.
          * @param[in, out] eta Vector to which the draw is assigned; must already

--- a/src/test/unit/services/experimental/advi/fullrank_test.cpp
+++ b/src/test/unit/services/experimental/advi/fullrank_test.cpp
@@ -76,6 +76,31 @@ TEST_F(ServicesExperimentalAdvi, fullrank) {
                logger, init, parameter, diagnostic);
   EXPECT_EQ(0, return_code);
 
+  std::vector<std::vector<std::string> > parameter_names;
+  parameter_names = parameter.vector_string_values();
+  std::vector<std::vector<double> > parameter_values;
+  parameter_values = parameter.vector_double_values();
+  std::vector<std::vector<std::string> > diagnostic_names;
+  diagnostic_names = diagnostic.vector_string_values();
+  std::vector<std::vector<double> > diagnostic_values;
+  diagnostic_values = diagnostic.vector_double_values();
+  
+  // Expectations of parameter parameter names.
+  ASSERT_EQ(6, parameter_names[0].size());
+  EXPECT_EQ("lp__", parameter_names[0][0]);
+  EXPECT_EQ("log_p__", parameter_names[0][1]);
+  EXPECT_EQ("log_g__", parameter_names[0][2]);
+  EXPECT_EQ("y", parameter_names[0][3]);
+  EXPECT_EQ("z", parameter_names[0][4]);
+  EXPECT_EQ("xgq", parameter_names[0][5]);
+  
+  // Expect one name per parameter value.
+  EXPECT_EQ(parameter_names[0].size(), parameter_values[0].size());
+  EXPECT_EQ(diagnostic_names[0].size(), diagnostic_values[0].size());
+  
+  EXPECT_EQ("lp__", diagnostic_names[0][0]);
+  EXPECT_EQ("log_p__", diagnostic_names[0][1]);
+  
   ASSERT_EQ(1, init.vector_double_values().size());
   ASSERT_EQ(2, init.vector_double_values().at(0).size());
   std::vector<double> init_values = init.vector_double_values().at(0);

--- a/src/test/unit/services/experimental/advi/fullrank_test.cpp
+++ b/src/test/unit/services/experimental/advi/fullrank_test.cpp
@@ -80,27 +80,21 @@ TEST_F(ServicesExperimentalAdvi, fullrank) {
   parameter_names = parameter.vector_string_values();
   std::vector<std::vector<double> > parameter_values;
   parameter_values = parameter.vector_double_values();
-  std::vector<std::vector<std::string> > diagnostic_names;
-  diagnostic_names = diagnostic.vector_string_values();
-  std::vector<std::vector<double> > diagnostic_values;
-  diagnostic_values = diagnostic.vector_double_values();
-  
+
   // Expectations of parameter parameter names.
-  ASSERT_EQ(6, parameter_names[0].size());
+  ASSERT_EQ(8, parameter_names[0].size());
   EXPECT_EQ("lp__", parameter_names[0][0]);
   EXPECT_EQ("log_p__", parameter_names[0][1]);
   EXPECT_EQ("log_g__", parameter_names[0][2]);
-  EXPECT_EQ("y", parameter_names[0][3]);
-  EXPECT_EQ("z", parameter_names[0][4]);
-  EXPECT_EQ("xgq", parameter_names[0][5]);
-  
+  EXPECT_EQ("y.1", parameter_names[0][3]);
+  EXPECT_EQ("y.2", parameter_names[0][4]);
+  EXPECT_EQ("z.1", parameter_names[0][5]);
+  EXPECT_EQ("z.2", parameter_names[0][6]);
+  EXPECT_EQ("xgq", parameter_names[0][7]);
+
   // Expect one name per parameter value.
   EXPECT_EQ(parameter_names[0].size(), parameter_values[0].size());
-  EXPECT_EQ(diagnostic_names[0].size(), diagnostic_values[0].size());
-  
-  EXPECT_EQ("lp__", diagnostic_names[0][0]);
-  EXPECT_EQ("log_p__", diagnostic_names[0][1]);
-  
+
   ASSERT_EQ(1, init.vector_double_values().size());
   ASSERT_EQ(2, init.vector_double_values().at(0).size());
   std::vector<double> init_values = init.vector_double_values().at(0);

--- a/src/test/unit/services/experimental/advi/meanfield_test.cpp
+++ b/src/test/unit/services/experimental/advi/meanfield_test.cpp
@@ -80,27 +80,21 @@ TEST_F(ServicesExperimentalAdvi, meanfield) {
   parameter_names = parameter.vector_string_values();
   std::vector<std::vector<double> > parameter_values;
   parameter_values = parameter.vector_double_values();
-  std::vector<std::vector<std::string> > diagnostic_names;
-  diagnostic_names = diagnostic.vector_string_values();
-  std::vector<std::vector<double> > diagnostic_values;
-  diagnostic_values = diagnostic.vector_double_values();
-  
+
   // Expectations of parameter parameter names.
-  ASSERT_EQ(6, parameter_names[0].size());
+  ASSERT_EQ(8, parameter_names[0].size());
   EXPECT_EQ("lp__", parameter_names[0][0]);
   EXPECT_EQ("log_p__", parameter_names[0][1]);
   EXPECT_EQ("log_g__", parameter_names[0][2]);
-  EXPECT_EQ("y", parameter_names[0][3]);
-  EXPECT_EQ("z", parameter_names[0][4]);
-  EXPECT_EQ("xgq", parameter_names[0][5]);
-  
+  EXPECT_EQ("y.1", parameter_names[0][3]);
+  EXPECT_EQ("y.2", parameter_names[0][4]);
+  EXPECT_EQ("z.1", parameter_names[0][5]);
+  EXPECT_EQ("z.2", parameter_names[0][6]);
+  EXPECT_EQ("xgq", parameter_names[0][7]);
+
   // Expect one name per parameter value.
   EXPECT_EQ(parameter_names[0].size(), parameter_values[0].size());
-  EXPECT_EQ(diagnostic_names[0].size(), diagnostic_values[0].size());
-  
-  EXPECT_EQ("lp__", diagnostic_names[0][0]);
-  EXPECT_EQ("log_p__", diagnostic_names[0][1]);
-  
+
   ASSERT_EQ(1, init.vector_double_values().size());
   ASSERT_EQ(2, init.vector_double_values().at(0).size());
   std::vector<double> init_values = init.vector_double_values().at(0);

--- a/src/test/unit/services/experimental/advi/meanfield_test.cpp
+++ b/src/test/unit/services/experimental/advi/meanfield_test.cpp
@@ -76,6 +76,31 @@ TEST_F(ServicesExperimentalAdvi, meanfield) {
                logger, init, parameter, diagnostic);
   EXPECT_EQ(0, return_code);
 
+  std::vector<std::vector<std::string> > parameter_names;
+  parameter_names = parameter.vector_string_values();
+  std::vector<std::vector<double> > parameter_values;
+  parameter_values = parameter.vector_double_values();
+  std::vector<std::vector<std::string> > diagnostic_names;
+  diagnostic_names = diagnostic.vector_string_values();
+  std::vector<std::vector<double> > diagnostic_values;
+  diagnostic_values = diagnostic.vector_double_values();
+  
+  // Expectations of parameter parameter names.
+  ASSERT_EQ(6, parameter_names[0].size());
+  EXPECT_EQ("lp__", parameter_names[0][0]);
+  EXPECT_EQ("log_p__", parameter_names[0][1]);
+  EXPECT_EQ("log_g__", parameter_names[0][2]);
+  EXPECT_EQ("y", parameter_names[0][3]);
+  EXPECT_EQ("z", parameter_names[0][4]);
+  EXPECT_EQ("xgq", parameter_names[0][5]);
+  
+  // Expect one name per parameter value.
+  EXPECT_EQ(parameter_names[0].size(), parameter_values[0].size());
+  EXPECT_EQ(diagnostic_names[0].size(), diagnostic_values[0].size());
+  
+  EXPECT_EQ("lp__", diagnostic_names[0][0]);
+  EXPECT_EQ("log_p__", diagnostic_names[0][1]);
+  
   ASSERT_EQ(1, init.vector_double_values().size());
   ASSERT_EQ(2, init.vector_double_values().at(0).size());
   std::vector<double> init_values = init.vector_double_values().at(0);

--- a/src/test/unit/variational/families/normal_fullrank_test.cpp
+++ b/src/test/unit/variational/families/normal_fullrank_test.cpp
@@ -166,7 +166,7 @@ TEST(normal_fullrank_test, log_g) {
 
   stan::variational::normal_fullrank my_normal_fullrank(mu, L);
 
-  double log_g_true = -76.196774908220817;
+  double log_g_true = -67.699049999999985;
 
   const double log_g_out = my_normal_fullrank.log_g(x);
 

--- a/src/test/unit/variational/families/normal_fullrank_test.cpp
+++ b/src/test/unit/variational/families/normal_fullrank_test.cpp
@@ -152,7 +152,7 @@ TEST(normal_fullrank_test, transform) {
                    std::domain_error);
 }
 
-TEST(normal_fullrank_test, log_g) {
+TEST(normal_fullrank_test, calc_log_g) {
   Eigen::Vector3d x;
   x << 7.1, -9.2, 0.59;
   
@@ -168,7 +168,7 @@ TEST(normal_fullrank_test, log_g) {
 
   double log_g_true = -67.699049999999985;
 
-  const double log_g_out = my_normal_fullrank.log_g(x);
+  const double log_g_out = my_normal_fullrank.calc_log_g(x);
 
   EXPECT_FLOAT_EQ(log_g_out, log_g_true);
 }

--- a/src/test/unit/variational/families/normal_fullrank_test.cpp
+++ b/src/test/unit/variational/families/normal_fullrank_test.cpp
@@ -151,3 +151,25 @@ TEST(normal_fullrank_test, transform) {
   EXPECT_THROW(my_normal_fullrank.transform(x_nan);,
                    std::domain_error);
 }
+
+TEST(normal_fullrank_test, log_g) {
+  Eigen::Vector3d x;
+  x << 7.1, -9.2, 0.59;
+  
+  Eigen::Vector3d mu;
+  mu << 5.7, -3.2, 0.1332;
+
+  Eigen::Matrix3d L;
+  L << 1.3, 0,  0,
+       2.3, 41, 0,
+       3.3, 42, 92;
+
+  stan::variational::normal_fullrank my_normal_fullrank(mu, L);
+
+  double log_g_true = -76.196774908220817;
+
+  const double log_g_out = my_normal_fullrank.log_g(x);
+
+  EXPECT_FLOAT_EQ(log_g_out, log_g_true);
+}
+

--- a/src/test/unit/variational/families/normal_meanfield_test.cpp
+++ b/src/test/unit/variational/families/normal_meanfield_test.cpp
@@ -138,3 +138,23 @@ TEST(normal_meanfield_test, transform) {
   EXPECT_THROW(my_normal_meanfield.transform(x_nan);,
                    std::domain_error);
 }
+
+TEST(normal_meanfield_test, log_g) {
+  Eigen::Vector3d x;
+  x << 7.1, -9.2, 0.59;
+  
+  Eigen::Vector3d mu;
+  mu << 5.7, -3.2, 0.1332;
+
+  Eigen::Vector3d omega;
+  omega << -0.42, 0.8922, 13.4;
+
+  double log_g_true = -81.571249999999992;
+
+  stan::variational::normal_meanfield my_normal_meanfield(mu, omega);
+
+  const double log_g_out = my_normal_meanfield.log_g(x);
+
+  EXPECT_FLOAT_EQ(log_g_out, log_g_true);
+
+}

--- a/src/test/unit/variational/families/normal_meanfield_test.cpp
+++ b/src/test/unit/variational/families/normal_meanfield_test.cpp
@@ -139,7 +139,7 @@ TEST(normal_meanfield_test, transform) {
                    std::domain_error);
 }
 
-TEST(normal_meanfield_test, log_g) {
+TEST(normal_meanfield_test, calc_log_g) {
   Eigen::Vector3d x;
   x << 7.1, -9.2, 0.59;
   
@@ -153,7 +153,7 @@ TEST(normal_meanfield_test, log_g) {
 
   stan::variational::normal_meanfield my_normal_meanfield(mu, omega);
 
-  const double log_g_out = my_normal_meanfield.log_g(x);
+  const double log_g_out = my_normal_meanfield.calc_log_g(x);
 
   EXPECT_FLOAT_EQ(log_g_out, log_g_true);
 

--- a/src/test/unit/variational/families/normal_meanfield_test.cpp
+++ b/src/test/unit/variational/families/normal_meanfield_test.cpp
@@ -149,7 +149,7 @@ TEST(normal_meanfield_test, log_g) {
   Eigen::Vector3d omega;
   omega << -0.42, 0.8922, 13.4;
 
-  double log_g_true = -81.571249999999992;
+  double log_g_true = -67.699049999999985;
 
   stan::variational::normal_meanfield my_normal_meanfield(mu, omega);
 


### PR DESCRIPTION
Update (15 Mar 2019, Aki):

1. change variable names. The output is now lp__, log_p__, log_g__, other_parameters.
2. separate calc_log_g for easier testing
3. tests for calc_log_g
4. tests for service output similarly as for sample and optimize

#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
   passed all unit tests in src/test/unit/variational except 
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
implementation of  #2474 

This paper proposes PSIS diagnostic for ADVI: Yuling Yao, Aki Vehtari, Daniel Simpson, and Andrew Gelman (2018). [Yes, but Did It Work?: Evaluating Variational Inference ](http://proceedings.mlr.press/v80/yao18a.html)

Currently ADVI in Stan samples N draws from the approximate distribution and outputs those. In addition lp__ column is inserted, but it has all 0's.

We added the following features:

1.  in `stan/src/stan/variational/family/normal_meanfield.hpp` and `normal_fullrank.hpp`:   compute log_p__ (unnormalized log density of the exact model) and log_g__ (unnormalized  log density under either the meanfield or fullrank gaussian approximation).  The latter one is obtained from normal-reparametrization and drops all constants. 

2. in `stan/src/stan/variational/advi.hpp`:  output log_p__ and log_g__  in the first two columns of the output csv file. 

Given the csv output we can compute diagnostic afterwards. 

The csv output structure may still not be optimal and may need better organization, while this is the minimal change.

#### How to Verify
All current unit tests in  src/test/unit/variational has been passed. 
#### Side Effects
Additional computation cost is ignorable as log_p__ and log_q__ are only computed after optimization.
#### Documentation
N/A
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)