### PR TITLE
Fix includes for Stan Math /prim flatten

### DIFF
--- a/src/stan/analyze/mcmc/autocovariance.hpp
+++ b/src/stan/analyze/mcmc/autocovariance.hpp
@@ -1,8 +1,7 @@
 #ifndef STAN_ANALYZE_MCMC_AUTOCOVARIANCE_HPP
 #define STAN_ANALYZE_MCMC_AUTOCOVARIANCE_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/variance.hpp>

--- a/src/stan/analyze/mcmc/compute_effective_sample_size.hpp
+++ b/src/stan/analyze/mcmc/compute_effective_sample_size.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_ANALYZE_MCMC_COMPUTE_EFFECTIVE_SAMPLE_SIZE_HPP
 #define STAN_ANALYZE_MCMC_COMPUTE_EFFECTIVE_SAMPLE_SIZE_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/analyze/mcmc/autocovariance.hpp>
 #include <stan/analyze/mcmc/split_chains.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>

--- a/src/stan/analyze/mcmc/compute_potential_scale_reduction.hpp
+++ b/src/stan/analyze/mcmc/compute_potential_scale_reduction.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_ANALYZE_MCMC_COMPUTE_POTENTIAL_SCALE_REDUCTION_HPP
 #define STAN_ANALYZE_MCMC_COMPUTE_POTENTIAL_SCALE_REDUCTION_HPP
 
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/analyze/mcmc/autocovariance.hpp>
 #include <stan/analyze/mcmc/split_chains.hpp>
 #include <boost/accumulators/accumulators.hpp>

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -4,7 +4,7 @@
 #include <stan/io/var_context.hpp>
 #include <stan/math.hpp>
 #include <boost/throw_exception.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <map>
 #include <algorithm>
 #include <functional>

--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/io/validate_zero_buf.hpp>
 #include <stan/io/var_context.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/type_traits/is_floating_point.hpp>

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -2,7 +2,7 @@
 #define STAN_IO_READER_HPP
 
 #include <boost/throw_exception.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -2,7 +2,7 @@
 #define STAN_IO_STAN_CSV_READER_HPP
 
 #include <boost/algorithm/string.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim.hpp>
 #include <istream>
 #include <iostream>
 #include <sstream>

--- a/src/stan/io/writer.hpp
+++ b/src/stan/io/writer.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_IO_WRITER_HPP
 #define STAN_IO_WRITER_HPP
 
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stdexcept>
 #include <vector>
 

--- a/src/stan/mcmc/chains.hpp
+++ b/src/stan/mcmc/chains.hpp
@@ -2,7 +2,7 @@
 #define STAN_MCMC_CHAINS_HPP
 
 #include <stan/io/stan_csv_reader.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/analyze/mcmc/compute_effective_sample_size.hpp>
 #include <stan/analyze/mcmc/compute_potential_scale_reduction.hpp>
 #include <boost/accumulators/accumulators.hpp>

--- a/src/stan/mcmc/covar_adaptation.hpp
+++ b/src/stan/mcmc/covar_adaptation.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MCMC_COVAR_ADAPTATION_HPP
 #define STAN_MCMC_COVAR_ADAPTATION_HPP
 
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/windowed_adaptation.hpp>
 #include <vector>
 

--- a/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
@@ -2,7 +2,7 @@
 #define STAN_MCMC_HMC_HAMILTONIANS_BASE_HAMILTONIAN_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/model/gradient.hpp>
 #include <stan/model/log_prob_propto.hpp>
 #include <Eigen/Dense>

--- a/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
@@ -2,7 +2,7 @@
 #define STAN_MCMC_HMC_HAMILTONIANS_DENSE_E_METRIC_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp>
 #include <stan/mcmc/hmc/hamiltonians/dense_e_point.hpp>
 #include <boost/random/variate_generator.hpp>

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -2,7 +2,7 @@
 #define STAN_MCMC_HMC_HAMILTONIANS_PS_POINT_HPP
 
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <boost/lexical_cast.hpp>
 #include <Eigen/Dense>
 #include <string>

