### PR TITLE
Fix url in preface.tex

### DIFF
--- a/src/docs/users-guide/preface.tex
+++ b/src/docs/users-guide/preface.tex
@@ -26,7 +26,7 @@ site (link below) for links and getting started instructions.
 The official resource for all things related to Stan is the web site:
 %
 \begin{quote}
-\url{http://mc-stan.org}
+\url{https://mc-stan.org}
 \end{quote}
 %
 The web site links to all of the packages comprising Stan for both
@@ -41,7 +41,7 @@ Stan's source code and much of the developer process is hosted on
 GitHub.  Stan's organization is:
 %
 \begin{quote}
-\url{http://https://github.com/stan-dev}
+\url{https://github.com/stan-dev}
 \end{quote}
 %
 Each package has its own repository within the \code{stan-dev}
@@ -57,7 +57,7 @@ Stan hosts message boards for discussing all things
 related to Stan.  
 %
 \begin{quote}
-\url{http://discourse.mc-stan.org}
+\url{https://discourse.mc-stan.org}
 \end{quote}
 %
 This is the place to ask questions about Stan, including modeling,


### PR DESCRIPTION
Spotted a few erros in url in the user manual

#### Submission Checklist

- [ - ] Run unit tests: `./runTests.py src/test/unit`
- [ - ] Run cpplint: `make cpplint`
- [ x ] Declare copyright holder and open-source license: see below

#### Summary

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
