### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: numfocus
+custom: https://numfocus.org/donate-to-stan


### PR DESCRIPTION
add NumFOCUS github sponsors button (recurring donations only)

This feature launched today at GitHub Universe!

Also add the custom link to point to the donation form for Stan.

#### Summary
Add a Sponsor button to the Stan repo.

#### Intended Effect
Give users the ability to donate NumFOCUS, either the all-projects fund or the Stan-designated fund.

#### How to Verify
Should show you how it will look in the preview. See also here: https://help.github.com/en/github/building-a-strong-community/displaying-a-sponsor-button-in-your-repository

#### Side Effects
Mo' money, mo' problems.

#### Copyright and Licensing

---

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

NumFOCUS

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)