### PR TITLE
Bugfix/2588 constr param size boundary

### DIFF
--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -4,6 +4,7 @@
 #include <boost/throw_exception.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace stan {

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/throw_exception.hpp>
 #include <stan/math/prim/mat.hpp>
+#include <stdexcept>
 #include <vector>
 
 namespace stan {
@@ -777,11 +778,16 @@ public:
    *
    * <p>See <code>stan::math::check_unit_vector</code>.
    *
-   * @param k Size of returned unit_vector.
-   * @return unit_vector read from the specified size number of scalars.
-   * @throw std::runtime_error if the k values is not a unit_vector.
+   * @param k Size of returned unit_vector
+   * @return unit_vector read from the specified size number of scalars
+   * @throw std::runtime_error if the next k values is not a unit_vector
+   * @throw std::invalid_argument if k is zero
    */
   inline vector_t unit_vector(size_t k) {
+    if (k == 0) {
+      std::string msg = "io::unit_vector: unit vectors cannot be size 0.";
+      throw std::invalid_argument(msg);
+    }
     vector_t theta(vector(k));
     stan::math::check_unit_vector("stan::io::unit_vector", "Constrained vector",
                                   theta);
@@ -797,8 +803,14 @@ public:
    *
    * @param k Number of dimensions in resulting unit_vector.
    * @return unit_vector derived from next <code>k</code> scalars.
+   * @throw std::invalid_argument if k is zero
    */
   inline Eigen::Matrix<T, Eigen::Dynamic, 1> unit_vector_constrain(size_t k) {
+    if (k == 0) {
+      std::string msg = "io::unit_vector_constrain:"
+          " unit vectors cannot be size 0.";
+      throw std::invalid_argument(msg);
+    }
     return stan::math::unit_vector_constrain(vector(k));
   }
 
@@ -813,8 +825,14 @@ public:
    * @param lp Log probability to increment with log absolute
    * Jacobian determinant.
    * @return The next unit_vector of the specified size.
+   * @throw std::invalid_argument if k is zero
    */
   inline vector_t unit_vector_constrain(size_t k, T &lp) {
+    if (k == 0) {
+      std::string msg = "io::unit_vector_constrain:"
+          " unit vectors cannot be size 0.";
+      throw std::invalid_argument(msg);
+    }
     return stan::math::unit_vector_constrain(vector(k), lp);
   }
 
@@ -827,8 +845,13 @@ public:
    * @param k Size of returned simplex.
    * @return Simplex read from the specified size number of scalars.
    * @throw std::runtime_error if the k values is not a simplex.
+   * @throw std::invalid_argument if k is zero
    */
   inline vector_t simplex(size_t k) {
+    if (k == 0) {
+      std::string msg = "io::simplex: simplexes cannot be size 0.";
+      throw std::invalid_argument(msg);
+    }
     vector_t theta(vector(k));
     stan::math::check_simplex("stan::io::simplex", "Constrained vector", theta);
     return theta;
@@ -841,10 +864,15 @@ public:
    *
    * <p>See <code>stan::math::simplex_constrain(Eigen::Matrix)</code>.
    *
-   * @param k Number of dimensions in resulting simplex.
-   * @return Simplex derived from next <code>k-1</code> scalars.
+   * @param k number of dimensions in resulting simplex
+   * @return simplex derived from next `k - 1` scalars
+   * @throws std::invalid_argument if number of dimensions (`k`) is zero
    */
   inline Eigen::Matrix<T, Eigen::Dynamic, 1> simplex_constrain(size_t k) {
+    if (k == 0) {
+      std::string msg = "io::simplex_constrain: simplexes cannot be size 0.";
+      throw std::invalid_argument(msg);
+    }
     return stan::math::simplex_constrain(vector(k - 1));
   }
 
@@ -859,8 +887,13 @@ public:
    * @param lp Log probability to increment with log absolute
    * Jacobian determinant.
    * @return The next simplex of the specified size.
+   * @throws std::invalid_argument if number of dimensions (`k`) is zero
    */
   inline vector_t simplex_constrain(size_t k, T &lp) {
+    if (k == 0) {
+      std::string msg = "io::simplex_constrain: simplexes cannot be size 0.";
+      throw std::invalid_argument(msg);
+    }
     return stan::math::simplex_constrain(vector(k - 1), lp);
   }
 

--- a/src/test/unit/io/reader_test.cpp
+++ b/src/test/unit/io/reader_test.cpp
@@ -1405,3 +1405,28 @@ TEST(io_reader, matrix_lub_constrain_lp) {
   double a = reader.scalar();
   EXPECT_FLOAT_EQ(13.0, a);
 }
+
+
+TEST(IoReader, SimplexThrows) {
+  std::vector<double> theta;
+  std::vector<int> theta_i;
+  stan::io::reader<double> reader(theta, theta_i);
+
+  double x = 0;
+  double lp = 0;
+  EXPECT_THROW(reader.simplex(x), std::invalid_argument);
+  EXPECT_THROW(reader.simplex_constrain(x), std::invalid_argument);
+  EXPECT_THROW(reader.simplex_constrain(x, lp), std::invalid_argument);
+}
+
+TEST(IoReader, UnitVectorThrows) {
+  std::vector<double> theta;
+  std::vector<int> theta_i;
+  stan::io::reader<double> reader(theta, theta_i);
+
+  double x = 0;
+  double lp = 0;
+  EXPECT_THROW(reader.unit_vector(x), std::invalid_argument);
+  EXPECT_THROW(reader.unit_vector_constrain(x), std::invalid_argument);
+  EXPECT_THROW(reader.unit_vector_constrain(x, lp), std::invalid_argument);
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add size zero tests to `io::simplex`, `io::simplex_constrain` (2 versions), `io::unit_vector`, and `io::unit_vector_constrain` (2 versions).   Effect is to throw `std::illegal_argument`.

#### Intended Effect

Declaring a size zero simplex in a Stan program will halt the program.

#### How to Verify

Unit tests.

#### Side Effects

No.  The current behavior is to throw an out of memory error when calculating `0 - 1` unsigned.

#### Documentation

Yes, added to API doc.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
