### PR TITLE
Add crtp method to base_hamiltonian

### DIFF
--- a/src/stan/command/stanc_helper.hpp
+++ b/src/stan/command/stanc_helper.hpp
@@ -333,7 +333,9 @@ inline int stanc_helper(int argc, const char* argv[], std::ostream* out_stream,
         out.close();
         break;
       }
-      default: { assert(false); }
+      default: {
+        assert(false);
+      }
     }
 
     if (!valid_input) {

--- a/src/stan/lang/ast/fun/returns_type_vis_def.hpp
+++ b/src/stan/lang/ast/fun/returns_type_vis_def.hpp
@@ -56,9 +56,10 @@ bool returns_type_vis::operator()(const no_op_statement& st) const {
 bool returns_type_vis::operator()(const statements& st) const {
   // last statement in sequence must return type
   if (st.statements_.size() == 0) {
-    error_msgs_ << ("Expecting return, found"
-                    " statement sequence with empty body.")
-                << std::endl;
+    error_msgs_
+        << ("Expecting return, found"
+            " statement sequence with empty body.")
+        << std::endl;
     return false;
   }
   return returns_type(return_type_, st.statements_.back(), error_msgs_);
@@ -96,9 +97,10 @@ bool returns_type_vis::operator()(const break_continue_statement& st) const {
 bool returns_type_vis::operator()(const conditional_statement& st) const {
   // all condition bodies must end in appropriate return
   if (st.bodies_.size() != (st.conditions_.size() + 1)) {
-    error_msgs_ << ("Expecting return, found conditional"
-                    " without final else.")
-                << std::endl;
+    error_msgs_
+        << ("Expecting return, found conditional"
+            " without final else.")
+        << std::endl;
     return false;
   }
   for (size_t i = 0; i < st.bodies_.size(); ++i)

--- a/src/stan/lang/grammars/block_var_decls_grammar_def.hpp
+++ b/src/stan/lang/grammars/block_var_decls_grammar_def.hpp
@@ -124,7 +124,7 @@ block_var_decls_grammar<Iterator>::block_var_decls_grammar(
   single_var_decl_r.name("single-element block var declaration");
   single_var_decl_r %= element_type_r(_r1) > identifier_r > opt_def_r(_r1)
                        > eps[validate_single_block_var_decl_f(
-                             _val, _pass, boost::phoenix::ref(error_msgs_))];
+                           _val, _pass, boost::phoenix::ref(error_msgs_))];
 
   element_type_r.name("block var element type declaration");
   element_type_r
@@ -245,13 +245,13 @@ block_var_decls_grammar<Iterator>::block_var_decls_grammar(
       = lit('<')[empty_range_f(_val, boost::phoenix::ref(error_msgs_))]
         > (((lit("lower") > lit('=')
              > expression07_g(_r1)[set_int_range_lower_f(
-                   _val, _1, _pass, boost::phoenix::ref(error_msgs_))])
+                 _val, _1, _pass, boost::phoenix::ref(error_msgs_))])
             > -(lit(',') > lit("upper") > lit('=')
                 > expression07_g(_r1)[set_int_range_upper_f(
-                      _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
+                    _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
            | (lit("upper") > lit('=')
               > expression07_g(_r1)[set_int_range_upper_f(
-                    _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
+                  _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
         > lit('>');
 
   // _r1 var scope
@@ -260,13 +260,13 @@ block_var_decls_grammar<Iterator>::block_var_decls_grammar(
       = lit('<')[empty_range_f(_val, boost::phoenix::ref(error_msgs_))]
         >> (((lit("lower") > lit('=')
               > expression07_g(_r1)[set_double_range_lower_f(
-                    _val, _1, _pass, boost::phoenix::ref(error_msgs_))])
+                  _val, _1, _pass, boost::phoenix::ref(error_msgs_))])
              > -(lit(',') > lit("upper") > lit('=')
                  > expression07_g(_r1)[set_double_range_upper_f(
-                       _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
+                     _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
             | (lit("upper") > lit('=')
                > expression07_g(_r1)[set_double_range_upper_f(
-                     _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
+                   _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
         > lit('>');
 
   // _r1 var scope
@@ -281,13 +281,13 @@ block_var_decls_grammar<Iterator>::block_var_decls_grammar(
                                            boost::phoenix::ref(error_msgs_))]
         > (((lit("offset") > lit('=')
              > expression07_g(_r1)[set_double_offset_multiplier_offset_f(
-                   _val, _1, _pass, boost::phoenix::ref(error_msgs_))])
+                 _val, _1, _pass, boost::phoenix::ref(error_msgs_))])
             > -(lit(',') > lit("multiplier") > lit('=')
                 > expression07_g(_r1)[set_double_offset_multiplier_multiplier_f(
-                      _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
+                    _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
            | (lit("multiplier") > lit('=')
               > expression07_g(_r1)[set_double_offset_multiplier_multiplier_f(
-                    _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
+                  _val, _1, _pass, boost::phoenix::ref(error_msgs_))]))
         > lit('>');
 
   // _r1 var scope

--- a/src/stan/lang/grammars/expression07_grammar_def.hpp
+++ b/src/stan/lang/grammars/expression07_grammar_def.hpp
@@ -29,16 +29,16 @@ expression07_grammar<Iterator>::expression07_grammar(
   using boost::spirit::qi::_pass;
   using boost::spirit::qi::_val;
   using boost::spirit::qi::eps;
-  using boost::spirit::qi::labels::_r1;
   using boost::spirit::qi::lit;
+  using boost::spirit::qi::labels::_r1;
 
   expression07_r.name("expression");
   expression07_r
       %= term_g(_r1)[assign_lhs_f(_val, _1)]
-         > *((lit('+') > term_g(_r1)[addition3_f(
-                             _val, _1, boost::phoenix::ref(error_msgs))])
+         > *((lit('+') > term_g(
+                  _r1)[addition3_f(_val, _1, boost::phoenix::ref(error_msgs))])
              | (lit('-') > term_g(_r1)[subtraction3_f(
-                               _val, _1, boost::phoenix::ref(error_msgs))]))
+                    _val, _1, boost::phoenix::ref(error_msgs))]))
          > eps[validate_expr_type3_f(_val, _pass,
                                      boost::phoenix::ref(error_msgs_))];
 }

--- a/src/stan/lang/grammars/expression_grammar_def.hpp
+++ b/src/stan/lang/grammars/expression_grammar_def.hpp
@@ -30,9 +30,9 @@ expression_grammar<Iterator>::expression_grammar(variable_map& var_map,
   using boost::spirit::qi::_val;
   using boost::spirit::qi::char_;
   using boost::spirit::qi::eps;
-  using boost::spirit::qi::labels::_r1;
   using boost::spirit::qi::lit;
   using boost::spirit::qi::no_skip;
+  using boost::spirit::qi::labels::_r1;
 
   expression_r.name("expression");
   expression_r %= (expression15_r(_r1) >> no_skip[!char_('?')] > eps)
@@ -42,52 +42,46 @@ expression_grammar<Iterator>::expression_grammar(variable_map& var_map,
   conditional_op_r %= expression15_r(_r1) >> lit("?") >> expression_r(_r1)
                       >> lit(":")
                       >> expression_r(_r1)[validate_conditional_op_f(
-                             _val, _r1, _pass, boost::phoenix::ref(var_map_),
-                             boost::phoenix::ref(error_msgs))];
+                          _val, _r1, _pass, boost::phoenix::ref(var_map_),
+                          boost::phoenix::ref(error_msgs))];
 
   expression15_r.name("expression");
-  expression15_r
-      = expression14_r(_r1)[assign_lhs_f(_val, _1)]
-        > *(lit("||") > expression14_r(
-                            _r1)[binary_op_f(_val, _1, "||", "logical_or",
-                                             boost::phoenix::ref(error_msgs))]);
+  expression15_r = expression14_r(_r1)[assign_lhs_f(_val, _1)]
+                   > *(lit("||") > expression14_r(
+                           _r1)[binary_op_f(_val, _1, "||", "logical_or",
+                                            boost::phoenix::ref(error_msgs))]);
 
   expression14_r.name("expression");
-  expression14_r
-      = expression10_r(_r1)[assign_lhs_f(_val, _1)]
-        > *(lit("&&") > expression10_r(
-                            _r1)[binary_op_f(_val, _1, "&&", "logical_and",
-                                             boost::phoenix::ref(error_msgs))]);
+  expression14_r = expression10_r(_r1)[assign_lhs_f(_val, _1)]
+                   > *(lit("&&") > expression10_r(
+                           _r1)[binary_op_f(_val, _1, "&&", "logical_and",
+                                            boost::phoenix::ref(error_msgs))]);
 
   expression10_r.name("expression");
   expression10_r
       = expression09_r(_r1)[assign_lhs_f(_val, _1)]
         > *((lit("==") > expression09_r(
-                             _r1)[binary_op_f(_val, _1, "==", "logical_eq",
-                                              boost::phoenix::ref(error_msgs))])
-            | (lit("!=")
-               > expression09_r(
-                     _r1)[binary_op_f(_val, _1, "!=", "logical_neq",
-                                      boost::phoenix::ref(error_msgs))]));
+                 _r1)[binary_op_f(_val, _1, "==", "logical_eq",
+                                  boost::phoenix::ref(error_msgs))])
+            | (lit("!=") > expression09_r(
+                   _r1)[binary_op_f(_val, _1, "!=", "logical_neq",
+                                    boost::phoenix::ref(error_msgs))]));
 
   expression09_r.name("expression");
   expression09_r
       = expression07_g(_r1)[assign_lhs_f(_val, _1)]
         > *((lit("<=") > expression07_g(
-                             _r1)[binary_op_f(_val, _1, "<", "logical_lte",
-                                              boost::phoenix::ref(error_msgs))])
-            | (lit("<")
-               > expression07_g(
-                     _r1)[binary_op_f(_val, _1, "<=", "logical_lt",
-                                      boost::phoenix::ref(error_msgs))])
-            | (lit(">=")
-               > expression07_g(
-                     _r1)[binary_op_f(_val, _1, ">", "logical_gte",
-                                      boost::phoenix::ref(error_msgs))])
-            | (lit(">")
-               > expression07_g(
-                     _r1)[binary_op_f(_val, _1, ">=", "logical_gt",
-                                      boost::phoenix::ref(error_msgs))]));
+                 _r1)[binary_op_f(_val, _1, "<", "logical_lte",
+                                  boost::phoenix::ref(error_msgs))])
+            | (lit("<") > expression07_g(
+                   _r1)[binary_op_f(_val, _1, "<=", "logical_lt",
+                                    boost::phoenix::ref(error_msgs))])
+            | (lit(">=") > expression07_g(
+                   _r1)[binary_op_f(_val, _1, ">", "logical_gte",
+                                    boost::phoenix::ref(error_msgs))])
+            | (lit(">") > expression07_g(
+                   _r1)[binary_op_f(_val, _1, ">=", "logical_gt",
+                                    boost::phoenix::ref(error_msgs))]));
 }
 }  // namespace lang
 }  // namespace stan

--- a/src/stan/lang/grammars/functions_grammar_def.hpp
+++ b/src/stan/lang/grammars/functions_grammar_def.hpp
@@ -47,9 +47,9 @@ functions_grammar<Iterator>::functions_grammar(variable_map& var_map,
   functions_r.name("function declarations and definitions");
   functions_r %= (lit("functions") > lit("{")) >> *function_r > lit('}')
                  > eps[validate_declarations_f(
-                       _pass, boost::phoenix::ref(functions_declared_),
-                       boost::phoenix::ref(functions_defined_),
-                       boost::phoenix::ref(error_msgs_), allow_undefined)];
+                     _pass, boost::phoenix::ref(functions_declared_),
+                     boost::phoenix::ref(functions_defined_),
+                     boost::phoenix::ref(error_msgs_), allow_undefined)];
 
   // locals: _a = scope (origin) function subtype void,rng,lp)
   function_r.name("function declaration or definition");
@@ -60,16 +60,16 @@ functions_grammar<Iterator>::functions_grammar(variable_map& var_map,
                                   _1, _pass, boost::phoenix::ref(error_msgs_))]
                 > lit('(') > arg_decls_r > close_arg_decls_r
                 > eps[validate_pmf_pdf_variate_f(
-                      _val, _pass, boost::phoenix::ref(error_msgs_))]
+                    _val, _pass, boost::phoenix::ref(error_msgs_))]
                 > eps[set_fun_params_scope_f(_a, boost::phoenix::ref(var_map_))]
                 > statement_g(_a, false)
                 > eps[unscope_variables_f(_val, boost::phoenix::ref(var_map_))]
                 > eps[validate_return_type_f(_val, _pass,
                                              boost::phoenix::ref(error_msgs_))]
                 > eps[add_function_signature_f(
-                      _val, _pass, boost::phoenix::ref(functions_declared_),
-                      boost::phoenix::ref(functions_defined_),
-                      boost::phoenix::ref(error_msgs_))];
+                    _val, _pass, boost::phoenix::ref(functions_declared_),
+                    boost::phoenix::ref(functions_defined_),
+                    boost::phoenix::ref(error_msgs_))];
 
   close_arg_decls_r.name(
       "argument declaration or close paren )"
@@ -84,7 +84,7 @@ functions_grammar<Iterator>::functions_grammar(variable_map& var_map,
   arg_decl_r
       %= -(lit("data")[set_data_origin_f(_a)])
          >> bare_type_g[validate_non_void_arg_f(
-                _1, _a, _pass, boost::phoenix::ref(error_msgs_))]
+             _1, _a, _pass, boost::phoenix::ref(error_msgs_))]
          > identifier_r
          > eps[add_fun_arg_var_f(_val, _a, _pass, boost::phoenix::ref(var_map_),
                                  boost::phoenix::ref(error_msgs_))];

