### PR TITLE
Fix includes of /err from Stan Math after flattening

### DIFF
--- a/src/stan/variational/print_progress.hpp
+++ b/src/stan/variational/print_progress.hpp
@@ -2,8 +2,7 @@
 #define STAN_VARIATIONAL_PRINT_PROGRESS_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/err.hpp>
 #include <cmath>
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

https://github.com/stan-dev/math/pull/1572 in Stan Math will remove the scal,mat,arr folder in the /err folder in fwd, mix, rev and prim. This PR fixes replaces the includes of two /err headers with the include of err.hpp.

This PR will be teste with the respective Math PR branch so both PRs have to be merged together in order to keep develop stable.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
