### PR TITLE
Fix tests for stan-dev/math#933.

### DIFF
--- a/src/stan/lang/generator/expression_visgen.hpp
+++ b/src/stan/lang/generator/expression_visgen.hpp
@@ -226,7 +226,7 @@ struct expression_visgen : public visgen {
     generate_expression(fx.x_r_, user_facing_, o_);
     o_ << ", ";
     generate_expression(fx.x_i_, user_facing_, o_);
-    o_ << ", *pstream__, ";
+    o_ << ", pstream__, ";
     generate_expression(fx.rel_tol_, user_facing_, o_);
     o_ << ")";
   }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Fixes the compiler to work with the corrected signature of integrate_1d from stan-dev/math#933.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
