### PR TITLE
[WIP] Add specialization for getting cols and cleanup of rvalue/lvalue

### DIFF
--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -26,10 +26,16 @@ namespace model {
  * @param[in] name Name of lvalue variable (default "ANON"); ignored
  * @param[in] depth Indexing depth (default 0; ignored
  */
-template <typename T, typename U>
+template <typename T, typename U, require_not_stan_scalar_t<U>...>
 inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
                    const char* name = "ANON", int depth = 0) {
   x = std::forward<U>(y);
+}
+
+template <typename T, typename U, require_stan_scalar_t<U>...>
+inline void assign(T& x, const nil_index_list& /* idxs */, const U& y,
+                   const char* name = "ANON", int depth = 0) {
+  x = y;
 }
 
 /**
@@ -45,11 +51,11 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
  */
 template <typename T, typename VecU, require_std_vector_t<VecU>...>
 inline void assign(std::vector<T>& x, const nil_index_list& /* idxs */,
-                   VecU&& y, const char* name = "ANON",
-                   int depth = 0) {
+                   VecU&& y, const char* name = "ANON", int depth = 0) {
   x.reserve(y.size());
   for (size_t i = 0; i < y.size(); ++i) {
-    assign(x[i], nil_index_list(), std::forward<decltype(y[0])>(y[i]), name, depth + 1);
+    assign(x[i], nil_index_list(), std::forward<decltype(y[0])>(y[i]), name,
+           depth + 1);
   }
 }
 
@@ -119,12 +125,12 @@ inline void assign(Eigen::Matrix<T, 1, C>& x,
  * @throw std::invalid_argument If the value size isn't the same as
  * the indexed size.
  */
-template <typename T, typename I, typename U, int R1, int R2, require_not_same_t<I, index_uni>...>
-inline void
-assign(Eigen::Matrix<T, R1, 1>& x,
-       const cons_index_list<I, nil_index_list>& idxs,
-       const Eigen::Matrix<U, R2, 1>& y, const char* name = "ANON",
-       int depth = 0) {
+template <typename T, typename I, typename U, int R1, int R2,
+          require_not_same_t<I, index_uni>...>
+inline void assign(Eigen::Matrix<T, R1, 1>& x,
+                   const cons_index_list<I, nil_index_list>& idxs,
+                   const Eigen::Matrix<U, R2, 1>& y, const char* name = "ANON",
+                   int depth = 0) {
   math::check_size_match("vector[multi] assign sizes", "lhs",
                          rvalue_index_size(idxs.head_, x.size()), name,
                          y.size());
@@ -154,12 +160,12 @@ assign(Eigen::Matrix<T, R1, 1>& x,
  * @throw std::invalid_argument If the value size isn't the same as
  * the indexed size.
  */
-template <typename T, typename I, typename U, int C1, int C2, require_not_same_t<index_uni, I>...>
-inline void
-assign(Eigen::Matrix<T, 1, C1>& x,
-       const cons_index_list<I, nil_index_list>& idxs,
-       const Eigen::Matrix<U, 1, C2>& y, const char* name = "ANON",
-       int depth = 0) {
+template <typename T, typename I, typename U, int C1, int C2,
+          require_not_same_t<index_uni, I>...>
+inline void assign(Eigen::Matrix<T, 1, C1>& x,
+                   const cons_index_list<I, nil_index_list>& idxs,
+                   const Eigen::Matrix<U, 1, C2>& y, const char* name = "ANON",
+                   int depth = 0) {
   math::check_size_match("row_vector[multi] assign sizes", "lhs",
                          rvalue_index_size(idxs.head_, x.size()), name,
                          y.size());
@@ -191,8 +197,8 @@ assign(Eigen::Matrix<T, 1, C1>& x,
 template <typename T, typename U, int R1, int C1, int C2>
 void assign(Eigen::Matrix<T, R1, C1>& x,
             const cons_index_list<index_uni, nil_index_list>& idxs,
-            const Eigen::Matrix<U, 1, C2>& y,
-            const char* name = "ANON", int depth = 0) {
+            const Eigen::Matrix<U, 1, C2>& y, const char* name = "ANON",
+            int depth = 0) {
   math::check_size_match("matrix[uni] assign sizes", "lhs", x.cols(), name,
                          y.cols());
   int i = idxs.head_.n_;
@@ -218,12 +224,12 @@ void assign(Eigen::Matrix<T, R1, C1>& x,
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side matrix do not match.
  */
-template <typename T, typename I, typename U, int R1, int C1, int R2, int C2, require_not_same_t<index_uni, I>...>
-inline void
-assign(Eigen::Matrix<T, R1, C1>& x,
-       const cons_index_list<I, nil_index_list>& idxs,
-       const Eigen::Matrix<U, R2, C2>& y,
-       const char* name = "ANON", int depth = 0) {
+template <typename T, typename I, typename U, int R1, int C1, int R2, int C2,
+          require_not_same_t<index_uni, I>...>
+inline void assign(Eigen::Matrix<T, R1, C1>& x,
+                   const cons_index_list<I, nil_index_list>& idxs,
+                   const Eigen::Matrix<U, R2, C2>& y, const char* name = "ANON",
+                   int depth = 0) {
   int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
   math::check_size_match("matrix[multi] assign row sizes", "lhs", x_idx_rows,
                          name, y.rows());
@@ -284,9 +290,9 @@ void assign(Eigen::Matrix<T, R, C>& x,
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side row vector do not match.
  */
-template <typename T, typename I, typename U, int R1, int C1, int C2, require_not_same_t<index_uni, I>...>
-inline void
-assign(
+template <typename T, typename I, typename U, int R1, int C1, int C2,
+          require_not_same_t<index_uni, I>...>
+inline void assign(
     Eigen::Matrix<T, R1, C1>& x,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idxs,
     const Eigen::Matrix<U, 1, C2>& y, const char* name = "ANON",
@@ -321,7 +327,8 @@ assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side vector do not match.
  */
-template <typename T, typename I, typename U, int R1, int C1, int R2, require_not_same_t<index_uni, I>...>
+template <typename T, typename I, typename U, int R1, int C1, int R2,
+          require_not_same_t<index_uni, I>...>
 inline void assign(
     Eigen::Matrix<T, R1, C1>& x,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idxs,
@@ -358,11 +365,13 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and value matrix do not match.
  */
-template <typename T, typename I1, typename I2, typename U, int R1, int C1, int R2, int C2, require_any_not_same_t<index_uni, I1, I2>...>
-inline void assign(Eigen::Matrix<T, R1, C1>& x,
-       const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
-       const Eigen::Matrix<U, R2, C2>& y,
-       const char* name = "ANON", int depth = 0) {
+template <typename T, typename I1, typename I2, typename U, int R1, int C1,
+          int R2, int C2, require_any_not_same_t<index_uni, I1, I2>...>
+inline void assign(
+    Eigen::Matrix<T, R1, C1>& x,
+    const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
+    const Eigen::Matrix<U, R2, C2>& y, const char* name = "ANON",
+    int depth = 0) {
   int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
   int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
   math::check_size_match("matrix[multi,multi] assign sizes", "lhs", x_idxs_rows,
@@ -436,17 +445,18 @@ inline void assign(std::vector<T>& x, const cons_index_list<index_uni, L>& idxs,
  * and size of first dimension of value do not match, or any of
  * the recursive tail assignment dimensions do not match.
  */
-template <typename T, typename I, typename L, typename VecU, require_not_same_t<index_uni, I>..., require_std_vector_t<VecU>...>
+template <typename T, typename I, typename L, typename VecU,
+          require_not_same_t<index_uni, I>..., require_std_vector_t<VecU>...>
 inline void assign(std::vector<T>& x, const cons_index_list<I, L>& idxs,
-                       VecU&& y, const char* name = "ANON",
-                       int depth = 0) {
+                   VecU&& y, const char* name = "ANON", int depth = 0) {
   int x_idx_size = rvalue_index_size(idxs.head_, x.size());
   math::check_size_match("vector[multi,...] assign sizes", "lhs", x_idx_size,
                          name, y.size());
   for (size_t n = 0; n < y.size(); ++n) {
     int i = rvalue_at(n, idxs.head_);
     math::check_range("vector[multi,...] assign range", name, x.size(), i);
-    assign(x[i - 1], idxs.tail_, std::forward<decltype(y[0])>(y[n]), name, depth + 1);
+    assign(x[i - 1], idxs.tail_, std::forward<decltype(y[0])>(y[n]), name,
+           depth + 1);
   }
 }
 

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -29,7 +29,7 @@ namespace model {
  */
 template <typename T, require_not_stan_scalar_t<T>...>
 inline auto&& rvalue(T&& c, const nil_index_list& /*idx*/,
-                const char* /*name*/ = "", int /*depth*/ = 0) {
+                     const char* /*name*/ = "", int /*depth*/ = 0) {
   return std::forward<T>(c);
 }
 
@@ -63,9 +63,10 @@ inline T rvalue(const T& c, const nil_index_list& /*idx*/,
  * @return Result of indexing vector.
  */
 template <typename T, int R>
-inline decltype(auto) rvalue(const Eigen::Matrix<T, R, 1>& v,
-                const cons_index_list<index_uni, nil_index_list>& idx,
-                const char* name = "ANON", int depth = 0) {
+inline decltype(auto) rvalue(
+    const Eigen::Matrix<T, R, 1>& v,
+    const cons_index_list<index_uni, nil_index_list>& idx,
+    const char* name = "ANON", int depth = 0) {
   int ones_idx = idx.head_.n_;
   math::check_range("vector[single] indexing", name, v.size(), ones_idx);
   return v.coeffRef(ones_idx - 1);
@@ -86,12 +87,13 @@ inline decltype(auto) rvalue(const Eigen::Matrix<T, R, 1>& v,
  * @return Result of indexing row vector.
  */
 template <typename T, int C>
-inline decltype(auto) rvalue(const Eigen::Matrix<T, 1, C>& rv,
-                const cons_index_list<index_uni, nil_index_list>& idx,
-                const char* name = "ANON", int depth = 0) {
+inline decltype(auto) rvalue(
+    const Eigen::Matrix<T, 1, C>& rv,
+    const cons_index_list<index_uni, nil_index_list>& idx,
+    const char* name = "ANON", int depth = 0) {
   int n = idx.head_.n_;
   math::check_range("row_vector[single] indexing", name, rv.size(), n);
-  return rv.coeffRef(n - 1);
+  return rv.coeff(n - 1);
 }
 
 /**
@@ -109,10 +111,9 @@ inline decltype(auto) rvalue(const Eigen::Matrix<T, 1, C>& rv,
  * @return Result of indexing vector.
  */
 template <typename T, typename I, int R, require_not_same_t<index_uni, I>...>
-inline auto
-rvalue(const Eigen::Matrix<T, R, 1>& v,
-       const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
-       int depth = 0) {
+inline auto rvalue(const Eigen::Matrix<T, R, 1>& v,
+                   const cons_index_list<I, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
   int size = rvalue_index_size(idx.head_, v.size());
   Eigen::Matrix<T, Eigen::Dynamic, 1> a(size);
   for (int i = 0; i < size; ++i) {
@@ -139,10 +140,9 @@ rvalue(const Eigen::Matrix<T, R, 1>& v,
  * @return Result of indexing vector.
  */
 template <typename T, typename I, int C, require_not_same_t<index_uni, I>...>
-inline auto
-rvalue(const Eigen::Matrix<T, 1, C>& rv,
-       const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
-       int depth = 0) {
+inline auto rvalue(const Eigen::Matrix<T, 1, C>& rv,
+                   const cons_index_list<I, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
   int size = rvalue_index_size(idx.head_, rv.size());
   Eigen::Matrix<T, 1, Eigen::Dynamic> a(size);
   for (int i = 0; i < size; ++i) {
@@ -167,10 +167,9 @@ rvalue(const Eigen::Matrix<T, 1, C>& rv,
  * @return Result of indexing matrix.
  */
 template <typename T, int R, int C>
-inline auto rvalue(
-    const Eigen::Matrix<T, R, C>& a,
-    const cons_index_list<index_uni, nil_index_list>& idx,
-    const char* name = "ANON", int depth = 0) {
+inline auto rvalue(const Eigen::Matrix<T, R, C>& a,
+                   const cons_index_list<index_uni, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
   int n = idx.head_.n_;
   math::check_range("matrix[uni, omni] indexing", name, a.rows(), n);
   return a.row(n - 1);
@@ -192,7 +191,8 @@ inline auto rvalue(
 template <typename T, int R, int C>
 inline decltype(auto) rvalue(
     Eigen::Matrix<T, R, C>& a,
-    const cons_index_list<index_omni, cons_index_list<index_uni, nil_index_list>>& idx,
+    const cons_index_list<index_omni,
+                          cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   int n = idx.tail_.head_.n_;
   math::check_range("matrix[omni, uni] indexing", name, a.cols(), n);
@@ -201,7 +201,8 @@ inline decltype(auto) rvalue(
 
 /**
  * Return the result of indexing the specified Eigen matrix with a
- * sequence consisting of a column index and a slice of rows, returning a row vector.
+ * sequence consisting of a column index and a slice of rows, returning a row
+ * vector.
  *
  * Types:  mat[min_max, single] : vec
  *
@@ -215,15 +216,20 @@ inline decltype(auto) rvalue(
 template <typename T, int R, int C>
 inline auto rvalue(
     Eigen::Matrix<T, R, C>& a,
-    const cons_index_list<index_min_max, cons_index_list<index_uni, nil_index_list>>& idx,
+    const cons_index_list<index_min_max,
+                          cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
-  math::check_range("matrix[min_max, uni] uni indexing", name, a.cols(), idx.tail_.head_.n_);
-  math::check_range("matrix[min_max, uni] min indexing", name, a.rows(), idx.head_.max_);
-  math::check_range("matrix[min_max, uni] max indexing", name, a.rows(), idx.head_.min_);
+  math::check_range("matrix[min_max, uni] uni indexing", name, a.cols(),
+                    idx.tail_.head_.n_);
+  math::check_range("matrix[min_max, uni] min indexing", name, a.rows(),
+                    idx.head_.max_);
+  math::check_range("matrix[min_max, uni] max indexing", name, a.rows(),
+                    idx.head_.min_);
   int bottom = idx.head_.max_;
   int top = idx.head_.min_ - 1;
   int n = idx.tail_.head_.n_ - 1;
-  return Eigen::Map<Eigen::Matrix<T, -1, 1>>(a.data() + top + (a.rows() * n), bottom);
+  return Eigen::Map<Eigen::Matrix<T, -1, 1>>(a.data() + top + (a.rows() * n),
+                                             bottom);
 }
 
 /**
@@ -240,11 +246,11 @@ inline auto rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename T, typename I, int R, int C, require_not_same_t<index_uni, I>...>
-inline auto
-rvalue(const Eigen::Matrix<T, R, C>& a,
-       const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
-       int depth = 0) {
+template <typename T, typename I, int R, int C,
+          require_not_same_t<index_uni, I>...>
+inline auto rvalue(const Eigen::Matrix<T, R, C>& a,
+                   const cons_index_list<I, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
   int n_rows = rvalue_index_size(idx.head_, a.rows());
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> b(n_rows, a.cols());
   for (int i = 0; i < n_rows; ++i) {
@@ -269,16 +275,15 @@ rvalue(const Eigen::Matrix<T, R, C>& a,
  * @return Result of indexing matrix.
  */
 template <typename T, int R, int C>
-inline T rvalue(
-    const Eigen::Matrix<T, R, C>& a,
-    const cons_index_list<index_uni,
-                          cons_index_list<index_uni, nil_index_list> >& idx,
-    const char* name = "ANON", int depth = 0) {
+inline T rvalue(const Eigen::Matrix<T, R, C>& a,
+                const cons_index_list<
+                    index_uni, cons_index_list<index_uni, nil_index_list>>& idx,
+                const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
   int n = idx.tail_.head_.n_;
   math::check_range("matrix[uni,uni] indexing, row", name, a.rows(), m);
   math::check_range("matrix[uni,uni] indexing, col", name, a.cols(), n);
-  return a.coeffRef(m - 1, n - 1);
+  return a.coeff(m - 1, n - 1);
 }
 
 /**
@@ -296,11 +301,11 @@ inline T rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename T, typename I, int R, int C, require_not_same_t<index_uni, I>...>
-inline auto
-rvalue(
+template <typename T, typename I, int R, int C,
+          require_not_same_t<index_uni, I>...>
+inline auto rvalue(
     const Eigen::Matrix<T, R, C>& a,
-    const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idx,
+    const cons_index_list<index_uni, cons_index_list<I, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
   math::check_range("matrix[uni,multi] indexing, row", name, a.rows(), m);
@@ -323,11 +328,11 @@ rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename T, typename I, int R, int C, require_not_same_t<index_uni, I>...>
-inline auto
-rvalue(
+template <typename T, typename I, int R, int C,
+          require_not_same_t<index_uni, I>...>
+inline auto rvalue(
     const Eigen::Matrix<T, R, C>& a,
-    const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idx,
+    const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   int rows = rvalue_index_size(idx.head_, a.rows());
   Eigen::Matrix<T, Eigen::Dynamic, 1> c(rows);
@@ -356,11 +361,12 @@ rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename T, typename I1, typename I2, int R, int C, require_any_not_same_t<index_uni, I1, I2>...>
-inline auto
-rvalue(const Eigen::Matrix<T, R, C>& a,
-       const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idx,
-       const char* name = "ANON", int depth = 0) {
+template <typename T, typename I1, typename I2, int R, int C,
+          require_any_not_same_t<index_uni, I1, I2>...>
+inline auto rvalue(
+    const Eigen::Matrix<T, R, C>& a,
+    const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idx,
+    const char* name = "ANON", int depth = 0) {
   int rows = rvalue_index_size(idx.head_, a.rows());
   int cols = rvalue_index_size(idx.tail_.head_, a.cols());
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> c(rows, cols);
@@ -393,12 +399,12 @@ rvalue(const Eigen::Matrix<T, R, C>& a,
  * @return Result of indexing array.
  */
 template <typename VecT, typename L, require_std_vector_t<VecT>...>
-inline auto
-    rvalue(VecT&& c, const cons_index_list<index_uni, L>& idx,
-           const char* name = "ANON", int depth = 0) {
+inline auto rvalue(VecT&& c, const cons_index_list<index_uni, L>& idx,
+                   const char* name = "ANON", int depth = 0) {
   int n = idx.head_.n_;
   math::check_range("array[uni,...] index", name, c.size(), n);
-  return rvalue(std::forward<decltype(c[0])>(c[n - 1]), idx.tail_, name, depth + 1);
+  return rvalue(std::forward<decltype(c[0])>(c[n - 1]), idx.tail_, name,
+                depth + 1);
 }
 
 /**
@@ -418,14 +424,15 @@ inline auto
  * @return Result of indexing array.
  */
 template <typename VecT, typename I, typename L, require_std_vector_t<VecT>...>
-inline auto
-rvalue(VecT&& c, const cons_index_list<I, L>& idx,
-       const char* name = "ANON", int depth = 0) {
-  typename rvalue_return<std::vector<value_type_t<VecT>>, cons_index_list<I, L> >::type result;
+inline auto rvalue(VecT&& c, const cons_index_list<I, L>& idx,
+                   const char* name = "ANON", int depth = 0) {
+  typename rvalue_return<std::vector<value_type_t<VecT>>,
+                         cons_index_list<I, L>>::type result;
   for (int i = 0; i < rvalue_index_size(idx.head_, c.size()); ++i) {
     int n = rvalue_at(i, idx.head_);
     math::check_range("array[multi,...] index", name, c.size(), n);
-    result.emplace_back(rvalue(std::forward<decltype(c[0])>(c[n - 1]), idx.tail_, name, depth + 1));
+    result.emplace_back(rvalue(std::forward<decltype(c[0])>(c[n - 1]),
+                               idx.tail_, name, depth + 1));
   }
   return result;
 }

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -150,14 +150,13 @@ TEST(ModelIndexing, rvalue_eigen_mat_min_max_nil) {
     x(i) = i;
   }
 
-  Eigen::Matrix<double, -1, 1> x_row_sub = rvalue(x, index_list(index_min_max(1, 3), index_uni(3)));
+  Eigen::Matrix<double, -1, 1> x_row_sub
+      = rvalue(x, index_list(index_min_max(1, 3), index_uni(3)));
   EXPECT_EQ(3, x_row_sub.size());
   EXPECT_EQ(8, x_row_sub(0));
   EXPECT_EQ(9, x_row_sub(1));
   EXPECT_EQ(10, x_row_sub(2));
-
 }
-
 
 TEST(ModelIndexing, rvalue_doubless_uni_uni) {
   using std::vector;
@@ -344,7 +343,8 @@ TEST(ModelIndexing, rvalue_eigen_mat_omni_uni) {
     x(i) = i;
   }
 
-  Eigen::Matrix<double, -1, 1> x_row_sub = rvalue(x, index_list(index_omni(), index_uni(3)));
+  Eigen::Matrix<double, -1, 1> x_row_sub
+      = rvalue(x, index_list(index_omni(), index_uni(3)));
   EXPECT_EQ(4, x_row_sub.size());
   EXPECT_EQ(8, x_row_sub(0));
   EXPECT_EQ(9, x_row_sub(1));

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -144,6 +144,21 @@ TEST(ModelIndexing, rvalue_vector_min_max_nil) {
   test_out_of_range(x, index_list(index_min_max(2, 5)));
 }
 
+TEST(ModelIndexing, rvalue_eigen_mat_min_max_nil) {
+  Eigen::Matrix<double, -1, -1> x(4, 4);
+  for (int i = 0; i < 16; i++) {
+    x(i) = i;
+  }
+
+  Eigen::Matrix<double, -1, 1> x_row_sub = rvalue(x, index_list(index_min_max(1, 3), index_uni(3)));
+  EXPECT_EQ(3, x_row_sub.size());
+  EXPECT_EQ(8, x_row_sub(0));
+  EXPECT_EQ(9, x_row_sub(1));
+  EXPECT_EQ(10, x_row_sub(2));
+
+}
+
+
 TEST(ModelIndexing, rvalue_doubless_uni_uni) {
   using std::vector;
 
@@ -321,6 +336,20 @@ TEST(ModelIndexing, rvalue_doubless_multi_uni) {
 
   ns[ns.size() - 1] = 15;
   test_out_of_range(x, index_list(index_multi(ns), index_uni(1)));
+}
+
+TEST(ModelIndexing, rvalue_eigen_mat_omni_uni) {
+  Eigen::Matrix<double, -1, -1> x(4, 4);
+  for (int i = 0; i < 16; i++) {
+    x(i) = i;
+  }
+
+  Eigen::Matrix<double, -1, 1> x_row_sub = rvalue(x, index_list(index_omni(), index_uni(3)));
+  EXPECT_EQ(4, x_row_sub.size());
+  EXPECT_EQ(8, x_row_sub(0));
+  EXPECT_EQ(9, x_row_sub(1));
+  EXPECT_EQ(10, x_row_sub(2));
+  EXPECT_EQ(11, x_row_sub(3));
 }
 
 TEST(ModelIndexing, rvalue_doubless_multi_multi) {


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR is for two things

1. In brms issue [833](https://github.com/paul-buerkner/brms/issues/833) Paul found that traversing a matrix row-wise was actually faster. Looking into the code I think it's because `rvalue` has a specialization for pulling out a single row but not a single column. So I added a specializations for pulling out a column or a slice of a column

```stan
A[, M] // index_list(index_omni(), index_uni(M));
A[J:K, M] // index_list(index_min_max(J, K), index_uni(M));
```

I also ran a test program that did a bunch of `vec1 .* vec2 + ...` with min_max slices though heaptrack and found that it was a pretty big culprit for a lot of allocations

![image](https://user-images.githubusercontent.com/5857231/72780352-a4b70580-3bec-11ea-9a75-5c9398abc20b.png)

The flame graph above shows that a large number of allocations happened when pulling from rvalue(). I think in these min_max cases we should be able to just grab a slice of a column and not allocate anything

2. Some of the `rvalue()` code here couldn't take in fixed sized matrices, So I removed the Eigen::Dynamic values in the signature and replaced them with a template value

3. In the case of a nil_index_list for `rvalue` and `assign` I added a perfect forwarding right hand side so that in the case of a temporary the value can be moved into the value to be assigned instead of copied. It maybe good here to have one specialization that does a copy for smaller types while forwarding for larger types

4. We do our own bound checks so I changed instances of `A(i, j)` and `A.coeff(i, j)` with `A.coeffRef(i, j)`. This should remove Eigen's own bounds checking to save a little time

5. The templating here was a bit old school so I tried to update things to use the `require` library instead of boosts stuff

#### Intended Effect

This should give a very small performance bump to Stan code that does a lot of indexing. Though this code touches a lot of models and needs to go through more performance testing

#### How to Verify

I added two new tests to the cases mentioned in (1)

#### Side Effects

Hopefully less allocations. I am concerned that the `auto`'s here may have unintended side effects that need more testing

#### Documentation

New docs for `rvalue` specializations mentioned in (1)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