--- a/src/stan/lang/grammars/local_var_decls_grammar_def.hpp
+++ b/src/stan/lang/grammars/local_var_decls_grammar_def.hpp
@@ -81,7 +81,7 @@ local_var_decls_grammar<Iterator>::local_var_decls_grammar(
   single_local_var_decl_r
       %= local_element_type_r(_r1) > local_identifier_r > local_opt_def_r(_r1)
          > eps[validate_single_local_var_decl_f(
-               _val, _pass, boost::phoenix::ref(error_msgs_))];
+             _val, _pass, boost::phoenix::ref(error_msgs_))];
 
   local_element_type_r.name("local var element type declaration");
   local_element_type_r %= local_int_type_r(_r1) | local_double_type_r(_r1)

--- a/src/stan/lang/grammars/program_grammar_def.hpp
+++ b/src/stan/lang/grammars/program_grammar_def.hpp
@@ -52,10 +52,10 @@ program_grammar<Iterator>::program_grammar(const std::string& model_name,
   using boost::spirit::qi::_2;
   using boost::spirit::qi::_3;
   using boost::spirit::qi::eps;
-  using boost::spirit::qi::labels::_a;
   using boost::spirit::qi::lit;
   using boost::spirit::qi::on_error;
   using boost::spirit::qi::rethrow;
+  using boost::spirit::qi::labels::_a;
 
   // add model_name to var_map with special origin
   var_map_.add(model_name, var_decl(), scope(model_name_origin, true));

--- a/src/stan/lang/grammars/semantic_actions_def.cpp
+++ b/src/stan/lang/grammars/semantic_actions_def.cpp
@@ -1864,9 +1864,8 @@ void set_fun_type_named::operator()(expression &fun_result, fun &fun,
       || deprecate_suffix("_cdf_log", "'_lcdf'", fun, error_msgs)
       || deprecate_suffix("_ccdf_log", "'_lccdf'", fun, error_msgs)
       || deprecate_suffix(
-             "_log",
-             "'_lpdf' for density functions or '_lpmf' for mass functions", fun,
-             error_msgs);
+          "_log", "'_lpdf' for density functions or '_lpmf' for mass functions",
+          fun, error_msgs);
 
   // use old function names for built-in prob funs
   if (!function_signatures::instance().has_user_defined_key(fun.name_)) {

--- a/src/stan/lang/grammars/statement_2_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_2_grammar_def.hpp
@@ -27,10 +27,10 @@ statement_2_grammar<Iterator>::statement_2_grammar(
   using boost::spirit::qi::_pass;
   using boost::spirit::qi::_val;
   using boost::spirit::qi::char_;
-  using boost::spirit::qi::labels::_r1;
-  using boost::spirit::qi::labels::_r2;
   using boost::spirit::qi::lit;
   using boost::spirit::qi::no_skip;
+  using boost::spirit::qi::labels::_r1;
+  using boost::spirit::qi::labels::_r2;
 
   //   _r1 var_scope
   //   _r2 true if in loop (allowing break/continue)
@@ -43,12 +43,12 @@ statement_2_grammar<Iterator>::statement_2_grammar(
   conditional_statement_r
       = (lit("if") >> no_skip[!char_("a-zA-Z0-9_")]) > lit('(')
         > expression_g(_r1)[add_conditional_condition_f(
-              _val, _1, _pass, boost::phoenix::ref(error_msgs_))]
+            _val, _1, _pass, boost::phoenix::ref(error_msgs_))]
         > lit(')') > statement_g(_r1, _r2)[add_conditional_body_f(_val, _1)]
         > *(((lit("else") >> no_skip[!char_("a-zA-Z0-9_")])
              >> (lit("if") >> no_skip[!char_("a-zA-Z0-9_")]))
             > lit('(') > expression_g(_r1)[add_conditional_condition_f(
-                             _val, _1, _pass, boost::phoenix::ref(error_msgs_))]
+                _val, _1, _pass, boost::phoenix::ref(error_msgs_))]
             > lit(')')
             > statement_g(_r1, _r2)[add_conditional_body_f(_val, _1)])
         > -((lit("else") >> no_skip[!char_("a-zA-Z0-9_")])

--- a/src/stan/lang/grammars/statement_grammar_def.hpp
+++ b/src/stan/lang/grammars/statement_grammar_def.hpp
@@ -125,8 +125,8 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
          | assgn_r(_r1)                         // var[idxs] = expr
          | sample_r(_r1)                        // expression "~"
          | expression_g(_r1)                    // expression
-               [expression_as_statement_f(_pass, _1,
-                                          boost::phoenix::ref(error_msgs_))];
+             [expression_as_statement_f(_pass, _1,
+                                        boost::phoenix::ref(error_msgs_))];
 
   // _r1 = var scope,  _r2 = true if in loop,  _a var_decls, _b local scope
   statement_seq_r.name("sequence of statements");
@@ -145,25 +145,24 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
          > eps[validate_allow_sample_f(_r1, _pass,
                                        boost::phoenix::ref(error_msgs_))]
          > lit('(') > expression_g(_r1)[validate_non_void_expression_f(
-                          _1, _pass, boost::phoenix::ref(error_msgs_))]
+             _1, _pass, boost::phoenix::ref(error_msgs_))]
          > lit(')') > lit(';');
 
   // just variant syntax for increment_log_prob_r (see above)
   // _r1 = var scope
   increment_target_statement_r.name("increment target statement");
   increment_target_statement_r
-      %= (lit("target") >> lit("+="))
-         > eps[validate_allow_sample_f(_r1, _pass,
-                                       boost::phoenix::ref(error_msgs_))]
+      %= (lit("target") >> lit("+=")) > eps[validate_allow_sample_f(
+             _r1, _pass, boost::phoenix::ref(error_msgs_))]
          > expression_g(_r1)[validate_non_void_expression_f(
-               _1, _pass, boost::phoenix::ref(error_msgs_))]
+             _1, _pass, boost::phoenix::ref(error_msgs_))]
          > lit(';');
 
   // _r1 = var scope
   while_statement_r.name("while statement");
   while_statement_r = (lit("while") >> no_skip[!char_("a-zA-Z0-9_")]) > lit('(')
                       > expression_g(_r1)[add_while_condition_f(
-                            _val, _1, _pass, boost::phoenix::ref(error_msgs_))]
+                          _val, _1, _pass, boost::phoenix::ref(error_msgs_))]
                       > lit(')')
                       > statement_r(_r1, true)[add_while_body_f(_val, _1)];
 
@@ -179,8 +178,8 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
   for_statement_r
       %= lit("for") >> no_skip[!char_("a-zA-Z0-9_")] >> lit('(')
          >> identifier_r[store_loop_identifier_f(
-                _1, _a, _pass, boost::phoenix::ref(var_map_),
-                boost::phoenix::ref(error_msgs_))]
+             _1, _a, _pass, boost::phoenix::ref(var_map_),
+             boost::phoenix::ref(error_msgs_))]
          >> lit("in") >> (range_r(_r1) > lit(')'))
          >> (eps[add_loop_identifier_f(_a, _r1, boost::phoenix::ref(var_map_))]
              > statement_r(_r1, true))
