### PR TITLE
Bugfix/2693 functions manual

### DIFF
--- a/make/manual
+++ b/make/manual
@@ -19,7 +19,7 @@ functions-reference: doc/functions-reference-$(VERSION_STRING).pdf $(STAN)doc/fu
 
 doc/reference-manual-$(VERSION_STRING).pdf: $(STAN)src/docs/reference-manual/*.Rmd $(STAN)src/docs/reference-manual/*.yml $(STAN)src/docs/reference-manual/*.R $(STAN)src/docs/reference-manual/*.css $(STAN)src/docs/reference-manual/*.tex
 	cd $(STAN)src/docs/reference-manual; Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book')"
-	mkdir -p doc
+	mkdir -p doc   # needed for cmdstan docs
 	mkdir -p $(STAN)doc
 	mv -f $(STAN)src/docs/reference-manual/_book/_main.pdf doc/reference-manual-$(VERSION_STRING).pdf
 
@@ -32,7 +32,7 @@ $(STAN)doc/reference-manual/index.html:  $(STAN)src/docs/reference-manual/*.Rmd 
 
 doc/functions-reference-$(VERSION_STRING).pdf: $(STAN)src/docs/functions/*.Rmd $(STAN)src/docs/functions/*.yml $(STAN)src/docs/functions/*.css $(STAN)src/docs/functions/*.tex
 	cd $(STAN)src/docs/functions; Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book')"
-	mkdir -p doc
+	mkdir -p doc   # needed for cmdstan docs
 	mkdir -p $(STAN)doc
 	mv -f $(STAN)src/docs/functions/_book/_main.pdf doc/functions-reference-$(VERSION_STRING).pdf
 

--- a/make/manual
+++ b/make/manual
@@ -19,6 +19,7 @@ functions-reference: doc/functions-reference-$(VERSION_STRING).pdf $(STAN)doc/fu
 
 doc/reference-manual-$(VERSION_STRING).pdf: $(STAN)src/docs/reference-manual/*.Rmd $(STAN)src/docs/reference-manual/*.yml $(STAN)src/docs/reference-manual/*.R $(STAN)src/docs/reference-manual/*.css $(STAN)src/docs/reference-manual/*.tex
 	cd $(STAN)src/docs/reference-manual; Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book')"
+	mkdir -p doc
 	mkdir -p $(STAN)doc
 	mv -f $(STAN)src/docs/reference-manual/_book/_main.pdf doc/reference-manual-$(VERSION_STRING).pdf
 
@@ -31,6 +32,7 @@ $(STAN)doc/reference-manual/index.html:  $(STAN)src/docs/reference-manual/*.Rmd 
 
 doc/functions-reference-$(VERSION_STRING).pdf: $(STAN)src/docs/functions/*.Rmd $(STAN)src/docs/functions/*.yml $(STAN)src/docs/functions/*.css $(STAN)src/docs/functions/*.tex
 	cd $(STAN)src/docs/functions; Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book')"
+	mkdir -p doc
 	mkdir -p $(STAN)doc
 	mv -f $(STAN)src/docs/functions/_book/_main.pdf doc/functions-reference-$(VERSION_STRING).pdf
 

--- a/src/docs/functions/array_operations.Rmd
+++ b/src/docs/functions/array_operations.Rmd
@@ -190,7 +190,7 @@ follows,
 ```
  real x[7,8,9];
  matrix[8,9] y[7];
- ```
+```
 
 then calling `dims(x)` or `dims(y)` returns an integer array of size 3
 containing the elements 7, 8, and 9 in that order.
@@ -200,7 +200,7 @@ This is just the top-level elements, so if the array is declared as
 
 ```
  real a[M,N];
- ```
+```
 
 the size of `a` is `M`.
 
@@ -281,7 +281,7 @@ assignment
  
  x = y;                  // illegal
  y = x;                  // illegal
- ```
+```
 
 If the value being repeated `v` is a vector (i.e., `T` is `vector`),
 then `rep_array(v,27)` is a size 27 array consisting of 27 copies of
@@ -293,7 +293,7 @@ the vector `v`.
  
  a = rep_array(v,3);  // fill a with copies of v
  a[2,4] = 9.0;        // v[4], a[1,4], a[2,4] unchanged
- ```
+```
 
 If the type T of x is itself an array type, then the result will be an
 array with one, two, or three added dimensions, depending on which of
@@ -306,7 +306,7 @@ following legal code snippet.
  
  b = rep_array(a,3,4); //  make (3 x 4) copies of a
  b[1,1,1,1] = 27.9;    //  a[1,1] unchanged
- ```
+```
 
 After the assignment to `b`, the value for `b[j,k,m,n]` is equal to
 `a[m,n]` where it is defined, for `j` in `1:3`, `k` in `1:4`, `m` in
@@ -332,7 +332,7 @@ Any mismatches will cause an error to be thrown.
  matrix[4, 6] x3[5, 1, 7];
  
  x3 = append_array(x1, x2);
- ```
+```
 
 ## Sorting functions {#sorting-functions}
 

--- a/src/docs/functions/circular_distributions.Rmd
+++ b/src/docs/functions/circular_distributions.Rmd
@@ -74,5 +74,5 @@ with
    y ~ von_mises(mu, kappa);
  else
    y ~ normal(mu, sqrt(1 / kappa));
- ```
+```
 

--- a/src/docs/functions/compound_arithmetic_and_assignment.Rmd
+++ b/src/docs/functions/compound_arithmetic_and_assignment.Rmd
@@ -5,13 +5,13 @@ operation and assignment,
 
 ```
  x = x op y;
- ```
+```
 
 replacing them with the compound form
 
 ```
  x op= y;
- ```
+```
 
 For example, `x = x + 1` may be replaced with `x += 1`.
 

--- a/src/docs/functions/conventions_for_probability_functions.Rmd
+++ b/src/docs/functions/conventions_for_probability_functions.Rmd
@@ -52,14 +52,14 @@ The notation
 
 ```
  y ~ normal(mu, sigma);
- ```
+```
 
 provides the same (proportional) contribution to the model log density
 as the explicit target density increment,
 
 ```
  target += normal_lpdf(y | mu, sigma);
- ```
+```
 
 In both cases, the effect is to add terms to the target log density.
 The only difference is that the example with the sampling (`~`)
@@ -174,7 +174,7 @@ The normal probability function is specified with the signature
 
 ```
  normal_lpdf(reals | reals, reals);
- ```
+```
 
 The pseudotype `reals` is used to indicate that an argument position
 may be vectorized.  Argument positions declared as `reals` may be
@@ -191,7 +191,7 @@ vector arguments is written as
 
 ```
  multi_normal_lpdf(vectors | vectors, matrix);
- ```
+```
 
 These arguments may be row vectors, column vectors, or arrays of row
 vectors or column vectors.
@@ -211,7 +211,7 @@ then
 
 ```
  ll = normal_lpdf(y | mu, sigma);
- ```
+```
 
 is just a more efficient way to write
 
@@ -219,20 +219,20 @@ is just a more efficient way to write
  ll = 0;
  for (n in 1:N)
    ll = ll + normal_lpdf(y[n] | mu[n], sigma);
- ```
+```
 
 With the same arguments, the vectorized sampling statement
 
 ```
  y ~ normal(mu, sigma);
- ```
+```
 
 has the same effect on the total log probability as
 
 ```
  for (n in 1:N)
    y[n] ~ normal(mu[n], sigma);
- ```
+```
 
 ### Evaluating Vectorized PRNG Functions {#prng-vectorization}
 
@@ -245,7 +245,7 @@ quantities block.
 ```
  vector[3] mu = ...;
  real x[3] = normal_rng(mu, 3);
- ```
+```
 
 #### Argument types
 
@@ -269,7 +269,7 @@ number of elements.
  vector[3] mu = ...;
  real sigma[3] = ...;
  real x[3] = normal_rng(mu, sigma);
- ```
+```
 
 #### Return type
 

--- a/src/docs/functions/higher-order_functions.Rmd
+++ b/src/docs/functions/higher-order_functions.Rmd
@@ -40,7 +40,7 @@ this signature:
 ```
  vector algebra_system(vector y, vector theta,
                               real[] x_r, int[] x_i)
- ```
+```
 
 The algebraic system function should return the value of the algebraic
 function which goes to 0, when we plug in the solution to the
@@ -163,7 +163,7 @@ signature:
 ```
  real[] ode(real time, real[] state, real[] theta,
             real[] x_r, int[] x_i)
- ```
+```
 
 The ODE system function should return the derivative of the state with
 respect to time at the time provided. The length of the returned real
@@ -301,7 +301,7 @@ the function `f` in the following declaration.
 ```
  vector f(vector phi, vector theta,
           data real[] x_r, data int[] x_i);
- ```
+```
 
 The map function returns the sequence of results for the particular
 shard being evaluated.  The arguments to the mapped function are:

--- a/src/docs/functions/matrix_operations.Rmd
+++ b/src/docs/functions/matrix_operations.Rmd
@@ -845,7 +845,7 @@ broadcasting behave similarly.
  vector[3] x;
  x = rep_vector(1, 3);
  x = rep_vector(1.0, 3);
- ```
+```
 
 There are no integer vector or matrix types, so integer values are
 automatically promoted.
@@ -870,14 +870,14 @@ converting a diagonal to a full matrix for use as a covariance matrix,
 
 ```
  y ~ multi_normal(mu, diag_matrix(square(sigma)));
- ```
+```
 
 it is much more efficient to just use a univariate normal, which
 produces the same density,
 
 ```
  y ~ normal(mu, sigma);
- ```
+```
 
 Rather than writing `m * diag_matrix(v)` where `m` is a matrix and `v`
 is a vector, it is much more efficient to write `diag_post_multiply(m,

--- a/src/docs/functions/real-valued_basic_functions.Rmd
+++ b/src/docs/functions/real-valued_basic_functions.Rmd
@@ -61,14 +61,14 @@ elementwise.  For example,
  y0 = exp(x0);
  y1 = exp(x1);
  y2 = exp(x2);
- ```
+```
 
 When `exp` is applied to an array, it applies elementwise.  For
 example, the statement above,
 
 ```
  y2 = exp(x2);
- ```
+```
 
 produces the same result for `y2` as the explicit loop
 
@@ -76,7 +76,7 @@ produces the same result for `y2` as the explicit loop
  for (i in 1:4)
    for (j in 1:7)
      y2[i, j] = exp(x2[i, j]);
- ```
+```
 
 #### Vector and matrix arguments
 
@@ -95,7 +95,7 @@ For example,
  yv = exp(xv);
  yrv = exp(xrv);
  ym = exp(xm);
- ```
+```
 
 Arrays of vectors and matrices work the same way.  For example,
 
@@ -105,7 +105,7 @@ Arrays of vectors and matrices work the same way.  For example,
  matrix[17, 93] z[12];
  
  z = exp(u);
- ```
+```
 
 After this has been executed, `z[i, j, k]` will be equal to `exp(u[i,
 j, k])`.
@@ -122,7 +122,7 @@ with the same number of elements as `n2`.  For example,
  int n1[23];
  real z1[23];
  z1 = exp(n1);
- ```
+```
 
 It would be illegal to try to assign `exp(n1)` to an array of
 integers; the return type is a real array.

--- a/src/docs/functions/simplex_distributions.Rmd
+++ b/src/docs/functions/simplex_distributions.Rmd
@@ -39,7 +39,7 @@ code this in Stan,
  generated quantities {
    vector[K] theta = dirichlet_rng(rep_vector(alpha, K));
  }
- ```
+```
 
 Taking $K = 10$, here are the first five draws for $\alpha = 0.001$.
 For $\alpha = 1$, the distribution is uniform over simplexes.
@@ -50,7 +50,7 @@ For $\alpha = 1$, the distribution is uniform over simplexes.
  3) 0.02 0.03 0.22 0.29 0.17 0.10 0.09 0.00 0.05 0.03
  4) 0.04 0.03 0.21 0.13 0.04 0.01 0.10 0.04 0.22 0.18
  5) 0.11 0.22 0.02 0.01 0.06 0.18 0.33 0.04 0.01 0.01
- ```
+```
 
 That does not mean it's uniform over the marginal probabilities of
 each element.  As the size of the simplex grows, the marginal draws
@@ -70,7 +70,7 @@ of the simplex.  Here are the first five draws for $\alpha = 0.001$.
  3) 1e-308 0e+00 1e-213 0e+000 0e+000 8e-75 0e+000 1e+000 4e-58 7e-112
  4) 6e-166 5e-65 3e-068 3e-147 0e+000 1e+00 3e-249 0e+000 0e+00 0e+000
  5) 2e-091 0e+00 0e+000 0e+000 1e-060 0e+00 4e-312 1e+000 0e+00 0e+000
- ```
+```
 
 Each row denotes a draw.  Each draw has a single value that rounds to
 one and other values that are very close to zero or rounded down to
@@ -85,7 +85,7 @@ $\alpha = 1000$,
  3) 0.10 0.10 0.10 0.10 0.10 0.10 0.10 0.10 0.10 0.10
  4) 0.10 0.10 0.10 0.10 0.10 0.10 0.10 0.10 0.10 0.10
  5) 0.10 0.10 0.10 0.10 0.10 0.10 0.10 0.10 0.10 0.10
- ```
+```
 
 ### Sampling Statement
 


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
fixes issue #2693; also adds extra mkdir stmt to file `make/manual` so that when cmdstan builds its docs, the Stan functions manual and reference manual will be generated as part of cmdstan documentation suite.

#### Intended Effect
allow Ubuntu users to build Stan docs suite.

#### How to Verify
run task `make manual`

#### Side Effects
cmdstan task `make manual` will succeed when dir `cmdstan/doc` doesn't exist

#### Documentation
NA

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
