### PR TITLE
Updated Jenkinsfile to support new warnings plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,19 @@ pipeline {
             }
             post {
                 always {
-                    warnings consoleParsers: [[parserName: 'CppLint']], canRunOnFailed: true
+
+                    recordIssues id: "lint_doc_checks", 
+                    name: "Linting & Doc checks",
+                    enabledForFailure: true, 
+                    aggregatingResults : true, 
+                    tools: [
+                        cppLint(id: "non_windows_cpplint", name: "Linting & Doc checks@CPPLINT")
+                    ],
+                    blameDisabled: false,
+                    qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                    healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                    referenceJobName: env.BRANCH_NAME
+
                     deleteDir()
                 }
             }
@@ -162,8 +174,18 @@ pipeline {
     post {
         always {
             node("osx || linux") {
-                warnings consoleParsers: [[parserName: 'GNU C Compiler 4 (gcc)']], canRunOnFailed: true
-                warnings consoleParsers: [[parserName: 'Clang (LLVM based)']], canRunOnFailed: true
+                recordIssues id: "pipeline", 
+                name: "Entire pipeline results",
+                enabledForFailure: true, 
+                aggregatingResults : true, 
+                tools: [
+                    gcc4(id: "pipeline_gcc4", name: "Pipeline@GCC4"),
+                    clang(id: "pipeline_clang", name: "Pipeline@CLANG")
+                ],
+                blameDisabled: false,
+                qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
+                referenceJobName: env.BRANCH_NAME
             }
         }
         success {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
                     enabledForFailure: true, 
                     aggregatingResults : true, 
                     tools: [
-                        cppLint(id: "non_windows_cpplint", name: "Linting & Doc checks@CPPLINT")
+                        cppLint(id: "cpplint", name: "Linting & Doc checks@CPPLINT")
                     ],
                     blameDisabled: false,
                     qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
@@ -177,13 +177,13 @@ pipeline {
                 recordIssues id: "pipeline", 
                 name: "Entire pipeline results",
                 enabledForFailure: true, 
-                aggregatingResults : true, 
+                aggregatingResults : false, 
                 tools: [
-                    gcc4(id: "pipeline_gcc4", name: "Pipeline@GCC4"),
-                    clang(id: "pipeline_clang", name: "Pipeline@CLANG")
+                    gcc4(id: "pipeline_gcc4", name: "GNU C Compiler"),
+                    clang(id: "pipeline_clang", name: "LLVM/Clang")
                 ],
                 blameDisabled: false,
-                qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
+                qualityGates: [[threshold: 30, type: 'TOTAL', unstable: true]],
                 healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH',
                 referenceJobName: env.BRANCH_NAME
             }


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary: Updated Jenkinsfile to support the new warnings plugin.

#### Intended Effect: Stop using the deprecated,  old plugin. Visualize warnings. Make use of new features.

#### How to Verify: Check the Jenkins pipeline results.

#### Side Effects: None

#### Documentation: 

`aggregatingResults` - Ties the results together, so we have tied together the gcc4 & clang in the same UI. Can be disabled by setting it to `false`
`blameDisabled` - Determines who is the author of an issue. ( See https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#source-code-blames-for-git-projects )
`qualityGates` - Quality gates let you modify Jenkins' build status so that you immediately see if the desired quality of your product is met ( See https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#quality-gate-configuration )
`healthy` - Health report of the project ( See https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#health-report-configuration )
`referenceJobName` - References the baseline, used for the classification of issues. ( See 
https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#control-the-selection-of-the-reference-build-baseline )

For the complete documentation please visit: https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md
For the complete list of tools please visit: https://github.com/jenkinsci/warnings-ng-plugin/blob/master/SUPPORTED-FORMATS.md

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
