### PR TITLE
Feature/make stan functions

### DIFF
--- a/make/manual
+++ b/make/manual
@@ -1,4 +1,4 @@
-.PHONY: manual doc reference-manual functions-reference
+.PHONY: manual doc reference-manual functions-reference stan-functions
 
 STAN_MAJOR := $(shell grep "\#define STAN_MAJOR" $(STAN)src/stan/version.hpp | sed -e 's/.*STAN_MAJOR \(.*\)/\1/')
 STAN_MINOR := $(shell grep "\#define STAN_MINOR" $(STAN)src/stan/version.hpp | sed -e 's/.*STAN_MINOR \(.*\)/\1/')
@@ -7,11 +7,51 @@ VERSION_STRING := $(STAN_MAJOR).$(STAN_MINOR).$(STAN_PATCH)
 
 manual: doc
 
-doc: reference-manual functions-reference
+doc: reference-manual functions-reference stan-functions
 
 reference-manual: doc/reference-manual-$(VERSION_STRING).pdf $(STAN)doc/reference-manual/index.html
 
 functions-reference: doc/functions-reference-$(VERSION_STRING).pdf $(STAN)doc/functions/index.html
+
+stan-functions:
+	@grep --no-filename "hyperpage" $(STAN)src/docs/functions/*.Rmd > doc/functions/stan-functions.txt
+	@sed -i.bak 's/\\index{{\\tt \\bfseries //g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/}!{\\tt //g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/}|hyperpage}//g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/\\_/_/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/: /;/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/(/;(/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/}!sampling statement|hyperpage}/~;real/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/~|~/|/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_compound_add/operator+=/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_compound_subtract/operator-=/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_compound_multiply/operator*=/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_compound_divide/operator\/=/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_compound_elt_multiply/operator.*=/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_compound_elt_divide/operator.\/=/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_subtract/operator-/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_add/operator+/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_multiply/operator*/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_divide/operator\//g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_elt_divide/operator.\//g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_elt_multiply/operator.*/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_left_div/operator\\/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_logical_and/operator\&\&/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_logical_or/operator||/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_logical_greater_than_equal/operator>=/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_logical_less_than_equal/operator<=/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_logical_greater_than/operator>/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_logical_less_than/operator</g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_logical_not_equal/operator!=/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_logical_equal/operator==/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_mod/operator%/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_negation/operator!/g' doc/functions/stan-functions.txt
+	@sed -i.bak 's/operator_pow/operator^/g' doc/functions/stan-functions.txt
+	@sed -i.bak "s/operator_transpose/operator'/g" doc/functions/stan-functions.txt
+	@sort doc/functions/stan-functions.txt | uniq > doc/functions/stan-functions.txt.bak
+	@echo "# This file is semicolon delimited\nStanFunction;Arguments;ReturnType" > doc/functions/stan-functions.txt
+	@cat doc/functions/stan-functions.txt.bak >> doc/functions/stan-functions.txt
+	@rm doc/functions/stan-functions.txt.bak
 
 %.pdf: %.tex
 	cd $(dir $@); latexmk -pdf -pdflatex="pdflatex -file-line-error" -use-make $(notdir $^)
@@ -52,3 +92,4 @@ clean-docs:
 	rm -rf $(STAN)src/docs/reference-manual/reference-manual.pdf
 	rm -rf $(STAN)src/docs/reference-manual/_book/
 	rm -rf $(STAN)src/docs/reference-manual/_main.rds
+	rm -rf $(STAN)src/docs/functions/stan-functions.txt

--- a/src/docs/functions/real-valued_basic_functions.Rmd
+++ b/src/docs/functions/real-valued_basic_functions.Rmd
@@ -308,13 +308,13 @@ Return 1 if x is greater than or equal to y and 0 otherwise. \[
 \text{otherwise} \end{cases} \]
 
 <!-- int; operator==; (int x, int y); -->
-\index{{\tt \bfseries operator\_logial\_equal}!{\tt (int x, int y): int}|hyperpage}
+\index{{\tt \bfseries operator\_logical\_equal}!{\tt (int x, int y): int}|hyperpage}
 
 `int` **`operator==`**`(int x, int y)`<br>\newline
 
 
 <!-- int; operator==; (real x, real y); -->
-\index{{\tt \bfseries operator\_logial\_equal}!{\tt (real x, real y): int}|hyperpage}
+\index{{\tt \bfseries operator\_logical\_equal}!{\tt (real x, real y): int}|hyperpage}
 
 `int` **`operator==`**`(real x, real y)`<br>\newline
 Return 1 if x is equal to y and 0 otherwise. \[ \text{operator==}(x,y)

--- a/src/docs/functions/scripts/munge_all.py
+++ b/src/docs/functions/scripts/munge_all.py
@@ -349,7 +349,7 @@ def clean(name):
         return name[0:(len(name)-4)]
     if (not name.startswith("operator")):
         return name
-    name = name.replace("==","_logial_equal")
+    name = name.replace("==","_logical_equal")
     name = name.replace("!=","_logical_not_equal")
     name = name.replace("!","_negation")
     name = name.replace("<=","_logical_less_than_equal")


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit` Does not touch C++ code
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary

Adds a `make` target to create the stan-functions.txt file that we had before the switch to RMarkdown-based documentation

#### Intended Effect

Fixes #2740

#### How to Verify

```
make manual
```

#### Side Effects

None

#### Documentation

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
