### PR TITLE
add ifdef for R new_model, fixes #2797

### DIFF
--- a/src/stan/lang/generator/generate_model_typedef.hpp
+++ b/src/stan/lang/generator/generate_model_typedef.hpp
@@ -22,6 +22,8 @@ namespace stan {
       o << "typedef " << model_name << "_namespace::" << model_name
         << " stan_model;" << EOL2;
 
+      o << "#ifndef USING_R" << EOL2;
+
       o << "stan::model::model_base& new_model(" << EOL
         << "        stan::io::var_context& data_context," << EOL
         << "        unsigned int seed," << EOL
@@ -30,6 +32,8 @@ namespace stan {
         << EOL
         << "  return *m;" << EOL
         << "}" << EOL2;
+
+      o << "#endif" << EOL2;
     }
   }
 }

--- a/src/test/unit/lang/generator/generate_new_model_test.cpp
+++ b/src/test/unit/lang/generator/generate_new_model_test.cpp
@@ -1,0 +1,31 @@
+#include <stan/lang/ast_def.cpp>
+#include <stan/lang/generator.hpp>
+#include <test/unit/lang/utility.hpp>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sstream>
+
+TEST(langGenerator, generateNewModel) {
+  stan::lang::program prog;
+  std::string model_name = "m";
+  std::stringstream code_stream;
+
+  stan::io::program_reader reader;
+  // fake reader history - no stan program, just AST
+  reader.add_event(0, 0, "start", "generator-test");
+  reader.add_event(500, 500, "end", "generator-test");
+
+  stan::lang::generate_cpp(prog, model_name, reader.history(), code_stream);
+  std::string generated_code = code_stream.str();
+  EXPECT_EQ(1, count_matches(
+      "#ifndef USING_R\n\n"
+      "stan::model::model_base& new_model(\n"
+      "        stan::io::var_context& data_context,\n"
+      "        unsigned int seed,\n"
+      "        std::ostream* msg_stream) {\n"
+      "  stan_model* m = new stan_model(data_context, seed, msg_stream);\n"
+      "  return *m;\n"
+      "}\n\n"
+      "#endif\n",
+      generated_code));
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Added ifdef around new_model to prevent it being compiled in R.

#### Intended Effect

Let R have multiple Stan models in a single translation unit.

#### How to Verify

New unit test.

#### Side Effects

No.

#### Documentation

n/a

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
