### PR TITLE
Bugfix/issue 2576 Address segfault in optimizing simple exponential model

### DIFF
--- a/src/stan/optimization/bfgs.hpp
+++ b/src/stan/optimization/bfgs.hpp
@@ -57,13 +57,15 @@ namespace stan {
       LSOptions() {
         c1 = 1e-4;
         c2 = 0.9;
-        minAlpha = 1e-12;
         alpha0 = 1e-3;
+        minAlpha = 1e-12;
+        maxLSRetries = 20;
       }
       Scalar c1;
       Scalar c2;
       Scalar alpha0;
       Scalar minAlpha;
+      Scalar maxLSRetries;
     };
     template<typename FunctorType, typename QNUpdateType,
              typename Scalar = double, int DimAtCompile = Eigen::Dynamic>
@@ -201,7 +203,7 @@ namespace stan {
           retCode = WolfeLineSearch(_func, _alpha, _xk_1, _fk_1, _gk_1,
                                     _pk, _xk, _fk, _gk,
                                     _ls_opts.c1, _ls_opts.c2,
-                                    _ls_opts.minAlpha);
+                                    _ls_opts.minAlpha, _ls_opts.maxLSRetries);
           if (retCode) {
             // Line search failed...
             if (resetB) {

--- a/src/stan/optimization/bfgs_linesearch.hpp
+++ b/src/stan/optimization/bfgs_linesearch.hpp
@@ -203,7 +203,7 @@ namespace stan {
      *
      * @param f0 Value of function at starting point, \f$ f(x_0) \f$.
      *
-     * @param gradx0 Value of function gradient at starting point, 
+     * @param gradx0 Value of function gradient at starting point,
      *    \f$ g(x_0) \f$.
      *
      * @param c1 Parameter of the Wolfe conditions. \f$ 0 < c_1 < c_2 < 1 \f$
@@ -214,6 +214,9 @@ namespace stan {
      *
      * @param minAlpha Smallest allowable step-size.
      *
+     * @param maxLSRetries Maximum number times line search can update
+     * step-size and retry to find approximate solution.
+     *
      * @return Returns zero on success, non-zero otherwise.
      **/
     template<typename FunctorType, typename Scalar, typename XType>
@@ -223,7 +226,7 @@ namespace stan {
                         const XType &p,
                         const XType &x0, const Scalar &f0, const XType &gradx0,
                         const Scalar &c1, const Scalar &c2,
-                        const Scalar &minAlpha) {
+                        const Scalar &minAlpha, const Scalar &maxLSRetries) {
       const Scalar dfp(gradx0.dot(p));
       const Scalar c1dfp(c1*dfp);
       const Scalar c2dfp(c2*dfp);
@@ -236,13 +239,18 @@ namespace stan {
       Scalar prevDFp(dfp);
       Scalar newDFp;
 
-      int retCode = 0, nits = 0, ret;
+      int retCode = 0, nits = 0, lsRetries = 0, ret;
 
       while (1) {
         x1.noalias() = x0 + alpha1 * p;
         ret = func(x1, f1, gradx1);
         if (ret != 0) {
+          if (lsRetries >= maxLSRetries) {
+            retCode = 1;
+            break;
+          }
           alpha1 = 0.5 * (alpha0 + alpha1);
+          lsRetries++;
           continue;
         }
         newDFp = gradx1.dot(p);

--- a/src/test/unit/optimization/bfgs_linesearch_test.cpp
+++ b/src/test/unit/optimization/bfgs_linesearch_test.cpp
@@ -78,8 +78,8 @@ class linesearch_testfunc {
 public:
   double operator()(const Eigen::Matrix<double,Eigen::Dynamic,1> &x) {
     return x.dot(x) - 1.0;
-  } 
-  int operator()(const Eigen::Matrix<double,Eigen::Dynamic,1> &x, 
+  }
+  int operator()(const Eigen::Matrix<double,Eigen::Dynamic,1> &x,
                  double &f, Eigen::Matrix<double,Eigen::Dynamic,1> &g) {
     f = x.dot(x) - 1.0;
     g = 2.0*x;
@@ -154,6 +154,7 @@ TEST(OptimizationBfgsLinesearch, wolfeLineSearch) {
   static const double c1 = 1e-4;
   static const double c2 = 0.9;
   static const double minAlpha = 1e-16;
+  static const double maxLSRetries = 20;
 
   linesearch_testfunc func1;
   Eigen::Matrix<double,-1,1> x0,x1;
@@ -171,7 +172,7 @@ TEST(OptimizationBfgsLinesearch, wolfeLineSearch) {
   ret = WolfeLineSearch(func1, alpha,
                         x1, f1, gradx1,
                         p, x0, f0, gradx0,
-                        c1, c2, minAlpha);
+                        c1, c2, minAlpha, maxLSRetries);
   EXPECT_EQ(0,ret);
   EXPECT_NEAR(0.5,alpha,1e-8);
   EXPECT_NEAR(0,(x1 - (x0 + alpha*p)).norm(),1e-8);
@@ -183,7 +184,7 @@ TEST(OptimizationBfgsLinesearch, wolfeLineSearch) {
   ret = WolfeLineSearch(func1, alpha,
                         x1, f1, gradx1,
                         p, x0, f0, gradx0,
-                        c1, c2, minAlpha);
+                        c1, c2, minAlpha, maxLSRetries);
   EXPECT_EQ(0,ret);
   EXPECT_NEAR(0.5,alpha,1e-8);
   EXPECT_NEAR(0,(x1 - (x0 + alpha*p)).norm(),1e-8);
@@ -195,7 +196,7 @@ TEST(OptimizationBfgsLinesearch, wolfeLineSearch) {
   ret = WolfeLineSearch(func1, alpha,
                         x1, f1, gradx1,
                         p, x0, f0, gradx0,
-                        c1, c2, minAlpha);
+                        c1, c2, minAlpha, maxLSRetries);
   EXPECT_EQ(0,ret);
   EXPECT_NEAR(0.25,alpha,1e-8);
   EXPECT_NEAR(0,(x1 - (x0 + alpha*p)).norm(),1e-8);


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit/optimization`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Provide a fix to the segfault found in optimizing a simple exponential model, issue https://github.com/stan-dev/stan/issues/2576.

The line https://github.com/stan-dev/stan/blob/cf5a69f2bb0ac4def33792d582b7ee417cf95ab7/src/stan/optimization/bfgs_linesearch.hpp#L243 can have a non-zero return, inducing an infinite loop.  My solution breaks this infinite loop by adding a maximum number of line search approximation retries, which defaults to 20 (per outer lbfgs iteration).  The number 20 was chosen to match Python's [Scipy'](https://docs.scipy.org/doc/scipy-0.18.1/reference/optimize.minimize-lbfgsb.html#optimize-minimize-lbfgsb)s `scipy.optimize.minimize(..., method="L-BFGS-B")` maximum number of line search iterations argument `maxls`. 

#### Intended Effect

Make Stan's lbfgs algorithm more robust to ill specified models.

#### How to Verify

Issue https://github.com/stan-dev/stan/issues/2576 provides an example that previously made Stan segfault.  Stan now exits with the error message
```
Optimization terminated with error: 
  Line search failed to achieve a sufficient decrease, no more progress can be made
``` 
which matches `scipy.optimize.minimize`'s error message for the equivalent model.  Hence, Stan and `scipy.optimize.minimize` now have the same behavior on the proposed model.

Should I add a test for the model provided in issue https://github.com/stan-dev/stan/issues/2576 as a bad model, for which Stan should appropriately fail?

#### Side Effects

None intended.

#### Documentation

Add inline documentation for the new argument to `src/stan/optimization/bfgs_linesearch.hpp
:WolfeLineSearch`, which is handed down from `/src/stan/optimization/bfgs.hpp`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): California State University, Chico

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
