### PR TITLE
Feature/issue 2799 robust no u turn

### DIFF
--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -82,17 +82,17 @@ namespace stan {
         this->hamiltonian_.init(this->z_, logger);
 
         ps_point z_fwd(this->z_);  // State at forward end of trajectory
-        ps_point z_bck(z_plus);    // State at backward end of trajectory
+        ps_point z_bck(z_fwd);    // State at backward end of trajectory
 
-        ps_point z_sample(z_plus);
-        ps_point z_propose(z_plus);
+        ps_point z_sample(z_fwd);
+        ps_point z_propose(z_fwd);
 
         // Momentum and sharp momentum at forward end of forward subtree
         Eigen::VectorXd p_fwd_fwd = this->z_.p;
         Eigen::VectorXd p_sharp_fwd_fwd = this->hamiltonian_.dtau_dp(this->z_);
 
         // Momentum and sharp momentum at backward end of forward subtree
-        Eigen::VectorXd p_fwd_bkc = this->z_.p;
+        Eigen::VectorXd p_fwd_bck = this->z_.p;
         Eigen::VectorXd p_sharp_fwd_bck = p_sharp_fwd_fwd;
 
         // Momentum and sharp momentum at forward end of backward subtree
@@ -145,7 +145,7 @@ namespace stan {
             valid_subtree
               = build_tree(this->depth_, z_propose,
                            p_sharp_bck_fwd, p_sharp_bck_bck,
-                           rho_minus, p_bck_fwd, p_bck_bck,
+                           rho_bck, p_bck_fwd, p_bck_bck,
                            H0, -1, n_leapfrog,
                            log_sum_weight_subtree, sum_metro_prob,
                            logger);
@@ -170,11 +170,11 @@ namespace stan {
             = math::log_sum_exp(log_sum_weight, log_sum_weight_subtree);
 
           // Break when no-u-turn criterion is no longer satisfied
-          rho = rho_minus + rho_plus;
+          rho = rho_bck + rho_fwd;
 
           // Demand satisfaction around merged subtrees
           bool persist_criterion =
-            compute_criterion(p_sharp_bkc_bck,
+            compute_criterion(p_sharp_bck_bck,
                               p_sharp_fwd_fwd,
                               rho);
 

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -104,8 +104,8 @@ namespace stan {
         Eigen::VectorXd p_sharp_bck_bck = p_sharp_fwd_fwd;
 
         // Integrated momenta along trajectory
-        Eigen::VectorXd rho = this->z_.p;
-
+        Eigen::VectorXd rho = this->z_.p.transpose();
+        
         // Log sum of state weights (offset by H0) along trajectory
         double log_sum_weight = 0;  // log(exp(H0 - H0))
         double H0 = this->hamiltonian_.H(this->z_);
@@ -130,6 +130,9 @@ namespace stan {
             // Extend the current trajectory forward
             this->z_.ps_point::operator=(z_fwd);
             rho_bck = rho;
+            p_bck_fwd = p_fwd_fwd;
+            p_sharp_bck_fwd = p_sharp_fwd_fwd;
+            
             valid_subtree
               = build_tree(this->depth_, z_propose,
                            p_sharp_fwd_bck, p_sharp_fwd_fwd,
@@ -142,6 +145,9 @@ namespace stan {
             // Extend the current trajectory backwards
             this->z_.ps_point::operator=(z_bck);
             rho_fwd = rho;
+            p_fwd_bck = p_bck_bck;
+            p_sharp_fwd_bck = p_sharp_bck_bck;
+            
             valid_subtree
               = build_tree(this->depth_, z_propose,
                            p_sharp_bck_fwd, p_sharp_bck_bck,

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -105,7 +105,7 @@ namespace stan {
 
         // Integrated momenta along trajectory
         Eigen::VectorXd rho = this->z_.p.transpose();
-        
+
         // Log sum of state weights (offset by H0) along trajectory
         double log_sum_weight = 0;  // log(exp(H0 - H0))
         double H0 = this->hamiltonian_.H(this->z_);
@@ -132,7 +132,7 @@ namespace stan {
             rho_bck = rho;
             p_bck_fwd = p_fwd_fwd;
             p_sharp_bck_fwd = p_sharp_fwd_fwd;
-            
+
             valid_subtree
               = build_tree(this->depth_, z_propose,
                            p_sharp_fwd_bck, p_sharp_fwd_fwd,
@@ -147,7 +147,7 @@ namespace stan {
             rho_fwd = rho;
             p_fwd_bck = p_bck_bck;
             p_sharp_fwd_bck = p_sharp_bck_bck;
-            
+
             valid_subtree
               = build_tree(this->depth_, z_propose,
                            p_sharp_bck_fwd, p_sharp_bck_bck,

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -108,31 +108,31 @@ TEST_F(performance, values_from_tagged_version) {
     << "last tagged version, 2.17.0, had " << N_values << " elements";
 
   std::vector<double> first_run = last_draws_per_run[0];
-  EXPECT_FLOAT_EQ(-66.222504, first_run[0])
+  EXPECT_FLOAT_EQ(-65.216301, first_run[0])
     << "lp__: index 0";
 
-  EXPECT_FLOAT_EQ(1.0, first_run[1])
+  EXPECT_FLOAT_EQ(0.91851199, first_run[1])
     << "accept_stat__: index 1";
 
-  EXPECT_FLOAT_EQ(1.00182, first_run[2])
+  EXPECT_FLOAT_EQ(0.76885599, first_run[2])
     << "stepsize__: index 2";
 
   EXPECT_FLOAT_EQ(2, first_run[3])
     << "treedepth__: index 3";
 
-  EXPECT_FLOAT_EQ(7, first_run[4])
+  EXPECT_FLOAT_EQ(3, first_run[4])
     << "n_leapfrog__: index 4";
 
   EXPECT_FLOAT_EQ(0, first_run[5])
     << "divergent__: index 5";
 
-  EXPECT_FLOAT_EQ(67.6213, first_run[6])
+  EXPECT_FLOAT_EQ(66.696503, first_run[6])
     << "energy__: index 6";
 
-  EXPECT_FLOAT_EQ(1.36304, first_run[7])
+  EXPECT_FLOAT_EQ(1.3577, first_run[7])
     << "beta.1: index 7";
 
-  EXPECT_FLOAT_EQ(-0.86114103, first_run[8])
+  EXPECT_FLOAT_EQ(-0.511895, first_run[8])
     << "beta.2: index 8";
 
   matches_tagged_version = !HasNonfatalFailure();

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -114,7 +114,7 @@ TEST_F(performance, values_from_tagged_version) {
   EXPECT_FLOAT_EQ(0.91851199, first_run[1])
     << "accept_stat__: index 1";
 
-  EXPECT_FLOAT_EQ(0.76885599, first_run[2])
+  EXPECT_FLOAT_EQ(0.76885802, first_run[2])
     << "stepsize__: index 2";
 
   EXPECT_FLOAT_EQ(2, first_run[3])
@@ -132,7 +132,7 @@ TEST_F(performance, values_from_tagged_version) {
   EXPECT_FLOAT_EQ(1.3577, first_run[7])
     << "beta.1: index 7";
 
-  EXPECT_FLOAT_EQ(-0.511895, first_run[8])
+  EXPECT_FLOAT_EQ(-0.51189202, first_run[8])
     << "beta.2: index 8";
 
   matches_tagged_version = !HasNonfatalFailure();

--- a/src/test/performance/logistic_test.cpp
+++ b/src/test/performance/logistic_test.cpp
@@ -108,13 +108,13 @@ TEST_F(performance, values_from_tagged_version) {
     << "last tagged version, 2.17.0, had " << N_values << " elements";
 
   std::vector<double> first_run = last_draws_per_run[0];
-  EXPECT_FLOAT_EQ(-65.781998, first_run[0])
+  EXPECT_FLOAT_EQ(-66.222504, first_run[0])
     << "lp__: index 0";
 
   EXPECT_FLOAT_EQ(1.0, first_run[1])
     << "accept_stat__: index 1";
 
-  EXPECT_FLOAT_EQ(0.76853198, first_run[2])
+  EXPECT_FLOAT_EQ(1.00182, first_run[2])
     << "stepsize__: index 2";
 
   EXPECT_FLOAT_EQ(2, first_run[3])
@@ -126,13 +126,13 @@ TEST_F(performance, values_from_tagged_version) {
   EXPECT_FLOAT_EQ(0, first_run[5])
     << "divergent__: index 5";
 
-  EXPECT_FLOAT_EQ(66.6695, first_run[6])
+  EXPECT_FLOAT_EQ(67.6213, first_run[6])
     << "energy__: index 6";
 
-  EXPECT_FLOAT_EQ(1.55186, first_run[7])
+  EXPECT_FLOAT_EQ(1.36304, first_run[7])
     << "beta.1: index 7";
 
-  EXPECT_FLOAT_EQ(-0.52400702, first_run[8])
+  EXPECT_FLOAT_EQ(-0.86114103, first_run[8])
     << "beta.2: index 8";
 
   matches_tagged_version = !HasNonfatalFailure();

--- a/src/test/unit/mcmc/hmc/mock_hmc.hpp
+++ b/src/test/unit/mcmc/hmc/mock_hmc.hpp
@@ -64,7 +64,7 @@ namespace stan {
 
       // Ensures that NUTS non-termination criterion is always true
       Eigen::VectorXd dtau_dp(ps_point& z) {
-        return Eigen::VectorXd::Ones(this->model_.num_params_r());
+        return z.q;
       }
 
       Eigen::VectorXd dphi_dq(ps_point& z,

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -149,9 +149,12 @@ TEST(McmcNutsBaseNuts, build_tree_test) {
 
   stan::mcmc::ps_point z_propose(model_size);
 
-  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(model_size);
-  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_begin = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_sharp_begin = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_end = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_sharp_end = Eigen::VectorXd::Zero(model_size);
   Eigen::VectorXd rho = z_init.p;
+  
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
@@ -170,15 +173,18 @@ TEST(McmcNutsBaseNuts, build_tree_test) {
   stan::callbacks::stream_logger logger(debug, info, warn, error, fatal);
 
   bool valid_subtree = sampler.build_tree(3, z_propose,
-                                          p_sharp_left, p_sharp_right, rho,
+                                          p_sharp_begin, p_sharp_end, 
+                                          rho, p_begin, p_end,
                                           H0, 1, n_leapfrog, log_sum_weight,
                                           sum_metro_prob, logger);
 
   EXPECT_TRUE(valid_subtree);
 
   EXPECT_EQ(init_momentum * (n_leapfrog + 1), rho(0));
-  EXPECT_EQ(1, p_sharp_left(0));
-  EXPECT_EQ(1, p_sharp_right(0));
+  EXPECT_EQ(1.5, p_begin(0));
+  EXPECT_EQ(1, p_sharp_begin(0));
+  EXPECT_EQ(1.5, p_end(0));
+  EXPECT_EQ(1, p_sharp_end(0));
 
   EXPECT_EQ(8 * init_momentum, sampler.z().q(0));
   EXPECT_EQ(init_momentum, sampler.z().p(0));
@@ -207,9 +213,12 @@ TEST(McmcNutsBaseNuts, rho_aggregation_test) {
 
   stan::mcmc::ps_point z_propose(model_size);
 
-  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(model_size);
-  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_begin = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_sharp_begin = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_end = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_sharp_end = Eigen::VectorXd::Zero(model_size);
   Eigen::VectorXd rho = z_init.p;
+  
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
@@ -228,18 +237,19 @@ TEST(McmcNutsBaseNuts, rho_aggregation_test) {
   stan::callbacks::stream_logger logger(debug, info, warn, error, fatal);
 
   sampler.build_tree(3, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, 1, n_leapfrog, log_sum_weight,
                      sum_metro_prob, logger);
 
-  EXPECT_EQ(7, sampler.rho_values.size());
+  EXPECT_EQ(7 * 3, sampler.rho_values.size());
   EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(0));
   EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(1));
-  EXPECT_EQ(4 * init_momentum, sampler.rho_values.at(2));
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(2));
   EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(3));
   EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(4));
-  EXPECT_EQ(4 * init_momentum, sampler.rho_values.at(5));
-  EXPECT_EQ(8 * init_momentum, sampler.rho_values.at(6));
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(5));
+  EXPECT_EQ(4 * init_momentum, sampler.rho_values.at(6));
 }
 
 TEST(McmcNutsBaseNuts, divergence_test) {
@@ -255,9 +265,12 @@ TEST(McmcNutsBaseNuts, divergence_test) {
 
   stan::mcmc::ps_point z_propose(model_size);
 
-  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(model_size);
-  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_begin = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_sharp_begin = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_end = Eigen::VectorXd::Zero(model_size);
+  Eigen::VectorXd p_sharp_end = Eigen::VectorXd::Zero(model_size);
   Eigen::VectorXd rho = z_init.p;
+  
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
@@ -279,7 +292,8 @@ TEST(McmcNutsBaseNuts, divergence_test) {
 
   sampler.z().V = -750;
   valid_subtree = sampler.build_tree(0, z_propose,
-                                     p_sharp_left, p_sharp_right, rho,
+                                     p_sharp_begin, p_sharp_end, 
+                                     rho, p_begin, p_end,
                                      H0, 1, n_leapfrog, log_sum_weight,
                                      sum_metro_prob,
                                      logger);
@@ -288,7 +302,8 @@ TEST(McmcNutsBaseNuts, divergence_test) {
 
   sampler.z().V = -250;
   valid_subtree = sampler.build_tree(0, z_propose,
-                                     p_sharp_left, p_sharp_right, rho,
+                                     p_sharp_begin, p_sharp_end, 
+                                     rho, p_begin, p_end,
                                      H0, 1, n_leapfrog, log_sum_weight,
                                      sum_metro_prob,
                                      logger);
@@ -298,7 +313,8 @@ TEST(McmcNutsBaseNuts, divergence_test) {
 
   sampler.z().V = 750;
   valid_subtree = sampler.build_tree(0, z_propose,
-                                     p_sharp_left, p_sharp_right, rho,
+                                     p_sharp_begin, p_sharp_end, 
+                                     rho, p_begin, p_end,
                                      H0, 1, n_leapfrog, log_sum_weight,
                                      sum_metro_prob,
                                      logger);

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -244,12 +244,32 @@ TEST(McmcNutsBaseNuts, rho_aggregation_test) {
 
   EXPECT_EQ(7 * 3, sampler.rho_values.size());
   
-  std::vector<double> rho_scales = {2, 2, 2, 2, 2, 2, 4, 3, 3, 2, 2,
-                                    2, 2, 2, 2, 4, 3, 3, 8, 5, 5};
+  // Trajectory component spanning rhos
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[0]);
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[3]);
+  EXPECT_EQ(4 * init_momentum, sampler.rho_values[6]);
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[9]);
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[12]);
+  EXPECT_EQ(4 * init_momentum, sampler.rho_values[15]);
+  EXPECT_EQ(8 * init_momentum, sampler.rho_values[18]);
   
-  for (int n = 0; n < 21; ++n) {
-     EXPECT_EQ(rho_scales[n] * init_momentum, sampler.rho_values[n]);
-  }
+  // Cross trajectory component rhos
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[1]);
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[4]);
+  EXPECT_EQ(3 * init_momentum, sampler.rho_values[7]);
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[10]);
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[13]);
+  EXPECT_EQ(3 * init_momentum, sampler.rho_values[16]);
+  EXPECT_EQ(5 * init_momentum, sampler.rho_values[19]);
+
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[2]);
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[5]);
+  EXPECT_EQ(3 * init_momentum, sampler.rho_values[8]);
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[11]);
+  EXPECT_EQ(2 * init_momentum, sampler.rho_values[14]);
+  EXPECT_EQ(3 * init_momentum, sampler.rho_values[17]);
+  EXPECT_EQ(5 * init_momentum, sampler.rho_values[20]);
+  
 }
 
 TEST(McmcNutsBaseNuts, divergence_test) {

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -243,13 +243,13 @@ TEST(McmcNutsBaseNuts, rho_aggregation_test) {
                      sum_metro_prob, logger);
 
   EXPECT_EQ(7 * 3, sampler.rho_values.size());
-  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(0));
-  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(1));
-  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(2));
-  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(3));
-  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(4));
-  EXPECT_EQ(2 * init_momentum, sampler.rho_values.at(5));
-  EXPECT_EQ(4 * init_momentum, sampler.rho_values.at(6));
+  
+  std::vector<double> rho_scales = {2, 2, 2, 2, 2, 2, 4, 3, 3, 2, 2,
+                                    2, 2, 2, 2, 4, 3, 3, 8, 5, 5};
+  
+  for (int n = 0; n < 21; ++n) {
+     EXPECT_EQ(rho_scales[n] * init_momentum, sampler.rho_values[n]);
+  }
 }
 
 TEST(McmcNutsBaseNuts, divergence_test) {

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -20,13 +20,18 @@ namespace stan {
       mock_nuts(const mock_model &m, rng_t& rng)
         : base_nuts<mock_model,mock_hamiltonian,mock_integrator,rng_t>(m, rng)
       { }
+                                        
+      bool compute_criterion(Eigen::VectorXd& p_sharp_minus,
+                             Eigen::VectorXd& p_sharp_plus,
+                             Eigen::VectorXd& rho) {
+        return true;
+      }
     };
 
     class rho_inspector_mock_nuts: public base_nuts<mock_model,
                                                     mock_hamiltonian,
                                                     mock_integrator,
                                                     rng_t> {
-
     public:
       std::vector<double> rho_values;
       rho_inspector_mock_nuts(const mock_model &m, rng_t& rng)
@@ -40,6 +45,26 @@ namespace stan {
         return true;
       }
     };
+
+    class edge_inspector_mock_nuts: public base_nuts<mock_model,
+                                                     mock_hamiltonian,
+                                                     mock_integrator,
+                                                     rng_t> {
+    public:
+      std::vector<double> p_sharp_minus_values;
+      std::vector<double> p_sharp_plus_values;
+      edge_inspector_mock_nuts(const mock_model &m, rng_t& rng)
+        : base_nuts<mock_model,mock_hamiltonian,mock_integrator,rng_t>(m, rng)
+    { }
+    
+    bool compute_criterion(Eigen::VectorXd& p_sharp_minus,
+                           Eigen::VectorXd& p_sharp_plus,
+                           Eigen::VectorXd& rho) {
+      p_sharp_minus_values.push_back(p_sharp_minus(0));
+      p_sharp_plus_values.push_back(p_sharp_plus(0));
+      return true;
+    }
+  };
 
     // Mock Hamiltonian
     template <typename M, typename BaseRNG>
@@ -182,9 +207,9 @@ TEST(McmcNutsBaseNuts, build_tree_test) {
 
   EXPECT_EQ(init_momentum * (n_leapfrog + 1), rho(0));
   EXPECT_EQ(1.5, p_begin(0));
-  EXPECT_EQ(1, p_sharp_begin(0));
+  EXPECT_EQ(1.5, p_sharp_begin(0));
   EXPECT_EQ(1.5, p_end(0));
-  EXPECT_EQ(1, p_sharp_end(0));
+  EXPECT_EQ(12, p_sharp_end(0));
 
   EXPECT_EQ(8 * init_momentum, sampler.z().q(0));
   EXPECT_EQ(init_momentum, sampler.z().p(0));
@@ -388,4 +413,71 @@ TEST(McmcNutsBaseNuts, transition) {
   EXPECT_EQ("", warn.str());
   EXPECT_EQ("", error.str());
   EXPECT_EQ("", fatal.str());
+}
+
+TEST(McmcNutsBaseNuts, transition_egde_momenta) {
+  
+  rng_t base_rng(0);
+  
+  int model_size = 1;
+  double init_momentum = 1.5;
+  
+  stan::mcmc::ps_point z_init(model_size);
+  z_init.q(0) = 0;
+  z_init.p(0) = init_momentum;
+  
+  stan::mcmc::mock_model model(model_size);
+  stan::mcmc::edge_inspector_mock_nuts sampler(model, base_rng);
+  
+  sampler.set_max_depth(2);
+  
+  sampler.set_nominal_stepsize(1);
+  sampler.set_stepsize_jitter(0);
+  sampler.sample_stepsize();
+  sampler.z() = z_init;
+  
+  std::stringstream debug, info, warn, error, fatal;
+  stan::callbacks::stream_logger logger(debug, info, warn, error, fatal);
+  
+  stan::mcmc::sample init_sample(z_init.q, 0, 0);
+  
+  // Transition will expand trajectory until max_depth is hit
+  stan::mcmc::sample s = sampler.transition(init_sample, logger);
+  
+  EXPECT_EQ(2, sampler.depth_);
+  EXPECT_EQ((2 << (sampler.get_max_depth() - 1)) - 1, sampler.n_leapfrog_);
+  EXPECT_FALSE(sampler.divergent_);
+  
+  
+  EXPECT_EQ(9, sampler.p_sharp_minus_values.size());
+
+  // Depth 0 Transition Check
+  EXPECT_EQ(0, sampler.p_sharp_minus_values[0]);
+  EXPECT_EQ(init_momentum, sampler.p_sharp_plus_values[0]);
+
+  EXPECT_EQ(0, sampler.p_sharp_minus_values[1]);
+  EXPECT_EQ(init_momentum, sampler.p_sharp_plus_values[1]);
+  
+  EXPECT_EQ(0, sampler.p_sharp_minus_values[2]);
+  EXPECT_EQ(init_momentum, sampler.p_sharp_plus_values[2]);
+  
+  // Depth 1 Build Tree Check
+  EXPECT_EQ(2 * init_momentum, sampler.p_sharp_minus_values[3]);
+  EXPECT_EQ(3 * init_momentum, sampler.p_sharp_plus_values[3]);
+  
+  EXPECT_EQ(2 * init_momentum, sampler.p_sharp_minus_values[4]);
+  EXPECT_EQ(3 * init_momentum, sampler.p_sharp_plus_values[4]);
+  
+  EXPECT_EQ(2 * init_momentum, sampler.p_sharp_minus_values[5]);
+  EXPECT_EQ(3 * init_momentum, sampler.p_sharp_plus_values[5]);
+  
+  // Depth 1 Transition Check
+  EXPECT_EQ(0, sampler.p_sharp_minus_values[6]);
+  EXPECT_EQ(3 * init_momentum, sampler.p_sharp_plus_values[6]);
+  
+  EXPECT_EQ(0, sampler.p_sharp_minus_values[7]);
+  EXPECT_EQ(2 * init_momentum, sampler.p_sharp_plus_values[7]);
+  
+  EXPECT_EQ(init_momentum, sampler.p_sharp_minus_values[8]);
+  EXPECT_EQ(3 * init_momentum, sampler.p_sharp_plus_values[8]);
 }

--- a/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
@@ -38,9 +38,12 @@ TEST(McmcSoftAbsNuts, build_tree_test) {
 
   stan::mcmc::ps_point z_propose = z_init;
 
-  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(z_init.p.size());
-  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_begin = Eigen::VectorXd::Zero(3);
+  Eigen::VectorXd p_sharp_begin = Eigen::VectorXd::Zero(3);
+  Eigen::VectorXd p_end = Eigen::VectorXd::Zero(3);
+  Eigen::VectorXd p_sharp_end = Eigen::VectorXd::Zero(3);
   Eigen::VectorXd rho = z_init.p;
+  
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
@@ -48,7 +51,8 @@ TEST(McmcSoftAbsNuts, build_tree_test) {
   double sum_metro_prob = 0;
 
   bool valid_subtree = sampler.build_tree(3, z_propose,
-                                          p_sharp_left, p_sharp_right, rho,
+                                          p_sharp_begin, p_sharp_end, 
+                                          rho, p_begin, p_end,
                                           H0, 1, n_leapfrog, log_sum_weight,
                                           sum_metro_prob, logger);
 
@@ -59,6 +63,22 @@ TEST(McmcSoftAbsNuts, build_tree_test) {
   EXPECT_FLOAT_EQ(-11.679803, rho(0));
   EXPECT_FLOAT_EQ(11.679803, rho(1));
   EXPECT_FLOAT_EQ(-11.679803, rho(2));
+
+  EXPECT_FLOAT_EQ(-1.0960016, p_begin(0));
+  EXPECT_FLOAT_EQ(1.0960016, p_begin(1));
+  EXPECT_FLOAT_EQ(-1.0960016, p_begin(2));
+  
+  EXPECT_FLOAT_EQ(-0.83470845, p_sharp_begin(0));
+  EXPECT_FLOAT_EQ(0.83470845, p_sharp_begin(1));
+  EXPECT_FLOAT_EQ(-0.83470845, p_sharp_begin(2));
+  
+  EXPECT_FLOAT_EQ(-1.5019561, p_end(0));
+  EXPECT_FLOAT_EQ(1.5019561, p_end(1));
+  EXPECT_FLOAT_EQ(-1.5019561, p_end(2));
+  
+  EXPECT_FLOAT_EQ(-1.143881, p_sharp_end(0));
+  EXPECT_FLOAT_EQ(1.143881, p_sharp_end(1));
+  EXPECT_FLOAT_EQ(-1.143881, p_sharp_end(2));
 
   EXPECT_FLOAT_EQ(0.20423166, sampler.z().q(0));
   EXPECT_FLOAT_EQ(-0.20423166, sampler.z().q(1));
@@ -110,38 +130,46 @@ TEST(McmcSoftAbsNuts, tree_boundary_test) {
   metric.init(z_test, logger);
 
   softabs_integrator.evolve(z_test, metric, epsilon, logger);
+  Eigen::VectorXd p_forward_1 = z_test.p;
   Eigen::VectorXd p_sharp_forward_1 = metric.dtau_dp(z_test);
 
   softabs_integrator.evolve(z_test, metric, epsilon, logger);
+  Eigen::VectorXd p_forward_2 = z_test.p;
   Eigen::VectorXd p_sharp_forward_2 = metric.dtau_dp(z_test);
 
   softabs_integrator.evolve(z_test, metric, epsilon, logger);
   softabs_integrator.evolve(z_test, metric, epsilon, logger);
+  Eigen::VectorXd p_forward_3 = z_test.p;
   Eigen::VectorXd p_sharp_forward_3 = metric.dtau_dp(z_test);
 
   softabs_integrator.evolve(z_test, metric, epsilon, logger);
   softabs_integrator.evolve(z_test, metric, epsilon, logger);
   softabs_integrator.evolve(z_test, metric, epsilon, logger);
   softabs_integrator.evolve(z_test, metric, epsilon, logger);
+  Eigen::VectorXd p_forward_4 = z_test.p;
   Eigen::VectorXd p_sharp_forward_4 = metric.dtau_dp(z_test);
 
   z_test = z_init;
   metric.init(z_test, logger);
 
   softabs_integrator.evolve(z_test, metric, -epsilon, logger);
+  Eigen::VectorXd p_backward_1 = z_test.p;
   Eigen::VectorXd p_sharp_backward_1 = metric.dtau_dp(z_test);
 
   softabs_integrator.evolve(z_test, metric, -epsilon, logger);
+  Eigen::VectorXd p_backward_2 = z_test.p;
   Eigen::VectorXd p_sharp_backward_2 = metric.dtau_dp(z_test);
 
   softabs_integrator.evolve(z_test, metric, -epsilon, logger);
   softabs_integrator.evolve(z_test, metric, -epsilon, logger);
+  Eigen::VectorXd p_backward_3 = z_test.p;
   Eigen::VectorXd p_sharp_backward_3 = metric.dtau_dp(z_test);
 
   softabs_integrator.evolve(z_test, metric, -epsilon, logger);
   softabs_integrator.evolve(z_test, metric, -epsilon, logger);
   softabs_integrator.evolve(z_test, metric, -epsilon, logger);
   softabs_integrator.evolve(z_test, metric, -epsilon, logger);
+  Eigen::VectorXd p_backward_4 = z_test.p;
   Eigen::VectorXd p_sharp_backward_4 = metric.dtau_dp(z_test);
 
   // Check expected tree boundaries to those dynamically geneated by NUTS
@@ -153,9 +181,12 @@ TEST(McmcSoftAbsNuts, tree_boundary_test) {
 
   stan::mcmc::ps_point z_propose = z_init;
 
-  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(z_init.p.size());
-  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_begin = Eigen::VectorXd::Zero(3);
+  Eigen::VectorXd p_sharp_begin = Eigen::VectorXd::Zero(3);
+  Eigen::VectorXd p_end = Eigen::VectorXd::Zero(3);
+  Eigen::VectorXd p_sharp_end = Eigen::VectorXd::Zero(3);
   Eigen::VectorXd rho = z_init.p;
+  
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
@@ -166,121 +197,145 @@ TEST(McmcSoftAbsNuts, tree_boundary_test) {
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(0, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, 1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_forward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_forward_1(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_end(n));
+  }
 
   // Depth 1 forward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(1, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, 1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_2(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_forward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_forward_2(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_2(n), p_sharp_end(n));
+  }
 
   // Depth 2 forward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(2, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, 1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_3(n), p_sharp_right(n));
-
+  for (int n = 0; n < rho.size(); ++n) {
+   EXPECT_FLOAT_EQ(p_forward_1(n), p_begin(n));
+   EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_begin(n));
+   
+   EXPECT_FLOAT_EQ(p_forward_3(n), p_end(n));
+   EXPECT_FLOAT_EQ(p_sharp_forward_3(n), p_sharp_end(n));
+  }
+  
   // Depth 3 forward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(3, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, 1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_forward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_begin(n));
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_4(n), p_sharp_right(n));
+    EXPECT_FLOAT_EQ(p_forward_4(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_4(n), p_sharp_end(n));
+  }
 
   // Depth 0 backward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(0, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, -1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_backward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_backward_1(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_end(n));
+  }
 
   // Depth 1 backward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(1, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, -1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_2(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_backward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_backward_2(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_2(n), p_sharp_end(n));
+  }
 
   // Depth 2 backward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(2, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, -1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_3(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_backward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_backward_3(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_3(n), p_sharp_end(n));
+  }
 
   // Depth 3 backward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(3, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, -1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_4(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_backward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_backward_4(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_4(n), p_sharp_end(n));
+  }
 }
 
 TEST(McmcSoftAbsNuts, transition_test) {

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -38,9 +38,12 @@ TEST(McmcUnitENuts, build_tree_test) {
 
   stan::mcmc::ps_point z_propose = z_init;
 
-  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(z_init.p.size());
-  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_begin = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_sharp_begin = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_end = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_sharp_end = Eigen::VectorXd::Zero(z_init.p.size());
   Eigen::VectorXd rho = z_init.p;
+  
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
@@ -48,7 +51,8 @@ TEST(McmcUnitENuts, build_tree_test) {
   double sum_metro_prob = 0;
 
   bool valid_subtree = sampler.build_tree(3, z_propose,
-                                          p_sharp_left, p_sharp_right, rho,
+                                          p_sharp_begin, p_sharp_end, 
+                                          rho, p_begin, p_end,
                                           H0, 1, n_leapfrog, log_sum_weight,
                                           sum_metro_prob,
                                           logger);
@@ -60,6 +64,22 @@ TEST(McmcUnitENuts, build_tree_test) {
   EXPECT_FLOAT_EQ(-11.401228, rho(0));
   EXPECT_FLOAT_EQ(11.401228, rho(1));
   EXPECT_FLOAT_EQ(-11.401228, rho(2));
+  
+  EXPECT_FLOAT_EQ(-1.09475, p_begin(0));
+  EXPECT_FLOAT_EQ(1.09475, p_begin(1));
+  EXPECT_FLOAT_EQ(-1.09475, p_begin(2));
+  
+  EXPECT_FLOAT_EQ(-1.09475, p_sharp_begin(0));
+  EXPECT_FLOAT_EQ(1.09475, p_sharp_begin(1));
+  EXPECT_FLOAT_EQ(-1.09475, p_sharp_begin(2));
+  
+  EXPECT_FLOAT_EQ(-1.4131583, p_end(0));
+  EXPECT_FLOAT_EQ(1.4131583, p_end(1));
+  EXPECT_FLOAT_EQ(-1.4131583, p_end(2));
+  
+  EXPECT_FLOAT_EQ(-1.4131583, p_sharp_end(0));
+  EXPECT_FLOAT_EQ(1.4131583, p_sharp_end(1));
+  EXPECT_FLOAT_EQ(-1.4131583, p_sharp_end(2));
 
   EXPECT_FLOAT_EQ(-0.022019938, sampler.z().q(0));
   EXPECT_FLOAT_EQ(0.022019938, sampler.z().q(1));
@@ -111,38 +131,46 @@ TEST(McmcUnitENuts, tree_boundary_test) {
   metric.init(z_test, logger);
 
   unit_e_integrator.evolve(z_test, metric, epsilon, logger);
+    Eigen::VectorXd p_forward_1 = z_test.p;
   Eigen::VectorXd p_sharp_forward_1 = metric.dtau_dp(z_test);
 
   unit_e_integrator.evolve(z_test, metric, epsilon, logger);
+  Eigen::VectorXd p_forward_2 = z_test.p;
   Eigen::VectorXd p_sharp_forward_2 = metric.dtau_dp(z_test);
 
   unit_e_integrator.evolve(z_test, metric, epsilon, logger);
   unit_e_integrator.evolve(z_test, metric, epsilon, logger);
+  Eigen::VectorXd p_forward_3 = z_test.p;
   Eigen::VectorXd p_sharp_forward_3 = metric.dtau_dp(z_test);
 
   unit_e_integrator.evolve(z_test, metric, epsilon, logger);
   unit_e_integrator.evolve(z_test, metric, epsilon, logger);
   unit_e_integrator.evolve(z_test, metric, epsilon, logger);
   unit_e_integrator.evolve(z_test, metric, epsilon, logger);
+  Eigen::VectorXd p_forward_4 = z_test.p;
   Eigen::VectorXd p_sharp_forward_4 = metric.dtau_dp(z_test);
 
   z_test = z_init;
   metric.init(z_test, logger);
 
   unit_e_integrator.evolve(z_test, metric, -epsilon, logger);
+  Eigen::VectorXd p_backward_1 = z_test.p;
   Eigen::VectorXd p_sharp_backward_1 = metric.dtau_dp(z_test);
 
   unit_e_integrator.evolve(z_test, metric, -epsilon, logger);
+  Eigen::VectorXd p_backward_2 = z_test.p;
   Eigen::VectorXd p_sharp_backward_2 = metric.dtau_dp(z_test);
 
   unit_e_integrator.evolve(z_test, metric, -epsilon, logger);
   unit_e_integrator.evolve(z_test, metric, -epsilon, logger);
+  Eigen::VectorXd p_backward_3 = z_test.p;
   Eigen::VectorXd p_sharp_backward_3 = metric.dtau_dp(z_test);
 
   unit_e_integrator.evolve(z_test, metric, -epsilon, logger);
   unit_e_integrator.evolve(z_test, metric, -epsilon, logger);
   unit_e_integrator.evolve(z_test, metric, -epsilon, logger);
   unit_e_integrator.evolve(z_test, metric, -epsilon, logger);
+  Eigen::VectorXd p_backward_4 = z_test.p;
   Eigen::VectorXd p_sharp_backward_4 = metric.dtau_dp(z_test);
 
   // Check expected tree boundaries to those dynamically geneated by NUTS
@@ -154,9 +182,12 @@ TEST(McmcUnitENuts, tree_boundary_test) {
 
   stan::mcmc::ps_point z_propose = z_init;
 
-  Eigen::VectorXd p_sharp_left = Eigen::VectorXd::Zero(z_init.p.size());
-  Eigen::VectorXd p_sharp_right = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_begin = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_sharp_begin = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_end = Eigen::VectorXd::Zero(z_init.p.size());
+  Eigen::VectorXd p_sharp_end = Eigen::VectorXd::Zero(z_init.p.size());
   Eigen::VectorXd rho = z_init.p;
+  
   double log_sum_weight = -std::numeric_limits<double>::infinity();
 
   double H0 = -0.1;
@@ -167,121 +198,146 @@ TEST(McmcUnitENuts, tree_boundary_test) {
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(0, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, 1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_right(n));
-
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_forward_1(n), p_begin(n)); 
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_begin(n));
+   
+    EXPECT_FLOAT_EQ(p_forward_1(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_end(n));
+  }
+                     
   // Depth 1 forward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(1, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, 1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_2(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_forward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_forward_2(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_2(n), p_sharp_end(n));
+  }
 
   // Depth 2 forward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(2, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, 1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_3(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_forward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_forward_3(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_3(n), p_sharp_end(n));
+  }
 
   // Depth 3 forward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(3, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, 1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_forward_4(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_forward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_forward_4(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_forward_4(n), p_sharp_end(n));
+  }
 
   // Depth 0 backward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(0, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, -1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_backward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_backward_1(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_end(n));
+  }
 
   // Depth 1 backward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(1, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, -1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_2(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_backward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_backward_2(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_2(n), p_sharp_end(n));
+  }
 
   // Depth 2 backward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(2, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, -1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
-
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_3(n), p_sharp_right(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_backward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_backward_3(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_3(n), p_sharp_end(n));
+  }
 
   // Depth 3 backward
   sampler.z() = z_init;
   sampler.init_hamiltonian(logger);
   sampler.build_tree(3, z_propose,
-                     p_sharp_left, p_sharp_right, rho,
+                     p_sharp_begin, p_sharp_end, 
+                     rho, p_begin, p_end,
                      H0, -1, n_leapfrog, log_sum_weight,
                      sum_metro_prob,
                      logger);
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_left(n));
+  for (int n = 0; n < rho.size(); ++n) {
+    EXPECT_FLOAT_EQ(p_backward_1(n), p_begin(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_1(n), p_sharp_begin(n));
+    
+    EXPECT_FLOAT_EQ(p_backward_4(n), p_end(n));
+    EXPECT_FLOAT_EQ(p_sharp_backward_4(n), p_sharp_end(n));
+  }
 
-  for (int n = 0; n < rho.size(); ++n)
-    EXPECT_FLOAT_EQ(p_sharp_backward_4(n), p_sharp_right(n));
 }
 
 TEST(McmcUnitENuts, transition_test) {


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py src/test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary

Resolves #2799.

#### Intended Effect

Adds additional no-u-turn checks across subtrees to avoid missing u-turns for approximately iid normal models. 

#### How to Verify

See https://discourse.mc-stan.org/t/nuts-misses-u-turns-runs-in-circles-until-max-treedepth/9727/36?u=betanalpha.

#### Side Effects

Decrease in antithetic behavior for component means in correlated models.

#### Documentation

Inline.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Michael Betancourt

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)