### PR TITLE
Stepsize adaptation and adapters const accessors (NFC)

### DIFF
--- a/src/stan/mcmc/stepsize_adaptation.hpp
+++ b/src/stan/mcmc/stepsize_adaptation.hpp
@@ -36,15 +36,15 @@ class stepsize_adaptation : public base_adaptation {
       t0_ = t;
   }
 
-  double get_mu() { return mu_; }
+  double get_mu() const noexcept { return mu_; }
 
-  double get_delta() { return delta_; }
+  double get_delta() const noexcept { return delta_; }
 
-  double get_gamma() { return gamma_; }
+  double get_gamma() const noexcept { return gamma_; }
 
-  double get_kappa() { return kappa_; }
+  double get_kappa() const noexcept { return kappa_; }
 
-  double get_t0() { return t0_; }
+  double get_t0() const noexcept { return t0_; }
 
   void restart() {
     counter_ = 0;

--- a/src/stan/mcmc/stepsize_adapter.hpp
+++ b/src/stan/mcmc/stepsize_adapter.hpp
@@ -16,6 +16,10 @@ class stepsize_adapter : public base_adapter {
     return stepsize_adaptation_;
   }
 
+  const stepsize_adaptation& get_stepsize_adaptation() const noexcept {
+    return stepsize_adaptation_;
+  }
+
  protected:
   stepsize_adaptation stepsize_adaptation_;
 };

--- a/src/stan/mcmc/stepsize_covar_adapter.hpp
+++ b/src/stan/mcmc/stepsize_covar_adapter.hpp
@@ -18,6 +18,10 @@ class stepsize_covar_adapter : public base_adapter {
     return stepsize_adaptation_;
   }
 
+  const stepsize_adaptation& get_stepsize_adaptation() const noexcept {
+    return stepsize_adaptation_;
+  }
+
   covar_adaptation& get_covar_adaptation() { return covar_adaptation_; }
 
   void set_window_params(unsigned int num_warmup, unsigned int init_buffer,

--- a/src/stan/mcmc/stepsize_var_adapter.hpp
+++ b/src/stan/mcmc/stepsize_var_adapter.hpp
@@ -17,6 +17,10 @@ class stepsize_var_adapter : public base_adapter {
     return stepsize_adaptation_;
   }
 
+  const stepsize_adaptation& get_stepsize_adaptation() const noexcept {
+    return stepsize_adaptation_;
+  }
+
   var_adaptation& get_var_adaptation() { return var_adaptation_; }
 
   void set_window_params(unsigned int num_warmup, unsigned int init_buffer,


### PR DESCRIPTION
#### Summary

Add `const noexcept` accessors to the stepsize adaptation class (for accessing delta, kappa, ...) and in the various adapters (for accessing the adaptation object).

#### Intended Effect

No functional change for Stan users.
Allow developers to query the adaptation parameters in contexts where it's natural to have a `const` sampler (logging, serialization, ...).

#### How to Verify

N/A (trivial)

#### Side Effects

None. 

#### Documentation

N/A (trivial)

#### Copyright and Licensing

Tal Kedar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