@@ -191,8 +190,8 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
   for_array_statement_r
       %= lit("for") >> no_skip[!char_("a-zA-Z0-9_")] >> lit('(')
          >> identifier_r[store_loop_identifier_f(
-                _1, _a, _pass, boost::phoenix::ref(var_map_),
-                boost::phoenix::ref(error_msgs_))]
+             _1, _a, _pass, boost::phoenix::ref(var_map_),
+             boost::phoenix::ref(error_msgs_))]
          >> lit("in")
          >> (expression_rhs_r(_r1)[add_array_loop_identifier_f(
                  _1, _a, _r1, _pass, boost::phoenix::ref(var_map_))]
@@ -205,11 +204,11 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
   for_matrix_statement_r
       %= (lit("for") >> no_skip[!char_("a-zA-Z0-9_")]) > lit('(')
          > identifier_r[store_loop_identifier_f(
-               _1, _a, _pass, boost::phoenix::ref(var_map_),
-               boost::phoenix::ref(error_msgs_))]
+             _1, _a, _pass, boost::phoenix::ref(var_map_),
+             boost::phoenix::ref(error_msgs_))]
          > lit("in") > expression_rhs_r(_r1)[add_matrix_loop_identifier_f(
-                           _1, _a, _r1, _pass, boost::phoenix::ref(var_map_),
-                           boost::phoenix::ref(error_msgs_))]
+             _1, _a, _r1, _pass, boost::phoenix::ref(var_map_),
+             boost::phoenix::ref(error_msgs_))]
 
          > lit(')') > statement_r(_r1, true)
          > eps[remove_loop_identifier_f(_a, boost::phoenix::ref(var_map_))];
@@ -228,7 +227,7 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
   printable_r.name("printable");
   printable_r %= printable_string_r
                  | expression_g(_r1)[non_void_expression_f(
-                       _1, _pass, boost::phoenix::ref(error_msgs_))];
+                     _1, _pass, boost::phoenix::ref(error_msgs_))];
 
   printable_string_r.name("printable quoted string");
   printable_string_r
@@ -242,7 +241,7 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
   range_r.name("range expression pair, colon");
   range_r %= expression_g(_r1)[validate_int_expr_silent_f(_1, _pass)]
              >> lit(':') >> expression_g(_r1)[validate_int_expr_f(
-                                _1, _pass, boost::phoenix::ref(error_msgs_))];
+                 _1, _pass, boost::phoenix::ref(error_msgs_))];
 
   // _r1 = var scope
   assgn_r.name("assignment statement");
@@ -253,8 +252,8 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
                                               boost::phoenix::ref(var_map_),
                                               boost::phoenix::ref(error_msgs_))]
                  > expression_rhs_r(_r1))[validate_assgn_f(
-                    _val, _pass, boost::phoenix::ref(var_map_),
-                    boost::phoenix::ref(error_msgs_))]
+                 _val, _pass, boost::phoenix::ref(var_map_),
+                 boost::phoenix::ref(error_msgs_))]
              > lit(';');
 
   assignment_operator_r.name("assignment operator");
@@ -262,7 +261,7 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
                            | string("-=") | string("*=") | string("/=")
                            | string(".*=") | string("./=")
                            | string("<-")[deprecate_old_assignment_op_f(
-                                 _val, boost::phoenix::ref(error_msgs_))];
+                               _val, boost::phoenix::ref(error_msgs_))];
 
   // _r1 = var scope
   expression_rhs_r.name("expression assignable to left-hand side");
@@ -277,9 +276,8 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
 
   // _r1 = var scope
   sample_r.name("distribution of expression");
-  sample_r %= (expression_g(_r1) >> lit('~'))
-              > eps[validate_allow_sample_f(_r1, _pass,
-                                            boost::phoenix::ref(error_msgs_))]
+  sample_r %= (expression_g(_r1) >> lit('~')) > eps[validate_allow_sample_f(
+                  _r1, _pass, boost::phoenix::ref(error_msgs_))]
               > distribution_r(_r1) > -truncation_range_r(_r1) > lit(';')
               > eps[validate_sample_f(_val, boost::phoenix::ref(var_map_),
                                       _pass, boost::phoenix::ref(error_msgs_))];
@@ -296,10 +294,9 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
 
   // _r1 = var scope
   void_return_statement_r.name("void return statement");
-  void_return_statement_r
-      = lit("return")[set_void_return_f(_val)]
-        >> lit(';')[validate_void_return_allowed_f(
-               _r1, _pass, boost::phoenix::ref(error_msgs_))];
+  void_return_statement_r = lit("return")[set_void_return_f(_val)]
+                            >> lit(';')[validate_void_return_allowed_f(
+                                _r1, _pass, boost::phoenix::ref(error_msgs_))];
 
   // _r1 = var scope
   return_statement_r.name("return statement");
@@ -309,7 +306,7 @@ statement_grammar<Iterator>::statement_grammar(variable_map& var_map,
                                   _r1, _pass, boost::phoenix::ref(error_msgs_))]
                               > expression_g(_r1)))
                         > lit(';')[validate_return_allowed_f(
-                              _r1, _pass, boost::phoenix::ref(error_msgs_))];
+                            _r1, _pass, boost::phoenix::ref(error_msgs_))];
 
   no_op_statement_r.name("no op statement");
   no_op_statement_r %= lit(';')[set_no_op_f(_val)];

--- a/src/stan/lang/grammars/term_grammar_def.hpp
+++ b/src/stan/lang/grammars/term_grammar_def.hpp
@@ -132,49 +132,41 @@ term_grammar<Iterator>::term_grammar(variable_map& var_map,
   using boost::phoenix::end;
 
   term_r.name("expression");
-  term_r
-      = (negated_factor_r(_r1)[assign_lhs_f(_val, _1)]
-         >> *((lit('*') > negated_factor_r(_r1)[multiplication_f(
-                              _val, _1, boost::phoenix::ref(error_msgs_))])
-              | (lit('/') > negated_factor_r(_r1)[division_f(
-                                _val, _1, boost::phoenix::ref(error_msgs_))])
-              | (lit('%')
-                 > negated_factor_r(_r1)[modulus_f(
-                       _val, _1, _pass, boost::phoenix::ref(error_msgs_))])
-              | (lit('\\')
-                 > negated_factor_r(_r1)[left_division_f(
-                       _val, _pass, _1, boost::phoenix::ref(error_msgs_))])
-              | (lit(".*") > negated_factor_r(_r1)[elt_multiplication_f(
-                                 _val, _1, boost::phoenix::ref(error_msgs_))])
-              | (lit("./")
-                 > negated_factor_r(_r1)[elt_division_f(
-                       _val, _1, boost::phoenix::ref(error_msgs_))])));
+  term_r = (negated_factor_r(_r1)[assign_lhs_f(_val, _1)]
+            >> *((lit('*') > negated_factor_r(_r1)[multiplication_f(
+                      _val, _1, boost::phoenix::ref(error_msgs_))])
+                 | (lit('/') > negated_factor_r(_r1)[division_f(
+                        _val, _1, boost::phoenix::ref(error_msgs_))])
+                 | (lit('%') > negated_factor_r(_r1)[modulus_f(
+                        _val, _1, _pass, boost::phoenix::ref(error_msgs_))])
+                 | (lit('\\') > negated_factor_r(_r1)[left_division_f(
+                        _val, _pass, _1, boost::phoenix::ref(error_msgs_))])
+                 | (lit(".*") > negated_factor_r(_r1)[elt_multiplication_f(
+                        _val, _1, boost::phoenix::ref(error_msgs_))])
+                 | (lit("./") > negated_factor_r(_r1)[elt_division_f(
+                        _val, _1, boost::phoenix::ref(error_msgs_))])));
 
   negated_factor_r.name("expression");
-  negated_factor_r
-      = lit('-') >> negated_factor_r(_r1)[negate_expr_f(
-                        _val, _1, _pass, boost::phoenix::ref(error_msgs_))]
-        | lit('!') >> negated_factor_r(_r1)[logical_negate_expr_f(
-                          _val, _1, boost::phoenix::ref(error_msgs_))]
-        | lit('+') >> negated_factor_r(_r1)[assign_lhs_f(_val, _1)]
-        | exponentiated_factor_r(_r1)[assign_lhs_f(_val, _1)];
+  negated_factor_r = lit('-') >> negated_factor_r(_r1)[negate_expr_f(
+                         _val, _1, _pass, boost::phoenix::ref(error_msgs_))]
+                     | lit('!') >> negated_factor_r(_r1)[logical_negate_expr_f(
+                           _val, _1, boost::phoenix::ref(error_msgs_))]
+                     | lit('+') >> negated_factor_r(_r1)[assign_lhs_f(_val, _1)]
+                     | exponentiated_factor_r(_r1)[assign_lhs_f(_val, _1)];
 
   exponentiated_factor_r.name("expression");
   exponentiated_factor_r
       = idx_factor_r(_r1)[assign_lhs_f(_val, _1)]
-        >> -(lit('^')
-             > negated_factor_r(_r1)[exponentiation_f(
-                   _val, _1, _r1, _pass, boost::phoenix::ref(error_msgs_))]);
+        >> -(lit('^') > negated_factor_r(_r1)[exponentiation_f(
+                 _val, _1, _r1, _pass, boost::phoenix::ref(error_msgs_))]);
 
   idx_factor_r.name("expression");
   idx_factor_r
       = factor_r(_r1)[assign_lhs_f(_val, _1)]
-        > *(((+dims_r(_r1))[assign_lhs_f(_a, _1)]
-             > eps[add_expression_dimss_f(_val, _a, _pass,
-                                          boost::phoenix::ref(error_msgs_))])
-            | (indexes_g(_r1)[assign_lhs_f(_b, _1)]
-               > eps[add_idxs_f(_val, _b, _pass,
-                                boost::phoenix::ref(error_msgs_))])
+        > *(((+dims_r(_r1))[assign_lhs_f(_a, _1)] > eps[add_expression_dimss_f(
+                 _val, _a, _pass, boost::phoenix::ref(error_msgs_))])
+            | (indexes_g(_r1)[assign_lhs_f(_b, _1)] > eps[add_idxs_f(
+                   _val, _b, _pass, boost::phoenix::ref(error_msgs_))])
             | (lit("'") > eps[transpose_f(_val, _pass,
                                           boost::phoenix::ref(error_msgs_))]));
 
@@ -196,8 +188,8 @@ term_grammar<Iterator>::term_grammar(variable_map& var_map,
          >> lit(',')
          >> expression_g(_r1)  // 10) maximum number of steps (data only)
          > lit(')')[validate_integrate_ode_control_f(
-               _val, boost::phoenix::ref(var_map_), _pass,
-               boost::phoenix::ref(error_msgs_))];
+             _val, boost::phoenix::ref(var_map_), _pass,
+             boost::phoenix::ref(error_msgs_))];
 
   integrate_ode_r.name("expression");
   integrate_ode_r
@@ -206,7 +198,7 @@ term_grammar<Iterator>::term_grammar(variable_map& var_map,
           | (string("integrate_ode_adams") >> no_skip[!char_("a-zA-Z0-9_")])
           | (string("integrate_ode")
              >> no_skip[!char_("a-zA-Z0-9_")])[deprecated_integrate_ode_f(
-                boost::phoenix::ref(error_msgs_))])
+              boost::phoenix::ref(error_msgs_))])
          > lit('(') > identifier_r  // 1) system function name (function only)
          > lit(',') > expression_g(_r1)  // 2) y0
          > lit(',') > expression_g(_r1)  // 3) t0
