### PR TITLE
Issue 2755 - Update Eigen includes to allow compilation with new plugin methods

### DIFF
--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/io/var_context.hpp>
 #include <boost/throw_exception.hpp>
-#include <Eigen/Dense>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <map>
 #include <sstream>
 #include <string>

--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -2,7 +2,7 @@
 #define STAN_IO_STAN_CSV_READER_HPP
 
 #include <boost/algorithm/string.hpp>
-#include <Eigen/Dense>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <istream>
 #include <iostream>
 #include <sstream>

--- a/src/stan/mcmc/hmc/integrators/expl_leapfrog.hpp
+++ b/src/stan/mcmc/hmc/integrators/expl_leapfrog.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/callbacks/logger.hpp>
 #include <stan/mcmc/hmc/integrators/base_leapfrog.hpp>
-#include <Eigen/Dense>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 
 namespace stan {
   namespace mcmc {

--- a/src/stan/mcmc/sample.hpp
+++ b/src/stan/mcmc/sample.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MCMC_SAMPLE_HPP
 #define STAN_MCMC_SAMPLE_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <vector>
 #include <string>
 

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -3,7 +3,6 @@
 
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <Eigen/Dense>
 #include <stan/math/prim/mat.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/index_list.hpp>

--- a/src/stan/model/model_functional.hpp
+++ b/src/stan/model/model_functional.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MODEL_MODEL_FUNCTIONAL_HPP
 #define STAN_MODEL_MODEL_FUNCTIONAL_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <iostream>
 
 namespace stan {

--- a/src/test/unit/services/sample/standalone_gqs_test.cpp
+++ b/src/test/unit/services/sample/standalone_gqs_test.cpp
@@ -1,4 +1,3 @@
-#include <Eigen/Dense>
 #include <boost/algorithm/string.hpp>
 #include <gtest/gtest.h>
 #include <iostream>


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
The methods added using Eigen's plugin system in PR stan-dev/math#1216 cause compilation errors in the header and unit tests for Stan if any Eigen headers are included prior to ```math/prim/mat/fun/Eigen.hpp```.

This PR updates the minimum number of headers needed to allow these tests to pass with the new methods.

#### Intended Effect
No compilation errors

#### How to Verify
Tests compile and pass

#### Side Effects
N/A

#### Documentation
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
