### PR TITLE
Replace Eigen vectors of strings with std::vector<std::string>

### DIFF
--- a/src/stan/mcmc/chains.hpp
+++ b/src/stan/mcmc/chains.hpp
@@ -257,7 +257,8 @@ class chains {
       param_names_[i] = param_names(i);
   }
 
-  explicit chains(const stan::io::stan_csv& stan_csv) : chains(stan_csv.header) {
+  explicit chains(const stan::io::stan_csv& stan_csv)
+      : chains(stan_csv.header) {
     if (stan_csv.samples.rows() > 0)
       add(stan_csv);
   }

--- a/src/stan/mcmc/chains.hpp
+++ b/src/stan/mcmc/chains.hpp
@@ -267,9 +267,7 @@ class chains {
 
   inline int num_params() const { return param_names_.size(); }
 
-  const std::vector<std::string>& param_names() const {
-    return param_names_;
-  }
+  const std::vector<std::string>& param_names() const { return param_names_; }
 
   const std::string& param_name(int j) const { return param_names_[j]; }
 

--- a/src/stan/mcmc/chains.hpp
+++ b/src/stan/mcmc/chains.hpp
@@ -380,9 +380,10 @@ class chains {
           " sample does not match chains");
     for (int i = 0; i < num_params(); i++) {
       if (param_names_[i] != stan_csv.header(i)) {
-        throw std::invalid_argument(
-            "add(stan_csv): header does not match"
-            " chain's header");
+        std::stringstream ss;
+        ss << "add(stan_csv): header " << param_names_[i]
+           << " does not match chain's header (" << stan_csv.header(i) << ")";
+        throw std::invalid_argument(ss.str());
       }
     }
     add(stan_csv.samples);

--- a/src/test/unit/mcmc/chains_test.cpp
+++ b/src/test/unit/mcmc/chains_test.cpp
@@ -231,7 +231,7 @@ TEST_F(McmcChains, blocker1_param_names) {
   ASSERT_EQ(blocker1.header.size(), chains.num_params());
   ASSERT_EQ(blocker1.header.size(), chains.param_names().size());
   for (int i = 0; i < blocker1.header.size(); i++) {
-    EXPECT_EQ(blocker1.header(i), chains.param_names()(i));
+    EXPECT_EQ(blocker1.header(i), chains.param_names()[i]);
   }
 }
 TEST_F(McmcChains, blocker1_param_name) {


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py src/test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary
This changes the `Eigen::Matrix<std::string, Dynamic, 1>` containers to `std::vector<std::string>` for `stan::mcmc::chains`, as suggested in the first point of #1479. 

#### How to Verify
Current tests should pass.

#### Side Effects
It's not clear to me if other interfaces use this header directly (at least rstan shouldn't be affected, from by inspection), and what guarantees we make about not chaning this.

The only potentially breaking change is that now `param_names()` returns a `const std::vector<std::string>&` rather than `const Eigen::Matrix<std::string, Dynamic, 1>&`, which means that indexing the resulting container will have to use `operator[]` instead of `operator()`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