@@ -215,8 +207,8 @@ term_grammar<Iterator>::term_grammar(variable_map& var_map,
          > lit(',') > expression_g(_r1)  // 6) x (data only)
          > lit(',') > expression_g(_r1)  // 7) x_int (data only)
          > lit(')')[validate_integrate_ode_f(
-               _val, boost::phoenix::ref(var_map_), _pass,
-               boost::phoenix::ref(error_msgs_))];
+             _val, boost::phoenix::ref(var_map_), _pass,
+             boost::phoenix::ref(error_msgs_))];
 
   algebra_solver_control_r.name("expression");
   algebra_solver_control_r
@@ -231,8 +223,8 @@ term_grammar<Iterator>::term_grammar(variable_map& var_map,
          >> lit(',')
          >> expression_g(_r1)  // 8) maximum number of steps (data only)
          > lit(')')[validate_algebra_solver_control_f(
-               _val, boost::phoenix::ref(var_map_), _pass,
-               boost::phoenix::ref(error_msgs_))];
+             _val, boost::phoenix::ref(var_map_), _pass,
+             boost::phoenix::ref(error_msgs_))];
 
   algebra_solver_r.name("expression");
   algebra_solver_r %= (lit("algebra_solver") >> no_skip[!char_("a-zA-Z0-9_")])
@@ -243,8 +235,8 @@ term_grammar<Iterator>::term_grammar(variable_map& var_map,
                       > lit(',') > expression_g(_r1)  // 4) x_r (data only)
                       > lit(',') > expression_g(_r1)  // 5) x_i (data only)
                       > lit(')')[validate_algebra_solver_f(
-                            _val, boost::phoenix::ref(var_map_), _pass,
-                            boost::phoenix::ref(error_msgs_))];
+                          _val, boost::phoenix::ref(var_map_), _pass,
+                          boost::phoenix::ref(error_msgs_))];
 
   map_rect_r.name("map_rect");
   map_rect_r
@@ -254,9 +246,9 @@ term_grammar<Iterator>::term_grammar(variable_map& var_map,
          > lit(',') > expression_g(_r1)  // 3) job-specific param vector
          > lit(',') > expression_g(_r1)  // 4) job-specific real data vector
          > lit(',') > expression_g(_r1)  // 4) job-specific integer data vector
-         > lit(')')[validate_map_rect_f(_val, boost::phoenix::ref(var_map_),
-                                        _pass,
-                                        boost::phoenix::ref(error_msgs_))];
+         > lit(
+             ')')[validate_map_rect_f(_val, boost::phoenix::ref(var_map_),
+                                      _pass, boost::phoenix::ref(error_msgs_))];
 
   integrate_1d_r.name("integrate_1d");
   integrate_1d_r
@@ -280,10 +272,9 @@ term_grammar<Iterator>::term_grammar(variable_map& var_map,
         | algebra_solver_control_r(_r1)[assign_lhs_f(_val, _1)]
         | algebra_solver_r(_r1)[assign_lhs_f(_val, _1)]
         | map_rect_r(_r1)[assign_lhs_f(_val, _1)]
-        | (fun_r(_r1)[assign_lhs_f(_b, _1)]
-           > eps[set_fun_type_named_f(_val, _b, _r1, _pass,
-                                      boost::phoenix::ref(var_map_),
-                                      boost::phoenix::ref(error_msgs_))])
+        | (fun_r(_r1)[assign_lhs_f(_b, _1)] > eps[set_fun_type_named_f(
+               _val, _b, _r1, _pass, boost::phoenix::ref(var_map_),
+               boost::phoenix::ref(error_msgs_))])
         | (variable_r[assign_lhs_f(_a, _1)]
            > eps[set_var_type_f(_a, _val, boost::phoenix::ref(var_map_),
                                 boost::phoenix::ref(error_msgs_), _pass)])
@@ -295,8 +286,8 @@ term_grammar<Iterator>::term_grammar(variable_map& var_map,
                                          boost::phoenix::ref(error_msgs_))])
         | (vec_expr_r(_r1)[assign_lhs_f(_d, _1)]
            > eps[infer_vec_or_matrix_expr_type_f(
-                 _val, _d, _r1, _pass, boost::phoenix::ref(var_map_),
-                 boost::phoenix::ref(error_msgs_))])
+               _val, _d, _r1, _pass, boost::phoenix::ref(var_map_),
+               boost::phoenix::ref(error_msgs_))])
         | (lit('(') > expression_g(_r1)[assign_lhs_f(_val, _1)] > lit(')'));
 
   str_double_literal_r.name("double literal");

--- a/src/stan/lang/grammars/whitespace_grammar_def.hpp
+++ b/src/stan/lang/grammars/whitespace_grammar_def.hpp
@@ -21,7 +21,7 @@ whitespace_grammar<Iterator>::whitespace_grammar(std::stringstream& ss)
   whitespace = ((omit["/*"] >> *(char_ - "*/")) > omit["*/"])
                | (omit["//"] >> *(char_ - eol))
                | (omit["#"] >> *(char_ - eol))[deprecate_pound_comment_f(
-                     boost::phoenix::ref(error_msgs_))]
+                   boost::phoenix::ref(error_msgs_))]
                | boost::spirit::ascii::space_type();
 }
 

--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -134,7 +134,7 @@ class base_hmc : public base_mcmc {
     this->z_.ps_point::operator=(z_init);
   }
 
