### PR TITLE
Fixing broken travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,47 +68,47 @@ matrix:
           PARALLEL=2
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
           TESTFOLDER="src/test/unit/lang/*.cpp"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
           TESTFOLDER="src/test/unit/services  src/test/unit/version_test.cpp"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
           TESTFOLDER="src/test/unit/variational"
           PARALLEL=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_script:
   - echo "CXX=$CXX" > make/local
   - echo "CXXFLAGS_OS+=$CXXFLAGS_OS" >> make/local
   - if [[ ! -z "$DEPFLAGS_OS" ]]; then echo "DEPFLAGS_OS=$DEPFLAGS_OS" >> make/local; fi
+  - cat make/local
 
 linux_clang: &linux_clang
   os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
   - ${CXX} --version
   - echo "CXX=$CXX" > make/local
   - echo "CXXFLAGS_OS+=$CXXFLAGS_OS" >> make/local
-  - [[ ! -z "$DEPFLAGS_OS" ]] && echo "DEPFLAGS_OS=$DEPFLAGS_OS" >> make/local
+  - if [[ ! -z "$DEPFLAGS_OS" ]]; then echo "DEPFLAGS_OS=$DEPFLAGS_OS" >> make/local; fi
 
 linux_clang: &linux_clang
   os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - ${CXX} --version
   - echo "CXX=$CXX" > make/local
   - echo "CXXFLAGS_OS+=$CXXFLAGS_OS" >> make/local
+  - [[ ! -z "$DEPFLAGS_OS" ]] && echo "DEPFLAGS_OS=$DEPFLAGS_OS" >> make/local
 
 linux_clang: &linux_clang
   os: linux
@@ -68,47 +69,47 @@ matrix:
           PARALLEL=2
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread && DEPFLAGS_OS='-M -E'"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread && DEPFLAGS_OS='-M -E'"
           TESTFOLDER="src/test/unit/lang/*.cpp"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread && DEPFLAGS_OS='-M -E'"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread && DEPFLAGS_OS='-M -E'"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread && DEPFLAGS_OS='-M -E'"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread && DEPFLAGS_OS='-M -E'"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread && DEPFLAGS_OS='-M -E'"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread && DEPFLAGS_OS='-M -E'"
           TESTFOLDER="src/test/unit/services  src/test/unit/version_test.cpp"
           PARALLEL=1
     - <<: *linux_gcc
       env:
-        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread"
+        - MATRIX_EVAL="CXX=g++-4.9 && CXXFLAGS_OS=-pthread && DEPFLAGS_OS='-M -E'"
           TESTFOLDER="src/test/unit/variational"
           PARALLEL=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_script:
   - eval "${MATRIX_EVAL}"
   - echo ${CXX}
   - ${CXX} --version
-  - echo "CC=$CXX" > make/local
-  - echo "LDFLAGS_OS+=$LDFLAGS_OS" >> make/local
+  - echo "CXX=$CXX" > make/local
+  - echo "CXXFLAGS_OS+=$CXXFLAGS_OS" >> make/local
 
 linux_clang: &linux_clang
   os: linux
@@ -33,37 +33,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=clang++-3.8 && LDFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && LDFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && LDFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && LDFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && LDFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && LDFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && LDFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
This should fix the broken Travis build.

Here are the different things that are being done in this PR:
1. changing make/local to set `CXX` instead of `CC`.
2. Changing the `-stdlib=libc++` to be added to `CXXFLAGS_OS` instead of `LDFLAGS_OS`. Some of these failures occurred because the `LDFLAGS_OS` are only added to the linking step, but not the compilation step (from `.cpp` to `.o`). It's needed there.
3. Adding `-pthread` to `CXXFLAGS_OS` for `g++-4.9`. I looked at the logs and it's in the build options that work pre-merge of the PR.
4. Changing the dependency generation flags. Perhaps this should be based on compiler (for a future issue): `DEPFLAGS_OS = -M -E`.

#### Intended Effect
Fix travis.

#### How to Verify
Hopefully it'll pass. I'll put up a link when it does.

#### Side Effects
None.

#### Documentation
None.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Generable

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
