### PR TITLE
Use tab separation in ADVI logs

### DIFF
--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -341,10 +341,10 @@ class advi {
     logger.info("Begin stochastic gradient ascent.");
     logger.info(
         "  iter"
-        "             ELBO"
-        "   delta_ELBO_mean"
-        "   delta_ELBO_med"
-        "   notes ");
+        "\tELBO"
+        "\tdelta_ELBO_mean"
+        "\tdelta_ELBO_med"
+        "\tnotes ");
 
     // Timing variables
     clock_t start = clock();
@@ -383,10 +383,10 @@ class advi {
               / static_cast<double>(elbo_diff.size());
         delta_elbo_med = circ_buff_median(elbo_diff);
         std::stringstream ss;
-        ss << "  " << std::setw(4) << iter_counter << "  " << std::setw(15)
-           << std::fixed << std::setprecision(3) << elbo << "  "
+        ss << "  " << std::setw(4) << iter_counter << "\t" << std::setw(15)
+           << std::fixed << std::setprecision(3) << elbo << "\t"
            << std::setw(16) << std::fixed << std::setprecision(3)
-           << delta_elbo_ave << "  " << std::setw(15) << std::fixed
+           << delta_elbo_ave << "\t" << std::setw(15) << std::fixed
            << std::setprecision(3) << delta_elbo_med;
 
         end = clock();
@@ -400,18 +400,18 @@ class advi {
         diagnostic_writer(print_vector);
 
         if (delta_elbo_ave < tol_rel_obj) {
-          ss << "   MEAN ELBO CONVERGED";
+          ss << "\tMEAN ELBO CONVERGED";
           do_more_iterations = false;
         }
 
         if (delta_elbo_med < tol_rel_obj) {
-          ss << "   MEDIAN ELBO CONVERGED";
+          ss << "\tMEDIAN ELBO CONVERGED";
           do_more_iterations = false;
         }
 
         if (iter_counter > 10 * eval_elbo_) {
           if (delta_elbo_med > 0.5 || delta_elbo_ave > 0.5) {
-            ss << "   MAY BE DIVERGING... INSPECT ELBO";
+            ss << "\tMAY BE DIVERGING... INSPECT ELBO";
           }
         }
 


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary
It can be useful to parse and plot the ELBO to demonstrate convergence. This is really tricky at the moment as spaces are used in as delim and also within field (notes in particular).

#### Intended Effect
Make ADVI output easier to parse as text while looking the same (or similar) visually.

#### How to Verify
Not sure about this.

#### Side Effects
Possibly break existing scripts for parsing output.

#### Documentation
Not necessary; it's just an internal change. Though mentioning in changelog etc would obvs be useful in case people have parsing scripts.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
