### PR TITLE
[WIP] incorrect sampling from mulivariate normal specified by its precision matrix

### DIFF
--- a/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
@@ -58,7 +58,7 @@ namespace stan {
         for (idx_t i = 0; i < u.size(); ++i)
           u(i) = rand_dense_gaus();
 
-        z.p = z.inv_e_metric_.llt().matrixL().solve(u);
+        z.p = z.inv_e_metric_.llt().matrixU().solve(u);
       }
     };
 

--- a/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
@@ -7,7 +7,6 @@
 #include <stan/callbacks/stream_logger.hpp>
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
-#include <iostream>
 
 typedef boost::ecuyer1988 rng_t;
 

--- a/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
@@ -19,17 +19,17 @@ TEST(McmcDenseEMetric, sample_p) {
   q(1) = 1;
 
   Eigen::MatrixXd  m(2,2);
-  m(0,0) = 3.0;
-  m(1,0) = -2.0;
-  m(0,1) = -2.0;
-  m(1,1) = 4.0;
+  m(0, 0) = 3.0;
+  m(1, 0) = -2.0;
+  m(0, 1) = -2.0;
+  m(1, 1) = 4.0;
 
   Eigen::MatrixXd  m_inv(2,2);
-  double det_inv = 1.0/(3.0*4.0 - (-2.0)*(-2.0));
-  m_inv(0,0) = m(1,1)*det_inv;
-  m_inv(1,0) = -1.0*m(1,0)*det_inv;
-  m_inv(0,1) = -1.0*m(0,1)*det_inv;
-  m_inv(1,1) = m(0,0)*det_inv;
+  double det_inv = 1.0 / (3.0 * 4.0 - (-2.0) * (-2.0));
+  m_inv(0, 0) = m(1, 1) * det_inv;
+  m_inv(1, 0) = -1.0 * m(1, 0) * det_inv;
+  m_inv(0, 1) = -1.0 * m(0, 1) * det_inv;
+  m_inv(1, 1) = m(0, 0) * det_inv;
 
   stan::mcmc::mock_model model(q.size());
 
@@ -40,30 +40,30 @@ TEST(McmcDenseEMetric, sample_p) {
   int n_samples = 1000;
 
   Eigen::MatrixXd sample_cov(2,2);
-  sample_cov(0,0) = 0.0;
-  sample_cov(0,1) = 0.0;
-  sample_cov(1,0) = 0.0;
-  sample_cov(1,1) = 0.0;
+  sample_cov(0, 0) = 0.0;
+  sample_cov(0, 1) = 0.0;
+  sample_cov(1, 0) = 0.0;
+  sample_cov(1, 1) = 0.0;
 
   for (int i = 0; i < n_samples; ++i) {
     metric.sample_p(z, base_rng);
-    sample_cov(0,0) += z.p[0]*z.p[0]/(n_samples+0.0);
-    sample_cov(0,1) += z.p[0]*z.p[1]/(n_samples+0.0);
-    sample_cov(1,0) += z.p[1]*z.p[0]/(n_samples+0.0);
-    sample_cov(1,1) += z.p[1]*z.p[1]/(n_samples+0.0);
+    sample_cov(0, 0) += z.p[0] * z.p[0] / (n_samples + 0.0);
+    sample_cov(0, 1) += z.p[0] * z.p[1] / (n_samples + 0.0);
+    sample_cov(1, 0) += z.p[1] * z.p[0] / (n_samples + 0.0);
+    sample_cov(1, 1) += z.p[1] * z.p[1] / (n_samples + 0.0);
   }
 
   Eigen::MatrixXd var(2,2);
-  var(0,0) = 2*m(0,0);
-  var(1,0) = m(1,0)*m(1,0) + m(1,1)*m(0,0);
-  var(0,1) = m(0,1)*m(0,1) + m(1,1)*m(0,0);
-  var(1,1) = 2*m(1,1);
-  
+  var(0, 0) = 2 * m(0, 0);
+  var(1, 0) = m(1, 0) * m(1, 0) + m(1, 1) * m(0, 0);
+  var(0, 1) = m(0, 1) * m(0, 1) + m(1, 1) * m(0, 0);
+  var(1, 1) = 2 * m(1, 1);
+
   // Covariance matrix within 5sigma of expected value (comes from a Wishart distribution)
-  EXPECT_TRUE(std::fabs(m(0,0)   - sample_cov(0,0)) < 5.0 * sqrt(var(0,0)/n_samples));
-  EXPECT_TRUE(std::fabs(m(1,0)   - sample_cov(1,0)) < 5.0 * sqrt(var(1,0)/n_samples));
-  EXPECT_TRUE(std::fabs(m(0,1)   - sample_cov(0,1)) < 5.0 * sqrt(var(0,1)/n_samples));
-  EXPECT_TRUE(std::fabs(m(1,1)   - sample_cov(1,1)) < 5.0 * sqrt(var(1,1)/n_samples));
+  EXPECT_TRUE(std::fabs(m(0, 0)   - sample_cov(0, 0)) < 5.0 * sqrt(var(0, 0) / n_samples));
+  EXPECT_TRUE(std::fabs(m(1, 0)   - sample_cov(1, 0)) < 5.0 * sqrt(var(1, 0) / n_samples));
+  EXPECT_TRUE(std::fabs(m(0, 1)   - sample_cov(0, 1)) < 5.0 * sqrt(var(0, 1) / n_samples));
+  EXPECT_TRUE(std::fabs(m(1, 1)   - sample_cov(1, 1)) < 5.0 * sqrt(var(1, 1) / n_samples));
 }
 
 

--- a/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
@@ -37,10 +37,10 @@ TEST(McmcDenseEMetric, sample_p) {
 
   for (int i = 0; i < n_samples; ++i) {
     metric.sample_p(z, base_rng);
-    sample_cov(0, 0) += z.p[0] * z.p[0] / (n_samples + 0.0);
-    sample_cov(0, 1) += z.p[0] * z.p[1] / (n_samples + 0.0);
-    sample_cov(1, 0) += z.p[1] * z.p[0] / (n_samples + 0.0);
-    sample_cov(1, 1) += z.p[1] * z.p[1] / (n_samples + 0.0);
+    sample_cov(0, 0) += z.p[0] * z.p[0] / n_samples;
+    sample_cov(0, 1) += z.p[0] * z.p[1] / n_samples;
+    sample_cov(1, 0) += z.p[1] * z.p[0] / n_samples;
+    sample_cov(1, 1) += z.p[1] * z.p[1] / n_samples;
   }
 
   Eigen::Matrix2d var(2,2);

--- a/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
@@ -23,9 +23,6 @@ TEST(McmcDenseEMetric, sample_p) {
   m(1,0) = -2.0;
   m(0,1) = -2.0;
   m(1,1) = 4.0;
-  std::cout << "m"<<std::endl;
-  std::cout << m(0,0) << "  " << m(0,1) << std::endl;
-  std::cout << m(1,0) << "  " << m(1,1) << std::endl;
 
   Eigen::MatrixXd  m_inv(2,2);
   double det_inv = 1.0/(3.0*4.0 - (-2.0)*(-2.0));
@@ -33,9 +30,6 @@ TEST(McmcDenseEMetric, sample_p) {
   m_inv(1,0) = -1.0*m(1,0)*det_inv;
   m_inv(0,1) = -1.0*m(0,1)*det_inv;
   m_inv(1,1) = m(0,0)*det_inv;
-  std::cout << "m_inv" << std::endl;
-  std::cout << m_inv(0,0) << "  " << m_inv(0,1) << std::endl;
-  std::cout << m_inv(1,0) << "  " << m_inv(1,1) << std::endl;
 
   stan::mcmc::mock_model model(q.size());
 
@@ -59,19 +53,12 @@ TEST(McmcDenseEMetric, sample_p) {
     sample_cov(1,1) += z.p[1]*z.p[1]/(n_samples+0.0);
   }
 
-  std::cout << "sample_cov" << std::endl;
-  std::cout << sample_cov(0,0) << "  " << sample_cov(0,1) << std::endl;
-  std::cout << sample_cov(1,0) << "  " << sample_cov(1,1) << std::endl;
-
   Eigen::MatrixXd var(2,2);
   var(0,0) = 2*m(0,0);
   var(1,0) = m(1,0)*m(1,0) + m(1,1)*m(0,0);
   var(0,1) = m(0,1)*m(0,1) + m(1,1)*m(0,0);
   var(1,1) = 2*m(1,1);
-  std::cout << "var" << std::endl;
-  std::cout << var(0,0) << "  " << var(0,1) << std::endl;
-  std::cout << var(1,0) << "  " << var(1,1) << std::endl;
-
+  
   // Covariance matrix within 5sigma of expected value (comes from a Wishart distribution)
   EXPECT_TRUE(std::fabs(m(0,0)   - sample_cov(0,0)) < 5.0 * sqrt(var(0,0)/n_samples));
   EXPECT_TRUE(std::fabs(m(1,0)   - sample_cov(1,0)) < 5.0 * sqrt(var(1,0)/n_samples));

--- a/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
@@ -17,40 +17,6 @@ TEST(McmcDenseEMetric, sample_p) {
   q(0) = 5;
   q(1) = 1;
 
-  stan::mcmc::mock_model model(q.size());
-
-  stan::mcmc::dense_e_metric<stan::mcmc::mock_model, rng_t> metric(model);
-  stan::mcmc::dense_e_point z(q.size());
-
-  int n_samples = 1000;
-  double m = 0;
-  double m2 = 0;
-
-  for (int i = 0; i < n_samples; ++i) {
-    metric.sample_p(z, base_rng);
-    double tau = metric.tau(z);
-
-    double delta = tau - m;
-    m += delta / static_cast<double>(i + 1);
-    m2 += delta * (tau - m);
-  }
-
-  double var = m2 / (n_samples + 1.0);
-
-  // Mean within 5sigma of expected value (d / 2)
-  EXPECT_TRUE(std::fabs(m   - 0.5 * q.size()) < 5.0 * sqrt(var));
-
-  // Variance within 10% of expected value (d / 2)
-  EXPECT_TRUE(std::fabs(var - 0.5 * q.size()) < 0.1 * q.size());
-}
-
-TEST(McmcDenseEMetric, sample_p_new) {
-  rng_t base_rng(0);
-
-  Eigen::VectorXd q(2);
-  q(0) = 5;
-  q(1) = 1;
-
   Eigen::MatrixXd  m(2,2);
   m(0,0) = 3.0;
   m(1,0) = -2.0;
@@ -92,14 +58,11 @@ TEST(McmcDenseEMetric, sample_p_new) {
   var(0,1) = m(0,1)*m(0,1) + m(1,1)*m(0,0);
   var(1,1) = 2*m(1,1);
 
-
-  // Covariance matrix within 5sigma of expected value (d / 2)
+  // Covariance matrix within 5sigma of expected value (comes from a Wishart distribution)
   EXPECT_TRUE(std::fabs(m(0,0)   - sample_cov(0,0)) < 5.0 * sqrt(var(0,0)/n_samples));
   EXPECT_TRUE(std::fabs(m(1,0)   - sample_cov(1,0)) < 5.0 * sqrt(var(1,0)/n_samples));
   EXPECT_TRUE(std::fabs(m(0,1)   - sample_cov(0,1)) < 5.0 * sqrt(var(0,1)/n_samples));
   EXPECT_TRUE(std::fabs(m(1,1)   - sample_cov(1,1)) < 5.0 * sqrt(var(1,1)/n_samples));
-
-
 }
 
 

--- a/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/dense_e_metric_test.cpp
@@ -14,32 +14,23 @@ typedef boost::ecuyer1988 rng_t;
 TEST(McmcDenseEMetric, sample_p) {
   rng_t base_rng(0);
 
-  Eigen::VectorXd q(2);
-  q(0) = 5;
-  q(1) = 1;
-
-  Eigen::MatrixXd  m(2,2);
+  Eigen::Matrix2d  m(2,2);
   m(0, 0) = 3.0;
   m(1, 0) = -2.0;
   m(0, 1) = -2.0;
   m(1, 1) = 4.0;
 
-  Eigen::MatrixXd  m_inv(2,2);
-  double det_inv = 1.0 / (3.0 * 4.0 - (-2.0) * (-2.0));
-  m_inv(0, 0) = m(1, 1) * det_inv;
-  m_inv(1, 0) = -1.0 * m(1, 0) * det_inv;
-  m_inv(0, 1) = -1.0 * m(0, 1) * det_inv;
-  m_inv(1, 1) = m(0, 0) * det_inv;
+  Eigen::Matrix2d  m_inv = m.inverse();
 
-  stan::mcmc::mock_model model(q.size());
+  stan::mcmc::mock_model model(2);
 
   stan::mcmc::dense_e_metric<stan::mcmc::mock_model, rng_t> metric(model);
-  stan::mcmc::dense_e_point z(q.size());
+  stan::mcmc::dense_e_point z(2);
   z.set_metric(m_inv);
 
   int n_samples = 1000;
 
-  Eigen::MatrixXd sample_cov(2,2);
+  Eigen::Matrix2d sample_cov(2,2);
   sample_cov(0, 0) = 0.0;
   sample_cov(0, 1) = 0.0;
   sample_cov(1, 0) = 0.0;
@@ -53,7 +44,7 @@ TEST(McmcDenseEMetric, sample_p) {
     sample_cov(1, 1) += z.p[1] * z.p[1] / (n_samples + 0.0);
   }
 
-  Eigen::MatrixXd var(2,2);
+  Eigen::Matrix2d var(2,2);
   var(0, 0) = 2 * m(0, 0);
   var(1, 0) = m(1, 0) * m(1, 0) + m(1, 1) * m(0, 0);
   var(0, 1) = m(0, 1) * m(0, 1) + m(1, 1) * m(0, 0);


### PR DESCRIPTION
#### Submission Checklist

- [ x] Run unit tests: `./runTests.py src/test/unit`
- [ x] Run cpplint: `make cpplint`
- [x ] Declare copyright holder and open-source license: see below

#### Summary
Fixed the bug described in https://github.com/stan-dev/stan/issues/2671

#### How to Verify
The maths is correct. I am unsure what the current tests are testing. Maybe they should be improved.


#### Side Effects

#### Documentation
None
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): University of Toronto



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)