### PR TITLE
move semantics for stan::mcmc::sample

### DIFF
--- a/src/stan/mcmc/sample.hpp
+++ b/src/stan/mcmc/sample.hpp
@@ -15,7 +15,15 @@ namespace stan {
         : cont_params_(q), log_prob_(log_prob), accept_stat_(stat) {
       }
 
-      virtual ~sample() {}  // No-op
+      sample(const sample&) = default;
+
+      sample(sample&&) = default;
+
+      sample& operator=(const sample&) = default;
+
+      sample& operator=(sample&&) = default;
+
+      virtual ~sample() = default;
 
       int size_cont() const {
         return cont_params_.size();

--- a/src/stan/mcmc/sample.hpp
+++ b/src/stan/mcmc/sample.hpp
@@ -15,7 +15,7 @@ namespace stan {
         : cont_params_(q), log_prob_(log_prob), accept_stat_(stat) {
       }
 
-      sample(Eigen::VectorXd&& q, double log_prob, double stat)
+      sample(Eigen::VectorXd && q, double log_prob, double stat)
         : cont_params_(std::move(q)), log_prob_(log_prob), accept_stat_(stat) {
       }
 

--- a/src/stan/mcmc/sample.hpp
+++ b/src/stan/mcmc/sample.hpp
@@ -15,6 +15,10 @@ namespace stan {
         : cont_params_(q), log_prob_(log_prob), accept_stat_(stat) {
       }
 
+      sample(Eigen::VectorXd&& q, double log_prob, double stat)
+        : cont_params_(std::move(q)), log_prob_(log_prob), accept_stat_(stat) {
+      }
+
       sample(const sample&) = default;
 
       sample(sample&&) = default;


### PR DESCRIPTION
Added explicit default copy and move c'tor and assignment operator, and made the d'tor default (instead of an explicit no-op), to enable move semantics for stan::mcmc::sample

Addresses issue #2646.

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Tal Kedar
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
