### PR TITLE
Allow CSV reader to read max_depth from CmdStan CSV file

### DIFF
--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -156,8 +156,8 @@ namespace stan {
           } else if (name.compare("engine") == 0) {
             metadata.engine = value;
           } else if (name.compare("max_depth") == 0) {
-	    metadata.max_depth = boost::lexical_cast<int>(value);
-	  }
+            metadata.max_depth = boost::lexical_cast<int>(value);
+          }
         }
         if (ss.good() == true)
           return false;

--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -32,6 +32,7 @@ namespace stan {
       bool append_samples;
       std::string algorithm;
       std::string engine;
+      int max_depth;
 
       stan_csv_metadata()
         : stan_version_major(0), stan_version_minor(0), stan_version_patch(0),
@@ -39,7 +40,7 @@ namespace stan {
           chain_id(1), seed(0), random_seed(false),
           num_samples(0), num_warmup(0), save_warmup(false), thin(0),
           append_samples(false),
-          algorithm(""), engine("") {}
+          algorithm(""), engine(""), max_depth(10) {}
     };
 
     struct stan_csv_adaptation {
@@ -154,7 +155,9 @@ namespace stan {
             metadata.algorithm = value;
           } else if (name.compare("engine") == 0) {
             metadata.engine = value;
-          }
+          } else if (name.compare("max_depth") == 0) {
+	    metadata.max_depth = boost::lexical_cast<int>(value);
+	  }
         }
         if (ss.good() == true)
           return false;

--- a/src/test/unit/io/stan_csv_reader_test.cpp
+++ b/src/test/unit/io/stan_csv_reader_test.cpp
@@ -70,6 +70,7 @@ TEST_F(StanIoStanCsvReader,read_metadata1) {
   EXPECT_EQ(2U, metadata.thin);
   EXPECT_EQ("hmc", metadata.algorithm);
   EXPECT_EQ("nuts", metadata.engine);
+  EXPECT_EQ(10, metadata.max_depth);
 }
 TEST_F(StanIoStanCsvReader,read_metadata3) {
   stan::io::stan_csv_metadata metadata;
@@ -92,6 +93,7 @@ TEST_F(StanIoStanCsvReader,read_metadata3) {
   EXPECT_EQ(2U, metadata.thin);
   EXPECT_EQ("hmc", metadata.algorithm);
   EXPECT_EQ("nuts", metadata.engine);
+  EXPECT_EQ(15, metadata.max_depth);
 }
 TEST_F(StanIoStanCsvReader,read_header1) {
   Eigen::Matrix<std::string, Eigen::Dynamic, 1> header;

--- a/src/test/unit/io/test_csv_files/metadata3.csv
+++ b/src/test/unit/io/test_csv_files/metadata3.csv
@@ -21,7 +21,7 @@
 #       hmc
 #         engine = nuts (Default)
 #           nuts
-#             max_depth = 10 (Default)
+#             max_depth = 15
 #         metric = diag_e (Default)
 #         stepsize = 1 (Default)
 #         stepsize_jitter = 0 (Default)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is a prerequisite needed to fix the bug described in https://github.com/stan-dev/cmdstan/issues/646 and implements the modifications to the CSV reader described in https://discourse.mc-stan.org/t/modifying-stan-csv-reader-to-fix-a-problem-in-cmdstan/5307.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Myself, i.e., J. J. Ramsey

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
