### PR TITLE
Fix include rev flatten

### DIFF
--- a/src/stan/model/gradient.hpp
+++ b/src/stan/model/gradient.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/rev/mat.hpp>
+#include <stan/math/rev.hpp>
 #include <stan/model/model_functional.hpp>
 #include <sstream>
 #include <stdexcept>

--- a/src/stan/model/log_prob_grad.hpp
+++ b/src/stan/model/log_prob_grad.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MODEL_LOG_PROB_GRAD_HPP
 #define STAN_MODEL_LOG_PROB_GRAD_HPP
 
-#include <stan/math/rev/mat.hpp>
+#include <stan/math/rev.hpp>
 #include <iostream>
 #include <vector>
 

--- a/src/stan/model/log_prob_propto.hpp
+++ b/src/stan/model/log_prob_propto.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MODEL_LOG_PROB_PROPTO_HPP
 #define STAN_MODEL_LOG_PROB_PROPTO_HPP
 
-#include <stan/math/rev/mat.hpp>
+#include <stan/math/rev.hpp>
 #include <iostream>
 #include <vector>
 

--- a/src/test/unit/model/indexing/lvalue_test.cpp
+++ b/src/test/unit/model/indexing/lvalue_test.cpp
@@ -2,7 +2,7 @@
 #include <stdexcept>
 #include <vector>
 #include <stan/model/indexing/lvalue.hpp>
-#include <stan/math/rev/mat.hpp>
+#include <stan/math/rev.hpp>
 #include <gtest/gtest.h>
 
 using Eigen::Dynamic;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

The flattening of rev happening in stan-dev/math#1593 replaces stan/math/rev/mat.hpp with stan/math/rev.hpp, so this is required alongside those changes.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
