### PR TITLE
[WIP] Refactor IO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,9 @@ stan.kdev4
 
 #clang-tidy fixes yaml
 .clang-fixes.log
+
+# Visual Studio Settings
+.vscode/*
+
+# clangd compiler database
+compile_commands.json

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ include make/cpplint                      # cpplint
 include make/tests                        # tests
 include make/clang-tidy
 
-INC_FIRST = -I $(if $(STAN),$(STAN)/src,src)
+INC_FIRST = -I $(if $(STAN),$(STAN)/src,src) -I ./src/
 LDLIBS_STANC ?= -Ltest -lstanc
 
 

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -12,6 +12,8 @@
 #include <utility>
 #include <numeric>
 #include <unordered_map>
+#include <functional>
+#include <type_traits>
 
 namespace stan {
 

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -180,7 +180,7 @@ class array_var_context : public var_context {
                     const std::vector<std::string>& names_i,
                     const std::vector<int>& values_i,
                     const std::vector<std::vector<size_t>>& dim_i)
-      : vars_i_(names_i.size()), vars_r_(names_r.size()) {
+      : vars_r_(names_r.size()), vars_i_(names_i.size()) {
     add_i(names_i, values_i, dim_i);
     add_r(names_r, values_r, dim_r);
   }
@@ -191,7 +191,7 @@ class array_var_context : public var_context {
                     const std::vector<std::string>& names_i,
                     const std::vector<int>& values_i,
                     const std::vector<std::vector<size_t>>& dim_i)
-      : vars_i_(names_i.size()), vars_r_(names_r.size()) {
+      : vars_r_(names_r.size()), vars_i_(names_i.size()) {
     add_i(names_i, values_i, dim_i);
     add_r(names_r, values_r, dim_r);
   }

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -2,6 +2,7 @@
 #define STAN_IO_ARRAY_VAR_CONTEXT_HPP
 
 #include <stan/io/var_context.hpp>
+#include <stan/math/prim/meta.hpp>
 #include <boost/throw_exception.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <map>
@@ -9,18 +10,13 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <numeric>
+#include <unordered_map>
 
 namespace stan {
 
 namespace io {
 
-template <typename T>
-T product(std::vector<T> dims) {
-  T y = 1;
-  for (size_t i = 0; i < dims.size(); ++i)
-    y *= dims[i];
-  return y;
-}
 
 /**
  * An array_var_context object represents a named arrays
@@ -29,10 +25,15 @@ T product(std::vector<T> dims) {
  */
 class array_var_context : public var_context {
  private:
-  std::map<std::string, std::pair<std::vector<double>, std::vector<size_t> > >
-      vars_r_;
-  std::map<std::string, std::pair<std::vector<int>, std::vector<size_t> > >
-      vars_i_;
+  // Map holding reals
+  using pair_r_ = std::pair<std::vector<double>, std::vector<size_t>>;
+  using map_r_ = std::unordered_map<std::string, pair_r_>;
+  map_r_ vars_r_;
+  // Map holding integers
+  using pair_i_ =std::pair<std::vector<int>, std::vector<size_t>>;
+  using map_i_ = std::unordered_map<std::string, pair_i_>;
+  map_i_ vars_i_;
+  // When search for variable name fails, return one these
   std::vector<double> const empty_vec_r_;
   std::vector<int> const empty_vec_i_;
   std::vector<size_t> const empty_vec_ui_;
@@ -45,12 +46,16 @@ class array_var_context : public var_context {
    * Check (1) if the vector size of dimensions is no smaller
    * than the name vector size; (2) if the size of the input
    * array is large enough for what is needed.
+   * @param names The names for each variable
+   * @param array_size The total size of the vector holding the values we want to access.
+   * @param dims Vector holding the dimensions for each variable.
+   * @return If the array size is equal to the number of dimensions, 
+   * a vector of the total dimensions for each element in dims.
    */
   template <typename T>
-  void validate(const std::vector<std::string>& names, const T& array,
-                const std::vector<std::vector<size_t> >& dims) {
-    size_t total = 0;
-    size_t num_par = names.size();
+  std::vector<size_t> validate_dims(const std::vector<std::string>& names, const T array_size,
+                const std::vector<std::vector<size_t>>& dims) {
+    const size_t num_par = names.size();
     if (num_par > dims.size()) {
       std::stringstream msg;
       msg << "size of vector of dimensions (found " << dims.size() << ") "
@@ -58,62 +63,54 @@ class array_var_context : public var_context {
           << ").";
       BOOST_THROW_EXCEPTION(std::invalid_argument(msg.str()));
     }
-    for (size_t i = 0; i < num_par; i++)
-      total += stan::io::product(dims[i]);
-    size_t array_len = array.size();
-    if (total > array_len) {
+    std::vector<size_t> elem_dims_total(dims.size() + 1);
+    elem_dims_total[0] = 0;
+    std::transform(dims.begin(), dims.end(), elem_dims_total.begin() + 1, [](auto&& x) {
+      return std::accumulate(x.begin(), x.end(), 1, std::multiplies<T>());
+    });
+    auto total = std::accumulate(elem_dims_total.begin(), elem_dims_total.end(), 0);
+    if (total > array_size) {
       std::stringstream msg;
-      msg << "array is not long enough for all elements: " << array_len
+      msg << "array is not long enough for all elements: " << array_size
           << " is found, but " << total << " is needed.";
       BOOST_THROW_EXCEPTION(std::invalid_argument(msg.str()));
     }
+    return elem_dims_total;
   }
 
   void add_r(const std::vector<std::string>& names,
              const std::vector<double>& values,
-             const std::vector<std::vector<size_t> >& dims) {
-    validate(names, values, dims);
-    size_t start = 0;
-    size_t end = 0;
+             const std::vector<std::vector<size_t>>& dims) {
+    std::vector<size_t> dim_vec = validate_dims(names, values.size(), dims);
+    std::vector<size_t> end_vec(dim_vec.size());
+    std::partial_sum(dim_vec.begin(), dim_vec.end(), end_vec.begin());
     for (size_t i = 0; i < names.size(); i++) {
-      end += product(dims[i]);
-      std::vector<double> v(values.begin() + start, values.begin() + end);
-      vars_r_[names[i]]
-          = std::pair<std::vector<double>, std::vector<size_t> >(v, dims[i]);
-      start = end;
+      vars_r_[names[i]] = {{values.data() + end_vec[i],
+                            values.data() + end_vec[i + 1]}, dims[i]};
     }
   }
 
   void add_r(const std::vector<std::string>& names,
              const Eigen::VectorXd& values,
-             const std::vector<std::vector<size_t> >& dims) {
-    validate(names, values, dims);
-    size_t start = 0;
-    size_t end = 0;
+             const std::vector<std::vector<size_t>>& dims) {
+    std::vector<size_t> dim_vec = validate_dims(names, values.size(), dims);
+    std::vector<size_t> end_vec(dim_vec.size());
+    std::partial_sum(dim_vec.begin(), dim_vec.end(), end_vec.begin());
     for (size_t i = 0; i < names.size(); i++) {
-      end += product(dims[i]);
-      size_t v_len = end - start;
-      std::vector<double> v(v_len);
-      for (size_t i = 0; i < v_len; ++i)
-        v[i] = values(start + i);
-      vars_r_[names[i]]
-          = std::pair<std::vector<double>, std::vector<size_t> >(v, dims[i]);
-      start = end;
+      vars_r_[names[i]] = {{values.data() + end_vec[i],
+                            values.data() + end_vec[i + 1]}, dims[i]};
     }
   }
 
   void add_i(const std::vector<std::string>& names,
              const std::vector<int>& values,
-             const std::vector<std::vector<size_t> >& dims) {
-    validate(names, values, dims);
-    size_t start = 0;
-    size_t end = 0;
+             const std::vector<std::vector<size_t>>& dims) {
+    std::vector<size_t> dim_vec = validate_dims(names, values.size(), dims);
+    std::vector<size_t> end_vec(dim_vec.size());
+    std::partial_sum(dim_vec.begin(), dim_vec.end(), end_vec.begin());
     for (size_t i = 0; i < names.size(); i++) {
-      end += product(dims[i]);
-      std::vector<int> v(values.begin() + start, values.begin() + end);
-      vars_i_[names[i]]
-          = std::pair<std::vector<int>, std::vector<size_t> >(v, dims[i]);
-      start = end;
+      vars_i_[names[i]] = {{values.data() + end_vec[i],
+                            values.data() + end_vec[i + 1]}, dims[i]};
     }
   }
 
@@ -127,7 +124,7 @@ class array_var_context : public var_context {
    */
   array_var_context(const std::vector<std::string>& names_r,
                     const std::vector<double>& values_r,
-                    const std::vector<std::vector<size_t> >& dim_r) {
+                    const std::vector<std::vector<size_t>>& dim_r) {
     add_r(names_r, values_r, dim_r);
   }
 
@@ -140,7 +137,7 @@ class array_var_context : public var_context {
    */
   array_var_context(const std::vector<std::string>& names_r,
                     const Eigen::RowVectorXd& values_r,
-                    const std::vector<std::vector<size_t> >& dim_r) {
+                    const std::vector<std::vector<size_t>>& dim_r) {
     add_r(names_r, values_r, dim_r);
   }
 
@@ -153,7 +150,7 @@ class array_var_context : public var_context {
    */
   array_var_context(const std::vector<std::string>& names_i,
                     const std::vector<int>& values_i,
-                    const std::vector<std::vector<size_t> >& dim_i) {
+                    const std::vector<std::vector<size_t>>& dim_i) {
     add_i(names_i, values_i, dim_i);
   }
 
@@ -164,10 +161,10 @@ class array_var_context : public var_context {
    */
   array_var_context(const std::vector<std::string>& names_r,
                     const std::vector<double>& values_r,
-                    const std::vector<std::vector<size_t> >& dim_r,
+                    const std::vector<std::vector<size_t>>& dim_r,
                     const std::vector<std::string>& names_i,
                     const std::vector<int>& values_i,
-                    const std::vector<std::vector<size_t> >& dim_i) {
+                    const std::vector<std::vector<size_t>>& dim_i) {
     add_i(names_i, values_i, dim_i);
     add_r(names_r, values_r, dim_r);
   }
@@ -202,17 +199,14 @@ class array_var_context : public var_context {
    *
    * @param name Name of variable.
    * @return Values of variable.
+   *
    */
   std::vector<double> vals_r(const std::string& name) const {
     if (contains_r_only(name)) {
       return (vars_r_.find(name)->second).first;
     } else if (contains_i(name)) {
       std::vector<int> vec_int = (vars_i_.find(name)->second).first;
-      std::vector<double> vec_r(vec_int.size());
-      for (size_t ii = 0; ii < vec_int.size(); ii++) {
-        vec_r[ii] = vec_int[ii];
-      }
-      return vec_r;
+      return {vec_int.begin(), vec_int.end()};
     }
     return empty_vec_r_;
   }
@@ -268,13 +262,10 @@ class array_var_context : public var_context {
    * @param names Vector to store the list of names in.
    */
   virtual void names_r(std::vector<std::string>& names) const {
-    names.resize(0);
-    for (std::map<std::string, std::pair<std::vector<double>,
-                                         std::vector<size_t> > >::const_iterator
-             it
-         = vars_r_.begin();
-         it != vars_r_.end(); ++it)
-      names.push_back((*it).first);
+    names.clear();
+    for (auto& vars_r_iter : vars_r_) {
+      names.push_back(vars_r_iter.first);
+    }
   }
 
   /**
@@ -284,13 +275,10 @@ class array_var_context : public var_context {
    * @param names Vector to store the list of names in.
    */
   virtual void names_i(std::vector<std::string>& names) const {
-    names.resize(0);
-    for (std::map<std::string, std::pair<std::vector<int>,
-                                         std::vector<size_t> > >::const_iterator
-             it
-         = vars_i_.begin();
-         it != vars_i_.end(); ++it)
-      names.push_back((*it).first);
+    names.clear();
+    for (auto& vars_i_iter : vars_r_) {
+      names.push_back(vars_i_iter.first);
+    }
   }
 
   /**

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_IO_ARRAY_VAR_CONTEXT_HPP
 #define STAN_IO_ARRAY_VAR_CONTEXT_HPP
 
-#include <stan/math.hpp>
 #include <stan/io/var_context.hpp>
 #include <boost/throw_exception.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -270,7 +270,7 @@ class array_var_context : public var_context {
    */
   virtual void names_r(std::vector<std::string>& names) const {
     names.clear();
-    for (auto& vars_r_iter : vars_r_) {
+    for (const auto& vars_r_iter : vars_r_) {
       names.push_back(vars_r_iter.first);
     }
   }
@@ -283,7 +283,7 @@ class array_var_context : public var_context {
    */
   virtual void names_i(std::vector<std::string>& names) const {
     names.clear();
-    for (auto& vars_i_iter : vars_r_) {
+    for (const auto& vars_i_iter : vars_r_) {
       names.push_back(vars_i_iter.first);
     }
   }

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -93,9 +93,11 @@ class array_var_context : public var_context {
              T&& values,
              const std::vector<std::vector<size_t>>& dims) {
     std::vector<size_t> dim_vec = validate_dims(names, values.size(), dims);
+    using val_d_t = decltype(values.data());
     for (size_t i = 0; i < names.size(); i++) {
-      vars_r_[names[i]] = {{std::forward<decltype(values.data())>(values.data()) + dim_vec[i],
-                            std::forward<decltype(values.data())>(values.data()) + dim_vec[i + 1]}, dims[i]};
+      vars_r_[names[i]] = {{std::forward<val_d_t>(values.data()) + dim_vec[i],
+                            std::forward<val_d_t>(values.data()) +
+                            dim_vec[i + 1]}, dims[i]};
     }
   }
 

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -1226,7 +1226,8 @@ class reader {
   }
 
   template <typename TL>
-  inline row_vector_t row_vector_lb_constrain(const TL lb, const size_t m, T &lp) {
+  inline row_vector_t row_vector_lb_constrain(const TL lb, const size_t m,
+                                              T &lp) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lb_constrain(lb, lp);
@@ -1243,7 +1244,8 @@ class reader {
   }
 
   template <typename TL>
-  inline matrix_t matrix_lb_constrain(const TL lb, const size_t m, const size_t n) {
+  inline matrix_t matrix_lb_constrain(const TL lb, const size_t m,
+                                      const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1252,7 +1254,8 @@ class reader {
   }
 
   template <typename TL>
-  inline matrix_t matrix_lb_constrain(const TL lb, const size_t m, const size_t n, T &lp) {
+  inline matrix_t matrix_lb_constrain(const TL lb, const size_t m,
+                                      const size_t n, T &lp) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1301,7 +1304,8 @@ class reader {
   }
 
   template <typename TU>
-  inline row_vector_t row_vector_ub_constrain(const TU ub, const size_t m, T &lp) {
+  inline row_vector_t row_vector_ub_constrain(const TU ub, const size_t m,
+                                              T &lp) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_ub_constrain(ub, lp);
@@ -1318,7 +1322,8 @@ class reader {
   }
 
   template <typename TU>
-  inline matrix_t matrix_ub_constrain(const TU ub, const size_t m, const size_t n) {
+  inline matrix_t matrix_ub_constrain(const TU ub, const size_t m,
+                                      const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1327,7 +1332,8 @@ class reader {
   }
 
   template <typename TU>
-  inline matrix_t matrix_ub_constrain(const TU ub, const size_t m, const size_t n, T &lp) {
+  inline matrix_t matrix_ub_constrain(const TU ub, const size_t m,
+                                      const size_t n, T &lp) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1344,7 +1350,8 @@ class reader {
   }
 
   template <typename TL, typename TU>
-  inline vector_t vector_lub_constrain(const TL lb, const TU ub, const size_t m) {
+  inline vector_t vector_lub_constrain(const TL lb, const TU ub,
+                                       const size_t m) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lub_constrain(lb, ub);
@@ -1386,7 +1393,8 @@ class reader {
   }
 
   template <typename TL, typename TU>
-  inline matrix_t matrix_lub(const TL lb, const TU ub, const size_t m, const size_t n) {
+  inline matrix_t matrix_lub(const TL lb, const TU ub, const size_t m,
+                             const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1406,7 +1414,7 @@ class reader {
 
   template <typename TL, typename TU>
   inline matrix_t matrix_lub_constrain(const TL lb, const TU ub, const size_t m,
-                                        const size_t n, T &lp) {
+                                       const size_t n, T &lp) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1484,7 +1492,8 @@ class reader {
   template <typename TL, typename TS>
   inline matrix_t matrix_offset_multiplier_constrain(const TL offset,
                                                      const TS multiplier,
-                                                     const size_t m, const size_t n) {
+                                                     const size_t m,
+                                                     const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1495,8 +1504,8 @@ class reader {
   template <typename TL, typename TS>
   inline matrix_t matrix_offset_multiplier_constrain(const TL offset,
                                                      const TS multiplier,
-                                                     const size_t m, const size_t n,
-                                                     T &lp) {
+                                                     const size_t m,
+                                                     const size_t n, T &lp) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -37,21 +37,21 @@ class reader {
  private:
   std::vector<T> &data_r_;
   std::vector<int> &data_i_;
-  size_t pos_;
-  size_t int_pos_;
+  size_t pos_{0};
+  size_t int_pos_{0};
 
-  inline T &scalar_ptr() { return data_r_.at(pos_); }
+  inline T &scalar_ptr() { return data_r_[pos_]; }
 
   inline T &scalar_ptr_increment(size_t m) {
     pos_ += m;
-    return data_r_.at(pos_ - m);
+    return data_r_[pos_ - m];
   }
 
-  inline int &int_ptr() { return data_i_.at(int_pos_); }
+  inline int &int_ptr() { return data_i_[int_pos_]; }
 
   inline int &int_ptr_increment(size_t m) {
     int_pos_ += m;
-    return data_i_.at(int_pos_ - m);
+    return data_i_[int_pos_ - m];
   }
 
  public:
@@ -75,7 +75,7 @@ class reader {
    * @param data_i Sequence of integer values.
    */
   reader(std::vector<T> &data_r, std::vector<int> &data_i)
-      : data_r_(data_r), data_i_(data_i), pos_(0), int_pos_(0) {}
+      : data_r_(data_r), data_i_(data_i) {}
 
   /**
    * Destroy this variable reader.
@@ -167,9 +167,9 @@ class reader {
   inline std::vector<T> std_vector(size_t m) {
     if (m == 0)
       return std::vector<T>();
-    std::vector<T> vec;
-    T &start = scalar_ptr_increment(m);
-    vec.insert(vec.begin(), &start, &scalar_ptr());
+    std::vector<T> vec(&this->data_r_[this->pos_],
+                       &this->data_r_[this->pos_ + m]);
+    this->pos_ += m;
     return vec;
   }
 
@@ -1186,7 +1186,7 @@ class reader {
   }
 
   template <typename TL>
-  inline vector_t vector_lb(const TL lb, size_t m) {
+  inline vector_t vector_lb(const TL lb, const size_t m) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lb(lb);
@@ -1194,7 +1194,7 @@ class reader {
   }
 
   template <typename TL>
-  inline vector_t vector_lb_constrain(const TL lb, size_t m) {
+  inline vector_t vector_lb_constrain(const TL lb, const size_t m) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lb_constrain(lb);
@@ -1202,7 +1202,7 @@ class reader {
   }
 
   template <typename TL>
-  inline vector_t vector_lb_constrain(const TL lb, size_t m, T &lp) {
+  inline vector_t vector_lb_constrain(const TL lb, const size_t m, T &lp) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lb_constrain(lb, lp);
@@ -1210,7 +1210,7 @@ class reader {
   }
 
   template <typename TL>
-  inline row_vector_t row_vector_lb(const TL lb, size_t m) {
+  inline row_vector_t row_vector_lb(const TL lb, const size_t m) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lb(lb);
@@ -1218,7 +1218,7 @@ class reader {
   }
 
   template <typename TL>
-  inline row_vector_t row_vector_lb_constrain(const TL lb, size_t m) {
+  inline row_vector_t row_vector_lb_constrain(const TL lb, const size_t m) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lb_constrain(lb);
@@ -1226,7 +1226,7 @@ class reader {
   }
 
   template <typename TL>
-  inline row_vector_t row_vector_lb_constrain(const TL lb, size_t m, T &lp) {
+  inline row_vector_t row_vector_lb_constrain(const TL lb, const size_t m, T &lp) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lb_constrain(lb, lp);
@@ -1234,7 +1234,7 @@ class reader {
   }
 
   template <typename TL>
-  inline matrix_t matrix_lb(const TL lb, size_t m, size_t n) {
+  inline matrix_t matrix_lb(const TL lb, const size_t m, const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1243,7 +1243,7 @@ class reader {
   }
 
   template <typename TL>
-  inline matrix_t matrix_lb_constrain(const TL lb, size_t m, size_t n) {
+  inline matrix_t matrix_lb_constrain(const TL lb, const size_t m, const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1252,7 +1252,7 @@ class reader {
   }
 
   template <typename TL>
-  inline matrix_t matrix_lb_constrain(const TL lb, size_t m, size_t n, T &lp) {
+  inline matrix_t matrix_lb_constrain(const TL lb, const size_t m, const size_t n, T &lp) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1261,7 +1261,7 @@ class reader {
   }
 
   template <typename TU>
-  inline vector_t vector_ub(const TU ub, size_t m) {
+  inline vector_t vector_ub(const TU ub, const size_t m) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_ub(ub);
@@ -1269,7 +1269,7 @@ class reader {
   }
 
   template <typename TU>
-  inline vector_t vector_ub_constrain(const TU ub, size_t m) {
+  inline vector_t vector_ub_constrain(const TU ub, const size_t m) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_ub_constrain(ub);
@@ -1277,7 +1277,7 @@ class reader {
   }
 
   template <typename TU>
-  inline vector_t vector_ub_constrain(const TU ub, size_t m, T &lp) {
+  inline vector_t vector_ub_constrain(const TU ub, const size_t m, T &lp) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_ub_constrain(ub, lp);
@@ -1285,7 +1285,7 @@ class reader {
   }
 
   template <typename TU>
-  inline row_vector_t row_vector_ub(const TU ub, size_t m) {
+  inline row_vector_t row_vector_ub(const TU ub, const size_t m) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_ub(ub);
@@ -1293,7 +1293,7 @@ class reader {
   }
 
   template <typename TU>
-  inline row_vector_t row_vector_ub_constrain(const TU ub, size_t m) {
+  inline row_vector_t row_vector_ub_constrain(const TU ub, const size_t m) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_ub_constrain(ub);
@@ -1301,7 +1301,7 @@ class reader {
   }
 
   template <typename TU>
-  inline row_vector_t row_vector_ub_constrain(const TU ub, size_t m, T &lp) {
+  inline row_vector_t row_vector_ub_constrain(const TU ub, const size_t m, T &lp) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_ub_constrain(ub, lp);
@@ -1309,7 +1309,7 @@ class reader {
   }
 
   template <typename TU>
-  inline matrix_t matrix_ub(const TU ub, size_t m, size_t n) {
+  inline matrix_t matrix_ub(const TU ub, size_t m, const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1318,7 +1318,7 @@ class reader {
   }
 
   template <typename TU>
-  inline matrix_t matrix_ub_constrain(const TU ub, size_t m, size_t n) {
+  inline matrix_t matrix_ub_constrain(const TU ub, const size_t m, const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1327,7 +1327,7 @@ class reader {
   }
 
   template <typename TU>
-  inline matrix_t matrix_ub_constrain(const TU ub, size_t m, size_t n, T &lp) {
+  inline matrix_t matrix_ub_constrain(const TU ub, const size_t m, const size_t n, T &lp) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1336,7 +1336,7 @@ class reader {
   }
 
   template <typename TL, typename TU>
-  inline vector_t vector_lub(const TL lb, const TU ub, size_t m) {
+  inline vector_t vector_lub(const TL lb, const TU ub, const size_t m) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lub(lb, ub);
@@ -1344,7 +1344,7 @@ class reader {
   }
 
   template <typename TL, typename TU>
-  inline vector_t vector_lub_constrain(const TL lb, const TU ub, size_t m) {
+  inline vector_t vector_lub_constrain(const TL lb, const TU ub, const size_t m) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lub_constrain(lb, ub);
@@ -1352,7 +1352,7 @@ class reader {
   }
 
   template <typename TL, typename TU>
-  inline vector_t vector_lub_constrain(const TL lb, const TU ub, size_t m,
+  inline vector_t vector_lub_constrain(const TL lb, const TU ub, const size_t m,
                                        T &lp) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
@@ -1361,7 +1361,7 @@ class reader {
   }
 
   template <typename TL, typename TU>
-  inline row_vector_t row_vector_lub(const TL lb, const TU ub, size_t m) {
+  inline row_vector_t row_vector_lub(const TL lb, const TU ub, const size_t m) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lub(lb, ub);
@@ -1369,7 +1369,7 @@ class reader {
   }
   template <typename TL, typename TU>
   inline row_vector_t row_vector_lub_constrain(const TL lb, const TU ub,
-                                               size_t m) {
+                                               const size_t m) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_lub_constrain(lb, ub);
@@ -1386,7 +1386,7 @@ class reader {
   }
 
   template <typename TL, typename TU>
-  inline matrix_t matrix_lub(const TL lb, const TU ub, size_t m, size_t n) {
+  inline matrix_t matrix_lub(const TL lb, const TU ub, const size_t m, const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1395,8 +1395,8 @@ class reader {
   }
 
   template <typename TL, typename TU>
-  inline matrix_t matrix_lub_constrain(const TL lb, const TU ub, size_t m,
-                                       size_t n) {
+  inline matrix_t matrix_lub_constrain(const TL lb, const TU ub, const size_t m,
+                                       const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1405,8 +1405,8 @@ class reader {
   }
 
   template <typename TL, typename TU>
-  inline matrix_t matrix_lub_constrain(const TL lb, const TU ub, size_t m,
-                                       size_t n, T &lp) {
+  inline matrix_t matrix_lub_constrain(const TL lb, const TU ub, const size_t m,
+                                        const size_t n, T &lp) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1416,7 +1416,7 @@ class reader {
 
   template <typename TL, typename TS>
   inline vector_t vector_offset_multiplier(const TL offset, const TS multiplier,
-                                           size_t m) {
+                                           const size_t m) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_offset_multiplier(offset, multiplier);
@@ -1426,7 +1426,7 @@ class reader {
   template <typename TL, typename TS>
   inline vector_t vector_offset_multiplier_constrain(const TL offset,
                                                      const TS multiplier,
-                                                     size_t m) {
+                                                     const size_t m) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_offset_multiplier_constrain(offset, multiplier);
@@ -1436,7 +1436,7 @@ class reader {
   template <typename TL, typename TS>
   inline vector_t vector_offset_multiplier_constrain(const TL offset,
                                                      const TS multiplier,
-                                                     size_t m, T &lp) {
+                                                     const size_t m, T &lp) {
     vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_offset_multiplier_constrain(offset, multiplier, lp);
@@ -1446,7 +1446,7 @@ class reader {
   template <typename TL, typename TS>
   inline row_vector_t row_vector_offset_multiplier(const TL offset,
                                                    const TS multiplier,
-                                                   size_t m) {
+                                                   const size_t m) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_offset_multiplier(offset, multiplier);
@@ -1455,7 +1455,7 @@ class reader {
 
   template <typename TL, typename TS>
   inline row_vector_t row_vector_offset_multiplier_constrain(
-      const TL offset, const TS multiplier, size_t m) {
+      const TL offset, const TS multiplier, const size_t m) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_offset_multiplier_constrain(offset, multiplier);
@@ -1464,7 +1464,7 @@ class reader {
 
   template <typename TL, typename TS>
   inline row_vector_t row_vector_offset_multiplier_constrain(
-      const TL offset, const TS multiplier, size_t m, T &lp) {
+      const TL offset, const TS multiplier, const size_t m, T &lp) {
     row_vector_t v(m);
     for (size_t i = 0; i < m; ++i)
       v(i) = scalar_offset_multiplier_constrain(offset, multiplier, lp);
@@ -1473,7 +1473,7 @@ class reader {
 
   template <typename TL, typename TS>
   inline matrix_t matrix_offset_multiplier(const TL offset, const TS multiplier,
-                                           size_t m, size_t n) {
+                                           const size_t m, const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1484,7 +1484,7 @@ class reader {
   template <typename TL, typename TS>
   inline matrix_t matrix_offset_multiplier_constrain(const TL offset,
                                                      const TS multiplier,
-                                                     size_t m, size_t n) {
+                                                     const size_t m, const size_t n) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)
       for (size_t i = 0; i < m; ++i)
@@ -1495,7 +1495,7 @@ class reader {
   template <typename TL, typename TS>
   inline matrix_t matrix_offset_multiplier_constrain(const TL offset,
                                                      const TS multiplier,
-                                                     size_t m, size_t n,
+                                                     const size_t m, const size_t n,
                                                      T &lp) {
     matrix_t v(m, n);
     for (size_t j = 0; j < n; ++j)


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is a refactor of the `array_var_context` and `reader` classes. This is built off of PR #2805 so it looks like there are a lot of changes rn but it's really just the files which hold these two classes. 

Changes include:

1. Previously in `add_r` and `add_i` we were calculating the inner dimensions of the `dim` vector twice. Once in `validate()` and again in the main loop of both functions. `validate` has been renamed to `validate_dims` and if `validate_dims` throws no errors it gives back a vector with the cumulative sum of the product of the dimensions for each vector inside of dims. This uses a few of the stl algorithms and a lambda so it may look a bit odd.

2. With (1) we can now clean up `add_r` and `add_i`'s loop. The body of the function now loops over names and dim_vec adding them to the table of values.

3. `using` is used rather liberally to clean up some of the loops and types.

4. `vars_*_` are now `unordered_maps` instead of `maps`. I made this change heuristically but would like to test a bit whether this is better. My assumption on this is that we tend to do access in this class more often then insertion and deletion.

5. We now use the braced initializer list style on insertion to the `vars_*_` maps along with perfect forwarding in the floating point vector case. This looks a little wonky but removes a good few temporaries.

```cpp
// tbh I'm really not sure if forwarding this is meaningful
vars_r_[name[i]] = {{std::forward<val_d_t>(values.data()) + dim_vec[i],
                                std::forward<val_d_t>(values.data()) + dim_vec[i + 1]}, dims[i]};
```

6. `vars_*_` are initialized in the constructor initialization list with a number of elements equal to the size of `names_*`. This should save a few reallocations and remove the bad side of unordered maps cost of new insertions at least during initialization.

7. Cleans up the loops so they use the range based style.

8. Made the arguments for the `for` loops in the accessors of `reader` const. This should help the compiler a little bit.

#### Intended Effect

I was trying to understand how some things worked here so did a bit of updating. This should also (hopefully) give us a teeny performance increase. Though I don't expect much

#### How to Verify

This just uses the tests that already existed but if we want to add any additional tests to the reader and array context then I'm happy to add them to this PR.

#### Side Effects

Hopefully none!

#### Documentation

Updating documentation for existing functions.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder
