### PR TITLE
Add requires_ to functions in model folder

### DIFF
--- a/make/cpplint
+++ b/make/cpplint
@@ -10,4 +10,4 @@ endif
 
 .PHONY: cpplint
 cpplint:
-	@$(PYTHON2) $(CPPLINT)/cpplint.py --output=vs7 --counting=detailed --root=src --extension=hpp,cpp --filter=-runtime/indentation_namespace,-readability/namespace,-legal/copyright,-whitespace/indent,-runtime/reference,-build/c++11 $(shell find src/stan -name '*.hpp' -o -name '*.cpp')
+	@$(PYTHON2) $(CPPLINT)/cpplint.py --output=vs7 --counting=detailed --root=src --extension=hpp,cpp --filter=-runtime/indentation_namespace,-readability/namespace,-legal/copyright,-whitespace/indent,-runtime/reference,-build/c++11,-whitespace/operators $(shell find src/stan -name '*.hpp' -o -name '*.cpp')

--- a/src/stan/model/grad_hess_log_prob.hpp
+++ b/src/stan/model/grad_hess_log_prob.hpp
@@ -30,13 +30,14 @@ namespace model {
  * @param[in, out] msgs Stream to which print statements in Stan
  * programs are written, default is 0
  */
-template <bool propto, bool jacobian_adjust_transform, class M,
-  typename VecParamR, typename VecParamI, typename VecGrad, typename VecHess,
-  require_vector_like_vt<std::is_arithmetic, VecParamR, VecGrad, VecHess>...,
-  require_vector_like_vt<std::is_integral, VecParamI>...>
+template <
+    bool propto, bool jacobian_adjust_transform, class M, typename VecParamR,
+    typename VecParamI, typename VecGrad, typename VecHess,
+    require_vector_like_vt<std::is_arithmetic, VecParamR, VecGrad, VecHess>...,
+    require_vector_like_vt<std::is_integral, VecParamI>...>
 double grad_hess_log_prob(const M& model, VecParamR&& params_r,
-  VecParamI&& params_i, VecGrad&& gradient, VecHess&& hessian,
-  std::ostream* msgs = 0) {
+                          VecParamI&& params_i, VecGrad&& gradient,
+                          VecHess&& hessian, std::ostream* msgs = 0) {
   static const double epsilon = 1e-3;
   static const double half_epsilon = 0.5 * epsilon;
   static const int order = 4;

--- a/src/stan/model/grad_hess_log_prob.hpp
+++ b/src/stan/model/grad_hess_log_prob.hpp
@@ -30,12 +30,13 @@ namespace model {
  * @param[in, out] msgs Stream to which print statements in Stan
  * programs are written, default is 0
  */
-template <bool propto, bool jacobian_adjust_transform, class M>
-double grad_hess_log_prob(const M& model, std::vector<double>& params_r,
-                          std::vector<int>& params_i,
-                          std::vector<double>& gradient,
-                          std::vector<double>& hessian,
-                          std::ostream* msgs = 0) {
+template <bool propto, bool jacobian_adjust_transform, class M,
+  typename VecParamR, typename VecParamI, typename VecGrad, typename VecHess,
+  require_vector_like_vt<std::is_arithmetic, VecParamR, VecGrad, VecHess>...,
+  require_vector_like_vt<std::is_integral, VecParamI>...>
+double grad_hess_log_prob(const M& model, VecParamR&& params_r,
+  VecParamI&& params_i, VecGrad&& gradient, VecHess&& hessian,
+  std::ostream* msgs = 0) {
   static const double epsilon = 1e-3;
   static const double half_epsilon = 0.5 * epsilon;
   static const int order = 4;

--- a/src/stan/model/grad_tr_mat_times_hessian.hpp
+++ b/src/stan/model/grad_tr_mat_times_hessian.hpp
@@ -8,14 +8,14 @@
 namespace stan {
 namespace model {
 
-template <class M>
-void grad_tr_mat_times_hessian(
-    const M& model, const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
-    const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& X,
-    Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_tr_X_hess_f,
-    std::ostream* msgs = 0) {
-  stan::math::grad_tr_mat_times_hessian(model_functional<M>(model, msgs), x, X,
-                                        grad_tr_X_hess_f);
+template <class M, typename VecX, typename MatX, typename VecGrad,
+ require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...,
+ require_eigen_vt<std::is_arithmetic, MatX>...>
+void grad_tr_mat_times_hessian(const M& model, VecX&& x, MatX&& X,
+   VecGrad&& grad_tr_X_hess_f, std::ostream* msgs = 0) {
+  stan::math::grad_tr_mat_times_hessian(model_functional<M>(model, msgs),
+   std::forward<VecX>(x), std::forward<MatX>(X),
+   std::forward<VecGrad>(grad_tr_X_hess_f));
 }
 
 }  // namespace model

--- a/src/stan/model/grad_tr_mat_times_hessian.hpp
+++ b/src/stan/model/grad_tr_mat_times_hessian.hpp
@@ -9,13 +9,14 @@ namespace stan {
 namespace model {
 
 template <class M, typename VecX, typename MatX, typename VecGrad,
- require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...,
- require_eigen_vt<std::is_arithmetic, MatX>...>
+          require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...,
+          require_eigen_vt<std::is_arithmetic, MatX>...>
 void grad_tr_mat_times_hessian(const M& model, VecX&& x, MatX&& X,
-   VecGrad&& grad_tr_X_hess_f, std::ostream* msgs = 0) {
-  stan::math::grad_tr_mat_times_hessian(model_functional<M>(model, msgs),
-   std::forward<VecX>(x), std::forward<MatX>(X),
-   std::forward<VecGrad>(grad_tr_X_hess_f));
+                               VecGrad&& grad_tr_X_hess_f,
+                               std::ostream* msgs = 0) {
+  stan::math::grad_tr_mat_times_hessian(
+      model_functional<M>(model, msgs), std::forward<VecX>(x),
+      std::forward<MatX>(X), std::forward<VecGrad>(grad_tr_X_hess_f));
 }
 
 }  // namespace model

--- a/src/stan/model/gradient.hpp
+++ b/src/stan/model/gradient.hpp
@@ -11,15 +11,18 @@
 namespace stan {
 namespace model {
 
-template <class M, typename VecX, typename VecGrad, require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...>
+template <class M, typename VecX, typename VecGrad,
+ require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...>
 void gradient(const M& model, VecX&& x, double& f, VecGrad&& grad_f,
   std::ostream* msgs = 0) {
   stan::math::gradient(model_functional<M>(model, msgs), std::forward<VecX>(x),
    f, std::forward<VecGrad>(grad_f));
 }
 
-template <class M, typename VecX, typename VecGrad, require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...>
-void gradient(const M& model, VecX&& x, double& f, VecGrad&& grad_f, callbacks::logger& logger) {
+template <class M, typename VecX, typename VecGrad,
+ require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...>
+void gradient(const M& model, VecX&& x, double& f, VecGrad&& grad_f,
+  callbacks::logger& logger) {
   std::stringstream ss;
   try {
     stan::math::gradient(model_functional<M>(model, &ss), std::forward<VecX>(x),

--- a/src/stan/model/gradient.hpp
+++ b/src/stan/model/gradient.hpp
@@ -12,21 +12,21 @@ namespace stan {
 namespace model {
 
 template <class M, typename VecX, typename VecGrad,
- require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...>
+          require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...>
 void gradient(const M& model, VecX&& x, double& f, VecGrad&& grad_f,
-  std::ostream* msgs = 0) {
+              std::ostream* msgs = 0) {
   stan::math::gradient(model_functional<M>(model, msgs), std::forward<VecX>(x),
-   f, std::forward<VecGrad>(grad_f));
+                       f, std::forward<VecGrad>(grad_f));
 }
 
 template <class M, typename VecX, typename VecGrad,
- require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...>
+          require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...>
 void gradient(const M& model, VecX&& x, double& f, VecGrad&& grad_f,
-  callbacks::logger& logger) {
+              callbacks::logger& logger) {
   std::stringstream ss;
   try {
     stan::math::gradient(model_functional<M>(model, &ss), std::forward<VecX>(x),
-     f, std::forward<VecGrad>(grad_f));
+                         f, std::forward<VecGrad>(grad_f));
   } catch (std::exception& e) {
     if (ss.str().length() > 0)
       logger.info(ss);

--- a/src/stan/model/gradient.hpp
+++ b/src/stan/model/gradient.hpp
@@ -11,20 +11,19 @@
 namespace stan {
 namespace model {
 
-template <class M>
-void gradient(const M& model, const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
-              double& f, Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_f,
-              std::ostream* msgs = 0) {
-  stan::math::gradient(model_functional<M>(model, msgs), x, f, grad_f);
+template <class M, typename VecX, typename VecGrad, require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...>
+void gradient(const M& model, VecX&& x, double& f, VecGrad&& grad_f,
+  std::ostream* msgs = 0) {
+  stan::math::gradient(model_functional<M>(model, msgs), std::forward<VecX>(x),
+   f, std::forward<VecGrad>(grad_f));
 }
 
-template <class M>
-void gradient(const M& model, const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
-              double& f, Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_f,
-              callbacks::logger& logger) {
+template <class M, typename VecX, typename VecGrad, require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...>
+void gradient(const M& model, VecX&& x, double& f, VecGrad&& grad_f, callbacks::logger& logger) {
   std::stringstream ss;
   try {
-    stan::math::gradient(model_functional<M>(model, &ss), x, f, grad_f);
+    stan::math::gradient(model_functional<M>(model, &ss), std::forward<VecX>(x),
+     f, std::forward<VecGrad>(grad_f));
   } catch (std::exception& e) {
     if (ss.str().length() > 0)
       logger.info(ss);

--- a/src/stan/model/gradient_dot_vector.hpp
+++ b/src/stan/model/gradient_dot_vector.hpp
@@ -9,12 +9,12 @@ namespace stan {
 namespace model {
 
 template <class M, typename VecX, typename VecV,
- require_all_vector_like_vt<std::is_arithmetic, VecX, VecV>...>
-void gradient_dot_vector(const M& model, VecX&& x, VecV&& v,
-                         double& f, double& grad_f_dot_v,
-                         std::ostream* msgs = 0) {
+          require_all_vector_like_vt<std::is_arithmetic, VecX, VecV>...>
+void gradient_dot_vector(const M& model, VecX&& x, VecV&& v, double& f,
+                         double& grad_f_dot_v, std::ostream* msgs = 0) {
   stan::math::gradient_dot_vector(model_functional<M>(model, msgs),
-   std::forward<VecX>(x), std::forward<VecV>(v), f, grad_f_dot_v);
+                                  std::forward<VecX>(x), std::forward<VecV>(v),
+                                  f, grad_f_dot_v);
 }
 
 }  // namespace model

--- a/src/stan/model/gradient_dot_vector.hpp
+++ b/src/stan/model/gradient_dot_vector.hpp
@@ -8,14 +8,12 @@
 namespace stan {
 namespace model {
 
-template <class M>
-void gradient_dot_vector(const M& model,
-                         const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
-                         const Eigen::Matrix<double, Eigen::Dynamic, 1>& v,
+template <class M, typename VecX, typename VecV, require_all_vector_like_vt<std::is_arithmetic, VecX, VecV>...>
+void gradient_dot_vector(const M& model, VecX&& x, VecV&& v,
                          double& f, double& grad_f_dot_v,
                          std::ostream* msgs = 0) {
-  stan::math::gradient_dot_vector(model_functional<M>(model, msgs), x, v, f,
-                                  grad_f_dot_v);
+  stan::math::gradient_dot_vector(model_functional<M>(model, msgs),
+   std::forward<VecX>(x), std::forward<VecV>(v), f, grad_f_dot_v);
 }
 
 }  // namespace model

--- a/src/stan/model/gradient_dot_vector.hpp
+++ b/src/stan/model/gradient_dot_vector.hpp
@@ -8,7 +8,8 @@
 namespace stan {
 namespace model {
 
-template <class M, typename VecX, typename VecV, require_all_vector_like_vt<std::is_arithmetic, VecX, VecV>...>
+template <class M, typename VecX, typename VecV,
+ require_all_vector_like_vt<std::is_arithmetic, VecX, VecV>...>
 void gradient_dot_vector(const M& model, VecX&& x, VecV&& v,
                          double& f, double& grad_f_dot_v,
                          std::ostream* msgs = 0) {

--- a/src/stan/model/hessian.hpp
+++ b/src/stan/model/hessian.hpp
@@ -9,13 +9,13 @@ namespace stan {
 namespace model {
 
 template <class M, typename VecX, typename VecGrad, typename MatHess,
-  require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...,
-  require_eigen_vt<std::is_arithmetic, MatHess>...>
+          require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...,
+          require_eigen_vt<std::is_arithmetic, MatHess>...>
 void hessian(const M& model, VecX&& x, double& f, VecGrad&& grad_f,
-   MatHess&& hess_f, std::ostream* msgs = 0) {
-  stan::math::hessian<model_functional<M> >(model_functional<M>(model, msgs),
-    std::forward<VecX>(x), f, std::forward<VecGrad>(grad_f),
-    std::forward<MatHess>(hess_f));
+             MatHess&& hess_f, std::ostream* msgs = 0) {
+  stan::math::hessian<model_functional<M> >(
+      model_functional<M>(model, msgs), std::forward<VecX>(x), f,
+      std::forward<VecGrad>(grad_f), std::forward<MatHess>(hess_f));
 }
 
 }  // namespace model

--- a/src/stan/model/hessian.hpp
+++ b/src/stan/model/hessian.hpp
@@ -11,8 +11,8 @@ namespace model {
 template <class M, typename VecX, typename VecGrad, typename MatHess,
   require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...,
   require_eigen_vt<std::is_arithmetic, MatHess>...>
-void hessian(const M& model, VecX&& x, double& f, VecGrad&& grad_f, MatHess&& hess_f,
-             std::ostream* msgs = 0) {
+void hessian(const M& model, VecX&& x, double& f, VecGrad&& grad_f,
+   MatHess&& hess_f, std::ostream* msgs = 0) {
   stan::math::hessian<model_functional<M> >(model_functional<M>(model, msgs),
     std::forward<VecX>(x), f, std::forward<VecGrad>(grad_f),
     std::forward<MatHess>(hess_f));

--- a/src/stan/model/hessian.hpp
+++ b/src/stan/model/hessian.hpp
@@ -8,13 +8,14 @@
 namespace stan {
 namespace model {
 
-template <class M>
-void hessian(const M& model, const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
-             double& f, Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_f,
-             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& hess_f,
+template <class M, typename VecX, typename VecGrad, typename MatHess,
+  require_all_vector_like_vt<std::is_arithmetic, VecX, VecGrad>...,
+  require_eigen_vt<std::is_arithmetic, MatHess>...>
+void hessian(const M& model, VecX&& x, double& f, VecGrad&& grad_f, MatHess&& hess_f,
              std::ostream* msgs = 0) {
-  stan::math::hessian<model_functional<M> >(model_functional<M>(model, msgs), x,
-                                            f, grad_f, hess_f);
+  stan::math::hessian<model_functional<M> >(model_functional<M>(model, msgs),
+    std::forward<VecX>(x), f, std::forward<VecGrad>(grad_f),
+    std::forward<MatHess>(hess_f));
 }
 
 }  // namespace model

--- a/src/stan/model/hessian_times_vector.hpp
+++ b/src/stan/model/hessian_times_vector.hpp
@@ -8,14 +8,14 @@
 namespace stan {
 namespace model {
 
-template <class M, typename VecX, typename VecV, typename VecHess,
-  require_all_vector_like_vt<std::is_arithmetic, VecX, VecV, VecHess>...>
-void hessian_times_vector(
-    const M& model, VecX&& x, VecV&& v, double& f, VecHess&& hess_f_dot_v,
-    std::ostream* msgs = 0) {
+template <
+    class M, typename VecX, typename VecV, typename VecHess,
+    require_all_vector_like_vt<std::is_arithmetic, VecX, VecV, VecHess>...>
+void hessian_times_vector(const M& model, VecX&& x, VecV&& v, double& f,
+                          VecHess&& hess_f_dot_v, std::ostream* msgs = 0) {
   stan::math::hessian_times_vector(model_functional<M>(model, msgs),
-    std::forward<VecX>(x), std::forward<VecV>(v), f,
-     std::forward<VecHess>(hess_f_dot_v));
+                                   std::forward<VecX>(x), std::forward<VecV>(v),
+                                   f, std::forward<VecHess>(hess_f_dot_v));
 }
 
 }  // namespace model

--- a/src/stan/model/hessian_times_vector.hpp
+++ b/src/stan/model/hessian_times_vector.hpp
@@ -8,14 +8,14 @@
 namespace stan {
 namespace model {
 
-template <class M>
+template <class M, typename VecX, typename VecV, typename VecHess,
+  require_all_vector_like_vt<std::is_arithmetic, VecX, VecV, VecHess>...>
 void hessian_times_vector(
-    const M& model, const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
-    const Eigen::Matrix<double, Eigen::Dynamic, 1>& v, double& f,
-    Eigen::Matrix<double, Eigen::Dynamic, 1>& hess_f_dot_v,
+    const M& model, VecX&& x, VecV&& v, double& f, VecHess&& hess_f_dot_v,
     std::ostream* msgs = 0) {
-  stan::math::hessian_times_vector(model_functional<M>(model, msgs), x, v, f,
-                                   hess_f_dot_v);
+  stan::math::hessian_times_vector(model_functional<M>(model, msgs),
+    std::forward<VecX>(x), std::forward<VecV>(v), f,
+     std::forward<VecHess>(hess_f_dot_v));
 }
 
 }  // namespace model

--- a/src/stan/model/log_prob_grad.hpp
+++ b/src/stan/model/log_prob_grad.hpp
@@ -26,11 +26,11 @@ namespace model {
  * @param[in,out] msgs
  */
 template <bool propto, bool jacobian_adjust_transform, class M, typename VecInt,
- typename VecParamR, typename VecGrad,
-  require_vector_like_vt<std::is_integral, VecInt>...,
-  require_all_vector_like_vt<std::is_arithmetic, VecParamR, VecGrad>...>
+          typename VecParamR, typename VecGrad,
+          require_vector_like_vt<std::is_integral, VecInt>...,
+          require_all_vector_like_vt<std::is_arithmetic, VecParamR, VecGrad>...>
 double log_prob_grad(const M& model, VecParamR&& params_r, VecInt&& params_i,
-   VecGrad&& gradient, std::ostream* msgs = 0) {
+                     VecGrad&& gradient, std::ostream* msgs = 0) {
   using stan::math::var;
   using std::vector;
   double lp;

--- a/src/stan/model/log_prob_grad.hpp
+++ b/src/stan/model/log_prob_grad.hpp
@@ -25,23 +25,21 @@ namespace model {
  * @param[out] gradient Vector into which gradient is written.
  * @param[in,out] msgs
  */
-template <bool propto, bool jacobian_adjust_transform, class M>
-double log_prob_grad(const M& model, std::vector<double>& params_r,
-                     std::vector<int>& params_i, std::vector<double>& gradient,
-                     std::ostream* msgs = 0) {
+template <bool propto, bool jacobian_adjust_transform, class M, typename VecInt,
+ typename VecParamR, typename VecGrad,
+  require_vector_like_vt<std::is_integral, VecInt>...,
+  require_all_vector_like_vt<std::is_arithmetic, VecParamR, VecGrad>...>
+double log_prob_grad(const M& model, VecParamR&& params_r, VecInt&& params_i,
+   VecGrad&& gradient, std::ostream* msgs = 0) {
   using stan::math::var;
   using std::vector;
   double lp;
   try {
-    vector<var> ad_params_r(params_r.size());
-    for (size_t i = 0; i < model.num_params_r(); ++i) {
-      stan::math::var var_i(params_r[i]);
-      ad_params_r[i] = var_i;
-    }
+    vector<var> ad_params_r{params_r.begin(), params_r.end()};
     var adLogProb = model.template log_prob<propto, jacobian_adjust_transform>(
-        ad_params_r, params_i, msgs);
+        ad_params_r, std::forward<VecInt>(params_i), msgs);
+    adLogProb.grad(ad_params_r, std::forward<VecGrad>(gradient));
     lp = adLogProb.val();
-    adLogProb.grad(ad_params_r, gradient);
   } catch (const std::exception& ex) {
     stan::math::recover_memory();
     throw;

--- a/src/stan/model/log_prob_propto.hpp
+++ b/src/stan/model/log_prob_propto.hpp
@@ -37,11 +37,15 @@ double log_prob_propto(const M& model, VecParamR&& params_r,
                        VecParamI&& params_i, std::ostream* msgs = 0) {
   using stan::math::var;
   using std::vector;
-  vector<var> ad_params_r{params_r.begin(), params_r.end()};
   try {
+    vector<var> ad_params_r(model.num_params_r());
+    for (size_t i = 0; i < model.num_params_r(); ++i) {
+      stan::math::var var_i(params_r[i]);
+      ad_params_r[i] = var_i;
+    }
     double lp = model
                     .template log_prob<true, jacobian_adjust_transform>(
-                        ad_params_r, std::forward<VecParamI>(params_i), msgs)
+                        ad_params_r, params_i, msgs)
                     .val();
     stan::math::recover_memory();
     return lp;
@@ -81,7 +85,11 @@ double log_prob_propto(const M& model, VecParamR&& params_r,
 
   double lp;
   try {
-    vector<var> ad_params_r{params_r.data(), params_r.data() + params_r.size()};
+    vector<var> ad_params_r(model.num_params_r());
+    for (size_t i = 0; i < model.num_params_r(); ++i) {
+      stan::math::var var_i(params_r[i]);
+      ad_params_r[i] = var_i;
+    }
     lp = model
              .template log_prob<true, jacobian_adjust_transform>(ad_params_r,
                                                                  params_i, msgs)

--- a/src/stan/model/log_prob_propto.hpp
+++ b/src/stan/model/log_prob_propto.hpp
@@ -29,8 +29,8 @@ namespace model {
  * @param[in] params_i Integer-valued parameters.
  * @param[in,out] msgs
  */
-template <bool jacobian_adjust_transform, class M, typename VecParamR, typename VecParamI,
-  require_vector_like_vt<std::is_arithmetic, VecParamR>...,
+template <bool jacobian_adjust_transform, class M, typename VecParamR,
+  typename VecParamI, require_vector_like_vt<std::is_arithmetic, VecParamR>...,
   require_vector_like_vt<std::is_integral, VecParamI>...>
 double log_prob_propto(const M& model, VecParamR&& params_r,
                        VecParamI&& params_i, std::ostream* msgs = 0) {

--- a/src/stan/model/log_prob_propto.hpp
+++ b/src/stan/model/log_prob_propto.hpp
@@ -30,8 +30,9 @@ namespace model {
  * @param[in,out] msgs
  */
 template <bool jacobian_adjust_transform, class M, typename VecParamR,
-  typename VecParamI, require_vector_like_vt<std::is_arithmetic, VecParamR>...,
-  require_vector_like_vt<std::is_integral, VecParamI>...>
+          typename VecParamI,
+          require_vector_like_vt<std::is_arithmetic, VecParamR>...,
+          require_vector_like_vt<std::is_integral, VecParamI>...>
 double log_prob_propto(const M& model, VecParamR&& params_r,
                        VecParamI&& params_i, std::ostream* msgs = 0) {
   using stan::math::var;
@@ -71,7 +72,7 @@ double log_prob_propto(const M& model, VecParamR&& params_r,
  * @param[in,out] msgs
  */
 template <bool jacobian_adjust_transform, class M, typename VecParamR,
-  require_vector_like_vt<std::is_arithmetic, VecParamR>...>
+          require_vector_like_vt<std::is_arithmetic, VecParamR>...>
 double log_prob_propto(const M& model, VecParamR&& params_r,
                        std::ostream* msgs = 0) {
   using stan::math::var;

--- a/src/stan/model/model_functional.hpp
+++ b/src/stan/model/model_functional.hpp
@@ -15,8 +15,8 @@ struct model_functional {
   std::ostream* o;
 
   template <typename Model, require_same_t<M, Model>...>
-  model_functional(Model&& m, std::ostream* out) :
-   model(std::forward<Model>(m)), o(out) {}
+  model_functional(Model&& m, std::ostream* out)
+      : model(std::forward<Model>(m)), o(out) {}
 
   template <typename Vec, require_vector_t<Vec>...>
   auto operator()(Vec&& x) const {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds generic templates to the functions in the `model` folder using the `requires_` stuff and uses `std::forward` on objects where appropriate

#### Intended Effect

The intent here is to make some of the function arguments for generic so that we can use better move semantics

#### How to Verify

Standard tests should apply but happy to add other tests

#### Side Effects

Functions now accept lvalue and rvalue types. cpplint does not like multiline signatures with universal references in them (`Var&&` etc.) so I had to add `-whitespace/operators` to the cpplint filters

#### Documentation

Refactor so docs that are already there

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Stephen Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
