### PR TITLE
Making sure distro is set as trusty for clang-6 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
 linux_clang: &linux_clang
   os: linux
   compiler: "clang-6.0"
-  dist: xenial
+  dist: trusty
   addons:
     apt:
       sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0' ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ before_script:
 linux_clang: &linux_clang
   os: linux
   compiler: "clang-6.0"
-  dist: trusty
+  dist: xenial
   addons:
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
       packages: [ 'clang-6.0', 'libc++-dev' ]
 
 linux_gcc: &linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ before_script:
 linux_clang: &linux_clang
   os: linux
   compiler: "clang-6.0"
-  dist: xenial
+  dist: trusty
   addons:
     apt:
-      sources: [ 'ubuntu-toolchain-r-test' ]
+      sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0' ]
       packages: [ 'clang-6.0', 'libc++-dev' ]
 
 linux_gcc: &linux_gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
 linux_clang: &linux_clang
   os: linux
   compiler: "clang-6.0"
+  dist: xenial
   addons:
     apt:
       sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0' ]


### PR DESCRIPTION
This PR will force Travis to use `trusty` instead of the now default `xenial`.

To add a bit of context, Travis started slowly rolling out `xenial` as the default distro a while ago, see thread [here](https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476) therefore it broke our pipeline.

See where stan failures were reported, thread [here](https://discourse.mc-stan.org/t/jenkins-updates-issues-requests/12426/3?u=serban-nicusor).