### PR TITLE
add inline to the declaration of compute_effective_sample_size(...) 

### DIFF
--- a/src/stan/analyze/mcmc/compute_effective_sample_size.hpp
+++ b/src/stan/analyze/mcmc/compute_effective_sample_size.hpp
@@ -22,7 +22,7 @@ namespace stan {
      * @param std::vector stores sizes of chains
      * @return effective sample size for the specified parameter
      */
-    double compute_effective_sample_size(std::vector<const double*> draws,
+    inline double compute_effective_sample_size(std::vector<const double*> draws,
                                          std::vector<size_t> sizes) {
       int num_chains = sizes.size();
 
@@ -84,7 +84,7 @@ namespace stan {
       return num_chains * num_draws / (1 + 2 * rho_hat_s.sum());
     }
 
-    double compute_effective_sample_size(std::vector<const double*> draws,
+    inline double compute_effective_sample_size(std::vector<const double*> draws,
                                          size_t size) {
       int num_chains = draws.size();
       std::vector<size_t> sizes(num_chains, size);

--- a/src/stan/analyze/mcmc/compute_effective_sample_size.hpp
+++ b/src/stan/analyze/mcmc/compute_effective_sample_size.hpp
@@ -22,7 +22,8 @@ namespace stan {
      * @param std::vector stores sizes of chains
      * @return effective sample size for the specified parameter
      */
-    inline double compute_effective_sample_size(std::vector<const double*> draws,
+    inline
+    double compute_effective_sample_size(std::vector<const double*> draws,
                                          std::vector<size_t> sizes) {
       int num_chains = sizes.size();
 
@@ -84,7 +85,8 @@ namespace stan {
       return num_chains * num_draws / (1 + 2 * rho_hat_s.sum());
     }
 
-    inline double compute_effective_sample_size(std::vector<const double*> draws,
+    inline
+    double compute_effective_sample_size(std::vector<const double*> draws,
                                          size_t size) {
       int num_chains = draws.size();
       std::vector<size_t> sizes(num_chains, size);


### PR DESCRIPTION
To allow including the header in multiple compilation units.

see https://github.com/stan-dev/stan/issues/2615

Copyright: Tal Kedar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
