### PR TITLE
Bug Fix: Add g_ to name of g vector name in ps_point

### DIFF
--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -28,7 +28,7 @@ class ps_point {
                                       std::vector<std::string>& names) {
     names.reserve(q.size() + p.size() + g.size());
     for (int i = 0; i < q.size(); ++i)
-      names.emplace_back(model_names[i]);
+      names.emplace_back(std::string("q_") + model_names[i]);
     for (int i = 0; i < p.size(); ++i)
       names.emplace_back(std::string("p_") + model_names[i]);
     for (int i = 0; i < g.size(); ++i)


### PR DESCRIPTION
Just a quick bug fix introduced in #2828 to add `std::string("g_")` to the names of the ps_point method.

#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
