### PR TITLE
Jenkins Windows fix - build math libs first

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,6 +167,7 @@ pipeline {
                         deleteDirWin()
                             unstash 'StanSetup'
                             setupCXX()
+                            bat "mingw32-make -f lib/stan_math/make/standalone math-libs"
                             bat "mingw32-make -j${env.PARALLEL} test-headers"
                             setupCXX(false)
                             runTestsWin("src/test/unit")


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This fix changes how Windows tests are run such that the Math libs are built first, with a single thread. This is in order to prevent errors such as this one: https://jenkins.mc-stan.org/blue/organizations/jenkins/Stan/detail/downstream_tests/1162/pipeline

Similar change was done in Stan Math in https://github.com/stan-dev/math/pull/1594

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
