### PR TITLE
Travis fix: bump clang version from 3.8 to 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_script:
   - ${CXX} --version
   - echo "CXX=$CXX" > make/local
   - echo "CXXFLAGS_OS+=$CXXFLAGS_OS" >> make/local
-  - echo "CXXFLAGS= -std=c++1y" >> make/local
   - if [[ ! -z "$DEPFLAGS_OS" ]]; then echo "DEPFLAGS_OS=$DEPFLAGS_OS" >> make/local; fi
   - cat make/local
 
@@ -36,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y&& CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ before_script:
 
 linux_clang: &linux_clang
   os: linux
-  compiler: "clang-3.8"
+  compiler: "clang-6.0"
   addons:
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8' ]
-      packages: [ 'clang-3.8', 'libc++-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0' ]
+      packages: [ 'clang-6.0', 'libc++-dev' ]
 
 linux_gcc: &linux_gcc
   os: linux
@@ -35,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-6.0 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-6.0 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-6.0 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-6.0 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-6.0 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-6.0 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-6.0 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
   - ${CXX} --version
   - echo "CXX=$CXX" > make/local
   - echo "CXXFLAGS_OS+=$CXXFLAGS_OS" >> make/local
-  - echo "CXXFLAGS= -std=c++14"
+  - echo "CXXFLAGS= -std=c++1y" >> make/local
   - if [[ ! -z "$DEPFLAGS_OS" ]]; then echo "DEPFLAGS_OS=$DEPFLAGS_OS" >> make/local; fi
   - cat make/local
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_script:
   - ${CXX} --version
   - echo "CXX=$CXX" > make/local
   - echo "CXXFLAGS_OS+=$CXXFLAGS_OS" >> make/local
-  - echo "CXXFLAGS= -std=c++14"
   - if [[ ! -z "$DEPFLAGS_OS" ]]; then echo "DEPFLAGS_OS=$DEPFLAGS_OS" >> make/local; fi
   - cat make/local
 
@@ -36,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y&& CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - ${CXX} --version
   - echo "CXX=$CXX" > make/local
   - echo "CXXFLAGS_OS+=$CXXFLAGS_OS" >> make/local
+  - echo "CXXFLAGS= -std=c++1y" >> make/local
   - if [[ ! -z "$DEPFLAGS_OS" ]]; then echo "DEPFLAGS_OS=$DEPFLAGS_OS" >> make/local; fi
   - cat make/local
 
@@ -35,37 +36,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y&& CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - ${CXX} --version
   - echo "CXX=$CXX" > make/local
   - echo "CXXFLAGS_OS+=$CXXFLAGS_OS" >> make/local
+  - echo "CXXFLAGS= -std=c++14"
   - if [[ ! -z "$DEPFLAGS_OS" ]]; then echo "DEPFLAGS_OS=$DEPFLAGS_OS" >> make/local; fi
   - cat make/local
 
@@ -35,37 +36,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++ -std=c++14"
+        - MATRIX_EVAL="CXX=clang++-3.8 && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CC=clang++3-8 CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CC=clang++3-8 && CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
   - ${CXX} --version
   - echo "CXX=$CXX" > make/local
   - echo "CXXFLAGS_OS+=$CXXFLAGS_OS" >> make/local
-  - echo "CXXFLAGS= -std=c++1y" >> make/local
+  - echo "CXXFLAGS= -std=c++14"
   - if [[ ! -z "$DEPFLAGS_OS" ]]; then echo "DEPFLAGS_OS=$DEPFLAGS_OS" >> make/local; fi
   - cat make/local
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,37 +35,37 @@ matrix:
     - <<: *linux_clang
       env:
           # For Travis's Ubuntu 14.04, the libstdc++ is broken with clang
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/callbacks src/test/unit/io"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y&& CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/ast"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/generator"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/parser"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/lang/reject"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/mcmc src/test/unit/model src/test/unit/optimization"
           PARALLEL=2
     - <<: *linux_clang
       env:
-        - MATRIX_EVAL="CXX=clang++-3.8 -std=c++1y && CXXFLAGS_OS=-stdlib=libc++"
+        - MATRIX_EVAL="CXX=\"clang++-3.8 -std=c++1y\" && CXXFLAGS_OS=-stdlib=libc++"
           TESTFOLDER="src/test/unit/services src/test/unit/variational src/test/unit/version_test.cpp"
           PARALLEL=2
     - <<: *linux_gcc


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR should fix the travis issue we are having since the introduction of TBB. Lets first wait if it fixes it, but it should.

Sidenote: Not sure we even need Travis at all anymore. See https://github.com/stan-dev/cmdstan/issues/728#issuecomment-532400217
But that is certainly not my call to make.

#### Intended Effect

fix travis

#### How to Verify

#### Side Effects
/
#### Documentation
/
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