--- a/src/stan/mcmc/hmc/integrators/expl_leapfrog.hpp
+++ b/src/stan/mcmc/hmc/integrators/expl_leapfrog.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/callbacks/logger.hpp>
 #include <stan/mcmc/hmc/integrators/base_leapfrog.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 
 namespace stan {
 namespace mcmc {

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/callbacks/logger.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <stan/math/prim/scal.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 #include <algorithm>

--- a/src/stan/mcmc/sample.hpp
+++ b/src/stan/mcmc/sample.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MCMC_SAMPLE_HPP
 #define STAN_MCMC_SAMPLE_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <vector>
 #include <string>
 

--- a/src/stan/mcmc/var_adaptation.hpp
+++ b/src/stan/mcmc/var_adaptation.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MCMC_VAR_ADAPTATION_HPP
 #define STAN_MCMC_VAR_ADAPTATION_HPP
 
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/windowed_adaptation.hpp>
 #include <vector>
 

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -3,7 +3,7 @@
 
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/index_list.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -3,7 +3,7 @@
 
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/index_list.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>

--- a/src/stan/model/model_functional.hpp
+++ b/src/stan/model/model_functional.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MODEL_MODEL_FUNCTIONAL_HPP
 #define STAN_MODEL_MODEL_FUNCTIONAL_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <iostream>
 
 namespace stan {

--- a/src/stan/optimization/bfgs.hpp
+++ b/src/stan/optimization/bfgs.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_OPTIMIZATION_BFGS_HPP
 #define STAN_OPTIMIZATION_BFGS_HPP
 
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/model/log_prob_propto.hpp>
 #include <stan/model/log_prob_grad.hpp>
 #include <stan/optimization/bfgs_linesearch.hpp>

--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -4,7 +4,7 @@
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/mcmc/fixed_param_sampler.hpp>
 #include <stan/services/error_codes.hpp>
 #include <stan/services/util/mcmc_writer.hpp>

--- a/src/stan/services/sample/hmc_nuts_dense_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e.hpp
@@ -4,8 +4,7 @@
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/hmc/nuts/dense_e_nuts.hpp>
 #include <stan/services/error_codes.hpp>
 #include <stan/services/util/run_sampler.hpp>

--- a/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
@@ -1,8 +1,7 @@
 #ifndef STAN_SERVICES_SAMPLE_HMC_NUTS_DENSE_E_ADAPT_HPP
 #define STAN_SERVICES_SAMPLE_HMC_NUTS_DENSE_E_ADAPT_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>

--- a/src/stan/services/sample/hmc_nuts_diag_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e.hpp
@@ -1,8 +1,7 @@
 #ifndef STAN_SERVICES_SAMPLE_HMC_NUTS_DIAG_E_HPP
 #define STAN_SERVICES_SAMPLE_HMC_NUTS_DIAG_E_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>

--- a/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
@@ -1,8 +1,7 @@
 #ifndef STAN_SERVICES_SAMPLE_HMC_NUTS_DIAG_E_ADAPT_HPP
 #define STAN_SERVICES_SAMPLE_HMC_NUTS_DIAG_E_ADAPT_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>

--- a/src/stan/services/sample/hmc_nuts_unit_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_unit_e.hpp
@@ -4,7 +4,7 @@
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/hmc/nuts/unit_e_nuts.hpp>
 #include <stan/services/error_codes.hpp>
 #include <stan/services/util/create_rng.hpp>

--- a/src/stan/services/sample/hmc_nuts_unit_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_unit_e_adapt.hpp
@@ -4,7 +4,7 @@
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/hmc/nuts/adapt_unit_e_nuts.hpp>
 #include <stan/services/error_codes.hpp>
 #include <stan/services/util/create_rng.hpp>

--- a/src/stan/services/sample/hmc_static_dense_e.hpp
+++ b/src/stan/services/sample/hmc_static_dense_e.hpp
@@ -4,8 +4,7 @@
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/hmc/static/dense_e_static_hmc.hpp>
 #include <stan/services/error_codes.hpp>
 #include <stan/services/util/run_sampler.hpp>

--- a/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
@@ -4,8 +4,7 @@
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/fixed_param_sampler.hpp>
 #include <stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp>
 #include <stan/services/error_codes.hpp>

--- a/src/stan/services/sample/hmc_static_diag_e.hpp
+++ b/src/stan/services/sample/hmc_static_diag_e.hpp
@@ -4,8 +4,7 @@
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/fixed_param_sampler.hpp>
 #include <stan/mcmc/hmc/static/diag_e_static_hmc.hpp>
 #include <stan/services/error_codes.hpp>

--- a/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
@@ -4,8 +4,7 @@
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/mcmc/fixed_param_sampler.hpp>
 #include <stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp>
 #include <stan/services/error_codes.hpp>

--- a/src/stan/services/sample/hmc_static_unit_e.hpp
+++ b/src/stan/services/sample/hmc_static_unit_e.hpp
@@ -4,7 +4,7 @@
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/mcmc/fixed_param_sampler.hpp>
 #include <stan/mcmc/hmc/static/unit_e_static_hmc.hpp>
 #include <stan/services/error_codes.hpp>

--- a/src/stan/services/sample/hmc_static_unit_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_unit_e_adapt.hpp
@@ -4,7 +4,7 @@
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/mcmc/fixed_param_sampler.hpp>
 #include <stan/mcmc/hmc/static/adapt_unit_e_static_hmc.hpp>
 #include <stan/services/error_codes.hpp>

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -7,7 +7,7 @@
 #include <stan/io/random_var_context.hpp>
 #include <stan/io/chained_var_context.hpp>
 #include <stan/model/log_prob_grad.hpp>
-#include <stan/math/prim/arr/fun/sum.hpp>
+#include <stan/math/prim.hpp>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/stan/services/util/read_dense_inv_metric.hpp
+++ b/src/stan/services/util/read_dense_inv_metric.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/callbacks/logger.hpp>
 #include <stan/io/var_context.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <limits>
 #include <sstream>
 #include <string>

--- a/src/stan/services/util/validate_dense_inv_metric.hpp
+++ b/src/stan/services/util/validate_dense_inv_metric.hpp
@@ -2,7 +2,7 @@
 #define STAN_SERVICES_UTIL_VALIDATE_DENSE_INV_METRIC_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 
 namespace stan {
 namespace services {

--- a/src/stan/services/util/validate_diag_inv_metric.hpp
+++ b/src/stan/services/util/validate_diag_inv_metric.hpp
@@ -2,7 +2,7 @@
 #define STAN_SERVICES_UTIL_VALIDATE_DIAG_INV_METRIC_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 
 namespace stan {
 namespace services {

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -2,7 +2,7 @@
 #define STAN_VARIATIONAL_BASE_FAMILY_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <algorithm>
 #include <ostream>
 

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -2,7 +2,7 @@
 #define STAN_VARIATIONAL_NORMAL_FULLRANK_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/model/gradient.hpp>
 #include <stan/variational/base_family.hpp>
 #include <algorithm>

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -2,7 +2,7 @@
 #define STAN_VARIATIONAL_NORMAL_MEANFIELD_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/model/gradient.hpp>
 #include <stan/variational/base_family.hpp>
 #include <algorithm>

--- a/src/test/unit/analyze/mcmc/autocovariance_test.cpp
+++ b/src/test/unit/analyze/mcmc/autocovariance_test.cpp
@@ -1,5 +1,4 @@
-#include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/analyze/mcmc/autocovariance.hpp>
 #include <gtest/gtest.h>
 #include <fstream>

--- a/src/test/unit/io/writer_test.cpp
+++ b/src/test/unit/io/writer_test.cpp
@@ -5,7 +5,7 @@
 #include <stan/io/reader.hpp>
 #include <stan/io/writer.hpp>
 
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 
 TEST(ioWriter, infBounds) {
   std::vector<int> theta_i;

--- a/src/test/unit/mcmc/hmc/mock_hmc.hpp
+++ b/src/test/unit/mcmc/hmc/mock_hmc.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN__MCMC__MOCK__HMC__BETA
 #define STAN__MCMC__MOCK__HMC__BETA
 
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/model/prob_grad.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 #include <stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp>

--- a/src/test/unit/model/test_model.hpp
+++ b/src/test/unit/model/test_model.hpp
@@ -1,7 +1,7 @@
 #ifndef TEST_UNIT_MODEL_TEST_MODEL_HPP
 #define TEST_UNIT_MODEL_TEST_MODEL_HPP
 
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/io/reader.hpp>
 
 class TestModel_uniform_01 {

--- a/src/test/unit/optimization/bfgs_linesearch_test.cpp
+++ b/src/test/unit/optimization/bfgs_linesearch_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include <stan/optimization/bfgs_linesearch.hpp>
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 
 TEST(OptimizationBfgsLinesearch, CubicInterp) {
   using stan::optimization::CubicInterp;

--- a/src/test/unit/services/sample/hmc_nuts_diag_e_test.cpp
+++ b/src/test/unit/services/sample/hmc_nuts_diag_e_test.cpp
@@ -1,4 +1,4 @@
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/services/sample/hmc_nuts_diag_e.hpp>
 #include <gtest/gtest.h>
 #include <stan/io/empty_var_context.hpp>

--- a/src/test/unit/services/sample/hmc_static_diag_e_test.cpp
+++ b/src/test/unit/services/sample/hmc_static_diag_e_test.cpp
@@ -1,4 +1,4 @@
-#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim.hpp>
 #include <stan/services/sample/hmc_static_diag_e.hpp>
 #include <gtest/gtest.h>
 #include <stan/io/empty_var_context.hpp>


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
https://github.com/stan-dev/math/pull/1606 will remove mat, arr and scal from the Stan Math's /prim folder. This PR fixes the includes in the Stan repo.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
