### PR TITLE
Use throw_domain_error instead of stan::math::domain_error

### DIFF
--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -115,8 +115,8 @@ class advi {
           const char* msg2
               = "). Your model may be either severely "
                 "ill-conditioned or misspecified.";
-          stan::math::domain_error(function, name, n_monte_carlo_elbo_, msg1,
-                                   msg2);
+          stan::math::throw_domain_error(function, name, n_monte_carlo_elbo_,
+                                         msg1, msg2);
         }
       }
     }
@@ -187,7 +187,7 @@ class advi {
       const char* msg1
           = "Your model may be either "
             "severely ill-conditioned or misspecified.";
-      stan::math::domain_error(function, name, "", msg1);
+      stan::math::throw_domain_error(function, name, "", msg1);
     }
 
     // Variational family to store gradients
@@ -279,7 +279,7 @@ class advi {
             const char* msg1
                 = "failed. Your model may be either "
                   "severely ill-conditioned or misspecified.";
-            stan::math::domain_error(function, name, "", msg1);
+            stan::math::throw_domain_error(function, name, "", msg1);
           }
         }
         // Reset

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -448,7 +448,7 @@ class normal_fullrank : public base_family {
           const char* msg2
               = "). Your model may be either severely "
                 "ill-conditioned or misspecified.";
-          stan::math::domain_error(function, name, y, msg1, msg2);
+          stan::math::throw_domain_error(function, name, y, msg1, msg2);
         }
       }
     }

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -378,7 +378,7 @@ class normal_meanfield : public base_family {
           const char* msg2
               = "). Your model may be either severely "
                 "ill-conditioned or misspecified.";
-          stan::math::domain_error(function, name, y, msg1, msg2);
+          stan::math::throw_domain_error(function, name, y, msg1, msg2);
         }
       }
     }


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py src/test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary
This replaces the few existing uses of `stan::math::domain_error` with `stan::math::throw_domain_error`.

#### How to Verify
Existing tests should run correctly.

#### Side Effects
None.

#### Documentation
Not needed.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
