### PR TITLE
Change PATH for TBB in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ def runTests(String testPath, Boolean separateMakeStep=true) {
 }
 
 def runTestsWin(String testPath) {
-    withEnv(['PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb']) {
+    withEnv(['PATH+TBB=${WORKSPACE}\\lib\\stan_math\\lib\\tbb']) {
        bat "echo %PATH%"
        bat "runTests.py -j${env.PARALLEL} ${testPath} --make-only"
        try { bat "runTests.py -j${env.PARALLEL} ${testPath}" }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,8 @@ def runTests(String testPath, Boolean separateMakeStep=true) {
 }
 
 def runTestsWin(String testPath) {
-    withEnv(['PATH+TBB=./lib/stan_math/lib/tbb']) {
+    withEnv(['PATH+TBB=${WORKSPACE}\\stan\\lib\\stan_math\\lib\\tbb']) {
+       bat "echo %PATH%"
        bat "runTests.py -j${env.PARALLEL} ${testPath} --make-only"
        try { bat "runTests.py -j${env.PARALLEL} ${testPath}" }
        finally { junit 'test/**/*.xml' }


### PR DESCRIPTION
This PR changes the PATH variable from unix path to windows path in Jenkinsfile avoid random pipeline failures because of TBB in PATH.

Changed from
```
./lib/stan_math/lib/tbb
```
to
```
${WORKSPACE}\\lib\\stan_math\\lib\\tbb
```

`${WORKSPACE}` will default to current working directory on the pipeline.
This change was done also in CmdStan with success.