### PR TITLE
Bugfix/2713 typedef transform inits

### DIFF
--- a/src/stan/lang/generator/generate_transform_inits_method.hpp
+++ b/src/stan/lang/generator/generate_transform_inits_method.hpp
@@ -41,6 +41,8 @@ namespace stan {
         << EOL;
       o << INDENT << "                     std::ostream* pstream__) const {"
         << EOL;
+      o << INDENT2 << "typedef double local_scalar_t__;"
+        << EOL;
       o << INDENT2 << "stan::io::writer<double> "
         << "writer__(params_r__, params_i__);"
         << EOL;

--- a/src/test/test-models/good/parser-generator/test_transform_inits.stan
+++ b/src/test/test-models/good/parser-generator/test_transform_inits.stan
@@ -1,0 +1,4 @@
+parameters {
+  real<lower=0> nu;
+  real<lower=0, upper=(nu == 0 ? 1 : positive_infinity())> lambda;
+}

--- a/src/test/test-models/good/parser-generator/test_transform_inits.stan
+++ b/src/test/test-models/good/parser-generator/test_transform_inits.stan
@@ -1,3 +1,4 @@
+// tickle issue 2713 bug
 parameters {
   real<lower=0> nu;
   real<lower=0, upper=(nu == 0 ? 1 : positive_infinity())> lambda;

--- a/src/test/unit/lang/generator/generate_cpp_test.cpp
+++ b/src/test/unit/lang/generator/generate_cpp_test.cpp
@@ -67,4 +67,14 @@ TEST(lang, generate_cpp) {
     << "generate_model_typedef()";
 
   EXPECT_EQ(0, count_matches("int main", output_str));
+
+}
+
+TEST(lang, generate_transform_inits_cpp) {
+  std::vector<stan::lang::block_var_decl> vs;
+  std::stringstream output;
+  stan::lang::generate_transform_inits_method(vs, output);
+  std::string output_str = output.str();
+  EXPECT_EQ(1, count_matches("typedef double local_scalar_t__;", output_str))
+    << "generate_transform_inits_method()";
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Fixes compiler bug which produced c++ code that doesn't compile -
Added typedef to generated c++ code for `transform_inits` method

#### Intended Effect
generated c++ code compiles

#### How to Verify
run unit tests; added test model `src/test/test-models/good/parser-generator/test_transform_inits.stan`

#### Side Effects
N/A

#### Documentation
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
