### PR TITLE
Fix mix includes for flatten

### DIFF
--- a/src/stan/mcmc/hmc/hamiltonians/softabs_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/softabs_metric.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MCMC_HMC_HAMILTONIANS_SOFTABS_METRIC_HPP
 #define STAN_MCMC_HMC_HAMILTONIANS_SOFTABS_METRIC_HPP
 
-#include <stan/math/mix/mat.hpp>
+#include <stan/math/mix.hpp>
 #include <stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp>
 #include <stan/mcmc/hmc/hamiltonians/softabs_point.hpp>
 #include <boost/random/variate_generator.hpp>

--- a/src/stan/model/grad_tr_mat_times_hessian.hpp
+++ b/src/stan/model/grad_tr_mat_times_hessian.hpp
@@ -1,8 +1,8 @@
 #ifndef STAN_MODEL_GRAD_TR_MAT_TIMES_HESSIAN_HPP
 #define STAN_MODEL_GRAD_TR_MAT_TIMES_HESSIAN_HPP
 
+#include <stan/math/mix.hpp>
 #include <stan/model/model_functional.hpp>
-#include <stan/math/mix/mat.hpp>
 #include <ostream>
 
 namespace stan {

--- a/src/stan/model/gradient_dot_vector.hpp
+++ b/src/stan/model/gradient_dot_vector.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MODEL_GRADIENT_DOT_VECTOR_HPP
 #define STAN_MODEL_GRADIENT_DOT_VECTOR_HPP
 
-#include <stan/math/mix/mat.hpp>
+#include <stan/math/mix.hpp>
 #include <stan/model/model_functional.hpp>
 #include <iostream>
 

--- a/src/stan/model/hessian.hpp
+++ b/src/stan/model/hessian.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MODEL_HESSIAN_HPP
 #define STAN_MODEL_HESSIAN_HPP
 
-#include <stan/math/mix/mat.hpp>
+#include <stan/math/mix.hpp>
 #include <stan/model/model_functional.hpp>
 #include <iostream>
 

--- a/src/stan/model/hessian_times_vector.hpp
+++ b/src/stan/model/hessian_times_vector.hpp
@@ -1,8 +1,8 @@
 #ifndef STAN_MODEL_HESSIAN_TIMES_VECTOR_HPP
 #define STAN_MODEL_HESSIAN_TIMES_VECTOR_HPP
 
+#include <stan/math/mix.hpp>
 #include <stan/model/model_functional.hpp>
-#include <stan/math/mix/mat.hpp>
 #include <ostream>
 
 namespace stan {


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py src/test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary

The flattening of mix happening in https://github.com/stan-dev/math/pull/1584 replaces `stan/math/mix/mat.hpp` with `stan/math/mix.hpp`, so this is required alongside those changes.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): 

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)