### PR TITLE
Feature/issue 2692 expose hessian methods

### DIFF
--- a/src/stan/model/hessian.hpp
+++ b/src/stan/model/hessian.hpp
@@ -7,7 +7,6 @@
 
 namespace stan {
   namespace model {
-
     template <class M>
     void hessian(const M& model,
                  const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
@@ -20,17 +19,35 @@ namespace stan {
                                                 x, f, grad_f, hess_f);
     }
 
+    /**
+     * Compute the gradient and hessian using a combination of reverse-mode
+     * and forward-mode automatic differentiation, writing the result into the
+     * specified grad_f and hess_f variables.
+     *
+     * @tparam propto True if calculation is up to proportion
+     * (double-only terms dropped).
+     * @tparam jacobian_adjust_transform True if the log absolute
+     * Jacobian determinant of inverse parameter transforms is added to
+     * the log probability.
+     * @tparam M Class of model.
+     * @param[in] model Model.
+     * @param[in] params_r Real-valued parameters.
+     * @param[out] f Double into which funciton value is written.
+     * @param[out] grad_f Vector into which gradient is written.
+     * @param[out] hess_f Vector into which hessian is written.
+     * @param[in,out] msgs
+     */
     template <bool propto, bool jacobian_adjust_transform, class M>
     void log_prob_hessian(
         const M& model,
-        const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
+        const Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
         double& f,
         Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_f,
         Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& hess_f,
         std::ostream* msgs = 0) {
       stan::math::hessian<model_functional_template<propto, jacobian_adjust_transform, M>>(
           model_functional_template<propto, jacobian_adjust_transform, M>(model, msgs),
-              x, f, grad_f, hess_f);
+              params_r, f, grad_f, hess_f);
     }
 
   }

--- a/src/stan/model/hessian.hpp
+++ b/src/stan/model/hessian.hpp
@@ -20,6 +20,19 @@ namespace stan {
                                                 x, f, grad_f, hess_f);
     }
 
+    template <bool propto, bool jacobian_adjust_transform, class M>
+    void log_prob_hessian(
+        const M& model,
+        const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
+        double& f,
+        Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_f,
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& hess_f,
+        std::ostream* msgs = 0) {
+      stan::math::hessian<model_functional_template<propto, jacobian_adjust_transform, M>>(
+          model_functional_template<propto, jacobian_adjust_transform, M>(model, msgs),
+              x, f, grad_f, hess_f);
+    }
+
   }
 }
 #endif

--- a/src/stan/model/hessian_times_vector.hpp
+++ b/src/stan/model/hessian_times_vector.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/model/model_functional.hpp>
 #include <stan/math/mix/mat.hpp>
-#include <ostream>
+#include <iostream>
 
 namespace stan {
   namespace model {
@@ -18,6 +18,20 @@ namespace stan {
                               std::ostream* msgs = 0) {
       stan::math::hessian_times_vector(model_functional<M>(model, msgs),
                                        x, v, f, hess_f_dot_v);
+    }
+
+    template <bool propto, bool jacobian_adjust_transform, class M>
+    void log_prob_hessian_times_vector(
+        const M& model,
+        const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
+        const Eigen::Matrix<double, Eigen::Dynamic, 1>& v,
+        double& f,
+        Eigen::Matrix<double, Eigen::Dynamic, 1>& hess_f_dot_v,
+        std::ostream* msgs = 0) {
+      stan::math::hessian_times_vector<
+        model_functional_template<propto, jacobian_adjust_transform, M>>(
+          model_functional_template<propto, jacobian_adjust_transform, M>(model, msgs),
+              x, v, f, hess_f_dot_v);
     }
 
   }

--- a/src/stan/model/hessian_times_vector.hpp
+++ b/src/stan/model/hessian_times_vector.hpp
@@ -20,18 +20,37 @@ namespace stan {
                                        x, v, f, hess_f_dot_v);
     }
 
