### PR TITLE
Feature/issue 2670 warmup stepsize factor

### DIFF
--- a/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
@@ -39,7 +39,8 @@ namespace stan {
             this->init_stepsize(logger);
 
             this->stepsize_adaptation_.set_mu(
-              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+              log(this->stepsize_adaptation_.get_log_mu_eps_scale()
+                  * this->nom_epsilon_));
 
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
@@ -38,7 +38,9 @@ namespace stan {
           if (update) {
             this->init_stepsize(logger);
 
-            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.set_mu(
+              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+
             this->stepsize_adaptation_.restart();
           }
         }

--- a/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
@@ -39,7 +39,8 @@ namespace stan {
             this->init_stepsize(logger);
 
             this->stepsize_adaptation_.set_mu(
-              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+              log(this->stepsize_adaptation_.get_log_mu_eps_scale()
+                  * this->nom_epsilon_));
 
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
@@ -38,7 +38,9 @@ namespace stan {
           if (update) {
             this->init_stepsize(logger);
 
-            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.set_mu(
+              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+
             this->stepsize_adaptation_.restart();
           }
         }

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
@@ -40,7 +40,8 @@ namespace stan {
             this->init_stepsize(logger);
 
             this->stepsize_adaptation_.set_mu(
-              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+              log(this->stepsize_adaptation_.get_log_mu_eps_scale()
+                  * this->nom_epsilon_));
 
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
@@ -39,7 +39,9 @@ namespace stan {
           if (update) {
             this->init_stepsize(logger);
 
-            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.set_mu(
+              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+
             this->stepsize_adaptation_.restart();
           }
         }

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
@@ -41,7 +41,8 @@ namespace stan {
             this->init_stepsize(logger);
 
             this->stepsize_adaptation_.set_mu(
-              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+              log(this->stepsize_adaptation_.get_log_mu_eps_scale()
+                  * this->nom_epsilon_));
 
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
@@ -40,7 +40,9 @@ namespace stan {
           if (update) {
             this->init_stepsize(logger);
 
-            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.set_mu(
+              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+
             this->stepsize_adaptation_.restart();
           }
         }

--- a/src/stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp
@@ -42,7 +42,8 @@ namespace stan {
             this->update_L_();
 
             this->stepsize_adaptation_.set_mu(
-              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+              log(this->stepsize_adaptation_.get_log_mu_eps_scale()
+                  * this->nom_epsilon_));
 
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp
@@ -41,7 +41,9 @@ namespace stan {
             this->init_stepsize(logger);
             this->update_L_();
 
-            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.set_mu(
+              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+
             this->stepsize_adaptation_.restart();
           }
         }

--- a/src/stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp
@@ -43,7 +43,8 @@ namespace stan {
             this->update_L_();
 
             this->stepsize_adaptation_.set_mu(
-              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+              log(this->stepsize_adaptation_.get_log_mu_eps_scale()
+                  * this->nom_epsilon_));
 
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp
@@ -42,7 +42,9 @@ namespace stan {
             this->init_stepsize(logger);
             this->update_L_();
 
-            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.set_mu(
+              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+
             this->stepsize_adaptation_.restart();
           }
         }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
@@ -40,7 +40,8 @@ namespace stan {
             this->init_stepsize(logger);
 
             this->stepsize_adaptation_.set_mu(
-              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+              log(this->stepsize_adaptation_.get_log_mu_eps_scale()
+                  * this->nom_epsilon_));
 
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
@@ -38,7 +38,10 @@ namespace stan {
 
           if (update) {
             this->init_stepsize(logger);
-            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+
+            this->stepsize_adaptation_.set_mu(
+              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+
             this->stepsize_adaptation_.restart();
           }
         }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
@@ -40,7 +40,8 @@ namespace stan {
             this->init_stepsize(logger);
 
             this->stepsize_adaptation_.set_mu(
-              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+              log(this->stepsize_adaptation_.get_log_mu_eps_scale()
+                  * this->nom_epsilon_));
 
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
@@ -38,7 +38,10 @@ namespace stan {
                                               this->z_.q);
           if (update) {
             this->init_stepsize(logger);
-            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+
+            this->stepsize_adaptation_.set_mu(
+              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+
             this->stepsize_adaptation_.restart();
           }
         }

--- a/src/stan/mcmc/hmc/xhmc/adapt_dense_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_dense_e_xhmc.hpp
@@ -39,7 +39,8 @@ namespace stan {
             this->init_stepsize(logger);
 
             this->stepsize_adaptation_.set_mu(
-              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+              log(this->stepsize_adaptation_.get_log_mu_eps_scale()
+                  * this->nom_epsilon_));
 
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/xhmc/adapt_dense_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_dense_e_xhmc.hpp
@@ -38,7 +38,9 @@ namespace stan {
           if (update) {
             this->init_stepsize(logger);
 
-            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.set_mu(
+              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+
             this->stepsize_adaptation_.restart();
           }
         }

--- a/src/stan/mcmc/hmc/xhmc/adapt_diag_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_diag_e_xhmc.hpp
@@ -39,7 +39,8 @@ namespace stan {
             this->init_stepsize(logger);
 
             this->stepsize_adaptation_.set_mu(
-              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+              log(this->stepsize_adaptation_.get_log_mu_eps_scale()
+                  * this->nom_epsilon_));
 
             this->stepsize_adaptation_.restart();
           }

--- a/src/stan/mcmc/hmc/xhmc/adapt_diag_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_diag_e_xhmc.hpp
@@ -38,7 +38,9 @@ namespace stan {
           if (update) {
             this->init_stepsize(logger);
 
-            this->stepsize_adaptation_.set_mu(log(10 * this->nom_epsilon_));
+            this->stepsize_adaptation_.set_mu(
+              log(this->stepsize_adaptation_.get_mu_c() * this->nom_epsilon_));
+
             this->stepsize_adaptation_.restart();
           }
         }

--- a/src/stan/mcmc/stepsize_adaptation.hpp
+++ b/src/stan/mcmc/stepsize_adaptation.hpp
@@ -12,12 +12,16 @@ namespace stan {
     public:
       stepsize_adaptation()
         : mu_(0.5), delta_(0.5), gamma_(0.05),
-          kappa_(0.75), t0_(10) {
+          kappa_(0.75), t0_(10), mu_c_(10) {
         restart();
       }
 
       void set_mu(double m) {
         mu_ = m;
+      }
+
+      void set_mu_c(double c) {
+        mu_c_ = c;
       }
 
       void set_delta(double d) {
@@ -41,6 +45,10 @@ namespace stan {
 
       double get_mu() {
         return mu_;
+      }
+
+      double get_mu_c() {
+        return mu_c_;
       }
 
       double get_delta() {
@@ -92,6 +100,7 @@ namespace stan {
       double s_bar_;    // Moving average statistic
       double x_bar_;    // Moving average parameter
       double mu_;       // Asymptotic mean of parameter
+      double mu_c_;     // Coefficient of stepsize for setting mu
       double delta_;    // Target value of statistic
       double gamma_;    // Adaptation scaling
       double kappa_;    // Adaptation shrinkage

--- a/src/stan/mcmc/stepsize_adaptation.hpp
+++ b/src/stan/mcmc/stepsize_adaptation.hpp
@@ -100,11 +100,11 @@ namespace stan {
       double s_bar_;    // Moving average statistic
       double x_bar_;    // Moving average parameter
       double mu_;       // Asymptotic mean of parameter
-      double mu_c_;     // Coefficient of stepsize for setting mu
       double delta_;    // Target value of statistic
       double gamma_;    // Adaptation scaling
       double kappa_;    // Adaptation shrinkage
       double t0_;       // Effective starting iteration
+      double mu_c_;     // Coefficient of stepsize for setting mu
     };
 
   }  // mcmc

--- a/src/stan/mcmc/stepsize_adaptation.hpp
+++ b/src/stan/mcmc/stepsize_adaptation.hpp
@@ -12,7 +12,7 @@ namespace stan {
     public:
       stepsize_adaptation()
         : mu_(0.5), delta_(0.5), gamma_(0.05),
-          kappa_(0.75), t0_(10), mu_c_(10) {
+          kappa_(0.75), t0_(10), log_mu_eps_scale_(10) {
         restart();
       }
 
@@ -20,8 +20,8 @@ namespace stan {
         mu_ = m;
       }
 
-      void set_mu_c(double c) {
-        mu_c_ = c;
+      void set_log_mu_eps_scale(double c) {
+        log_mu_eps_scale_ = c;
       }
 
       void set_delta(double d) {
@@ -47,8 +47,8 @@ namespace stan {
         return mu_;
       }
 
-      double get_mu_c() {
-        return mu_c_;
+      double get_log_mu_eps_scale() {
+        return log_mu_eps_scale_;
       }
 
       double get_delta() {
@@ -96,15 +96,15 @@ namespace stan {
       }
 
     protected:
-      double counter_;  // Adaptation iteration
-      double s_bar_;    // Moving average statistic
-      double x_bar_;    // Moving average parameter
-      double mu_;       // Asymptotic mean of parameter
-      double delta_;    // Target value of statistic
-      double gamma_;    // Adaptation scaling
-      double kappa_;    // Adaptation shrinkage
-      double t0_;       // Effective starting iteration
-      double mu_c_;     // Coefficient of stepsize for setting mu
+      double counter_;              // Adaptation iteration
+      double s_bar_;                // Moving average statistic
+      double x_bar_;                // Moving average parameter
+      double mu_;                   // Asymptotic mean of parameter
+      double delta_;                // Target value of statistic
+      double gamma_;                // Adaptation scaling
+      double kappa_;                // Adaptation shrinkage
+      double t0_;                   // Effective starting iteration
+      double log_mu_eps_scale_;     // Coefficient of stepsize for setting mu
     };
 
   }  // mcmc

--- a/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
@@ -39,7 +39,7 @@ namespace stan {
        * @param[in] stepsize initial stepsize for discrete evolution
        * @param[in] stepsize_jitter uniform random jitter of stepsize
        * @param[in] max_depth Maximum tree depth
-       * @param[in] mu_c stepsize factor for warmup initialization
+       * @param[in] log_mu_eps_scale stepsize factor for warmup initialization
        * @param[in] delta adaptation target acceptance statistic
        * @param[in] gamma adaptation regularization scale
        * @param[in] kappa adaptation relaxation exponent
@@ -62,8 +62,8 @@ namespace stan {
                                  int num_samples, int num_thin,
                                  bool save_warmup, int refresh, double stepsize,
                                  double stepsize_jitter, int max_depth,
-                                 double mu_c, double delta, double gamma,
-                                 double kappa, double t0,
+                                 double log_mu_eps_scale, double delta,
+                                 double gamma, double kappa, double t0,
                                  unsigned int init_buffer,
                                  unsigned int term_buffer, unsigned int window,
                                  callbacks::interrupt& interrupt,
@@ -97,8 +97,10 @@ namespace stan {
         sampler.set_stepsize_jitter(stepsize_jitter);
         sampler.set_max_depth(max_depth);
 
-        sampler.get_stepsize_adaptation().set_mu_c(mu_c);
-        sampler.get_stepsize_adaptation().set_mu(log(mu_c * stepsize));
+        sampler.get_stepsize_adaptation().set_log_mu_eps_scale(
+          log_mu_eps_scale);
+        sampler.get_stepsize_adaptation().set_mu(
+          log(log_mu_eps_scale * stepsize));
         sampler.get_stepsize_adaptation().set_delta(delta);
         sampler.get_stepsize_adaptation().set_gamma(gamma);
         sampler.get_stepsize_adaptation().set_kappa(kappa);

--- a/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
@@ -39,6 +39,102 @@ namespace stan {
        * @param[in] stepsize initial stepsize for discrete evolution
        * @param[in] stepsize_jitter uniform random jitter of stepsize
        * @param[in] max_depth Maximum tree depth
+       * @param[in] mu_c stepsize factor for warmup initialization
+       * @param[in] delta adaptation target acceptance statistic
+       * @param[in] gamma adaptation regularization scale
+       * @param[in] kappa adaptation relaxation exponent
+       * @param[in] t0 adaptation iteration offset
+       * @param[in] init_buffer width of initial fast adaptation interval
+       * @param[in] term_buffer width of final fast adaptation interval
+       * @param[in] window initial width of slow adaptation interval
+       * @param[in,out] interrupt Callback for interrupts
+       * @param[in,out] logger Logger for messages
+       * @param[in,out] init_writer Writer callback for unconstrained inits
+       * @param[in,out] sample_writer Writer for draws
+       * @param[in,out] diagnostic_writer Writer for diagnostic information
+       * @return error_codes::OK if successful
+       */
+      template <class Model>
+      int hmc_nuts_dense_e_adapt(Model& model, stan::io::var_context& init,
+                                 stan::io::var_context& init_inv_metric,
+                                 unsigned int random_seed, unsigned int chain,
+                                 double init_radius, int num_warmup,
+                                 int num_samples, int num_thin,
+                                 bool save_warmup, int refresh, double stepsize,
+                                 double stepsize_jitter, int max_depth,
+                                 double mu_c, double delta, double gamma,
+                                 double kappa, double t0,
+                                 unsigned int init_buffer,
+                                 unsigned int term_buffer, unsigned int window,
+                                 callbacks::interrupt& interrupt,
+                                 callbacks::logger& logger,
+                                 callbacks::writer& init_writer,
+                                 callbacks::writer& sample_writer,
+                                 callbacks::writer& diagnostic_writer) {
+        boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
+
+        std::vector<int> disc_vector;
+        std::vector<double> cont_vector
+          = util::initialize(model, init, rng, init_radius, true,
+                             logger, init_writer);
+
+        Eigen::MatrixXd inv_metric;
+        try {
+          inv_metric =
+            util::read_dense_inv_metric(init_inv_metric, model.num_params_r(),
+                                        logger);
+          util::validate_dense_inv_metric(inv_metric, logger);
+        } catch (const std::domain_error& e) {
+          return error_codes::CONFIG;
+        }
+
+        stan::mcmc::adapt_dense_e_nuts<Model, boost::ecuyer1988>
+          sampler(model, rng);
+
+        sampler.set_metric(inv_metric);
+
+        sampler.set_nominal_stepsize(stepsize);
+        sampler.set_stepsize_jitter(stepsize_jitter);
+        sampler.set_max_depth(max_depth);
+
+        sampler.get_stepsize_adaptation().set_mu_c(mu_c);
+        sampler.get_stepsize_adaptation().set_mu(log(mu_c * stepsize));
+        sampler.get_stepsize_adaptation().set_delta(delta);
+        sampler.get_stepsize_adaptation().set_gamma(gamma);
+        sampler.get_stepsize_adaptation().set_kappa(kappa);
+        sampler.get_stepsize_adaptation().set_t0(t0);
+
+        sampler.set_window_params(num_warmup, init_buffer, term_buffer,
+                                  window, logger);
+
+        util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
+                                   num_samples, num_thin, refresh, save_warmup,
+                                   rng, interrupt, logger,
+                                   sample_writer, diagnostic_writer);
+
+        return error_codes::OK;
+      }
+
+      /**
+       * Runs HMC with NUTS with adaptation using dense Euclidean metric
+       * with a pre-specified Euclidean metric.
+       *
+       * @tparam Model Model class
+       * @param[in] model Input model to test (with data already instantiated)
+       * @param[in] init var context for initialization
+       * @param[in] init_inv_metric var context exposing an initial dense
+                    inverse Euclidean metric (must be positive definite)
+       * @param[in] random_seed random seed for the random number generator
+       * @param[in] chain chain id to advance the pseudo random number generator
+       * @param[in] init_radius radius to initialize
+       * @param[in] num_warmup Number of warmup samples
+       * @param[in] num_samples Number of samples
+       * @param[in] num_thin Number to thin the samples
+       * @param[in] save_warmup Indicates whether to save the warmup iterations
+       * @param[in] refresh Controls the output
+       * @param[in] stepsize initial stepsize for discrete evolution
+       * @param[in] stepsize_jitter uniform random jitter of stepsize
+       * @param[in] max_depth Maximum tree depth
        * @param[in] delta adaptation target acceptance statistic
        * @param[in] gamma adaptation regularization scale
        * @param[in] kappa adaptation relaxation exponent

--- a/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
@@ -165,47 +165,15 @@ namespace stan {
                                  callbacks::writer& init_writer,
                                  callbacks::writer& sample_writer,
                                  callbacks::writer& diagnostic_writer) {
-        boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
-
-        std::vector<int> disc_vector;
-        std::vector<double> cont_vector
-          = util::initialize(model, init, rng, init_radius, true,
-                             logger, init_writer);
-
-        Eigen::MatrixXd inv_metric;
-        try {
-          inv_metric =
-            util::read_dense_inv_metric(init_inv_metric, model.num_params_r(),
-                                        logger);
-          util::validate_dense_inv_metric(inv_metric, logger);
-        } catch (const std::domain_error& e) {
-          return error_codes::CONFIG;
-        }
-
-        stan::mcmc::adapt_dense_e_nuts<Model, boost::ecuyer1988>
-          sampler(model, rng);
-
-        sampler.set_metric(inv_metric);
-
-        sampler.set_nominal_stepsize(stepsize);
-        sampler.set_stepsize_jitter(stepsize_jitter);
-        sampler.set_max_depth(max_depth);
-
-        sampler.get_stepsize_adaptation().set_mu(log(10 * stepsize));
-        sampler.get_stepsize_adaptation().set_delta(delta);
-        sampler.get_stepsize_adaptation().set_gamma(gamma);
-        sampler.get_stepsize_adaptation().set_kappa(kappa);
-        sampler.get_stepsize_adaptation().set_t0(t0);
-
-        sampler.set_window_params(num_warmup, init_buffer, term_buffer,
-                                  window, logger);
-
-        util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
-                                   num_samples, num_thin, refresh, save_warmup,
-                                   rng, interrupt, logger,
-                                   sample_writer, diagnostic_writer);
-
-        return error_codes::OK;
+        return hmc_nuts_dense_e_adapt(model, init, init_inv_metric,
+                                      random_seed, chain, init_radius,
+                                      num_warmup, num_samples, num_thin,
+                                      save_warmup, refresh, stepsize,
+                                      stepsize_jitter, max_depth, 10.0,
+                                      delta, gamma, kappa, t0, init_buffer,
+                                      term_buffer, window,
+                                      interrupt, logger, init_writer,
+                                      sample_writer, diagnostic_writer);
       }
 
       /**

--- a/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
@@ -39,7 +39,7 @@ namespace stan {
        * @param[in] stepsize initial stepsize for discrete evolution
        * @param[in] stepsize_jitter uniform random jitter of stepsize
        * @param[in] max_depth Maximum tree depth
-       * @param[in] mu_c stepsize factor for warmup initialization
+       * @param[in] log_mu_eps_scale stepsize factor for warmup initialization
        * @param[in] delta adaptation target acceptance statistic
        * @param[in] gamma adaptation regularization scale
        * @param[in] kappa adaptation relaxation exponent
@@ -62,8 +62,8 @@ namespace stan {
                                 int num_samples, int num_thin, bool save_warmup,
                                 int refresh, double stepsize,
                                 double stepsize_jitter, int max_depth,
-                                double mu_c, double delta, double gamma,
-                                double kappa, double t0,
+                                double log_mu_eps_scale, double delta,
+                                double gamma, double kappa, double t0,
                                 unsigned int init_buffer,
                                 unsigned int term_buffer, unsigned int window,
                                 callbacks::interrupt& interrupt,
@@ -96,8 +96,10 @@ namespace stan {
         sampler.set_stepsize_jitter(stepsize_jitter);
         sampler.set_max_depth(max_depth);
 
-        sampler.get_stepsize_adaptation().set_mu_c(mu_c);
-        sampler.get_stepsize_adaptation().set_mu(log(mu_c * stepsize));
+        sampler.get_stepsize_adaptation().set_log_mu_eps_scale(
+          log_mu_eps_scale);
+        sampler.get_stepsize_adaptation().set_mu(
+          log(log_mu_eps_scale * stepsize));
         sampler.get_stepsize_adaptation().set_delta(delta);
         sampler.get_stepsize_adaptation().set_gamma(gamma);
         sampler.get_stepsize_adaptation().set_kappa(kappa);

--- a/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
@@ -39,6 +39,101 @@ namespace stan {
        * @param[in] stepsize initial stepsize for discrete evolution
        * @param[in] stepsize_jitter uniform random jitter of stepsize
        * @param[in] max_depth Maximum tree depth
+       * @param[in] mu_c stepsize factor for warmup initialization
+       * @param[in] delta adaptation target acceptance statistic
+       * @param[in] gamma adaptation regularization scale
+       * @param[in] kappa adaptation relaxation exponent
+       * @param[in] t0 adaptation iteration offset
+       * @param[in] init_buffer width of initial fast adaptation interval
+       * @param[in] term_buffer width of final fast adaptation interval
+       * @param[in] window initial width of slow adaptation interval
+       * @param[in,out] interrupt Callback for interrupts
+       * @param[in,out] logger Logger for messages
+       * @param[in,out] init_writer Writer callback for unconstrained inits
+       * @param[in,out] sample_writer Writer for draws
+       * @param[in,out] diagnostic_writer Writer for diagnostic information
+       * @return error_codes::OK if successful
+       */
+      template <class Model>
+      int hmc_nuts_diag_e_adapt(Model& model, stan::io::var_context& init,
+                                stan::io::var_context& init_inv_metric,
+                                unsigned int random_seed, unsigned int chain,
+                                double init_radius, int num_warmup,
+                                int num_samples, int num_thin, bool save_warmup,
+                                int refresh, double stepsize,
+                                double stepsize_jitter, int max_depth,
+                                double mu_c, double delta, double gamma,
+                                double kappa, double t0,
+                                unsigned int init_buffer,
+                                unsigned int term_buffer, unsigned int window,
+                                callbacks::interrupt& interrupt,
+                                callbacks::logger& logger,
+                                callbacks::writer& init_writer,
+                                callbacks::writer& sample_writer,
+                                callbacks::writer& diagnostic_writer) {
+        boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
+
+        std::vector<int> disc_vector;
+        std::vector<double> cont_vector
+          = util::initialize(model, init, rng, init_radius, true,
+                             logger, init_writer);
+
+        Eigen::VectorXd inv_metric;
+        try {
+          inv_metric =
+            util::read_diag_inv_metric(init_inv_metric, model.num_params_r(),
+                                        logger);
+          util::validate_diag_inv_metric(inv_metric, logger);
+        } catch (const std::domain_error& e) {
+          return error_codes::CONFIG;
+        }
+
+        stan::mcmc::adapt_diag_e_nuts<Model, boost::ecuyer1988>
+          sampler(model, rng);
+
+        sampler.set_metric(inv_metric);
+        sampler.set_nominal_stepsize(stepsize);
+        sampler.set_stepsize_jitter(stepsize_jitter);
+        sampler.set_max_depth(max_depth);
+
+        sampler.get_stepsize_adaptation().set_mu_c(mu_c);
+        sampler.get_stepsize_adaptation().set_mu(log(mu_c * stepsize));
+        sampler.get_stepsize_adaptation().set_delta(delta);
+        sampler.get_stepsize_adaptation().set_gamma(gamma);
+        sampler.get_stepsize_adaptation().set_kappa(kappa);
+        sampler.get_stepsize_adaptation().set_t0(t0);
+
+        sampler.set_window_params(num_warmup, init_buffer, term_buffer,
+                                  window, logger);
+
+        util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
+                                   num_samples, num_thin, refresh, save_warmup,
+                                   rng, interrupt, logger,
+                                   sample_writer, diagnostic_writer);
+
+        return error_codes::OK;
+      }
+
+      /**
+       * Runs HMC with NUTS with adaptation using diagonal Euclidean metric
+       * with a pre-specified Euclidean metric.
+       *
+       * @tparam Model Model class
+       * @param[in] model Input model to test (with data already instantiated)
+       * @param[in] init var context for initialization
+       * @param[in] init_inv_metric var context exposing an initial diagonal
+                    inverse Euclidean metric (must be positive definite)
+       * @param[in] random_seed random seed for the random number generator
+       * @param[in] chain chain id to advance the pseudo random number generator
+       * @param[in] init_radius radius to initialize
+       * @param[in] num_warmup Number of warmup samples
+       * @param[in] num_samples Number of samples
+       * @param[in] num_thin Number to thin the samples
+       * @param[in] save_warmup Indicates whether to save the warmup iterations
+       * @param[in] refresh Controls the output
+       * @param[in] stepsize initial stepsize for discrete evolution
+       * @param[in] stepsize_jitter uniform random jitter of stepsize
+       * @param[in] max_depth Maximum tree depth
        * @param[in] delta adaptation target acceptance statistic
        * @param[in] gamma adaptation regularization scale
        * @param[in] kappa adaptation relaxation exponent

--- a/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
@@ -39,7 +39,7 @@ namespace stan {
        * @param[in] stepsize initial stepsize for discrete evolution
        * @param[in] stepsize_jitter uniform random jitter of stepsize
        * @param[in] int_time integration time
-       * @param[in] mu_c stepsize factor for warmup initialization
+       * @param[in] log_mu_eps_scale stepsize factor for warmup initialization
        * @param[in] delta adaptation target acceptance statistic
        * @param[in] gamma adaptation regularization scale
        * @param[in] kappa adaptation relaxation exponent
@@ -62,8 +62,9 @@ namespace stan {
                                    int num_samples, int num_thin,
                                    bool save_warmup, int refresh,
                                    double stepsize, double stepsize_jitter,
-                                   double int_time, double mu_c, double delta,
-                                   double gamma, double kappa, double t0,
+                                   double int_time, double log_mu_eps_scale,
+                                   double delta, double gamma, double kappa,
+                                   double t0,
                                    unsigned int init_buffer,
                                    unsigned int term_buffer,
                                    unsigned int window,
@@ -96,8 +97,10 @@ namespace stan {
         sampler.set_nominal_stepsize_and_T(stepsize, int_time);
         sampler.set_stepsize_jitter(stepsize_jitter);
 
-        sampler.get_stepsize_adaptation().set_mu_c(mu_c);
-        sampler.get_stepsize_adaptation().set_mu(log(mu_c * stepsize));
+        sampler.get_stepsize_adaptation().set_log_mu_eps_scale(
+          log_mu_eps_scale);
+        sampler.get_stepsize_adaptation().set_mu(
+          log(log_mu_eps_scale * stepsize));
         sampler.get_stepsize_adaptation().set_delta(delta);
         sampler.get_stepsize_adaptation().set_gamma(gamma);
         sampler.get_stepsize_adaptation().set_kappa(kappa);

--- a/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
@@ -39,99 +39,6 @@ namespace stan {
        * @param[in] stepsize initial stepsize for discrete evolution
        * @param[in] stepsize_jitter uniform random jitter of stepsize
        * @param[in] int_time integration time
-       * @param[in] delta adaptation target acceptance statistic
-       * @param[in] gamma adaptation regularization scale
-       * @param[in] kappa adaptation relaxation exponent
-       * @param[in] t0 adaptation iteration offset
-       * @param[in] init_buffer width of initial fast adaptation interval
-       * @param[in] term_buffer width of final fast adaptation interval
-       * @param[in] window initial width of slow adaptation interval
-       * @param[in,out] interrupt Callback for interrupts
-       * @param[in,out] logger Logger for messages
-       * @param[in,out] init_writer Writer callback for unconstrained inits
-       * @param[in,out] sample_writer Writer for draws
-       * @param[in,out] diagnostic_writer Writer for diagnostic information
-       * @return error_codes::OK if successful
-       */
-      template <class Model>
-      int hmc_static_dense_e_adapt(Model& model, stan::io::var_context& init,
-                                   stan::io::var_context& init_inv_metric,
-                                   unsigned int random_seed, unsigned int chain,
-                                   double init_radius, int num_warmup,
-                                   int num_samples, int num_thin,
-                                   bool save_warmup, int refresh,
-                                   double stepsize, double stepsize_jitter,
-                                   double int_time, double delta, double gamma,
-                                   double kappa, double t0,
-                                   unsigned int init_buffer,
-                                   unsigned int term_buffer,
-                                   unsigned int window,
-                                   callbacks::interrupt& interrupt,
-                                   callbacks::logger& logger,
-                                   callbacks::writer& init_writer,
-                                   callbacks::writer& sample_writer,
-                                   callbacks::writer& diagnostic_writer) {
-        boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
-
-        std::vector<int> disc_vector;
-        std::vector<double> cont_vector
-          = util::initialize(model, init, rng, init_radius, true,
-                             logger, init_writer);
-
-        Eigen::MatrixXd inv_metric;
-        try {
-          inv_metric =
-            util::read_dense_inv_metric(init_inv_metric, model.num_params_r(),
-                                         logger);
-          util::validate_dense_inv_metric(inv_metric, logger);
-        } catch (const std::domain_error& e) {
-          return error_codes::CONFIG;
-        }
-
-        stan::mcmc::adapt_dense_e_static_hmc<Model, boost::ecuyer1988>
-          sampler(model, rng);
-
-        sampler.set_metric(inv_metric);
-        sampler.set_nominal_stepsize_and_T(stepsize, int_time);
-        sampler.set_stepsize_jitter(stepsize_jitter);
-
-        sampler.get_stepsize_adaptation().set_mu(log(10 * stepsize));
-        sampler.get_stepsize_adaptation().set_delta(delta);
-        sampler.get_stepsize_adaptation().set_gamma(gamma);
-        sampler.get_stepsize_adaptation().set_kappa(kappa);
-        sampler.get_stepsize_adaptation().set_t0(t0);
-
-        sampler.set_window_params(num_warmup, init_buffer, term_buffer,
-                                  window, logger);
-
-        util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
-                                   num_samples, num_thin, refresh, save_warmup,
-                                   rng, interrupt, logger,
-                                   sample_writer, diagnostic_writer);
-
-        return error_codes::OK;
-      }
-
-      /**
-       * Runs static HMC with adaptation using dense Euclidean metric
-       * with a pre-specified Euclidean metric.
-       *
-       * @tparam Model Model class
-       * @param[in] model Input model to test (with data already instantiated)
-       * @param[in] init var context for initialization
-       * @param[in] init_inv_metric var context exposing an initial diagonal
-                    inverse Euclidean metric (must be positive definite)
-       * @param[in] random_seed random seed for the random number generator
-       * @param[in] chain chain id to advance the pseudo random number generator
-       * @param[in] init_radius radius to initialize
-       * @param[in] num_warmup Number of warmup samples
-       * @param[in] num_samples Number of samples
-       * @param[in] num_thin Number to thin the samples
-       * @param[in] save_warmup Indicates whether to save the warmup iterations
-       * @param[in] refresh Controls the output
-       * @param[in] stepsize initial stepsize for discrete evolution
-       * @param[in] stepsize_jitter uniform random jitter of stepsize
-       * @param[in] int_time integration time
        * @param[in] mu_c stepsize factor for warmup initialization
        * @param[in] delta adaptation target acceptance statistic
        * @param[in] gamma adaptation regularization scale
@@ -205,6 +112,69 @@ namespace stan {
                                    sample_writer, diagnostic_writer);
 
         return error_codes::OK;
+     }
+
+      /**
+       * Runs static HMC with adaptation using dense Euclidean metric
+       * with a pre-specified Euclidean metric.
+       *
+       * @tparam Model Model class
+       * @param[in] model Input model to test (with data already instantiated)
+       * @param[in] init var context for initialization
+       * @param[in] init_inv_metric var context exposing an initial diagonal
+                    inverse Euclidean metric (must be positive definite)
+       * @param[in] random_seed random seed for the random number generator
+       * @param[in] chain chain id to advance the pseudo random number generator
+       * @param[in] init_radius radius to initialize
+       * @param[in] num_warmup Number of warmup samples
+       * @param[in] num_samples Number of samples
+       * @param[in] num_thin Number to thin the samples
+       * @param[in] save_warmup Indicates whether to save the warmup iterations
+       * @param[in] refresh Controls the output
+       * @param[in] stepsize initial stepsize for discrete evolution
+       * @param[in] stepsize_jitter uniform random jitter of stepsize
+       * @param[in] int_time integration time
+       * @param[in] delta adaptation target acceptance statistic
+       * @param[in] gamma adaptation regularization scale
+       * @param[in] kappa adaptation relaxation exponent
+       * @param[in] t0 adaptation iteration offset
+       * @param[in] init_buffer width of initial fast adaptation interval
+       * @param[in] term_buffer width of final fast adaptation interval
+       * @param[in] window initial width of slow adaptation interval
+       * @param[in,out] interrupt Callback for interrupts
+       * @param[in,out] logger Logger for messages
+       * @param[in,out] init_writer Writer callback for unconstrained inits
+       * @param[in,out] sample_writer Writer for draws
+       * @param[in,out] diagnostic_writer Writer for diagnostic information
+       * @return error_codes::OK if successful
+       */
+      template <class Model>
+      int hmc_static_dense_e_adapt(Model& model, stan::io::var_context& init,
+                                   stan::io::var_context& init_inv_metric,
+                                   unsigned int random_seed, unsigned int chain,
+                                   double init_radius, int num_warmup,
+                                   int num_samples, int num_thin,
+                                   bool save_warmup, int refresh,
+                                   double stepsize, double stepsize_jitter,
+                                   double int_time, double delta, double gamma,
+                                   double kappa, double t0,
+                                   unsigned int init_buffer,
+                                   unsigned int term_buffer,
+                                   unsigned int window,
+                                   callbacks::interrupt& interrupt,
+                                   callbacks::logger& logger,
+                                   callbacks::writer& init_writer,
+                                   callbacks::writer& sample_writer,
+                                   callbacks::writer& diagnostic_writer) {
+        return hmc_static_dense_e_adapt(model, init, init_inv_metric,
+                                        random_seed, chain, init_radius,
+                                        num_warmup, num_samples, num_thin,
+                                        save_warmup, refresh, stepsize,
+                                        stepsize_jitter, int_time, 10.0, delta,
+                                        gamma, kappa, t0, init_buffer,
+                                        term_buffer, window, interrupt, logger,
+                                        init_writer, sample_writer,
+                                        diagnostic_writer);
       }
 
       /**

--- a/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
@@ -110,7 +110,102 @@ namespace stan {
                                    sample_writer, diagnostic_writer);
 
         return error_codes::OK;
-     }
+      }
+
+      /**
+       * Runs static HMC with adaptation using dense Euclidean metric
+       * with a pre-specified Euclidean metric.
+       *
+       * @tparam Model Model class
+       * @param[in] model Input model to test (with data already instantiated)
+       * @param[in] init var context for initialization
+       * @param[in] init_inv_metric var context exposing an initial diagonal
+                    inverse Euclidean metric (must be positive definite)
+       * @param[in] random_seed random seed for the random number generator
+       * @param[in] chain chain id to advance the pseudo random number generator
+       * @param[in] init_radius radius to initialize
+       * @param[in] num_warmup Number of warmup samples
+       * @param[in] num_samples Number of samples
+       * @param[in] num_thin Number to thin the samples
+       * @param[in] save_warmup Indicates whether to save the warmup iterations
+       * @param[in] refresh Controls the output
+       * @param[in] stepsize initial stepsize for discrete evolution
+       * @param[in] stepsize_jitter uniform random jitter of stepsize
+       * @param[in] int_time integration time
+       * @param[in] mu_c stepsize factor for warmup initialization
+       * @param[in] delta adaptation target acceptance statistic
+       * @param[in] gamma adaptation regularization scale
+       * @param[in] kappa adaptation relaxation exponent
+       * @param[in] t0 adaptation iteration offset
+       * @param[in] init_buffer width of initial fast adaptation interval
+       * @param[in] term_buffer width of final fast adaptation interval
+       * @param[in] window initial width of slow adaptation interval
+       * @param[in,out] interrupt Callback for interrupts
+       * @param[in,out] logger Logger for messages
+       * @param[in,out] init_writer Writer callback for unconstrained inits
+       * @param[in,out] sample_writer Writer for draws
+       * @param[in,out] diagnostic_writer Writer for diagnostic information
+       * @return error_codes::OK if successful
+       */
+      template <class Model>
+      int hmc_static_dense_e_adapt(Model& model, stan::io::var_context& init,
+                                   stan::io::var_context& init_inv_metric,
+                                   unsigned int random_seed, unsigned int chain,
+                                   double init_radius, int num_warmup,
+                                   int num_samples, int num_thin,
+                                   bool save_warmup, int refresh,
+                                   double stepsize, double stepsize_jitter,
+                                   double int_time, double mu_c, double delta,
+                                   double gamma, double kappa, double t0,
+                                   unsigned int init_buffer,
+                                   unsigned int term_buffer,
+                                   unsigned int window,
+                                   callbacks::interrupt& interrupt,
+                                   callbacks::logger& logger,
+                                   callbacks::writer& init_writer,
+                                   callbacks::writer& sample_writer,
+                                   callbacks::writer& diagnostic_writer) {
+        boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
+
+        std::vector<int> disc_vector;
+        std::vector<double> cont_vector
+          = util::initialize(model, init, rng, init_radius, true,
+                             logger, init_writer);
+
+        Eigen::MatrixXd inv_metric;
+        try {
+          inv_metric =
+            util::read_dense_inv_metric(init_inv_metric, model.num_params_r(),
+                                         logger);
+          util::validate_dense_inv_metric(inv_metric, logger);
+        } catch (const std::domain_error& e) {
+          return error_codes::CONFIG;
+        }
+
+        stan::mcmc::adapt_dense_e_static_hmc<Model, boost::ecuyer1988>
+          sampler(model, rng);
+
+        sampler.set_metric(inv_metric);
+        sampler.set_nominal_stepsize_and_T(stepsize, int_time);
+        sampler.set_stepsize_jitter(stepsize_jitter);
+
+        sampler.get_stepsize_adaptation().set_mu_c(mu_c);
+        sampler.get_stepsize_adaptation().set_mu(log(mu_c * stepsize));
+        sampler.get_stepsize_adaptation().set_delta(delta);
+        sampler.get_stepsize_adaptation().set_gamma(gamma);
+        sampler.get_stepsize_adaptation().set_kappa(kappa);
+        sampler.get_stepsize_adaptation().set_t0(t0);
+
+        sampler.set_window_params(num_warmup, init_buffer, term_buffer,
+                                  window, logger);
+
+        util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
+                                   num_samples, num_thin, refresh, save_warmup,
+                                   rng, interrupt, logger,
+                                   sample_writer, diagnostic_writer);
+
+        return error_codes::OK;
+      }
 
       /**
        * Runs static HMC with adaptation using dense Euclidean metric.

--- a/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
@@ -39,6 +39,100 @@ namespace stan {
        * @param[in] stepsize initial stepsize for discrete evolution
        * @param[in] stepsize_jitter uniform random jitter of stepsize
        * @param[in] int_time integration time
+       * @param[in] mu_c stepsize factor for warmup initialization
+       * @param[in] delta adaptation target acceptance statistic
+       * @param[in] gamma adaptation regularization scale
+       * @param[in] kappa adaptation relaxation exponent
+       * @param[in] t0 adaptation iteration offset
+       * @param[in] init_buffer width of initial fast adaptation interval
+       * @param[in] term_buffer width of final fast adaptation interval
+       * @param[in] window initial width of slow adaptation interval
+       * @param[in,out] interrupt Callback for interrupts
+       * @param[in,out] logger Logger for messages
+       * @param[in,out] init_writer Writer callback for unconstrained inits
+       * @param[in,out] sample_writer Writer for draws
+       * @param[in,out] diagnostic_writer Writer for diagnostic information
+       * @return error_codes::OK if successful
+       */
+      template <class Model>
+      int hmc_static_diag_e_adapt(Model& model, stan::io::var_context& init,
+                                  stan::io::var_context& init_inv_metric,
+                                  unsigned int random_seed, unsigned int chain,
+                                  double init_radius, int num_warmup,
+                                  int num_samples, int num_thin,
+                                  bool save_warmup, int refresh,
+                                  double stepsize, double stepsize_jitter,
+                                  double int_time, double mu_c, double delta,
+                                  double gamma, double kappa, double t0,
+                                  unsigned int init_buffer,
+                                  unsigned int term_buffer, unsigned int window,
+                                  callbacks::interrupt& interrupt,
+                                  callbacks::logger& logger,
+                                  callbacks::writer& init_writer,
+                                  callbacks::writer& sample_writer,
+                                  callbacks::writer& diagnostic_writer) {
+        boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
+
+        std::vector<int> disc_vector;
+        std::vector<double> cont_vector
+          = util::initialize(model, init, rng, init_radius, true,
+                             logger, init_writer);
+
+        Eigen::VectorXd inv_metric;
+        try {
+          inv_metric =
+            util::read_diag_inv_metric(init_inv_metric, model.num_params_r(),
+                                        logger);
+          util::validate_diag_inv_metric(inv_metric, logger);
+        } catch (const std::domain_error& e) {
+          return error_codes::CONFIG;
+        }
+
+        stan::mcmc::adapt_diag_e_static_hmc<Model, boost::ecuyer1988>
+          sampler(model, rng);
+
+        sampler.set_metric(inv_metric);
+        sampler.set_nominal_stepsize_and_T(stepsize, int_time);
+        sampler.set_stepsize_jitter(stepsize_jitter);
+
+        sampler.get_stepsize_adaptation().set_mu_c(mu_c);
+        sampler.get_stepsize_adaptation().set_mu(log(mu_c * stepsize));
+        sampler.get_stepsize_adaptation().set_delta(delta);
+        sampler.get_stepsize_adaptation().set_gamma(gamma);
+        sampler.get_stepsize_adaptation().set_kappa(kappa);
+        sampler.get_stepsize_adaptation().set_t0(t0);
+
+        sampler.set_window_params(num_warmup, init_buffer, term_buffer,
+                                  window, logger);
+
+        util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
+                                   num_samples, num_thin, refresh, save_warmup,
+                                   rng, interrupt, logger,
+                                   sample_writer, diagnostic_writer);
+
+        return error_codes::OK;
+      }
+
+      /**
+       * Runs static HMC with adaptation using diagonal Euclidean metric
+       * with a pre-specified Euclidean metric.
+       *
+       * @tparam Model Model class
+       * @param[in] model Input model to test (with data already instantiated)
+       * @param[in] init var context for initialization
+       * @param[in] init_inv_metric var context exposing an initial diagonal
+                    inverse Euclidean metric (must be positive definite)
+       * @param[in] random_seed random seed for the random number generator
+       * @param[in] chain chain id to advance the pseudo random number generator
+       * @param[in] init_radius radius to initialize
+       * @param[in] num_warmup Number of warmup samples
+       * @param[in] num_samples Number of samples
+       * @param[in] num_thin Number to thin the samples
+       * @param[in] save_warmup Indicates whether to save the warmup iterations
+       * @param[in] refresh Controls the output
+       * @param[in] stepsize initial stepsize for discrete evolution
+       * @param[in] stepsize_jitter uniform random jitter of stepsize
+       * @param[in] int_time integration time
        * @param[in] delta adaptation target acceptance statistic
        * @param[in] gamma adaptation regularization scale
        * @param[in] kappa adaptation relaxation exponent

--- a/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
@@ -164,45 +164,15 @@ namespace stan {
                                   callbacks::writer& init_writer,
                                   callbacks::writer& sample_writer,
                                   callbacks::writer& diagnostic_writer) {
-        boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
-
-        std::vector<int> disc_vector;
-        std::vector<double> cont_vector
-          = util::initialize(model, init, rng, init_radius, true,
-                             logger, init_writer);
-
-        Eigen::VectorXd inv_metric;
-        try {
-          inv_metric =
-            util::read_diag_inv_metric(init_inv_metric, model.num_params_r(),
-                                        logger);
-          util::validate_diag_inv_metric(inv_metric, logger);
-        } catch (const std::domain_error& e) {
-          return error_codes::CONFIG;
-        }
-
-        stan::mcmc::adapt_diag_e_static_hmc<Model, boost::ecuyer1988>
-          sampler(model, rng);
-
-        sampler.set_metric(inv_metric);
-        sampler.set_nominal_stepsize_and_T(stepsize, int_time);
-        sampler.set_stepsize_jitter(stepsize_jitter);
-
-        sampler.get_stepsize_adaptation().set_mu(log(10 * stepsize));
-        sampler.get_stepsize_adaptation().set_delta(delta);
-        sampler.get_stepsize_adaptation().set_gamma(gamma);
-        sampler.get_stepsize_adaptation().set_kappa(kappa);
-        sampler.get_stepsize_adaptation().set_t0(t0);
-
-        sampler.set_window_params(num_warmup, init_buffer, term_buffer,
-                                  window, logger);
-
-        util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
-                                   num_samples, num_thin, refresh, save_warmup,
-                                   rng, interrupt, logger,
-                                   sample_writer, diagnostic_writer);
-
-        return error_codes::OK;
+        return hmc_static_diag_e_adapt(model, init, init_inv_metric,
+                                       random_seed, chain, init_radius,
+                                       num_warmup, num_samples, num_thin,
+                                       save_warmup, refresh, stepsize,
+                                       stepsize_jitter, int_time, 10.0, delta,
+                                       gamma, kappa, t0, init_buffer,
+                                       term_buffer, window,
+                                       interrupt, logger, init_writer,
+                                       sample_writer, diagnostic_writer);
       }
 
       /**

--- a/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
@@ -39,7 +39,7 @@ namespace stan {
        * @param[in] stepsize initial stepsize for discrete evolution
        * @param[in] stepsize_jitter uniform random jitter of stepsize
        * @param[in] int_time integration time
-       * @param[in] mu_c stepsize factor for warmup initialization
+       * @param[in] log_mu_eps_scale stepsize factor for warmup initialization
        * @param[in] delta adaptation target acceptance statistic
        * @param[in] gamma adaptation regularization scale
        * @param[in] kappa adaptation relaxation exponent
@@ -62,8 +62,9 @@ namespace stan {
                                   int num_samples, int num_thin,
                                   bool save_warmup, int refresh,
                                   double stepsize, double stepsize_jitter,
-                                  double int_time, double mu_c, double delta,
-                                  double gamma, double kappa, double t0,
+                                  double int_time, double log_mu_eps_scale,
+                                  double delta, double gamma, double kappa,
+                                  double t0,
                                   unsigned int init_buffer,
                                   unsigned int term_buffer, unsigned int window,
                                   callbacks::interrupt& interrupt,
@@ -95,8 +96,10 @@ namespace stan {
         sampler.set_nominal_stepsize_and_T(stepsize, int_time);
         sampler.set_stepsize_jitter(stepsize_jitter);
 
-        sampler.get_stepsize_adaptation().set_mu_c(mu_c);
-        sampler.get_stepsize_adaptation().set_mu(log(mu_c * stepsize));
+        sampler.get_stepsize_adaptation().set_log_mu_eps_scale(
+          log_mu_eps_scale);
+        sampler.get_stepsize_adaptation().set_mu(
+          log(log_mu_eps_scale * stepsize));
         sampler.get_stepsize_adaptation().set_delta(delta);
         sampler.get_stepsize_adaptation().set_gamma(gamma);
         sampler.get_stepsize_adaptation().set_kappa(kappa);

--- a/src/test/unit/mcmc/stepsize_adaptation_test.cpp
+++ b/src/test/unit/mcmc/stepsize_adaptation_test.cpp
@@ -10,12 +10,12 @@ TEST(McmcStepsizeAdaptation, set_mu) {
   
 }
 
-TEST(McmcStepsizeAdaptation, set_mu_c) {
+TEST(McmcStepsizeAdaptation, set_log_mu_eps_scale) {
   stan::mcmc::stepsize_adaptation adaptation;
   
-  double old_mu_c = 5.0;
-  adaptation.set_mu_c(old_mu_c);
-  EXPECT_EQ(old_mu_c, adaptation.get_mu_c());
+  double old_log_mu_eps_scale = 5.0;
+  adaptation.set_log_mu_eps_scale(old_log_mu_eps_scale);
+  EXPECT_EQ(old_log_mu_eps_scale, adaptation.get_log_mu_eps_scale());
   
 }
 

--- a/src/test/unit/mcmc/stepsize_adaptation_test.cpp
+++ b/src/test/unit/mcmc/stepsize_adaptation_test.cpp
@@ -10,6 +10,15 @@ TEST(McmcStepsizeAdaptation, set_mu) {
   
 }
 
+TEST(McmcStepsizeAdaptation, set_mu_c) {
+  stan::mcmc::stepsize_adaptation adaptation;
+  
+  double old_mu_c = 5.0;
+  adaptation.set_mu_c(old_mu_c);
+  EXPECT_EQ(old_mu, adaptation.get_mu_c());
+  
+}
+
 TEST(McmcStepsizeAdaptation, set_delta) {
   stan::mcmc::stepsize_adaptation adaptation;
   

--- a/src/test/unit/mcmc/stepsize_adaptation_test.cpp
+++ b/src/test/unit/mcmc/stepsize_adaptation_test.cpp
@@ -15,7 +15,7 @@ TEST(McmcStepsizeAdaptation, set_mu_c) {
   
   double old_mu_c = 5.0;
   adaptation.set_mu_c(old_mu_c);
-  EXPECT_EQ(old_mu, adaptation.get_mu_c());
+  EXPECT_EQ(old_mu_c, adaptation.get_mu_c());
   
 }
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
As in issue [2670](https://github.com/stan-dev/stan/issues/2670).
The stepsize factor is exposed in the services via function overload of the existing algorithms.

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Jonas Kose



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)