### PR TITLE
Revert "[WIP] Removed fast copy funcs from ps_point and dependents"

### DIFF
--- a/src/stan/mcmc/hmc/hamiltonians/dense_e_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/dense_e_point.hpp
@@ -28,6 +28,17 @@ class dense_e_point : public ps_point {
   }
 
   /**
+   * Copy constructor which does fast copy of inverse mass matrix.
+   *
+   * @param z point to copy
+   */
+  dense_e_point(const dense_e_point& z)
+      : ps_point(z),
+        inv_e_metric_(z.inv_e_metric_.rows(), z.inv_e_metric_.cols()) {
+    fast_matrix_copy_<double>(inv_e_metric_, z.inv_e_metric_);
+  }
+
+  /**
    * Set elements of mass matrix
    *
    * @param inv_e_metric initial mass matrix

--- a/src/stan/mcmc/hmc/hamiltonians/diag_e_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/diag_e_point.hpp
@@ -28,6 +28,16 @@ class diag_e_point : public ps_point {
   }
 
   /**
+   * Copy constructor which does fast copy of inverse mass matrix.
+   *
+   * @param z point to copy
+   */
+  diag_e_point(const diag_e_point& z)
+      : ps_point(z), inv_e_metric_(z.inv_e_metric_.size()) {
+    fast_vector_copy_<double>(inv_e_metric_, z.inv_e_metric_);
+  }
+
+  /**
    * Set elements of mass matrix
    *
    * @param inv_e_metric initial mass matrix

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -16,33 +16,55 @@ using Eigen::Dynamic;
  * Point in a generic phase space
  */
 class ps_point {
+  friend class ps_point_test;
+
  public:
-  explicit ps_point(int n) : q(n), p(n), g(n) {}
+  explicit ps_point(int n) : q(n), p(n), V(0), g(n) {}
+
+  ps_point(const ps_point& z)
+      : q(z.q.size()), p(z.p.size()), V(z.V), g(z.g.size()) {
+    fast_vector_copy_<double>(q, z.q);
+    fast_vector_copy_<double>(p, z.p);
+    fast_vector_copy_<double>(g, z.g);
+  }
+
+  ps_point& operator=(const ps_point& z) {
+    if (this == &z)
+      return *this;
+
+    fast_vector_copy_<double>(q, z.q);
+
+    V = z.V;
+
+    fast_vector_copy_<double>(p, z.p);
+    fast_vector_copy_<double>(g, z.g);
+
+    return *this;
+  }
 
   Eigen::VectorXd q;
   Eigen::VectorXd p;
-  Eigen::VectorXd g;
-  double V{0};
 
-  virtual inline void get_param_names(std::vector<std::string>& model_names,
-                                      std::vector<std::string>& names) {
-    names.reserve(q.size() + p.size() + g.size());
+  double V;
+  Eigen::VectorXd g;
+
+  virtual void get_param_names(std::vector<std::string>& model_names,
+                               std::vector<std::string>& names) {
     for (int i = 0; i < q.size(); ++i)
-      names.emplace_back(model_names[i]);
-    for (int i = 0; i < p.size(); ++i)
-      names.emplace_back(std::string("p_") + model_names[i]);
-    for (int i = 0; i < g.size(); ++i)
-      names.emplace_back(std::string("g_") + model_names[i]);
+      names.push_back(model_names.at(i));
+    for (int i = 0; i < q.size(); ++i)
+      names.push_back(std::string("p_") + model_names.at(i));
+    for (int i = 0; i < q.size(); ++i)
+      names.push_back(std::string("g_") + model_names.at(i));
   }
 
-  virtual inline void get_params(std::vector<double>& values) {
-    values.reserve(q.size() + p.size() + g.size());
+  virtual void get_params(std::vector<double>& values) {
     for (int i = 0; i < q.size(); ++i)
-      values.push_back(q[i]);
-    for (int i = 0; i < p.size(); ++i)
-      values.push_back(p[i]);
-    for (int i = 0; i < g.size(); ++i)
-      values.push_back(g[i]);
+      values.push_back(q(i));
+    for (int i = 0; i < q.size(); ++i)
+      values.push_back(p(i));
+    for (int i = 0; i < q.size(); ++i)
+      values.push_back(g(i));
   }
 
   /**
@@ -51,6 +73,28 @@ class ps_point {
    * @param writer writer callback
    */
   virtual inline void write_metric(stan::callbacks::writer& writer) {}
+
+ protected:
+  template <typename T>
+  static inline void fast_vector_copy_(
+      Eigen::Matrix<T, Dynamic, 1>& v_to,
+      const Eigen::Matrix<T, Dynamic, 1>& v_from) {
+    int sz = v_from.size();
+    v_to.resize(sz);
+    if (sz > 0)
+      std::memcpy(&v_to(0), &v_from(0), v_from.size() * sizeof(double));
+  }
+
+  template <typename T>
+  static inline void fast_matrix_copy_(
+      Eigen::Matrix<T, Dynamic, Dynamic>& v_to,
+      const Eigen::Matrix<T, Dynamic, Dynamic>& v_from) {
+    int nr = v_from.rows();
+    int nc = v_from.cols();
+    v_to.resize(nr, nc);
+    if (nr > 0 && nc > 0)
+      std::memcpy(&v_to(0), &v_from(0), v_from.size() * sizeof(double));
+  }
 };
 
 }  // namespace mcmc

--- a/src/test/unit/mcmc/hmc/hamiltonians/ps_point_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/ps_point_test.cpp
@@ -7,6 +7,55 @@
 namespace stan {
 namespace mcmc {
 
+class ps_point_test : public ::testing::Test {
+ public:
+  typedef Eigen::Matrix<double, Eigen::Dynamic, 1> vector_t;
+  typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> matrix_t;
+
+  static void fast_vector_copy() {
+    vector_t from3(3);
+    from3 << 5.25, 3.125, -6.5;
+    vector_t to3(12);
+    ps_point::fast_vector_copy_(to3, from3);
+
+    EXPECT_EQ(from3, to3);
+
+    int zero = 0;
+    vector_t from0(zero);
+    vector_t to0(7);
+    ps_point::fast_vector_copy_(to0, from0);
+
+    EXPECT_EQ(from0, to0);
+  }
+
+  static void fast_matrix_copy() {
+    matrix_t from2_3(2, 3);
+    from2_3 << 5, 2, 7, -3, 4, -9;
+    matrix_t to2_3(1, 13);
+    ps_point::fast_matrix_copy_(to2_3, from2_3);
+
+    EXPECT_EQ(from2_3, to2_3);
+
+    int zero = 0;
+
+    matrix_t from2_0(2, zero);
+    matrix_t to2_0(8, 3);
+    ps_point::fast_matrix_copy_(to2_0, from2_0);
+
+    EXPECT_EQ(from2_0, to2_0);
+
+    matrix_t from0_5(zero, 5);
+    matrix_t to0_5(7, 4);
+    ps_point::fast_matrix_copy_(to0_5, from0_5);
+
+    EXPECT_EQ(from0_5, to0_5);
+  }
+};
+
+TEST(psPoint, fastVectorCopy) { ps_point_test::fast_vector_copy(); }
+
+TEST(psPoint, fastMatrixCopy) { ps_point_test::fast_matrix_copy(); }
+
 TEST(psPoint, write_metric_streams) {
   stan::test::capture_std_streams();
 


### PR DESCRIPTION
Reverts stan-dev/stan#2828

Michael merged it a bit too early and I had a small bug in the code