+    /**
+     * Compute the product between the Hessian and a vector using a combination
+     * of forward-mode and reverse-mode automatic differentiation, writing the
+     * result into the specified hess_f_dot_vec variable.
+     *
+     * @tparam propto True if calculation is up to proportion
+     * (double-only terms dropped).
+     * @tparam jacobian_adjust_transform True if the log absolute
+     * Jacobian determinant of inverse parameter transforms is added to
+     * the log probability.
+     * @tparam M Class of model.
+     * @param[in] model Model.
+     * @param[in] params_r Real-valued parameters.
+     * @param[in] vec Vector to be multiplied by the Hessian.
+     * @param[out] f Double into which funciton value is written.
+     * @param[out] hess_f_dot_vec Vector into which hessian-vector product is
+     * written.
+     * @param[in,out] msgs
+     */
     template <bool propto, bool jacobian_adjust_transform, class M>
     void log_prob_hessian_times_vector(
         const M& model,
-        const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
-        const Eigen::Matrix<double, Eigen::Dynamic, 1>& v,
+        const Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
+        const Eigen::Matrix<double, Eigen::Dynamic, 1>& vec,
         double& f,
-        Eigen::Matrix<double, Eigen::Dynamic, 1>& hess_f_dot_v,
+        Eigen::Matrix<double, Eigen::Dynamic, 1>& hess_f_dot_vec,
         std::ostream* msgs = 0) {
       stan::math::hessian_times_vector<
         model_functional_template<propto, jacobian_adjust_transform, M>>(
           model_functional_template<propto, jacobian_adjust_transform, M>(model, msgs),
-              x, v, f, hess_f_dot_v);
+              params_r, vec, f, hess_f_dot_vec);
     }
 
   }

--- a/src/stan/model/model_functional.hpp
+++ b/src/stan/model/model_functional.hpp
@@ -24,6 +24,24 @@ namespace stan {
       }
     };
 
+    // Interface for automatic differentiation of models
+    template <bool propto, bool jacobian_adjust_transform, class M>
+    struct model_functional_template {
+      const M& model;
+      std::ostream* o;
+
+      model_functional_template(const M& m, std::ostream* out)
+        : model(m), o(out) {}
+
+      template <typename T>
+      T operator()(const Eigen::Matrix<T, Eigen::Dynamic, 1>& x) const {
+        // log_prob() requires non-const but doesn't modify its argument
+        return model.template
+          log_prob<propto, jacobian_adjust_transform, T>(
+              const_cast<Eigen::Matrix<T, -1, 1>& >(x), o);
+      }
+    };
+
   }
 }
 #endif

--- a/src/stan/model/model_functional.hpp
+++ b/src/stan/model/model_functional.hpp
@@ -24,7 +24,7 @@ namespace stan {
       }
     };
 
-    // Interface for automatic differentiation of models
+    // Templated interface for automatic differentiation of models
     template <bool propto, bool jacobian_adjust_transform, class M>
     struct model_functional_template {
       const M& model;

--- a/src/test/unit/model/hessian_test.cpp
+++ b/src/test/unit/model/hessian_test.cpp
@@ -4,25 +4,25 @@
 
 TEST(ModelUtil, hessian) {
   int dim = 5;
-  
+
   Eigen::VectorXd x(dim);
   double f;
   Eigen::VectorXd grad_f(dim);
   Eigen::MatrixXd hess_f(dim, dim);
-  
+
   std::fstream data_stream(std::string("").c_str(), std::fstream::in);
   stan::io::dump data_var_context(data_stream);
   data_stream.close();
-  
+
   std::stringstream output;
   valid_model_namespace::valid_model valid_model(data_var_context, &output);
   EXPECT_NO_THROW(stan::model::hessian(valid_model, x, f, grad_f, hess_f));
-  
+
   EXPECT_FLOAT_EQ(dim, x.size());
   EXPECT_FLOAT_EQ(dim, grad_f.size());
   EXPECT_FLOAT_EQ(dim, hess_f.rows());
   EXPECT_FLOAT_EQ(dim, hess_f.cols());
-  
+
   EXPECT_EQ("", output.str());
 
   // Incorporate once operands and partials has been generalized

--- a/src/test/unit/model/log_prob_hessian_test.cpp
+++ b/src/test/unit/model/log_prob_hessian_test.cpp
@@ -1,0 +1,59 @@
+// The test cannot find stan/math/mix/mat.hpp.
+#include <stan/model/hessian.hpp>
+#include <test/test-models/good/model/valid.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+
+TEST(ModelUtil, streams) {
+  stan::test::capture_std_streams();
+
+  std::fstream data_stream(std::string("").c_str(), std::fstream::in);
+  stan::io::dump data_var_context(data_stream);
+  data_stream.close();
+
+
+  stan_model model(data_var_context, static_cast<std::stringstream*>(0));
+  std::vector<double> params_r(1);
+  std::vector<int> params_i(0);
+  Eigen::VectorXd grad_f(dim);
+  Eigen::MatrixXd hess_f(dim, dim);
+
+  std::stringstream out;
+
+  try {
+    stan::model::log_prob_hessian<true, true, stan_model>(model, params_r, grad_f, hess_f, 0);
+    stan::model::log_prob_hessian<true, false, stan_model>(model, params_r, grad_f, hess_f, 0);
+    stan::model::log_prob_hessian<false, true, stan_model>(model, params_r, grad_f, hess_f, 0);
+    stan::model::log_prob_hessian<false, false, stan_model>(model, params_r, grad_f, hess_f, 0);
+    out.str("");
+    stan::model::log_prob_hessian<true, true, stan_model>(model, params_r, grad_f, hess_f, &out);
+    stan::model::log_prob_hessian<true, false, stan_model>(model, params_r, grad_f, hess_f, &out);
+    stan::model::log_prob_hessian<false, true, stan_model>(model, params_r, grad_f, hess_f, &out);
+    stan::model::log_prob_hessian<false, false, stan_model>(model, params_r, grad_f, hess_f, &out);
+    EXPECT_EQ("", out.str());
+  } catch (...) {
+    FAIL() << "log_prob_hessian";
+  }
+
+  try {
+    Eigen::VectorXd p(1);
+    Eigen::VectorXd g(1);
+    Eigen::MatrixXd h(1, 1);
+    stan::model::log_prob_hessian<true, true, stan_model>(model, p, g, h, 0);
+    stan::model::log_prob_hessian<true, false, stan_model>(model, p, g, h, 0);
+    stan::model::log_prob_hessian<false, true, stan_model>(model, p, g, h, 0);
+    stan::model::log_prob_hessian<false, false, stan_model>(model, p, g, h, 0);
+    out.str("");
+    stan::model::log_prob_hessian<true, true, stan_model>(model, p, g, h, &out);
+    stan::model::log_prob_hessian<true, false, stan_model>(model, p, g, h, &out);
+    stan::model::log_prob_hessian<false, true, stan_model>(model, p, g, h, &out);
+    stan::model::log_prob_hessian<false, false, stan_model>(model, p, g, h, &out);
+    EXPECT_EQ("", out.str());
+  } catch (...) {
+    FAIL() << "log_prob_hessian";
+  }
+
+  stan::test::reset_std_streams();
+  EXPECT_EQ("", stan::test::cout_ss.str());
+  EXPECT_EQ("", stan::test::cerr_ss.str());
+}


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary

Create analogues of ```stan::model::log_prob_grad``` for the ```stan::math::hessian``` and ```stan::math::hessian_vector_product``` functions.

#### Intended Effect

#### How to Verify

This question under investigation.

#### Side Effects

None.

#### Documentation

In the code.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ryan Giordano

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