-  typename Hamiltonian<Model, BaseRNG>::PointType& z() { return z_; }
+  typename Hamiltonian<Model, BaseRNG>::point_type& z() { return z_; }
 
   virtual void set_nominal_stepsize(double e) {
     if (e > 0)
@@ -160,7 +160,7 @@ class base_hmc : public base_mcmc {
   }
 
  protected:
-  typename Hamiltonian<Model, BaseRNG>::PointType z_;
+  typename Hamiltonian<Model, BaseRNG>::point_type z_;
   Integrator<Hamiltonian<Model, BaseRNG> > integrator_;
   Hamiltonian<Model, BaseRNG> hamiltonian_;
 

--- a/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
@@ -14,7 +14,17 @@
 namespace stan {
 namespace mcmc {
 
-template <typename Derived, typename Model, typename PointType, typename BaseRNG>
+/**
+ * Base CRTP class for hamiltonians.
+ * @tparam Derived type that inherits from base_hamiltonian and defines members
+ * functions @c T, @c tau @c phi @c dG_dt, @c dtau_dq, @c dtau_dp, @c dphi_dq,
+ * and @c sample_p
+ * @tparam Model class that can take returns log probability
+ * @tparam PointType type that inherits from ps_point
+ * @tparam BaseRNG a random number generator class.
+ */
+template <typename Derived, typename Model, typename PointType,
+          typename BaseRNG>
 class base_hamiltonian {
  public:
   explicit base_hamiltonian(const Model& model) : model_(model) {}
@@ -23,21 +33,17 @@ class base_hamiltonian {
   // modifier to the derived class
   inline Derived& derived() { return static_cast<Derived&>(*this); }
   // inspector to the derived class
-  inline const Derived& derived() const { return static_cast<Derived const&>(*this); }
+  inline const Derived& derived() const {
+    return static_cast<Derived const&>(*this);
+  }
 
-  inline auto T(point_type& z) {
-    return this->derived().T(z);
-  };
+  inline auto T(point_type& z) { return this->derived().T(z); };
 
   inline auto V(point_type& z) { return z.V; }
 
-  inline auto tau(point_type& z){
-    return this->derived().tau(z);
-  };
+  inline auto tau(point_type& z) { return this->derived().tau(z); };
 
-  inline auto phi(point_type& z) {
-    return this->derived().phi(z);
-  };
+  inline auto phi(point_type& z) { return this->derived().phi(z); };
 
   inline auto H(point_type& z) { return T(z) + V(z); }
 
@@ -51,9 +57,7 @@ class base_hamiltonian {
     return this->derived().dtau_dq(z, logger);
   };
 
-  inline auto dtau_dp(point_type& z) {
-    return this->derived().dtau_dp(z);
-  };
+  inline auto dtau_dp(point_type& z) { return this->derived().dtau_dp(z); };
 
   // phi = 0.5 * log | Lambda (q) | + V(q)
   inline auto dphi_dq(point_type& z, callbacks::logger& logger) {
@@ -77,7 +81,8 @@ class base_hamiltonian {
     }
   }
 
-  inline void update_potential_gradient(point_type& z, callbacks::logger& logger) {
+  inline void update_potential_gradient(point_type& z,
+                                        callbacks::logger& logger) {
     try {
       stan::model::gradient(model_, z.q, z.V, z.g, logger);
       z.V = -z.V;
@@ -90,7 +95,8 @@ class base_hamiltonian {
 
   inline void update_metric(point_type& z, callbacks::logger& logger) {}
 
-  inline void update_metric_gradient(point_type& z, callbacks::logger& logger) {}
+  inline void update_metric_gradient(point_type& z, callbacks::logger& logger) {
+  }
 
   inline void update_gradients(point_type& z, callbacks::logger& logger) {
     update_potential_gradient(z, logger);
@@ -99,7 +105,8 @@ class base_hamiltonian {
  protected:
   const Model& model_;
 
-  inline void write_error_msg_(const std::exception& e, callbacks::logger& logger) {
+  inline void write_error_msg_(const std::exception& e,
+                               callbacks::logger& logger) {
     logger.error(
         "Informational Message: The current Metropolis proposal "
         "is about to be rejected because of the following issue:");

--- a/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
@@ -14,43 +14,61 @@
 namespace stan {
 namespace mcmc {
 
-template <class Model, class Point, class BaseRNG>
+template <typename Derived, typename Model, typename PointType, typename BaseRNG>
 class base_hamiltonian {
  public:
   explicit base_hamiltonian(const Model& model) : model_(model) {}
 
-  ~base_hamiltonian() {}
+  using point_type = PointType;
+  // modifier to the derived class
+  inline Derived& derived() { return static_cast<Derived&>(*this); }
+  // inspector to the derived class
+  inline const Derived& derived() const { return static_cast<Derived const&>(*this); }
 
-  typedef Point PointType;
+  inline auto T(point_type& z) {
+    return this->derived().T(z);
+  };
 
-  virtual double T(Point& z) = 0;
+  inline auto V(point_type& z) { return z.V; }
 
-  double V(Point& z) { return z.V; }
+  inline auto tau(point_type& z){
+    return this->derived().tau(z);
+  };
 
-  virtual double tau(Point& z) = 0;
+  inline auto phi(point_type& z) {
+    return this->derived().phi(z);
+  };
 
-  virtual double phi(Point& z) = 0;
-
-  double H(Point& z) { return T(z) + V(z); }
+  inline auto H(point_type& z) { return T(z) + V(z); }
 
   // The time derivative of the virial, G = \sum_{d = 1}^{D} q^{d} p_{d}.
-  virtual double dG_dt(Point& z, callbacks::logger& logger) = 0;
+  inline auto dG_dt(point_type& z, callbacks::logger& logger) {
+    return this->derived().dG_dt(z, logger);
+  };
 
   // tau = 0.5 p_{i} p_{j} Lambda^{ij} (q)
-  virtual Eigen::VectorXd dtau_dq(Point& z, callbacks::logger& logger) = 0;
+  inline auto dtau_dq(point_type& z, callbacks::logger& logger) {
+    return this->derived().dtau_dq(z, logger);
+  };
 
-  virtual Eigen::VectorXd dtau_dp(Point& z) = 0;
+  inline auto dtau_dp(point_type& z) {
+    return this->derived().dtau_dp(z);
+  };
 
   // phi = 0.5 * log | Lambda (q) | + V(q)
-  virtual Eigen::VectorXd dphi_dq(Point& z, callbacks::logger& logger) = 0;
+  inline auto dphi_dq(point_type& z, callbacks::logger& logger) {
+    return this->derived().dphi_dq(z, logger);
+  };
 
-  virtual void sample_p(Point& z, BaseRNG& rng) = 0;
+  inline void sample_p(point_type& z, BaseRNG& rng) {
+    this->derived().sample_p(z, rng);
+  };
 
-  void init(Point& z, callbacks::logger& logger) {
+  inline void init(point_type& z, callbacks::logger& logger) {
     this->update_potential_gradient(z, logger);
   }
 
-  void update_potential(Point& z, callbacks::logger& logger) {
+  inline void update_potential(point_type& z, callbacks::logger& logger) {
     try {
       z.V = -stan::model::log_prob_propto<true>(model_, z.q);
     } catch (const std::exception& e) {
@@ -59,7 +77,7 @@ class base_hamiltonian {
     }
   }
 
-  void update_potential_gradient(Point& z, callbacks::logger& logger) {
+  inline void update_potential_gradient(point_type& z, callbacks::logger& logger) {
     try {
       stan::model::gradient(model_, z.q, z.V, z.g, logger);
       z.V = -z.V;
@@ -70,18 +88,18 @@ class base_hamiltonian {
     z.g = -z.g;
   }
 
-  void update_metric(Point& z, callbacks::logger& logger) {}
+  inline void update_metric(point_type& z, callbacks::logger& logger) {}
 
-  void update_metric_gradient(Point& z, callbacks::logger& logger) {}
+  inline void update_metric_gradient(point_type& z, callbacks::logger& logger) {}
 
-  void update_gradients(Point& z, callbacks::logger& logger) {
+  inline void update_gradients(point_type& z, callbacks::logger& logger) {
     update_potential_gradient(z, logger);
   }
 
  protected:
   const Model& model_;
 
-  void write_error_msg_(const std::exception& e, callbacks::logger& logger) {
+  inline void write_error_msg_(const std::exception& e, callbacks::logger& logger) {
     logger.error(
         "Informational Message: The current Metropolis proposal "
         "is about to be rejected because of the following issue:");

--- a/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
@@ -14,34 +14,40 @@ namespace mcmc {
 
 // Euclidean manifold with dense metric
 template <class Model, class BaseRNG>
-class dense_e_metric : public base_hamiltonian<Model, dense_e_point, BaseRNG> {
+class dense_e_metric : public base_hamiltonian<dense_e_metric<Model, BaseRNG>, Model, dense_e_point, BaseRNG> {
  public:
   explicit dense_e_metric(const Model& model)
-      : base_hamiltonian<Model, dense_e_point, BaseRNG>(model) {}
-
-  double T(dense_e_point& z) {
+      : base_hamiltonian<dense_e_metric<Model, BaseRNG>, Model, dense_e_point, BaseRNG>(model) {
+        dtau_dq_ = Eigen::VectorXd::Zero(this->model_.num_params_r());
+      }
+  Eigen::VectorXd dtau_dq_;
+  inline auto T(dense_e_point& z) {
     return 0.5 * z.p.transpose() * z.inv_e_metric_ * z.p;
   }
 
-  double tau(dense_e_point& z) { return T(z); }
+  inline auto tau(dense_e_point& z) { return T(z); }
 
-  double phi(dense_e_point& z) { return this->V(z); }
+  inline auto phi(dense_e_point& z) { return this->V(z); }
 
-  double dG_dt(dense_e_point& z, callbacks::logger& logger) {
+  inline auto dG_dt(dense_e_point& z, callbacks::logger& logger) {
     return 2 * T(z) - z.q.dot(z.g);
   }
 
-  Eigen::VectorXd dtau_dq(dense_e_point& z, callbacks::logger& logger) {
-    return Eigen::VectorXd::Zero(this->model_.num_params_r());
+  inline auto dtau_dq(dense_e_point& z, callbacks::logger& logger) {
+    return dtau_dq_;
   }
 
-  Eigen::VectorXd dtau_dp(dense_e_point& z) { return z.inv_e_metric_ * z.p; }
+  inline const auto dtau_dq(dense_e_point& z, callbacks::logger& logger) const {
+    return dtau_dq_;
+  }
 
-  Eigen::VectorXd dphi_dq(dense_e_point& z, callbacks::logger& logger) {
+  inline auto dtau_dp(dense_e_point& z) { return z.inv_e_metric_ * z.p; }
+
+  inline auto& dphi_dq(dense_e_point& z, callbacks::logger& logger) {
     return z.g;
   }
 
-  void sample_p(dense_e_point& z, BaseRNG& rng) {
+  inline void sample_p(dense_e_point& z, BaseRNG& rng) {
     typedef typename stan::math::index_type<Eigen::VectorXd>::type idx_t;
     boost::variate_generator<BaseRNG&, boost::normal_distribution<> >
         rand_dense_gaus(rng, boost::normal_distribution<>());

--- a/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
@@ -14,12 +14,14 @@ namespace mcmc {
 
 // Euclidean manifold with dense metric
 template <class Model, class BaseRNG>
-class dense_e_metric : public base_hamiltonian<dense_e_metric<Model, BaseRNG>, Model, dense_e_point, BaseRNG> {
+class dense_e_metric : public base_hamiltonian<dense_e_metric<Model, BaseRNG>,
+                                               Model, dense_e_point, BaseRNG> {
  public:
   explicit dense_e_metric(const Model& model)
-      : base_hamiltonian<dense_e_metric<Model, BaseRNG>, Model, dense_e_point, BaseRNG>(model) {
-        dtau_dq_ = Eigen::VectorXd::Zero(this->model_.num_params_r());
-      }
+      : base_hamiltonian<dense_e_metric<Model, BaseRNG>, Model, dense_e_point,
+                         BaseRNG>(model) {
+    dtau_dq_ = Eigen::VectorXd::Zero(this->model_.num_params_r());
+  }
   Eigen::VectorXd dtau_dq_;
   inline auto T(dense_e_point& z) {
     return 0.5 * z.p.transpose() * z.inv_e_metric_ * z.p;

--- a/src/stan/mcmc/hmc/hamiltonians/dense_e_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/dense_e_point.hpp
@@ -32,7 +32,7 @@ class dense_e_point : public ps_point {
    *
    * @param inv_e_metric initial mass matrix
    */
-  void set_metric(const Eigen::MatrixXd& inv_e_metric) {
+  inline void set_metric(const Eigen::MatrixXd& inv_e_metric) {
     inv_e_metric_ = inv_e_metric;
   }
 

--- a/src/stan/mcmc/hmc/hamiltonians/dense_e_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/dense_e_point.hpp
@@ -41,7 +41,7 @@ class dense_e_point : public ps_point {
    *
    * @param writer Stan writer callback
    */
-  inline void write_metric(stan::callbacks::writer& writer) {
+  inline void write_metric(stan::callbacks::writer& writer) final {
     writer("Elements of inverse mass matrix:");
     for (int i = 0; i < inv_e_metric_.rows(); ++i) {
       std::stringstream inv_e_metric_ss;

--- a/src/stan/mcmc/hmc/hamiltonians/diag_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/diag_e_metric.hpp
@@ -12,36 +12,43 @@ namespace mcmc {
 
 // Euclidean manifold with diagonal metric
 template <class Model, class BaseRNG>
-class diag_e_metric : public base_hamiltonian<Model, diag_e_point, BaseRNG> {
+class diag_e_metric : public base_hamiltonian<diag_e_metric<Model, BaseRNG>, Model, diag_e_point, BaseRNG> {
  public:
   explicit diag_e_metric(const Model& model)
-      : base_hamiltonian<Model, diag_e_point, BaseRNG>(model) {}
+      : base_hamiltonian<diag_e_metric<Model, BaseRNG>, Model, diag_e_point, BaseRNG>(model) {
+        dtau_dq_ = Eigen::VectorXd::Zero(this->model_.num_params_r());
+  }
 
-  double T(diag_e_point& z) {
+  Eigen::VectorXd dtau_dq_;
+  inline auto T(diag_e_point& z) {
     return 0.5 * z.p.dot(z.inv_e_metric_.cwiseProduct(z.p));
   }
 
-  double tau(diag_e_point& z) { return T(z); }
+  inline auto tau(diag_e_point& z) { return T(z); }
 
-  double phi(diag_e_point& z) { return this->V(z); }
+  inline auto phi(diag_e_point& z) { return this->V(z); }
 
-  double dG_dt(diag_e_point& z, callbacks::logger& logger) {
+  inline auto dG_dt(diag_e_point& z, callbacks::logger& logger) {
     return 2 * T(z) - z.q.dot(z.g);
   }
 
-  Eigen::VectorXd dtau_dq(diag_e_point& z, callbacks::logger& logger) {
-    return Eigen::VectorXd::Zero(this->model_.num_params_r());
+  inline auto dtau_dq(diag_e_point& z, callbacks::logger& logger) {
+    return dtau_dq_;
   }
 
-  Eigen::VectorXd dtau_dp(diag_e_point& z) {
+  inline const auto dtau_dq(diag_e_point& z, callbacks::logger& logger) const {
+    return dtau_dq_;
+  }
+
+  inline auto dtau_dp(diag_e_point& z) {
     return z.inv_e_metric_.cwiseProduct(z.p);
   }
 
-  Eigen::VectorXd dphi_dq(diag_e_point& z, callbacks::logger& logger) {
+  inline auto dphi_dq(diag_e_point& z, callbacks::logger& logger) {
     return z.g;
   }
 
-  void sample_p(diag_e_point& z, BaseRNG& rng) {
+  inline void sample_p(diag_e_point& z, BaseRNG& rng) {
     boost::variate_generator<BaseRNG&, boost::normal_distribution<> >
         rand_diag_gaus(rng, boost::normal_distribution<>());
 

--- a/src/stan/mcmc/hmc/hamiltonians/diag_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/diag_e_metric.hpp
@@ -12,11 +12,13 @@ namespace mcmc {
 
 // Euclidean manifold with diagonal metric
 template <class Model, class BaseRNG>
-class diag_e_metric : public base_hamiltonian<diag_e_metric<Model, BaseRNG>, Model, diag_e_point, BaseRNG> {
+class diag_e_metric : public base_hamiltonian<diag_e_metric<Model, BaseRNG>,
+                                              Model, diag_e_point, BaseRNG> {
  public:
   explicit diag_e_metric(const Model& model)
-      : base_hamiltonian<diag_e_metric<Model, BaseRNG>, Model, diag_e_point, BaseRNG>(model) {
-        dtau_dq_ = Eigen::VectorXd::Zero(this->model_.num_params_r());
+      : base_hamiltonian<diag_e_metric<Model, BaseRNG>, Model, diag_e_point,
+                         BaseRNG>(model) {
+    dtau_dq_ = Eigen::VectorXd::Zero(this->model_.num_params_r());
   }
 
   Eigen::VectorXd dtau_dq_;

--- a/src/stan/mcmc/hmc/hamiltonians/diag_e_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/diag_e_point.hpp
@@ -41,7 +41,7 @@ class diag_e_point : public ps_point {
    *
    * @param writer Stan writer callback
    */
-  inline void write_metric(stan::callbacks::writer& writer) {
+  inline void write_metric(stan::callbacks::writer& writer) final {
     writer("Diagonal elements of inverse mass matrix:");
     std::stringstream inv_e_metric_ss;
     inv_e_metric_ss << inv_e_metric_(0);

--- a/src/stan/mcmc/hmc/hamiltonians/diag_e_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/diag_e_point.hpp
@@ -32,7 +32,7 @@ class diag_e_point : public ps_point {
    *
    * @param inv_e_metric initial mass matrix
    */
-  void set_metric(const Eigen::VectorXd& inv_e_metric) {
+  inline void set_metric(const Eigen::VectorXd& inv_e_metric) {
     inv_e_metric_ = inv_e_metric;
   }
 

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -25,7 +25,7 @@ class ps_point {
   double V{0};
 
   inline void get_param_names(std::vector<std::string>& model_names,
-                                      std::vector<std::string>& names) {
+                              std::vector<std::string>& names) {
     names.reserve(q.size() + p.size() + g.size());
     for (int i = 0; i < q.size(); ++i)
       names.emplace_back(model_names[i]);

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -24,7 +24,7 @@ class ps_point {
   Eigen::VectorXd g;
   double V{0};
 
-  virtual inline void get_param_names(std::vector<std::string>& model_names,
+  inline void get_param_names(std::vector<std::string>& model_names,
                                       std::vector<std::string>& names) {
     names.reserve(q.size() + p.size() + g.size());
     for (int i = 0; i < q.size(); ++i)
@@ -35,7 +35,7 @@ class ps_point {
       names.emplace_back(std::string("g_") + model_names[i]);
   }
 
-  virtual inline void get_params(std::vector<double>& values) {
+  inline void get_params(std::vector<double>& values) {
     values.reserve(q.size() + p.size() + g.size());
     for (int i = 0; i < q.size(); ++i)
       values.push_back(q[i]);

--- a/src/stan/mcmc/hmc/hamiltonians/softabs_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/softabs_point.hpp
@@ -40,7 +40,7 @@ class softabs_point : public ps_point {
   // Psuedo-Jacobian of the eigenvalues
   Eigen::MatrixXd pseudo_j;
 
-  virtual inline void write_metric(stan::callbacks::writer& writer) {
+  virtual inline void write_metric(stan::callbacks::writer& writer) final {
     writer("No free parameters for SoftAbs metric");
   }
 };

--- a/src/stan/mcmc/hmc/hamiltonians/unit_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/unit_e_metric.hpp
@@ -11,12 +11,14 @@ namespace mcmc {
 
 // Euclidean manifold with unit metric
 template <class Model, class BaseRNG>
-class unit_e_metric : public base_hamiltonian<unit_e_metric<Model, BaseRNG>, Model, unit_e_point, BaseRNG> {
+class unit_e_metric : public base_hamiltonian<unit_e_metric<Model, BaseRNG>,
+                                              Model, unit_e_point, BaseRNG> {
  public:
   explicit unit_e_metric(const Model& model)
-      : base_hamiltonian<unit_e_metric<Model, BaseRNG>, Model, unit_e_point, BaseRNG>(model) {
-        dtau_dq_ = Eigen::VectorXd::Zero(this->model_.num_params_r());
-      }
+      : base_hamiltonian<unit_e_metric<Model, BaseRNG>, Model, unit_e_point,
+                         BaseRNG>(model) {
+    dtau_dq_ = Eigen::VectorXd::Zero(this->model_.num_params_r());
+  }
   Eigen::VectorXd dtau_dq_;
   inline auto T(unit_e_point& z) { return 0.5 * z.p.squaredNorm(); }
 

--- a/src/stan/mcmc/hmc/hamiltonians/unit_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/unit_e_metric.hpp
@@ -11,32 +11,34 @@ namespace mcmc {
 
 // Euclidean manifold with unit metric
 template <class Model, class BaseRNG>
-class unit_e_metric : public base_hamiltonian<Model, unit_e_point, BaseRNG> {
+class unit_e_metric : public base_hamiltonian<unit_e_metric<Model, BaseRNG>, Model, unit_e_point, BaseRNG> {
  public:
   explicit unit_e_metric(const Model& model)
-      : base_hamiltonian<Model, unit_e_point, BaseRNG>(model) {}
+      : base_hamiltonian<unit_e_metric<Model, BaseRNG>, Model, unit_e_point, BaseRNG>(model) {
+        dtau_dq_ = Eigen::VectorXd::Zero(this->model_.num_params_r());
+      }
+  Eigen::VectorXd dtau_dq_;
+  inline auto T(unit_e_point& z) { return 0.5 * z.p.squaredNorm(); }
 
-  double T(unit_e_point& z) { return 0.5 * z.p.squaredNorm(); }
+  inline auto tau(unit_e_point& z) { return T(z); }
 
-  double tau(unit_e_point& z) { return T(z); }
+  inline auto phi(unit_e_point& z) { return this->V(z); }
 
-  double phi(unit_e_point& z) { return this->V(z); }
-
-  double dG_dt(unit_e_point& z, callbacks::logger& logger) {
+  inline auto dG_dt(unit_e_point& z, callbacks::logger& logger) {
     return 2 * T(z) - z.q.dot(z.g);
   }
 
-  Eigen::VectorXd dtau_dq(unit_e_point& z, callbacks::logger& logger) {
-    return Eigen::VectorXd::Zero(this->model_.num_params_r());
+  inline auto dtau_dq(unit_e_point& z, callbacks::logger& logger) {
+    return dtau_dq_;
   }
 
-  Eigen::VectorXd dtau_dp(unit_e_point& z) { return z.p; }
+  inline auto dtau_dp(unit_e_point& z) { return z.p; }
 
-  Eigen::VectorXd dphi_dq(unit_e_point& z, callbacks::logger& logger) {
+  inline auto dphi_dq(unit_e_point& z, callbacks::logger& logger) {
     return z.g;
   }
 
-  void sample_p(unit_e_point& z, BaseRNG& rng) {
+  inline void sample_p(unit_e_point& z, BaseRNG& rng) {
     boost::variate_generator<BaseRNG&, boost::normal_distribution<> >
         rand_unit_gaus(rng, boost::normal_distribution<>());
 

--- a/src/stan/mcmc/hmc/hamiltonians/unit_e_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/unit_e_point.hpp
@@ -12,11 +12,10 @@ namespace mcmc {
 class unit_e_point : public ps_point {
  public:
   explicit unit_e_point(int n) : ps_point(n) {}
+  inline void write_metric(stan::callbacks::writer& writer) final {
+    writer("No free parameters for unit metric");
+  }
 };
-
-inline void write_metric(stan::callbacks::writer& writer) {
-  writer("No free parameters for unit metric");
-}
 
 }  // namespace mcmc
 }  // namespace stan

--- a/src/stan/mcmc/hmc/integrators/base_integrator.hpp
+++ b/src/stan/mcmc/hmc/integrators/base_integrator.hpp
@@ -11,7 +11,7 @@ class base_integrator {
  public:
   base_integrator() {}
 
-  virtual void evolve(typename Hamiltonian::PointType& z,
+  virtual void evolve(typename Hamiltonian::point_type& z,
                       Hamiltonian& hamiltonian, const double epsilon,
                       callbacks::logger& logger)
       = 0;

--- a/src/stan/mcmc/hmc/integrators/base_leapfrog.hpp
+++ b/src/stan/mcmc/hmc/integrators/base_leapfrog.hpp
@@ -14,14 +14,14 @@ class base_leapfrog : public base_integrator<Hamiltonian> {
  public:
   base_leapfrog() : base_integrator<Hamiltonian>() {}
 
-  void evolve(typename Hamiltonian::PointType& z, Hamiltonian& hamiltonian,
+  void evolve(typename Hamiltonian::point_type& z, Hamiltonian& hamiltonian,
               const double epsilon, callbacks::logger& logger) {
     begin_update_p(z, hamiltonian, 0.5 * epsilon, logger);
     update_q(z, hamiltonian, epsilon, logger);
     end_update_p(z, hamiltonian, 0.5 * epsilon, logger);
   }
 
-  void verbose_evolve(typename Hamiltonian::PointType& z,
+  void verbose_evolve(typename Hamiltonian::point_type& z,
                       Hamiltonian& hamiltonian, const double epsilon,
                       callbacks::logger& logger) {
     std::stringstream msg;
@@ -97,16 +97,16 @@ class base_leapfrog : public base_integrator<Hamiltonian> {
     logger.info(msg);
   }
 
-  virtual void begin_update_p(typename Hamiltonian::PointType& z,
+  virtual void begin_update_p(typename Hamiltonian::point_type& z,
                               Hamiltonian& hamiltonian, double epsilon,
                               callbacks::logger& logger)
       = 0;
 
-  virtual void update_q(typename Hamiltonian::PointType& z,
+  virtual void update_q(typename Hamiltonian::point_type& z,
                         Hamiltonian& hamiltonian, double epsilon,
                         callbacks::logger& logger)
       = 0;
-  virtual void end_update_p(typename Hamiltonian::PointType& z,
+  virtual void end_update_p(typename Hamiltonian::point_type& z,
                             Hamiltonian& hamiltonian, double epsilon,
                             callbacks::logger& logger)
       = 0;

--- a/src/stan/mcmc/hmc/integrators/expl_leapfrog.hpp
+++ b/src/stan/mcmc/hmc/integrators/expl_leapfrog.hpp
@@ -13,19 +13,19 @@ class expl_leapfrog : public base_leapfrog<Hamiltonian> {
  public:
   expl_leapfrog() : base_leapfrog<Hamiltonian>() {}
 
-  void begin_update_p(typename Hamiltonian::PointType& z,
+  void begin_update_p(typename Hamiltonian::point_type& z,
                       Hamiltonian& hamiltonian, double epsilon,
                       callbacks::logger& logger) {
     z.p -= epsilon * hamiltonian.dphi_dq(z, logger);
   }
 
-  void update_q(typename Hamiltonian::PointType& z, Hamiltonian& hamiltonian,
+  void update_q(typename Hamiltonian::point_type& z, Hamiltonian& hamiltonian,
                 double epsilon, callbacks::logger& logger) {
     z.q += epsilon * hamiltonian.dtau_dp(z);
     hamiltonian.update_potential_gradient(z, logger);
   }
 
-  void end_update_p(typename Hamiltonian::PointType& z,
+  void end_update_p(typename Hamiltonian::point_type& z,
                     Hamiltonian& hamiltonian, double epsilon,
                     callbacks::logger& logger) {
     z.p -= epsilon * hamiltonian.dphi_dq(z, logger);

--- a/src/stan/mcmc/hmc/integrators/impl_leapfrog.hpp
+++ b/src/stan/mcmc/hmc/integrators/impl_leapfrog.hpp
@@ -15,14 +15,14 @@ class impl_leapfrog : public base_leapfrog<Hamiltonian> {
         max_num_fixed_point_(10),
         fixed_point_threshold_(1e-8) {}
 
-  void begin_update_p(typename Hamiltonian::PointType& z,
+  void begin_update_p(typename Hamiltonian::point_type& z,
                       Hamiltonian& hamiltonian, double epsilon,
                       callbacks::logger& logger) {
     hat_phi(z, hamiltonian, epsilon, logger);
     hat_tau(z, hamiltonian, epsilon, this->max_num_fixed_point_, logger);
   }
 
-  void update_q(typename Hamiltonian::PointType& z, Hamiltonian& hamiltonian,
+  void update_q(typename Hamiltonian::point_type& z, Hamiltonian& hamiltonian,
                 double epsilon, callbacks::logger& logger) {
     // hat{T} = dT/dp * d/dq
     Eigen::VectorXd q_init = z.q + 0.5 * epsilon * hamiltonian.dtau_dp(z);
@@ -40,7 +40,7 @@ class impl_leapfrog : public base_leapfrog<Hamiltonian> {
     hamiltonian.update_gradients(z, logger);
   }
 
-  void end_update_p(typename Hamiltonian::PointType& z,
+  void end_update_p(typename Hamiltonian::point_type& z,
                     Hamiltonian& hamiltonian, double epsilon,
                     callbacks::logger& logger) {
     hat_tau(z, hamiltonian, epsilon, 1, logger);
@@ -48,13 +48,13 @@ class impl_leapfrog : public base_leapfrog<Hamiltonian> {
   }
 
   // hat{phi} = dphi/dq * d/dp
-  void hat_phi(typename Hamiltonian::PointType& z, Hamiltonian& hamiltonian,
+  void hat_phi(typename Hamiltonian::point_type& z, Hamiltonian& hamiltonian,
                double epsilon, callbacks::logger& logger) {
     z.p -= epsilon * hamiltonian.dphi_dq(z, logger);
   }
 
   // hat{tau} = dtau/dq * d/dp
-  void hat_tau(typename Hamiltonian::PointType& z, Hamiltonian& hamiltonian,
+  void hat_tau(typename Hamiltonian::point_type& z, Hamiltonian& hamiltonian,
                double epsilon, int num_fixed_point, callbacks::logger& logger) {
     Eigen::VectorXd p_init = z.p;
     Eigen::VectorXd delta_p(z.p.size());

--- a/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
@@ -172,7 +172,7 @@ class base_nuts_classic
   }
 
   virtual bool compute_criterion(
-      ps_point& start, typename Hamiltonian<Model, BaseRNG>::PointType& finish,
+      ps_point& start, typename Hamiltonian<Model, BaseRNG>::point_type& finish,
       Eigen::VectorXd& rho)
       = 0;
 

--- a/src/stan/mcmc/hmc/static_uniform/dense_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/dense_e_static_uniform.hpp
@@ -20,7 +20,7 @@ class dense_e_static_uniform
  public:
   dense_e_static_uniform(const Model& model, BaseRNG& rng)
       : base_static_uniform<Model, dense_e_metric, expl_leapfrog, BaseRNG>(
-            model, rng) {}
+          model, rng) {}
 };
 }  // namespace mcmc
 }  // namespace stan

--- a/src/stan/mcmc/hmc/static_uniform/diag_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/diag_e_static_uniform.hpp
@@ -19,7 +19,7 @@ class diag_e_static_uniform
  public:
   diag_e_static_uniform(const Model& model, BaseRNG& rng)
       : base_static_uniform<Model, diag_e_metric, expl_leapfrog, BaseRNG>(
-            model, rng) {}
+          model, rng) {}
 };
 }  // namespace mcmc
 }  // namespace stan

--- a/src/stan/mcmc/hmc/static_uniform/softabs_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/softabs_static_uniform.hpp
@@ -20,7 +20,7 @@ class softabs_static_uniform
  public:
   softabs_static_uniform(const Model& model, BaseRNG& rng)
       : base_static_uniform<Model, softabs_metric, impl_leapfrog, BaseRNG>(
-            model, rng) {}
+          model, rng) {}
 };
 }  // namespace mcmc
 }  // namespace stan

--- a/src/stan/mcmc/hmc/static_uniform/unit_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/unit_e_static_uniform.hpp
@@ -19,7 +19,7 @@ class unit_e_static_uniform
  public:
   unit_e_static_uniform(const Model& model, BaseRNG& rng)
       : base_static_uniform<Model, unit_e_metric, expl_leapfrog, BaseRNG>(
-            model, rng) {}
+          model, rng) {}
 };
 }  // namespace mcmc
 }  // namespace stan

--- a/src/test/unit/lang/parser/test_statement_grammar_def.hpp
+++ b/src/test/unit/lang/parser/test_statement_grammar_def.hpp
@@ -32,9 +32,8 @@ test_statement_grammar<Iterator>::test_statement_grammar(
   using boost::spirit::qi::labels::_a;
 
   test_statement_r.name("test statement");
-  test_statement_r
-      %= eps[set_var_scope_f(_a, derived_origin)]
-         > statement_g(_a, false);  // not in loop, disallow break/continue
+  test_statement_r %= eps[set_var_scope_f(_a, derived_origin)] > statement_g(
+                          _a, false);  // not in loop, disallow break/continue
 }
 
 }  // namespace lang

--- a/src/test/unit/mcmc/hmc/mock_hmc.hpp
+++ b/src/test/unit/mcmc/hmc/mock_hmc.hpp
@@ -36,10 +36,13 @@ class mock_model : public model::prob_grad {
 
 // Mock Hamiltonian
 template <typename Model, typename BaseRNG>
-class mock_hamiltonian : public base_hamiltonian<mock_hamiltonian<Model, BaseRNG>, Model, ps_point, BaseRNG> {
+class mock_hamiltonian
+    : public base_hamiltonian<mock_hamiltonian<Model, BaseRNG>, Model, ps_point,
+                              BaseRNG> {
  public:
   explicit mock_hamiltonian(const Model& model)
-      : base_hamiltonian<mock_hamiltonian<Model, BaseRNG>, Model, ps_point, BaseRNG>(model) {}
+      : base_hamiltonian<mock_hamiltonian<Model, BaseRNG>, Model, ps_point,
+                         BaseRNG>(model) {}
 
   double T(ps_point& z) { return 0; }
 

--- a/src/test/unit/mcmc/hmc/mock_hmc.hpp
+++ b/src/test/unit/mcmc/hmc/mock_hmc.hpp
@@ -36,10 +36,10 @@ class mock_model : public model::prob_grad {
 
 // Mock Hamiltonian
 template <typename Model, typename BaseRNG>
-class mock_hamiltonian : public base_hamiltonian<Model, ps_point, BaseRNG> {
+class mock_hamiltonian : public base_hamiltonian<mock_hamiltonian<Model, BaseRNG>, Model, ps_point, BaseRNG> {
  public:
   explicit mock_hamiltonian(const Model& model)
-      : base_hamiltonian<Model, ps_point, BaseRNG>(model) {}
+      : base_hamiltonian<mock_hamiltonian<Model, BaseRNG>, Model, ps_point, BaseRNG>(model) {}
 
   double T(ps_point& z) { return 0; }
 
@@ -68,7 +68,7 @@ class mock_integrator : public base_integrator<Hamiltonian> {
  public:
   mock_integrator() : base_integrator<Hamiltonian>() {}
 
-  void evolve(typename Hamiltonian::PointType& z, Hamiltonian& hamiltonian,
+  void evolve(typename Hamiltonian::point_type& z, Hamiltonian& hamiltonian,
               const double epsilon, callbacks::logger& logger) {
     z.q += epsilon * z.p;
   };

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -58,11 +58,12 @@ class edge_inspector_mock_nuts
 
 // Mock Hamiltonian
 template <typename M, typename BaseRNG>
-class divergent_hamiltonian : public base_hamiltonian<M, ps_point, BaseRNG> {
+class divergent_hamiltonian : public base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG> {
  public:
   divergent_hamiltonian(const M& m)
-      : base_hamiltonian<M, ps_point, BaseRNG>(m) {}
+      : base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG>(m) {}
 
+  using point_type = ps_point;
   double T(ps_point& z) { return 0; }
 
   double tau(ps_point& z) { return T(z); }

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -58,10 +58,13 @@ class edge_inspector_mock_nuts
 
 // Mock Hamiltonian
 template <typename M, typename BaseRNG>
-class divergent_hamiltonian : public base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG> {
+class divergent_hamiltonian
+    : public base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point,
+                              BaseRNG> {
  public:
   divergent_hamiltonian(const M& m)
-      : base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG>(m) {}
+      : base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point,
+                         BaseRNG>(m) {}
 
   using point_type = ps_point;
   double T(ps_point& z) { return 0; }
@@ -97,7 +100,7 @@ class divergent_nuts : public base_nuts<mock_model, divergent_hamiltonian,
  public:
   divergent_nuts(const mock_model& m, rng_t& rng)
       : base_nuts<mock_model, divergent_hamiltonian, expl_leapfrog, rng_t>(
-            m, rng) {}
+          m, rng) {}
 };
 
 }  // namespace mcmc

--- a/src/test/unit/mcmc/hmc/nuts_classic/base_nuts_classic_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts_classic/base_nuts_classic_test.cpp
@@ -26,27 +26,28 @@ class mock_nuts_classic : public base_nuts_classic<mock_model, mock_hamiltonian,
 
 // Mock Hamiltonian
 template <typename M, typename BaseRNG>
-class divergent_hamiltonian : public base_hamiltonian<M, ps_point, BaseRNG> {
+class divergent_hamiltonian : public base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG> {
  public:
   divergent_hamiltonian(const M& m)
-      : base_hamiltonian<M, ps_point, BaseRNG>(m) {}
+      : base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG>(m) {}
 
-  double T(ps_point& z) { return 0; }
+  using point_type = ps_point;
+  auto T(ps_point& z) { return 0.0; }
 
-  double tau(ps_point& z) { return T(z); }
-  double phi(ps_point& z) { return this->V(z); }
+  auto tau(ps_point& z) { return T(z); }
+  auto phi(ps_point& z) { return this->V(z); }
 
-  double dG_dt(ps_point& z, callbacks::logger& logger) { return 2; }
+  auto dG_dt(ps_point& z, callbacks::logger& logger) { return 2; }
 
-  Eigen::VectorXd dtau_dq(ps_point& z, callbacks::logger& logger) {
+  auto dtau_dq(ps_point& z, callbacks::logger& logger) {
     return Eigen::VectorXd::Zero(this->model_.num_params_r());
   }
 
-  Eigen::VectorXd dtau_dp(ps_point& z) {
+  auto dtau_dp(ps_point& z) {
     return Eigen::VectorXd::Zero(this->model_.num_params_r());
   }
 
-  Eigen::VectorXd dphi_dq(ps_point& z, callbacks::logger& logger) {
+  auto dphi_dq(ps_point& z, callbacks::logger& logger) {
     return Eigen::VectorXd::Zero(this->model_.num_params_r());
   }
 

--- a/src/test/unit/mcmc/hmc/nuts_classic/base_nuts_classic_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts_classic/base_nuts_classic_test.cpp
@@ -15,7 +15,7 @@ class mock_nuts_classic : public base_nuts_classic<mock_model, mock_hamiltonian,
  public:
   mock_nuts_classic(const mock_model& m, rng_t& rng)
       : base_nuts_classic<mock_model, mock_hamiltonian, mock_integrator, rng_t>(
-            m, rng) {}
+          m, rng) {}
 
  private:
   bool compute_criterion(ps_point& start, ps_point& finish,
@@ -26,10 +26,13 @@ class mock_nuts_classic : public base_nuts_classic<mock_model, mock_hamiltonian,
 
 // Mock Hamiltonian
 template <typename M, typename BaseRNG>
-class divergent_hamiltonian : public base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG> {
+class divergent_hamiltonian
+    : public base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point,
+                              BaseRNG> {
  public:
   divergent_hamiltonian(const M& m)
-      : base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG>(m) {}
+      : base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point,
+                         BaseRNG>(m) {}
 
   using point_type = ps_point;
   auto T(ps_point& z) { return 0.0; }

--- a/src/test/unit/mcmc/hmc/static/base_static_hmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/static/base_static_hmc_test.cpp
@@ -16,7 +16,7 @@ class mock_static_hmc : public base_static_hmc<mock_model, mock_hamiltonian,
  public:
   mock_static_hmc(const mock_model& m, rng_t& rng)
       : base_static_hmc<mock_model, mock_hamiltonian, mock_integrator, rng_t>(
-            m, rng) {}
+          m, rng) {}
 };
 
 }  // namespace mcmc

--- a/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
@@ -20,27 +20,27 @@ class mock_xhmc
 
 // Mock Hamiltonian
 template <typename M, typename BaseRNG>
-class divergent_hamiltonian : public base_hamiltonian<M, ps_point, BaseRNG> {
+class divergent_hamiltonian : public base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG> {
  public:
   divergent_hamiltonian(const M& m)
-      : base_hamiltonian<M, ps_point, BaseRNG>(m) {}
+      : base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG>(m) {}
 
-  double T(ps_point& z) { return 0; }
+  auto T(ps_point& z) { return 0.0; }
 
-  double tau(ps_point& z) { return T(z); }
-  double phi(ps_point& z) { return this->V(z); }
+  auto tau(ps_point& z) { return T(z); }
+  auto phi(ps_point& z) { return this->V(z); }
 
-  double dG_dt(ps_point& z, callbacks::logger& logger) { return 2; }
+  auto dG_dt(ps_point& z, callbacks::logger& logger) { return 2; }
 
-  Eigen::VectorXd dtau_dq(ps_point& z, callbacks::logger& logger) {
+  auto dtau_dq(ps_point& z, callbacks::logger& logger) {
     return Eigen::VectorXd::Zero(this->model_.num_params_r());
   }
 
-  Eigen::VectorXd dtau_dp(ps_point& z) {
+  auto dtau_dp(ps_point& z) {
     return Eigen::VectorXd::Zero(this->model_.num_params_r());
   }
 
-  Eigen::VectorXd dphi_dq(ps_point& z, callbacks::logger& logger) {
+  auto dphi_dq(ps_point& z, callbacks::logger& logger) {
     return Eigen::VectorXd::Zero(this->model_.num_params_r());
   }
 

--- a/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
@@ -20,10 +20,13 @@ class mock_xhmc
 
 // Mock Hamiltonian
 template <typename M, typename BaseRNG>
-class divergent_hamiltonian : public base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG> {
+class divergent_hamiltonian
+    : public base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point,
+                              BaseRNG> {
  public:
   divergent_hamiltonian(const M& m)
-      : base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point, BaseRNG>(m) {}
+      : base_hamiltonian<divergent_hamiltonian<M, BaseRNG>, M, ps_point,
+                         BaseRNG>(m) {}
 
   auto T(ps_point& z) { return 0.0; }
 
@@ -58,7 +61,7 @@ class divergent_xhmc : public base_xhmc<mock_model, divergent_hamiltonian,
  public:
   divergent_xhmc(const mock_model& m, rng_t& rng)
       : base_xhmc<mock_model, divergent_hamiltonian, expl_leapfrog, rng_t>(
-            m, rng) {}
+          m, rng) {}
 };
 
 }  // namespace mcmc


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Like in #2850 this adds a CRTP to the `base_hamiltonian` so the method lookups are resolved at compile time

#### Intended Effect

Resolve method lookups at compile time

#### How to Verify
This is refactor but happy to add any additional tests if wanted

./runTests.py -j12 ./src/test/unit/mcmc/

#### Side Effects

Like with #2850 if people want to write a method that can use a derived type of `base_hamiltonian` they have to write

```cpp
template <typename Derived, typename Model, typename PointType, typename BaseRNG>
void my_func(stan::mcmc::base_hamiltonian<Derived, Model, PointType, BaseRNG>, ...)
```

instead of 

```cpp
template <typename Model, typename PointType, typename BaseRNG>
void my_func(stan::mcmc::base_hamiltonian<Model, PointType, BaseRNG>, ...)
```

#### Documentation

I'll add docs for the base hamiltonian describing it's derived template type

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
