### PR TITLE
Issue #2698 ADVI Add convergence diagnostic metrics to the diagnostic writer

### DIFF
--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -428,6 +428,8 @@ namespace stan {
             print_vector.push_back(iter_counter);
             print_vector.push_back(delta_t);
             print_vector.push_back(elbo);
+            print_vector.push_back(delta_elbo_ave);
+            print_vector.push_back(delta_elbo_med);
             diagnostic_writer(print_vector);
 
             if (delta_elbo_ave < tol_rel_obj) {
@@ -488,7 +490,8 @@ namespace stan {
               callbacks::writer& parameter_writer,
               callbacks::writer& diagnostic_writer)
         const {
-        diagnostic_writer("iter,time_in_seconds,ELBO");
+        diagnostic_writer("iter,time_in_seconds,ELBO,"
+                          "delta_ELBO_mean,delta_ELBO_med");
 
         // Initialize variational approximation
         Q variational = Q(cont_params_);


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Description in issue #2698 . 
#### Intended Effect
Add the convergence metrics `delta_ELBO_mean` and `delta_ELBO_med` to the diagnostics writer which will then end up in the csv diagnostics file, alongside existing `"iter,time_in_seconds,ELBO"` , produced by pystan model `vb()` call
#### How to Verify
Run the unit tests from `src/test/unit/variational` and `src/test/unit/callbacks`
#### Side Effects
None
#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
