### PR TITLE
Cleanup for window_adaption unsigned int inititalization to -1

### DIFF
--- a/src/stan/mcmc/windowed_adaptation.hpp
+++ b/src/stan/mcmc/windowed_adaptation.hpp
@@ -11,24 +11,19 @@ namespace mcmc {
 
 class windowed_adaptation : public base_adaptation {
  public:
-  explicit windowed_adaptation(std::string name) : estimator_name_(name) {
-    num_warmup_ = 0;
-    adapt_init_buffer_ = 0;
-    adapt_term_buffer_ = 0;
-    adapt_base_window_ = 0;
+  explicit windowed_adaptation(std::string name) : estimator_name_(name) {}
 
-    restart();
-  }
-
-  void restart() {
+  inline void restart() {
     adapt_window_counter_ = 0;
     adapt_window_size_ = adapt_base_window_;
     adapt_next_window_ = adapt_init_buffer_ + adapt_window_size_ - 1;
   }
 
-  void set_window_params(unsigned int num_warmup, unsigned int init_buffer,
-                         unsigned int term_buffer, unsigned int base_window,
-                         callbacks::logger& logger) {
+  inline void set_window_params(unsigned int num_warmup,
+                                unsigned int init_buffer,
+                                unsigned int term_buffer,
+                                unsigned int base_window,
+                                callbacks::logger& logger) {
     if (num_warmup < 20) {
       logger.info("WARNING: No " + estimator_name_ + " estimation is");
       logger.info("         performed for num_warmup < 20");
@@ -77,18 +72,18 @@ class windowed_adaptation : public base_adaptation {
     restart();
   }
 
-  bool adaptation_window() {
+  inline bool adaptation_window() {
     return (adapt_window_counter_ >= adapt_init_buffer_)
            && (adapt_window_counter_ < num_warmup_ - adapt_term_buffer_)
            && (adapt_window_counter_ != num_warmup_);
   }
 
-  bool end_adaptation_window() {
+  inline bool end_adaptation_window() {
     return (adapt_window_counter_ == adapt_next_window_)
            && (adapt_window_counter_ != num_warmup_);
   }
 
-  void compute_next_window() {
+  inline void compute_next_window() {
     if (adapt_next_window_ == num_warmup_ - adapt_term_buffer_ - 1)
       return;
 
@@ -112,14 +107,14 @@ class windowed_adaptation : public base_adaptation {
  protected:
   std::string estimator_name_;
 
-  unsigned int num_warmup_;
-  unsigned int adapt_init_buffer_;
-  unsigned int adapt_term_buffer_;
-  unsigned int adapt_base_window_;
+  unsigned int num_warmup_{0};
+  unsigned int adapt_init_buffer_{0};
+  unsigned int adapt_term_buffer_{0};
+  unsigned int adapt_base_window_{0};
 
-  unsigned int adapt_window_counter_;
-  unsigned int adapt_next_window_;
-  unsigned int adapt_window_size_;
+  int adapt_window_counter_{-1};
+  unsigned int adapt_next_window_{0};
+  unsigned int adapt_window_size_{0};
 };
 
 }  // namespace mcmc

--- a/src/stan/mcmc/windowed_adaptation.hpp
+++ b/src/stan/mcmc/windowed_adaptation.hpp
@@ -12,12 +12,12 @@ namespace mcmc {
 class windowed_adaptation : public base_adaptation {
  public:
   template <typename T>
-  using require_string_convertible =
-   std::enable_if_t<std::is_convertible<std::decay_t<T>, std::string>::value>;
+  using require_string_convertible = std::enable_if_t<
+      std::is_convertible<std::decay_t<T>, std::string>::value>;
 
   template <typename T, require_string_convertible<T>...>
-  explicit windowed_adaptation(T&& name) :
-    estimator_name_(std::forward<T>(name)) {}
+  explicit windowed_adaptation(T&& name)
+      : estimator_name_(std::forward<T>(name)) {}
 
   inline void restart() {
     adapt_window_counter_ = 0;

--- a/src/stan/mcmc/windowed_adaptation.hpp
+++ b/src/stan/mcmc/windowed_adaptation.hpp
@@ -16,7 +16,8 @@ class windowed_adaptation : public base_adaptation {
    std::enable_if_t<std::is_convertible<std::decay_t<T>, std::string>::value>;
 
   template <typename T, require_string_convertible<T>...>
-  explicit windowed_adaptation(T&& name) : estimator_name_(std::forward<T>(name)) {}
+  explicit windowed_adaptation(T&& name) :
+    estimator_name_(std::forward<T>(name)) {}
 
   inline void restart() {
     adapt_window_counter_ = 0;

--- a/src/stan/mcmc/windowed_adaptation.hpp
+++ b/src/stan/mcmc/windowed_adaptation.hpp
@@ -5,6 +5,7 @@
 #include <stan/mcmc/base_adaptation.hpp>
 #include <ostream>
 #include <string>
+#include <climits>
 
 namespace stan {
 namespace mcmc {
@@ -118,13 +119,14 @@ class windowed_adaptation : public base_adaptation {
  protected:
   std::string estimator_name_;
 
-  unsigned int num_warmup_{1};
+  unsigned int num_warmup_{0};
   unsigned int adapt_init_buffer_{0};
   unsigned int adapt_term_buffer_{0};
   unsigned int adapt_base_window_{0};
 
   unsigned int adapt_window_counter_{0};
-  unsigned int adapt_next_window_{0};
+  // the first iteration after initilization will roll this value over
+  unsigned int adapt_next_window_{UINT_MAX};
   unsigned int adapt_window_size_{0};
 };
 

--- a/src/test/unit/mcmc/windowed_adaptation_test.cpp
+++ b/src/test/unit/mcmc/windowed_adaptation_test.cpp
@@ -16,11 +16,11 @@ TEST(McmcWindowedAdaptation, set_window_params1) {
 // If you don't set the values, there should be no windows to roll through
 TEST(MmcmcWindowedAdaption, adaption_window_unset) {
   stan::mcmc::windowed_adaptation adapter("test");
-  EXPECT_TRUE((adapter.adaptation_window()));
-  EXPECT_TRUE((adapter.end_adaptation_window()));
+  EXPECT_FALSE((adapter.adaptation_window()));
+  EXPECT_FALSE((adapter.end_adaptation_window()));
   adapter.compute_next_window();
-  EXPECT_TRUE((adapter.adaptation_window()));
-  EXPECT_TRUE((adapter.end_adaptation_window()));
+  EXPECT_FALSE((adapter.adaptation_window()));
+  EXPECT_FALSE((adapter.end_adaptation_window()));
 }
 
 TEST(McmcWindowedAdaptation, set_window_params2) {

--- a/src/test/unit/mcmc/windowed_adaptation_test.cpp
+++ b/src/test/unit/mcmc/windowed_adaptation_test.cpp
@@ -13,6 +13,16 @@ TEST(McmcWindowedAdaptation, set_window_params1) {
   EXPECT_EQ(1, logger.find_info("performed for num_warmup < 20"));
 }
 
+// If you don't set the values, there should be no windows to roll through
+TEST(MmcmcWindowedAdaption, adaption_window_unset) {
+  stan::mcmc::windowed_adaptation adapter("test");
+  EXPECT_TRUE((adapter.adaptation_window()));
+  EXPECT_TRUE((adapter.end_adaptation_window()));
+  adapter.compute_next_window();
+  EXPECT_TRUE((adapter.adaptation_window()));
+  EXPECT_TRUE((adapter.end_adaptation_window()));
+}
+
 TEST(McmcWindowedAdaptation, set_window_params2) {
   stan::test::unit::instrumented_logger logger;
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

The class `window_adaption` was setting the default value of it's member `adapt_next_window_` to `-1` when `restart()` was called in the constructor. But `adapt_next_window_` is declared an unsigned int so it's default was actually MAX_UINT of the operating system. idk what's intended there but that feels like naughty behaviour. I declared adapt_next_window_ to be int and gave it a value of -1. Though I feel like that's wrong as well. What should the default value be there? Looking at `end_adaptation_window()` maybe it's zero so for first window starts sliding things forward?

This is adds a perfect forwarding constructor for `window_adaption` when the argument is convertible to a string. Then when something like `window_adaption("my_value")` is called that temp just moves on in to the class without making a string copy.

#### Intended Effect

bugfix!

#### How to Verify

Check it out!

#### Side Effects

Is this function used a lot? Looks like it's used in things like `covar_adaptation`. Should probably figure out a good default value for `adapt_next_window_` or there probably could be side effects somewhere

#### Documentation

Just a bug-fix/cleanup, though happy to add docs if needed

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
