### PR TITLE
Allow rvalue and assign to accept eigen expressions

### DIFF
--- a/src/stan/model/indexing/deep_copy.hpp
+++ b/src/stan/model/indexing/deep_copy.hpp
@@ -41,8 +41,8 @@ inline const T& deep_copy(const T& x) {
  * @return Deep copy of input.
  */
 template <typename EigMat, typename = require_eigen_t<EigMat>>
-inline auto deep_copy(const EigMat& a) {
-  typename EigMat::PlainObject result(a);
+inline auto deep_copy(EigMat&& a) {
+  typename std::decay_t<EigMat>::PlainObject result(a);
   return result;
 }
 

--- a/src/stan/model/indexing/deep_copy.hpp
+++ b/src/stan/model/indexing/deep_copy.hpp
@@ -1,7 +1,8 @@
 #ifndef STAN_MODEL_INDEXING_DEEP_COPY_HPP
 #define STAN_MODEL_INDEXING_DEEP_COPY_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim/Eigen.hpp>
+#include <stan/math/prim/meta.hpp>
 #include <vector>
 
 namespace stan {
@@ -39,8 +40,8 @@ inline const T& deep_copy(const T& x) {
  * @param a Input matrix, vector, or row vector.
  * @return Deep copy of input.
  */
-template <typename T, int R, int C>
-inline Eigen::Matrix<T, R, C> deep_copy(const Eigen::Matrix<T, R, C>& a) {
+template <typename EigMat, typename = require_eigen_t<EigMat>>
+inline auto deep_copy(const EigMat& a) {
   Eigen::Matrix<T, R, C> result(a);
   return result;
 }

--- a/src/stan/model/indexing/deep_copy.hpp
+++ b/src/stan/model/indexing/deep_copy.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MODEL_INDEXING_DEEP_COPY_HPP
 #define STAN_MODEL_INDEXING_DEEP_COPY_HPP
 
-#include <stan/math/prim/Eigen.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <vector>
 
@@ -21,7 +21,7 @@ namespace model {
  * @param x Input value.
  * @return Constant reference to input.
  */
-template <typename T>
+template <typename T, typename = require_not_eigen_t<T>>
 inline const T& deep_copy(const T& x) {
   return x;
 }
@@ -42,7 +42,7 @@ inline const T& deep_copy(const T& x) {
  */
 template <typename EigMat, typename = require_eigen_t<EigMat>>
 inline auto deep_copy(const EigMat& a) {
-  Eigen::Matrix<T, R, C> result(a);
+  typename EigMat::PlainObject result(a);
   return result;
 }
 

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -205,7 +205,8 @@ template <typename LhsEigMat, typename I, typename RhsEigMat,
           typename = require_not_eigen_vector_t<RhsEigMat>>
 inline void assign(LhsEigMat& x,
                    const cons_index_list<I, nil_index_list>& idxs,
-                   const RhsEigMat& y, const char* name = "ANON", int depth = 0) {
+                   const RhsEigMat& y,
+                   const char* name = "ANON", int depth = 0) {
   int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
   math::check_size_match("matrix[multi] assign row sizes", "lhs", x_idx_rows,
                          name, y.rows());

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -137,7 +137,7 @@ inline void assign(LhsEigVec& x, const cons_index_list<I, nil_index_list>& idxs,
  * Assign the specified Eigen matrix at the specified single index
  * to the specified row vector value.
  *
- * Types:  mat[,uni] = rowvec
+ * Types:  mat[uni,] = rowvec
  *
  * @tparam EigMat Type of matrix to be assigned to.
  * @tparam RowVec Type of Eigen Row Vector to be assigned from.

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -130,12 +130,10 @@ inline void assign(EigVec1& x, const cons_index_list<I, nil_index_list>& idxs,
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename EigMat, typename RowVec,
-          typename = require_eigen_t<EigMat>,
+template <typename EigMat, typename RowVec, typename = require_eigen_t<EigMat>,
           typename = require_not_eigen_vector_t<EigMat>,
           typename = require_t<is_eigen_row_vector<RowVec>>>
-void assign(EigMat& x,
-            const cons_index_list<index_uni, nil_index_list>& idxs,
+void assign(EigMat& x, const cons_index_list<index_uni, nil_index_list>& idxs,
             const RowVec& y, const char* name = "ANON", int depth = 0) {
   math::check_size_match("matrix[uni] assign sizes", "lhs", x.cols(), name,
                          y.cols());
@@ -163,8 +161,7 @@ void assign(EigMat& x,
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename EigMat, typename ColVec,
-          typename = require_eigen_t<EigMat>,
+template <typename EigMat, typename ColVec, typename = require_eigen_t<EigMat>,
           typename = require_not_eigen_vector_t<EigMat>,
           typename = require_t<is_eigen_col_vector<ColVec>>>
 void assign(EigMat& x,
@@ -203,10 +200,9 @@ template <typename LhsEigMat, typename I, typename RhsEigMat,
           typename = require_not_same_t<index_uni, I>,
           typename = require_eigen_t<RhsEigMat>,
           typename = require_not_eigen_vector_t<RhsEigMat>>
-inline void assign(LhsEigMat& x,
-                   const cons_index_list<I, nil_index_list>& idxs,
-                   const RhsEigMat& y,
-                   const char* name = "ANON", int depth = 0) {
+inline void assign(LhsEigMat& x, const cons_index_list<I, nil_index_list>& idxs,
+                   const RhsEigMat& y, const char* name = "ANON",
+                   int depth = 0) {
   int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
   math::check_size_match("matrix[multi] assign row sizes", "lhs", x_idx_rows,
                          name, y.rows());
@@ -238,8 +234,7 @@ inline void assign(LhsEigMat& x,
  * @param[in] depth Indexing depth (default 0).
  * @throw std::out_of_range If either of the indices are out of bounds.
  */
-template <typename EigMat, typename U,
-          typename = require_eigen_t<EigMat>,
+template <typename EigMat, typename U, typename = require_eigen_t<EigMat>,
           typename = require_not_eigen_vector_t<EigMat>>
 void assign(EigMat& x,
             const cons_index_list<

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -67,36 +67,14 @@ inline void assign(std::vector<T>& x, const nil_index_list& /* idxs */,
  * @param[in] depth Indexing depth (default 0).
  * @throw std::out_of_range If the index is out of bounds.
  */
-template <typename T, typename U>
-inline void assign(Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
+template <typename EigVec, typename Scalar,
+ typename = require_eigen_vector_t<EigVec>,
+ typename = require_stan_scalar_t<Scalar>>
+inline void assign(EigVec& x,
                    const cons_index_list<index_uni, nil_index_list>& idxs,
-                   const U& y, const char* name = "ANON", int depth = 0) {
+                   const Scalar& y, const char* name = "ANON", int depth = 0) {
   int i = idxs.head_.n_;
   math::check_range("vector[uni] assign range", name, x.size(), i);
-  x(i - 1) = y;
-}
-
-/**
- * Assign the specified Eigen vector at the specified single index
- * to the specified value.
- *
- * Types:  row_vec[uni] <- scalar
- *
- * @tparam T Type of assigned row vector scalar.
- * @tparam U Type of value (must be assignable to T).
- * @param[in] x Row vector variable to be assigned.
- * @param[in] idxs Sequence of one single index (from 1).
- * @param[in] y Value scalar.
- * @param[in] name Name of variable (default "ANON").
- * @param[in] depth Indexing depth (default 0).
- * @throw std::out_of_range Index is out of bounds.
- */
-template <typename T, typename U>
-inline void assign(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
-                   const cons_index_list<index_uni, nil_index_list>& idxs,
-                   const U& y, const char* name = "ANON", int depth = 0) {
-  int i = idxs.head_.n_;
-  math::check_range("row_vector[uni] assign range", name, x.size(), i);
   x(i - 1) = y;
 }
 

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -130,9 +130,11 @@ inline void assign(EigVec1& x, const cons_index_list<I, nil_index_list>& idxs,
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename T, typename RowVec,
+template <typename EigMat, typename RowVec,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>,
           typename = require_t<is_eigen_row_vector<RowVec>>>
-void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+void assign(EigMat& x,
             const cons_index_list<index_uni, nil_index_list>& idxs,
             const RowVec& y, const char* name = "ANON", int depth = 0) {
   math::check_size_match("matrix[uni] assign sizes", "lhs", x.cols(), name,
@@ -161,9 +163,11 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename T, typename ColVec,
+template <typename EigMat, typename ColVec,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>,
           typename = require_t<is_eigen_col_vector<ColVec>>>
-void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+void assign(EigMat& x,
             const cons_index_list<
                 index_omni, cons_index_list<index_uni, nil_index_list>>& idxs,
             const ColVec& y, const char* name = "ANON", int depth = 0) {
@@ -193,19 +197,21 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side matrix do not match.
  */
-template <typename T, typename I, typename EigMat,
+template <typename LhsEigMat, typename I, typename RhsEigMat,
+          typename = require_eigen_t<LhsEigMat>,
+          typename = require_not_eigen_vector_t<LhsEigMat>,
           typename = require_not_same_t<index_uni, I>,
-          typename = require_eigen_t<EigMat>,
-          typename = require_not_eigen_vector_t<EigMat>>
-inline void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+          typename = require_eigen_t<RhsEigMat>,
+          typename = require_not_eigen_vector_t<RhsEigMat>>
+inline void assign(LhsEigMat& x,
                    const cons_index_list<I, nil_index_list>& idxs,
-                   const EigMat& y, const char* name = "ANON", int depth = 0) {
+                   const RhsEigMat& y, const char* name = "ANON", int depth = 0) {
   int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
   math::check_size_match("matrix[multi] assign row sizes", "lhs", x_idx_rows,
                          name, y.rows());
   math::check_size_match("matrix[multi] assign col sizes", "lhs", x.cols(),
                          name, y.cols());
-  const Eigen::Ref<const typename EigMat::PlainObject>& mat = y;
+  const Eigen::Ref<const typename RhsEigMat::PlainObject>& mat = y;
 
   for (int i = 0; i < y.rows(); ++i) {
     int m = rvalue_at(i, idxs.head_);
@@ -231,8 +237,10 @@ inline void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * @param[in] depth Indexing depth (default 0).
  * @throw std::out_of_range If either of the indices are out of bounds.
  */
-template <typename T, typename U>
-void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+template <typename EigMat, typename U,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>>
+void assign(EigMat& x,
             const cons_index_list<
                 index_uni, cons_index_list<index_uni, nil_index_list>>& idxs,
             const U& y, const char* name = "ANON", int depth = 0) {
@@ -262,11 +270,13 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side row vector do not match.
  */
-template <typename T, typename I, typename RowVec,
+template <typename EigMat, typename I, typename RowVec,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>,
           typename = require_not_same_t<index_uni, I>,
           typename = require_t<is_eigen_row_vector<RowVec>>>
 inline void assign(
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+    EigMat& x,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list>>& idxs,
     const RowVec& y, const char* name = "ANON", int depth = 0) {
   int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
@@ -300,11 +310,13 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side vector do not match.
  */
-template <typename T, typename I, typename ColVec,
+template <typename EigMat, typename I, typename ColVec,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>,
           typename = require_not_same_t<index_uni, I>,
           typename = require_t<is_eigen_col_vector<ColVec>>>
 inline void assign(
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+    EigMat& x,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idxs,
     const ColVec& y, const char* name = "ANON", int depth = 0) {
   int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
@@ -339,21 +351,23 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and value matrix do not match.
  */
-template <typename T, typename I1, typename I2, typename EigMat,
+template <typename LhsEigMat, typename I1, typename I2, typename RhsEigMat,
+          typename = require_eigen_t<LhsEigMat>,
+          typename = require_not_eigen_vector_t<LhsEigMat>,
           typename = require_any_not_same_t<index_uni, I1, I2>,
-          typename = require_eigen_t<EigMat>,
-          typename = require_not_eigen_vector_t<EigMat>>
+          typename = require_eigen_t<RhsEigMat>,
+          typename = require_not_eigen_vector_t<RhsEigMat>>
 inline void assign(
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+    LhsEigMat& x,
     const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idxs,
-    const EigMat& y, const char* name = "ANON", int depth = 0) {
+    const RhsEigMat& y, const char* name = "ANON", int depth = 0) {
   int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
   int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
   math::check_size_match("matrix[multi,multi] assign sizes", "lhs", x_idxs_rows,
                          name, y.rows());
   math::check_size_match("matrix[multi,multi] assign sizes", "lhs", x_idxs_cols,
                          name, y.cols());
-  const Eigen::Ref<const typename EigMat::PlainObject>& mat = y;
+  const Eigen::Ref<const typename RhsEigMat::PlainObject>& mat = y;
   for (int j = 0; j < y.cols(); ++j) {
     int n = rvalue_at(j, idxs.tail_.head_);
     math::check_range("matrix[multi,multi] assign range", name, x.cols(), n);

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -119,23 +119,20 @@ inline void assign(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
  * the indexed size.
  */
 template <typename EigVec1, typename EigVec2, typename I,
-  typename = require_not_same_t<index_uni, I>,
-  typename = require_all_eigen_vector_t<EigVec1, EigVec2>>
-inline void assign(EigVec1& x,
-       const cons_index_list<I, nil_index_list>& idxs,
-       const EigVec2& y, const char* name = "ANON",
-       int depth = 0) {
+          typename = require_not_same_t<index_uni, I>,
+          typename = require_all_eigen_vector_t<EigVec1, EigVec2>>
+inline void assign(EigVec1& x, const cons_index_list<I, nil_index_list>& idxs,
+                   const EigVec2& y, const char* name = "ANON", int depth = 0) {
   math::check_size_match("vector[multi] assign sizes", "lhs",
                          rvalue_index_size(idxs.head_, x.size()), name,
                          y.size());
- const Eigen::Ref<const typename EigVec2::PlainObject>&  vec = y;
+  const Eigen::Ref<const typename EigVec2::PlainObject>& vec = y;
   for (int n = 0; n < y.size(); ++n) {
     int i = rvalue_at(n, idxs.head_);
     math::check_range("vector[multi] assign range", name, x.size(), i);
     x(i - 1) = vec(n);
   }
 }
-
 
 /**
  * Assign the specified Eigen matrix at the specified single index
@@ -155,16 +152,16 @@ inline void assign(EigVec1& x,
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename T, typename RowVec, typename = require_t<is_eigen_row_vector<RowVec>>>
+template <typename T, typename RowVec,
+          typename = require_t<is_eigen_row_vector<RowVec>>>
 void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
             const cons_index_list<index_uni, nil_index_list>& idxs,
-            const RowVec& y,
-            const char* name = "ANON", int depth = 0) {
+            const RowVec& y, const char* name = "ANON", int depth = 0) {
   math::check_size_match("matrix[uni] assign sizes", "lhs", x.cols(), name,
                          y.cols());
   int i = idxs.head_.n_;
   math::check_range("matrix[uni,] assign range", name, x.rows(), i);
-  const Eigen::Ref<const typename RowVec::PlainObject>&  vec = y;
+  const Eigen::Ref<const typename RowVec::PlainObject>& vec = y;
   x.row(i - 1) = vec;
 }
 
@@ -186,16 +183,17 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename T, typename ColVec, typename = require_t<is_eigen_col_vector<ColVec>>>
+template <typename T, typename ColVec,
+          typename = require_t<is_eigen_col_vector<ColVec>>>
 void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
-            const cons_index_list<index_omni, cons_index_list<index_uni, nil_index_list>>& idxs,
-            const ColVec& y,
-            const char* name = "ANON", int depth = 0) {
+            const cons_index_list<
+                index_omni, cons_index_list<index_uni, nil_index_list>>& idxs,
+            const ColVec& y, const char* name = "ANON", int depth = 0) {
   math::check_size_match("matrix[uni] assign sizes", "lhs", x.cols(), name,
                          y.cols());
   int i = idxs.tail_.head_.n_;
   math::check_range("matrix[uni,] assign range", name, x.rows(), i);
-  const Eigen::Ref<const typename ColVec::PlainObject>&  vec = y;
+  const Eigen::Ref<const typename ColVec::PlainObject>& vec = y;
   x.col(i - 1) = vec;
 }
 
@@ -218,20 +216,18 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and right-hand side matrix do not match.
  */
 template <typename T, typename I, typename EigMat,
- typename = require_not_same_t<index_uni, I>,
- typename = require_eigen_t<EigMat>,
- typename = require_not_eigen_vector_t<EigMat>>
-inline void
-assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
-       const cons_index_list<I, nil_index_list>& idxs,
-       const EigMat& y,
-       const char* name = "ANON", int depth = 0) {
+          typename = require_not_same_t<index_uni, I>,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>>
+inline void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+                   const cons_index_list<I, nil_index_list>& idxs,
+                   const EigMat& y, const char* name = "ANON", int depth = 0) {
   int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
   math::check_size_match("matrix[multi] assign row sizes", "lhs", x_idx_rows,
                          name, y.rows());
   math::check_size_match("matrix[multi] assign col sizes", "lhs", x.cols(),
                          name, y.cols());
- const Eigen::Ref<const typename EigMat::PlainObject>& mat = y;
+  const Eigen::Ref<const typename EigMat::PlainObject>& mat = y;
 
   for (int i = 0; i < y.rows(); ++i) {
     int m = rvalue_at(i, idxs.head_);
@@ -260,7 +256,7 @@ assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
 template <typename T, typename U>
 void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
             const cons_index_list<
-                index_uni, cons_index_list<index_uni, nil_index_list> >& idxs,
+                index_uni, cons_index_list<index_uni, nil_index_list>>& idxs,
             const U& y, const char* name = "ANON", int depth = 0) {
   int m = idxs.head_.n_;
   int n = idxs.tail_.head_.n_;
@@ -289,14 +285,12 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and right-hand side row vector do not match.
  */
 template <typename T, typename I, typename RowVec,
- typename = require_not_same_t<index_uni, I>,
- typename = require_t<is_eigen_row_vector<RowVec>>>
-inline void
-assign(
+          typename = require_not_same_t<index_uni, I>,
+          typename = require_t<is_eigen_row_vector<RowVec>>>
+inline void assign(
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
-    const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idxs,
-    const RowVec& y, const char* name = "ANON",
-    int depth = 0) {
+    const cons_index_list<index_uni, cons_index_list<I, nil_index_list>>& idxs,
+    const RowVec& y, const char* name = "ANON", int depth = 0) {
   int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
   math::check_size_match("matrix[uni,multi] assign sizes", "lhs", x_idxs_cols,
                          name, y.cols());
@@ -329,12 +323,12 @@ assign(
  * matrix and right-hand side vector do not match.
  */
 template <typename T, typename I, typename ColVec,
- typename = require_not_same_t<index_uni, I>,
- typename = require_t<is_eigen_col_vector<ColVec>>>
-inline void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
-    const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idxs,
-    const ColVec& y, const char* name = "ANON",
-    int depth = 0) {
+          typename = require_not_same_t<index_uni, I>,
+          typename = require_t<is_eigen_col_vector<ColVec>>>
+inline void assign(
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+    const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idxs,
+    const ColVec& y, const char* name = "ANON", int depth = 0) {
   int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
   math::check_size_match("matrix[multi,uni] assign sizes", "lhs", x_idxs_rows,
                          name, y.rows());
@@ -368,20 +362,20 @@ inline void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and value matrix do not match.
  */
 template <typename T, typename I1, typename I2, typename EigMat,
- typename = require_any_not_same_t<index_uni, I1, I2>,
- typename = require_eigen_t<EigMat>,
- typename = require_not_eigen_vector_t<EigMat>>
-inline void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
-       const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
-       const EigMat& y,
-       const char* name = "ANON", int depth = 0) {
+          typename = require_any_not_same_t<index_uni, I1, I2>,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>>
+inline void assign(
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+    const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idxs,
+    const EigMat& y, const char* name = "ANON", int depth = 0) {
   int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
   int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
   math::check_size_match("matrix[multi,multi] assign sizes", "lhs", x_idxs_rows,
                          name, y.rows());
   math::check_size_match("matrix[multi,multi] assign sizes", "lhs", x_idxs_cols,
                          name, y.cols());
- const Eigen::Ref<const typename EigMat::PlainObject>& mat = y;
+  const Eigen::Ref<const typename EigMat::PlainObject>& mat = y;
   for (int j = 0; j < y.cols(); ++j) {
     int n = rvalue_at(j, idxs.tail_.head_);
     math::check_range("matrix[multi,multi] assign range", name, x.cols(), n);
@@ -449,10 +443,11 @@ inline void assign(std::vector<T>& x, const cons_index_list<index_uni, L>& idxs,
  * and size of first dimension of value do not match, or any of
  * the recursive tail assignment dimensions do not match.
  */
-template <typename T, typename I, typename L, typename U, typename = require_not_same_t<index_uni, I>>
+template <typename T, typename I, typename L, typename U,
+          typename = require_not_same_t<index_uni, I>>
 inline void assign(std::vector<T>& x, const cons_index_list<I, L>& idxs,
-                       const std::vector<U>& y, const char* name = "ANON",
-                       int depth = 0) {
+                   const std::vector<U>& y, const char* name = "ANON",
+                   int depth = 0) {
   int x_idx_size = rvalue_index_size(idxs.head_, x.size());
   math::check_size_match("vector[multi,...] assign sizes", "lhs", x_idx_size,
                          name, y.size());

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -137,7 +137,7 @@ inline void assign(LhsEigVec& x, const cons_index_list<I, nil_index_list>& idxs,
  * Assign the specified Eigen matrix at the specified single index
  * to the specified row vector value.
  *
- * Types:  mat[uni,] = rowvec
+ * Types:  mat[,uni] = rowvec
  *
  * @tparam EigMat Type of matrix to be assigned to.
  * @tparam RowVec Type of Eigen Row Vector to be assigned from.

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -26,16 +26,15 @@ namespace model {
  * @param[in] name Name of lvalue variable (default "ANON"); ignored
  * @param[in] depth Indexing depth (default 0; ignored
  */
-template <typename T, typename U,
- typename = require_all_stan_scalar_t<U, T>>
+template <typename T, typename U, typename = require_all_stan_scalar_t<U, T>>
 inline void assign(T& x, const nil_index_list& /* idxs */, U y,
                    const char* name = "ANON", int depth = 0) {
   x = y;
 }
 
 /**
- * Assign the specified non-scalar rvalue to the specified non-scalar lvalue. The index
- * list's type must be `nil_index_list`, but its value will be
+ * Assign the specified non-scalar rvalue to the specified non-scalar lvalue.
+ * The index list's type must be `nil_index_list`, but its value will be
  * ignored.  The last two arguments are also ignored.
  *
  * @tparam T lvalue variable type
@@ -46,7 +45,7 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U y,
  * @param[in] depth Indexing depth (default 0; ignored
  */
 template <typename T, typename U,
- typename = require_all_not_stan_scalar_t<U, T>>
+          typename = require_all_not_stan_scalar_t<U, T>>
 inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
                    const char* name = "ANON", int depth = 0) {
   x = std::forward<U>(y);
@@ -121,7 +120,8 @@ template <typename LhsEigVec, typename RhsEigVec, typename I,
           typename = require_not_same_t<index_uni, I>,
           typename = require_all_eigen_vector_t<LhsEigVec, RhsEigVec>>
 inline void assign(LhsEigVec& x, const cons_index_list<I, nil_index_list>& idxs,
-                   const RhsEigVec& y, const char* name = "ANON", int depth = 0) {
+                   const RhsEigVec& y, const char* name = "ANON",
+                   int depth = 0) {
   math::check_size_match("vector[multi] assign sizes", "lhs",
                          rvalue_index_size(idxs.head_, x.size()), name,
                          y.size());

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -79,7 +79,8 @@ inline auto rvalue(const EigVec& v,
   int size = rvalue_index_size(idx.head_, v.size());
   const Eigen::Ref<const typename EigVec::PlainObject>& vec = v;
   Eigen::Matrix<scalar_type_t<EigVec>, EigVec::RowsAtCompileTime,
-   EigVec::ColsAtCompileTime> a(size);
+                EigVec::ColsAtCompileTime>
+      a(size);
   for (int i = 0; i < size; ++i) {
     int n = rvalue_at(i, idx.head_);
     math::check_range("vector[multi] indexing", name, v.size(), n);

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -48,10 +48,10 @@ inline T rvalue(const T& c, const nil_index_list& /*idx*/,
  */
 template <typename EigVec, typename = require_eigen_vector_t<EigVec>>
 inline auto rvalue(const EigVec& v,
-                const cons_index_list<index_uni, nil_index_list>& idx,
-                const char* name = "ANON", int depth = 0) {
+                   const cons_index_list<index_uni, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
   int ones_idx = idx.head_.n_;
-  const Eigen::Ref<const typename EigVec::PlainObject>&  vec = v;
+  const Eigen::Ref<const typename EigVec::PlainObject>& vec = v;
   math::check_range("vector[single] indexing", name, v.size(), ones_idx);
   return vec.coeff(ones_idx - 1);
 }
@@ -71,13 +71,13 @@ inline auto rvalue(const EigVec& v,
  * @return Result of indexing vector.
  */
 template <typename EigVec, typename I,
- typename = require_not_same_t<index_uni, I>,
- typename = require_eigen_vector_t<EigVec>>
+          typename = require_not_same_t<index_uni, I>,
+          typename = require_eigen_vector_t<EigVec>>
 inline auto rvalue(const EigVec& v,
-       const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
-       int depth = 0) {
+                   const cons_index_list<I, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
   int size = rvalue_index_size(idx.head_, v.size());
-  const Eigen::Ref<const typename EigVec::PlainObject>&  vec = v;
+  const Eigen::Ref<const typename EigVec::PlainObject>& vec = v;
   Eigen::Matrix<scalar_type_t<EigVec>, Eigen::Dynamic, 1> a(size);
   for (int i = 0; i < size; ++i) {
     int n = rvalue_at(i, idx.head_);
@@ -86,7 +86,6 @@ inline auto rvalue(const EigVec& v,
   }
   return a;
 }
-
 
 /**
  * Return the result of indexing the specified Eigen matrix with a
@@ -102,11 +101,10 @@ inline auto rvalue(const EigVec& v,
  * @return Result of indexing matrix.
  */
 template <typename EigMat, typename = require_eigen_t<EigMat>,
- typename = require_not_eigen_vector_t<EigMat>>
-inline auto rvalue(
-    const EigMat& a,
-    const cons_index_list<index_uni, nil_index_list>& idx,
-    const char* name = "ANON", int depth = 0) {
+          typename = require_not_eigen_vector_t<EigMat>>
+inline auto rvalue(const EigMat& a,
+                   const cons_index_list<index_uni, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
   int n = idx.head_.n_;
   math::check_range("matrix[uni] indexing", name, a.rows(), n);
   return a.row(n - 1);
@@ -126,10 +124,11 @@ inline auto rvalue(
  * @return Result of indexing matrix.
  */
 template <typename EigMat, typename = require_eigen_t<EigMat>,
- typename = require_not_eigen_vector_t<EigMat>>
+          typename = require_not_eigen_vector_t<EigMat>>
 inline auto rvalue(
     const EigMat& a,
-    const cons_index_list<index_omni, cons_index_list<index_uni, nil_index_list>>& idx,
+    const cons_index_list<index_omni,
+                          cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   int n = idx.tail_.head_.n_;
   math::check_range("matrix[uni] indexing", name, a.rows(), n);
@@ -151,15 +150,16 @@ inline auto rvalue(
  * @return Result of indexing matrix.
  */
 template <typename EigMat, typename I,
- typename = require_not_same_t<index_uni, I>,
- typename = require_eigen_t<EigMat>,
- typename = require_not_eigen_vector_t<EigMat>>
+          typename = require_not_same_t<index_uni, I>,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>>
 inline auto rvalue(const EigMat& a,
-       const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
-       int depth = 0) {
+                   const cons_index_list<I, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
   int n_rows = rvalue_index_size(idx.head_, a.rows());
-  Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> b(n_rows, a.cols());
-  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a;
+  Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> b(
+      n_rows, a.cols());
+  const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   for (int i = 0; i < n_rows; ++i) {
     int n = rvalue_at(i, idx.head_);
     math::check_range("matrix[multi] indexing", name, mat.rows(), n);
@@ -182,15 +182,15 @@ inline auto rvalue(const EigMat& a,
  * @return Result of indexing matrix.
  */
 template <typename EigMat, typename = require_eigen_t<EigMat>,
- typename = require_not_eigen_vector_t<EigMat>>
+          typename = require_not_eigen_vector_t<EigMat>>
 inline auto rvalue(
     const EigMat& a,
     const cons_index_list<index_uni,
-                          cons_index_list<index_uni, nil_index_list> >& idx,
+                          cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
   int n = idx.tail_.head_.n_;
-  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a;
+  const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   math::check_range("matrix[uni,uni] indexing, row", name, a.rows(), m);
   math::check_range("matrix[uni,uni] indexing, col", name, a.cols(), n);
   return mat.coeff(m - 1, n - 1);
@@ -211,12 +211,13 @@ inline auto rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename EigMat, typename I, typename = require_not_same_t<index_uni, I>,
- typename = require_eigen_t<EigMat>,
- typename = require_not_eigen_vector_t<EigMat>>
+template <typename EigMat, typename I,
+          typename = require_not_same_t<index_uni, I>,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>>
 inline auto rvalue(
     const EigMat& a,
-    const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idx,
+    const cons_index_list<index_uni, cons_index_list<I, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
   math::check_range("matrix[uni,multi] indexing, row", name, a.rows(), m);
@@ -239,15 +240,17 @@ inline auto rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename EigMat, typename I, typename = require_not_same_t<index_uni, I>,
- typename = require_eigen_t<EigMat>,
- typename = require_not_eigen_vector_t<EigMat>>
-inline auto rvalue(const EigMat& a,
-  const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idx,
-  const char* name = "ANON", int depth = 0) {
+template <typename EigMat, typename I,
+          typename = require_not_same_t<index_uni, I>,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>>
+inline auto rvalue(
+    const EigMat& a,
+    const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idx,
+    const char* name = "ANON", int depth = 0) {
   int rows = rvalue_index_size(idx.head_, a.rows());
   Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, 1> c(rows);
-  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a;
+  const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   for (int i = 0; i < rows; ++i) {
     int m = rvalue_at(i, idx.head_);
     int n = idx.tail_.head_.n_;
@@ -274,16 +277,18 @@ inline auto rvalue(const EigMat& a,
  * @return Result of indexing matrix.
  */
 template <typename EigMat, typename I1, typename I2,
- typename = require_any_not_same_t<index_uni, I1, I2>,
- typename = require_eigen_t<EigMat>,
- typename = require_not_eigen_vector_t<EigMat>>
-inline auto rvalue(const EigMat& a,
-       const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idx,
-       const char* name = "ANON", int depth = 0) {
+          typename = require_any_not_same_t<index_uni, I1, I2>,
+          typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>>
+inline auto rvalue(
+    const EigMat& a,
+    const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idx,
+    const char* name = "ANON", int depth = 0) {
   int rows = rvalue_index_size(idx.head_, a.rows());
   int cols = rvalue_index_size(idx.tail_.head_, a.cols());
-  Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> c(rows, cols);
-  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a;
+  Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> c(rows,
+                                                                         cols);
+  const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   for (int j = 0; j < cols; ++j) {
     for (int i = 0; i < rows; ++i) {
       int m = rvalue_at(i, idx.head_);
@@ -313,9 +318,9 @@ inline auto rvalue(const EigMat& a,
  * @return Result of indexing array.
  */
 template <typename T, typename L>
-inline auto
-    rvalue(const std::vector<T>& c, const cons_index_list<index_uni, L>& idx,
-           const char* name = "ANON", int depth = 0) {
+inline auto rvalue(const std::vector<T>& c,
+                   const cons_index_list<index_uni, L>& idx,
+                   const char* name = "ANON", int depth = 0) {
   int n = idx.head_.n_;
   math::check_range("array[uni,...] index", name, c.size(), n);
   return rvalue(c[n - 1], idx.tail_, name, depth + 1);
@@ -338,10 +343,9 @@ inline auto
  * @return Result of indexing array.
  */
 template <typename T, typename I, typename L>
-inline auto
-rvalue(const std::vector<T>& c, const cons_index_list<I, L>& idx,
-       const char* name = "ANON", int depth = 0) {
-  typename rvalue_return<std::vector<T>, cons_index_list<I, L> >::type result;
+inline auto rvalue(const std::vector<T>& c, const cons_index_list<I, L>& idx,
+                   const char* name = "ANON", int depth = 0) {
+  typename rvalue_return<std::vector<T>, cons_index_list<I, L>>::type result;
   for (int i = 0; i < rvalue_index_size(idx.head_, c.size()); ++i) {
     int n = rvalue_at(i, idx.head_);
     math::check_range("array[multi,...] index", name, c.size(), n);

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -28,7 +28,7 @@ namespace model {
  * @return Input value.
  */
 template <typename T, typename = require_stan_scalar_t<T>>
-inline T rvalue(T&& c, const nil_index_list& /*idx*/, const char* /*name*/ = "",
+inline T rvalue(T c, const nil_index_list& /*idx*/, const char* /*name*/ = "",
                 int /*depth*/ = 0) {
   return c;
 }
@@ -44,7 +44,7 @@ inline T rvalue(T&& c, const nil_index_list& /*idx*/, const char* /*name*/ = "",
  * @return Input value.
  */
 template <typename T, typename = require_not_stan_scalar_t<T>>
-inline auto&& rvalue(T&& c, const nil_index_list& /*idx*/,
+inline decltype(auto) rvalue(T&& c, const nil_index_list& /*idx*/,
                      const char* /*name*/ = "", int /*depth*/ = 0) {
   return std::forward<T>(c);
 }
@@ -265,8 +265,7 @@ inline auto rvalue(
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
   math::check_range("matrix[uni,multi] indexing, row", name, a.rows(), m);
-  auto&& r = a.row(m - 1);
-  return rvalue(r, idx.tail_);
+  return rvalue(a.row(m - 1), idx.tail_);
 }
 
 /**

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -28,8 +28,8 @@ namespace model {
  * @return Input value.
  */
 template <typename T, typename = require_stan_scalar_t<T>>
-inline T rvalue(T&& c, const nil_index_list& /*idx*/,
-                const char* /*name*/ = "", int /*depth*/ = 0) {
+inline T rvalue(T&& c, const nil_index_list& /*idx*/, const char* /*name*/ = "",
+                int /*depth*/ = 0) {
   return c;
 }
 
@@ -45,7 +45,7 @@ inline T rvalue(T&& c, const nil_index_list& /*idx*/,
  */
 template <typename T, typename = require_not_stan_scalar_t<T>>
 inline auto&& rvalue(T&& c, const nil_index_list& /*idx*/,
-                const char* /*name*/ = "", int /*depth*/ = 0) {
+                     const char* /*name*/ = "", int /*depth*/ = 0) {
   return std::forward<T>(c);
 }
 

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -78,7 +78,7 @@ inline auto rvalue(const EigVec& v,
                    const char* name = "ANON", int depth = 0) {
   int size = rvalue_index_size(idx.head_, v.size());
   const Eigen::Ref<const typename EigVec::PlainObject>& vec = v;
-  Eigen::Matrix<scalar_type_t<EigVec>, Eigen::Dynamic, 1> a(size);
+  Eigen::Matrix<scalar_type_t<EigVec>, EigVec::RowsAtCompileTime, 1> a(size);
   for (int i = 0; i < size; ++i) {
     int n = rvalue_at(i, idx.head_);
     math::check_range("vector[multi] indexing", name, v.size(), n);
@@ -182,7 +182,7 @@ inline auto rvalue(const EigMat& a,
                    const cons_index_list<I, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   int n_rows = rvalue_index_size(idx.head_, a.rows());
-  Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> b(
+  Eigen::Matrix<scalar_type_t<EigMat>, EigMat::RowsAtCompileTime, EigMat::ColsAtCompileTime> b(
       n_rows, a.cols());
   const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   for (int i = 0; i < n_rows; ++i) {
@@ -246,7 +246,7 @@ inline auto rvalue(
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
   math::check_range("matrix[uni,multi] indexing, row", name, a.rows(), m);
-  Eigen::Matrix<scalar_type_t<EigMat>, 1, Eigen::Dynamic> r = a.row(m - 1);
+  Eigen::Matrix<scalar_type_t<EigMat>, 1, EigMat::ColsAtCompileTime> r = a.row(m - 1);
   return rvalue(r, idx.tail_);
 }
 
@@ -274,7 +274,7 @@ inline auto rvalue(
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   int rows = rvalue_index_size(idx.head_, a.rows());
-  Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, 1> c(rows);
+  Eigen::Matrix<scalar_type_t<EigMat>, EigMat::RowsAtCompileTime, 1> c(rows);
   const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   for (int i = 0; i < rows; ++i) {
     int m = rvalue_at(i, idx.head_);
@@ -311,7 +311,7 @@ inline auto rvalue(
     const char* name = "ANON", int depth = 0) {
   int rows = rvalue_index_size(idx.head_, a.rows());
   int cols = rvalue_index_size(idx.tail_.head_, a.cols());
-  Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> c(rows,
+  Eigen::Matrix<scalar_type_t<EigMat>, EigMat::RowsAtCompileTime, EigMat::ColsAtCompileTime> c(rows,
                                                                          cols);
   const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   for (int j = 0; j < cols; ++j) {

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -45,7 +45,7 @@ inline T rvalue(T c, const nil_index_list& /*idx*/, const char* /*name*/ = "",
  */
 template <typename T, typename = require_not_stan_scalar_t<T>>
 inline decltype(auto) rvalue(T&& c, const nil_index_list& /*idx*/,
-                     const char* /*name*/ = "", int /*depth*/ = 0) {
+                             const char* /*name*/ = "", int /*depth*/ = 0) {
   return std::forward<T>(c);
 }
 

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -107,7 +107,7 @@ inline auto rvalue(const EigMat& a,
                    const char* name = "ANON", int depth = 0) {
   int n = idx.head_.n_;
   math::check_range("matrix[uni] indexing", name, a.rows(), n);
-  return a.row(n - 1);
+  return a.row(n - 1).eval();
 }
 
 /**
@@ -132,7 +132,7 @@ inline auto rvalue(
     const char* name = "ANON", int depth = 0) {
   int n = idx.tail_.head_.n_;
   math::check_range("matrix[uni] indexing", name, a.rows(), n);
-  return a.col(n - 1);
+  return a.col(n - 1).eval();
 }
 
 /**

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -182,7 +182,8 @@ inline auto rvalue(const EigMat& a,
                    const cons_index_list<I, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   int n_rows = rvalue_index_size(idx.head_, a.rows());
-  Eigen::Matrix<scalar_type_t<EigMat>, EigMat::RowsAtCompileTime, EigMat::ColsAtCompileTime> b(
+  Eigen::Matrix<scalar_type_t<EigMat>,
+   EigMat::RowsAtCompileTime, EigMat::ColsAtCompileTime> b(
       n_rows, a.cols());
   const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   for (int i = 0; i < n_rows; ++i) {
@@ -246,7 +247,8 @@ inline auto rvalue(
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
   math::check_range("matrix[uni,multi] indexing, row", name, a.rows(), m);
-  Eigen::Matrix<scalar_type_t<EigMat>, 1, EigMat::ColsAtCompileTime> r = a.row(m - 1);
+  Eigen::Matrix<scalar_type_t<EigMat>, 1,
+   EigMat::ColsAtCompileTime> r = a.row(m - 1);
   return rvalue(r, idx.tail_);
 }
 
@@ -311,8 +313,8 @@ inline auto rvalue(
     const char* name = "ANON", int depth = 0) {
   int rows = rvalue_index_size(idx.head_, a.rows());
   int cols = rvalue_index_size(idx.tail_.head_, a.cols());
-  Eigen::Matrix<scalar_type_t<EigMat>, EigMat::RowsAtCompileTime, EigMat::ColsAtCompileTime> c(rows,
-                                                                         cols);
+  Eigen::Matrix<scalar_type_t<EigMat>, EigMat::RowsAtCompileTime,
+   EigMat::ColsAtCompileTime> c(rows, cols);
   const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   for (int j = 0; j < cols; ++j) {
     for (int i = 0; i < rows; ++i) {

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -182,9 +182,9 @@ inline auto rvalue(const EigMat& a,
                    const cons_index_list<I, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   int n_rows = rvalue_index_size(idx.head_, a.rows());
-  Eigen::Matrix<scalar_type_t<EigMat>,
-   EigMat::RowsAtCompileTime, EigMat::ColsAtCompileTime> b(
-      n_rows, a.cols());
+  Eigen::Matrix<scalar_type_t<EigMat>, EigMat::RowsAtCompileTime,
+                EigMat::ColsAtCompileTime>
+      b(n_rows, a.cols());
   const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   for (int i = 0; i < n_rows; ++i) {
     int n = rvalue_at(i, idx.head_);
@@ -247,8 +247,8 @@ inline auto rvalue(
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
   math::check_range("matrix[uni,multi] indexing, row", name, a.rows(), m);
-  Eigen::Matrix<scalar_type_t<EigMat>, 1,
-   EigMat::ColsAtCompileTime> r = a.row(m - 1);
+  Eigen::Matrix<scalar_type_t<EigMat>, 1, EigMat::ColsAtCompileTime> r
+      = a.row(m - 1);
   return rvalue(r, idx.tail_);
 }
 
@@ -314,7 +314,8 @@ inline auto rvalue(
   int rows = rvalue_index_size(idx.head_, a.rows());
   int cols = rvalue_index_size(idx.tail_.head_, a.cols());
   Eigen::Matrix<scalar_type_t<EigMat>, EigMat::RowsAtCompileTime,
-   EigMat::ColsAtCompileTime> c(rows, cols);
+                EigMat::ColsAtCompileTime>
+      c(rows, cols);
   const Eigen::Ref<const typename EigMat::PlainObject>& mat = a;
   for (int j = 0; j < cols; ++j) {
     for (int i = 0; i < rows; ++i) {

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -78,7 +78,8 @@ inline auto rvalue(const EigVec& v,
                    const char* name = "ANON", int depth = 0) {
   int size = rvalue_index_size(idx.head_, v.size());
   const Eigen::Ref<const typename EigVec::PlainObject>& vec = v;
-  Eigen::Matrix<scalar_type_t<EigVec>, EigVec::RowsAtCompileTime, 1> a(size);
+  Eigen::Matrix<scalar_type_t<EigVec>, EigVec::RowsAtCompileTime,
+   EigVec::ColsAtCompileTime> a(size);
   for (int i = 0; i < size; ++i) {
     int n = rvalue_at(i, idx.head_);
     math::check_range("vector[multi] indexing", name, v.size(), n);

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -137,6 +137,31 @@ inline auto rvalue(
 
 /**
  * Return the result of indexing the specified Eigen matrix with a
+ * an omni index and a one single index, returning a vector.
+ *
+ * Types:  mat[single,] : vec
+ *
+ * @tparam T Scalar type.
+ * @param[in] a Eigen matrix.
+ * @param[in] idx Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
+template <typename EigMat, typename = require_eigen_t<EigMat>,
+          typename = require_not_eigen_vector_t<EigMat>>
+inline auto rvalue(
+    const EigMat& a,
+    const cons_index_list<index_uni,
+                          cons_index_list<index_omni, nil_index_list>>& idx,
+    const char* name = "ANON", int depth = 0) {
+  int n = idx.head_.n_;
+  math::check_range("matrix[uni] indexing", name, a.rows(), n);
+  return a.row(n - 1).eval();
+}
+
+/**
+ * Return the result of indexing the specified Eigen matrix with a
  * sequence consisting of a one multiple index, returning a matrix.
  *
  * Types:  mat[multiple] : mat

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -51,7 +51,7 @@ inline auto rvalue(const EigVec& v,
                 const cons_index_list<index_uni, nil_index_list>& idx,
                 const char* name = "ANON", int depth = 0) {
   int ones_idx = idx.head_.n_;
-  const Eigen::Ref<const typename EigVec::PlainObject>&  vec = v.eval();
+  const Eigen::Ref<const typename EigVec::PlainObject>&  vec = v;
   math::check_range("vector[single] indexing", name, v.size(), ones_idx);
   return vec.coeff(ones_idx - 1);
 }
@@ -77,7 +77,7 @@ inline auto rvalue(const EigVec& v,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
        int depth = 0) {
   int size = rvalue_index_size(idx.head_, v.size());
-  const Eigen::Ref<const typename EigVec::PlainObject>&  vec = v.eval();
+  const Eigen::Ref<const typename EigVec::PlainObject>&  vec = v;
   Eigen::Matrix<scalar_type_t<EigVec>, Eigen::Dynamic, 1> a(size);
   for (int i = 0; i < size; ++i) {
     int n = rvalue_at(i, idx.head_);
@@ -135,7 +135,7 @@ inline auto rvalue(const EigMat& a,
        int depth = 0) {
   int n_rows = rvalue_index_size(idx.head_, a.rows());
   Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> b(n_rows, a.cols());
-  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a.eval();
+  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a;
   for (int i = 0; i < n_rows; ++i) {
     int n = rvalue_at(i, idx.head_);
     math::check_range("matrix[multi] indexing", name, mat.rows(), n);
@@ -166,7 +166,7 @@ inline auto rvalue(
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
   int n = idx.tail_.head_.n_;
-  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a.eval();
+  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a;
   math::check_range("matrix[uni,uni] indexing, row", name, a.rows(), m);
   math::check_range("matrix[uni,uni] indexing, col", name, a.cols(), n);
   return mat.coeff(m - 1, n - 1);
@@ -223,7 +223,7 @@ inline auto rvalue(const EigMat& a,
   const char* name = "ANON", int depth = 0) {
   int rows = rvalue_index_size(idx.head_, a.rows());
   Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, 1> c(rows);
-  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a.eval();
+  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a;
   for (int i = 0; i < rows; ++i) {
     int m = rvalue_at(i, idx.head_);
     int n = idx.tail_.head_.n_;
@@ -259,7 +259,7 @@ inline auto rvalue(const EigMat& a,
   int rows = rvalue_index_size(idx.head_, a.rows());
   int cols = rvalue_index_size(idx.tail_.head_, a.cols());
   Eigen::Matrix<scalar_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> c(rows, cols);
-  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a.eval();
+  const Eigen::Ref<const typename EigMat::PlainObject>&  mat = a;
   for (int j = 0; j < cols; ++j) {
     for (int i = 0; i < rows; ++i) {
       int m = rvalue_at(i, idx.head_);

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -114,6 +114,30 @@ inline auto rvalue(
 
 /**
  * Return the result of indexing the specified Eigen matrix with a
+ * an omni index and a one single index, returning a vector.
+ *
+ * Types:  mat[,single] : vec
+ *
+ * @tparam T Scalar type.
+ * @param[in] a Eigen matrix.
+ * @param[in] idx Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
+template <typename EigMat, typename = require_eigen_t<EigMat>,
+ typename = require_not_eigen_vector_t<EigMat>>
+inline auto rvalue(
+    const EigMat& a,
+    const cons_index_list<index_omni, cons_index_list<index_uni, nil_index_list>>& idx,
+    const char* name = "ANON", int depth = 0) {
+  int n = idx.tail_.head_.n_;
+  math::check_range("matrix[uni] indexing", name, a.rows(), n);
+  return a.col(n - 1);
+}
+
+/**
+ * Return the result of indexing the specified Eigen matrix with a
  * sequence consisting of a one multiple index, returning a matrix.
  *
  * Types:  mat[multiple] : mat

--- a/src/test/test-models/good/compound-assign/indexed_expr_divide_equals.stan
+++ b/src/test/test-models/good/compound-assign/indexed_expr_divide_equals.stan
@@ -3,5 +3,7 @@ transformed data {
   a /= 5.0;
   print("a: ", a);
   a[1, ] /= 5.0;
+  a[1, 1:2] /= 5.0;
+  a[, 1:2] /= 5.0;
   print("r1 div 5: ", a);
 }

--- a/src/test/unit/model/indexing/lvalue_test.cpp
+++ b/src/test/unit/model/indexing/lvalue_test.cpp
@@ -21,283 +21,348 @@ using stan::model::index_uni;
 using stan::model::nil_index_list;
 using std::vector;
 
+/**
+ * Checks that an out of range error occurs
+ */
 template <typename T1, typename I, typename T2>
-void test_throw(T1& lhs, const I& idxs, const T2& rhs) {
-  EXPECT_THROW(stan::model::assign(lhs, idxs, rhs), std::out_of_range);
+void test_throw(T1& lhs, const I& idlhs_x, const T2& rhs) {
+  EXPECT_THROW(stan::model::assign(lhs, idlhs_x, rhs), std::out_of_range);
 }
 
+/**
+ * Checks that an invalid argument is given to assignment
+ */
 template <typename T1, typename I, typename T2>
-void test_throw_ia(T1& lhs, const I& idxs, const T2& rhs) {
-  EXPECT_THROW(stan::model::assign(lhs, idxs, rhs), std::invalid_argument);
+void test_throw_ia(T1& lhs, const I& idlhs_x, const T2& rhs) {
+  EXPECT_THROW(stan::model::assign(lhs, idlhs_x, rhs), std::invalid_argument);
 }
 
-TEST(ModelIndexing, lvalueNil) {
+TEST(model_indexing, assign_scalar_nilindex) {
   double x = 3;
   double y = 5;
   assign(x, nil_index_list(), y);
   EXPECT_FLOAT_EQ(5, x);
-
-  vector<double> xs;
-  xs.push_back(3);
-  xs.push_back(5);
-  vector<double> ys;
-  ys.push_back(13);
-  ys.push_back(15);
-  assign(xs, nil_index_list(), ys);
-  EXPECT_FLOAT_EQ(ys[0], xs[0]);
-  EXPECT_FLOAT_EQ(ys[1], xs[1]);
 }
 
-TEST(ModelIndexing, lvalueUni) {
-  vector<double> xs;
-  xs.push_back(3);
-  xs.push_back(5);
-  xs.push_back(7);
+TEST(model_indexing, assign_stdvec_nil_index) {
+  vector<double> lhs_x;
+  lhs_x.push_back(3);
+  lhs_x.push_back(5);
+  vector<double> rhs_y;
+  rhs_y.push_back(13);
+  rhs_y.push_back(15);
+  assign(lhs_x, nil_index_list(), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y[0], lhs_x[0]);
+  EXPECT_FLOAT_EQ(rhs_y[1], lhs_x[1]);
+}
+
+TEST(model_indexing, assign_stdvec_scalar_uni_index) {
+  vector<double> lhs_x;
+  lhs_x.push_back(3);
+  lhs_x.push_back(5);
+  lhs_x.push_back(7);
   double y = 15;
-  assign(xs, index_list(index_uni(2)), y);
-  EXPECT_FLOAT_EQ(y, xs[1]);
+  assign(lhs_x, index_list(index_uni(2)), y);
+  EXPECT_FLOAT_EQ(y, lhs_x[1]);
 
-  test_throw(xs, index_list(index_uni(0)), y);
-  test_throw(xs, index_list(index_uni(4)), y);
+  test_throw(lhs_x, index_list(index_uni(0)), y);
+  test_throw(lhs_x, index_list(index_uni(4)), y);
 }
 
-TEST(ModelIndexing, lvalueUniUni) {
-  vector<double> xs0;
-  xs0.push_back(0.0);
-  xs0.push_back(0.1);
-  xs0.push_back(0.2);
+TEST(model_indexing, assign_stdvec_scalar_uni_index_uniindex) {
+  vector<double> lhs_x0;
+  lhs_x0.push_back(0.0);
+  lhs_x0.push_back(0.1);
+  lhs_x0.push_back(0.2);
 
-  vector<double> xs1;
-  xs1.push_back(1.0);
-  xs1.push_back(1.1);
-  xs1.push_back(1.2);
+  vector<double> lhs_x1;
+  lhs_x1.push_back(1.0);
+  lhs_x1.push_back(1.1);
+  lhs_x1.push_back(1.2);
 
-  vector<vector<double> > xs;
-  xs.push_back(xs0);
-  xs.push_back(xs1);
+  vector<vector<double>> lhs_x;
+  lhs_x.push_back(lhs_x0);
+  lhs_x.push_back(lhs_x1);
 
   double y = 15;
-  assign(xs, index_list(index_uni(2), index_uni(3)), y);
-  EXPECT_FLOAT_EQ(y, xs[1][2]);
+  assign(lhs_x, index_list(index_uni(2), index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, lhs_x[1][2]);
 
-  test_throw(xs, index_list(index_uni(0), index_uni(3)), y);
-  test_throw(xs, index_list(index_uni(2), index_uni(0)), y);
-  test_throw(xs, index_list(index_uni(10), index_uni(3)), y);
-  test_throw(xs, index_list(index_uni(2), index_uni(10)), y);
+  test_throw(lhs_x, index_list(index_uni(0), index_uni(3)), y);
+  test_throw(lhs_x, index_list(index_uni(2), index_uni(0)), y);
+  test_throw(lhs_x, index_list(index_uni(10), index_uni(3)), y);
+  test_throw(lhs_x, index_list(index_uni(2), index_uni(10)), y);
 }
 
-TEST(ModelIndexing, lvalueMulti) {
-  vector<double> x;
-  for (int i = 0; i < 10; ++i)
-    x.push_back(i);
+TEST(model_indexing, assign_stdvec_stdvec_min_index_max_index) {
+  vector<double> lhs_x;
+  for (int i = 0; i < 10; ++i) {
+    lhs_x.push_back(i);
+  }
 
-  vector<double> y;
-  y.push_back(8.1);
-  y.push_back(9.1);
+  vector<double> rhs_y;
+  rhs_y.push_back(8.1);
+  rhs_y.push_back(9.1);
 
-  assign(x, index_list(index_min(9)), y);
-  EXPECT_FLOAT_EQ(y[0], x[8]);
-  EXPECT_FLOAT_EQ(y[1], x[9]);
-  test_throw_ia(x, index_list(index_min(0)), y);
+  assign(lhs_x, index_list(index_min(9)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y[0], lhs_x[8]);
+  EXPECT_FLOAT_EQ(rhs_y[1], lhs_x[9]);
+  test_throw_ia(lhs_x, index_list(index_min(0)), rhs_y);
 
-  assign(x, index_list(index_max(2)), y);
-  EXPECT_FLOAT_EQ(y[0], x[0]);
-  EXPECT_FLOAT_EQ(y[1], x[1]);
-  EXPECT_FLOAT_EQ(2, x[2]);
-  test_throw_ia(x, index_list(index_max(10)), y);
+  assign(lhs_x, index_list(index_max(2)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y[0], lhs_x[0]);
+  EXPECT_FLOAT_EQ(rhs_y[1], lhs_x[1]);
+  EXPECT_FLOAT_EQ(2, lhs_x[2]);
+  test_throw_ia(lhs_x, index_list(index_max(10)), rhs_y);
+}
+
+
+TEST(model_indexing, assign_stdvec_stdvec_multi_index) {
+  vector<double> lhs_x;
+  for (int i = 0; i < 10; ++i) {
+    lhs_x.push_back(i);
+  }
+
+  vector<double> rhs_y;
+  rhs_y.push_back(8.1);
+  rhs_y.push_back(9.1);
 
   vector<int> ns;
   ns.push_back(4);
   ns.push_back(6);
-  assign(x, index_list(index_multi(ns)), y);
-  EXPECT_FLOAT_EQ(y[0], x[3]);
-  EXPECT_FLOAT_EQ(y[1], x[5]);
+  assign(lhs_x, index_list(index_multi(ns)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y[0], lhs_x[3]);
+  EXPECT_FLOAT_EQ(rhs_y[1], lhs_x[5]);
 
   ns[0] = 0;
-  test_throw(x, index_list(index_multi(ns)), y);
+  test_throw(lhs_x, index_list(index_multi(ns)), rhs_y);
 
   ns[0] = 11;
-  test_throw(x, index_list(index_multi(ns)), y);
+  test_throw(lhs_x, index_list(index_multi(ns)), rhs_y);
 
   ns.push_back(3);
-  test_throw_ia(x, index_list(index_multi(ns)), y);
+  test_throw_ia(lhs_x, index_list(index_multi(ns)), rhs_y);
 }
 
-TEST(ModelIndexing, lvalueMultiMulti) {
-  vector<vector<double> > xs;
+TEST(model_indexing, assign_stdvecvec_stdvecvec_multi_min_index_max_index) {
+  vector<vector<double>> lhs_x;
   for (int i = 0; i < 10; ++i) {
-    vector<double> xsi;
-    for (int j = 0; j < 20; ++j)
-      xsi.push_back(i + j / 10.0);
-    xs.push_back(xsi);
+    vector<double> lhs_xi;
+    for (int j = 0; j < 20; ++j) {
+      lhs_xi.push_back(i + j / 10.0);
+    }
+    lhs_x.push_back(lhs_xi);
   }
 
-  vector<vector<double> > ys;
+  vector<vector<double>> rhs_y;
   for (int i = 0; i < 2; ++i) {
-    vector<double> ysi;
-    for (int j = 0; j < 3; ++j)
-      ysi.push_back(10 + i + j / 10.0);
-    ys.push_back(ysi);
+    vector<double> rhs_yi;
+    for (int j = 0; j < 3; ++j) {
+      rhs_yi.push_back(10 + i + j / 10.0);
+    }
+    rhs_y.push_back(rhs_yi);
   }
 
-  assign(xs, index_list(index_min(9), index_max(3)), ys);
+  assign(lhs_x, index_list(index_min(9), index_max(3)), rhs_y);
 
-  for (int i = 0; i < 2; ++i)
-    for (int j = 0; j < 3; ++j)
-      EXPECT_FLOAT_EQ(ys[i][j], xs[8 + i][j]);
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      EXPECT_FLOAT_EQ(rhs_y[i][j], lhs_x[8 + i][j]);
+    }
+  }
 
-  test_throw_ia(xs, index_list(index_min(7), index_max(3)), ys);
-  test_throw_ia(xs, index_list(index_min(9), index_max(2)), ys);
+  test_throw_ia(lhs_x, index_list(index_min(7), index_max(3)), rhs_y);
+  test_throw_ia(lhs_x, index_list(index_min(9), index_max(2)), rhs_y);
 }
 
-TEST(ModelIndexing, lvalueUniMulti) {
-  vector<vector<double> > xs;
+TEST(model_indexing, assign_stdvecvec_stdvec_index_uni_index_min_max_index) {
+  vector<vector<double>> lhs_x;
   for (int i = 0; i < 10; ++i) {
-    vector<double> xsi;
-    for (int j = 0; j < 20; ++j)
-      xsi.push_back(i + j / 10.0);
-    xs.push_back(xsi);
+    vector<double> lhs_xi;
+    for (int j = 0; j < 20; ++j) {
+      lhs_xi.push_back(i + j / 10.0);
+    }
+    lhs_x.push_back(lhs_xi);
   }
 
-  vector<double> ys;
-  for (int i = 0; i < 3; ++i)
-    ys.push_back(10 + i);
+  vector<double> rhs_y;
+  for (int i = 0; i < 3; ++i) {
+    rhs_y.push_back(10 + i);
+  }
 
-  assign(xs, index_list(index_uni(4), index_min_max(3, 5)), ys);
+  assign(lhs_x, index_list(index_uni(4), index_min_max(3, 5)), rhs_y);
 
-  for (int j = 0; j < 3; ++j)
-    EXPECT_FLOAT_EQ(ys[j], xs[3][j + 2]);
+  for (int j = 0; j < 3; ++j) {
+    EXPECT_FLOAT_EQ(rhs_y[j], lhs_x[3][j + 2]);
+  }
 
-  test_throw(xs, index_list(index_uni(0), index_min_max(3, 5)), ys);
-  test_throw(xs, index_list(index_uni(11), index_min_max(3, 5)), ys);
-  test_throw_ia(xs, index_list(index_uni(4), index_min_max(2, 5)), ys);
+  test_throw(lhs_x, index_list(index_uni(0), index_min_max(3, 5)), rhs_y);
+  test_throw(lhs_x, index_list(index_uni(11), index_min_max(3, 5)), rhs_y);
+  test_throw_ia(lhs_x, index_list(index_uni(4), index_min_max(2, 5)), rhs_y);
 }
 
-TEST(ModelIndexing, lvalueMultiUni) {
-  vector<vector<double> > xs;
+TEST(model_indexing, assign_stdvecvec_stdvec_min_max_index_uni_index) {
+  vector<vector<double>> lhs_x;
   for (int i = 0; i < 10; ++i) {
-    vector<double> xsi;
-    for (int j = 0; j < 20; ++j)
-      xsi.push_back(i + j / 10.0);
-    xs.push_back(xsi);
+    vector<double> lhs_xi;
+    for (int j = 0; j < 20; ++j) {
+      lhs_xi.push_back(i + j / 10.0);
+    }
+    lhs_x.push_back(lhs_xi);
   }
 
-  vector<double> ys;
-  for (int i = 0; i < 3; ++i)
-    ys.push_back(10 + i);
+  vector<double> rhs_y;
+  for (int i = 0; i < 3; ++i) {
+    rhs_y.push_back(10 + i);
+  }
 
-  assign(xs, index_list(index_min_max(5, 7), index_uni(8)), ys);
+  assign(lhs_x, index_list(index_min_max(5, 7), index_uni(8)), rhs_y);
 
-  for (int j = 0; j < 3; ++j)
-    EXPECT_FLOAT_EQ(ys[j], xs[j + 4][7]);
+  for (int j = 0; j < 3; ++j) {
+    EXPECT_FLOAT_EQ(rhs_y[j], lhs_x[j + 4][7]);
+  }
 
-  test_throw_ia(xs, index_list(index_min_max(3, 6), index_uni(7)), ys);
-  test_throw(xs, index_list(index_min_max(4, 6), index_uni(0)), ys);
-  test_throw(xs, index_list(index_min_max(4, 6), index_uni(30)), ys);
+  test_throw_ia(lhs_x, index_list(index_min_max(3, 6), index_uni(7)), rhs_y);
+  test_throw(lhs_x, index_list(index_min_max(4, 6), index_uni(0)), rhs_y);
+  test_throw(lhs_x, index_list(index_min_max(4, 6), index_uni(30)), rhs_y);
 }
 
-TEST(ModelIndexing, lvalueVecUni) {
-  VectorXd xs(5);
-  xs << 0, 1, 2, 3, 4;
+TEST(model_indexing, assign_eigvec_scalar_uni_index) {
+  VectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
   double y = 13;
-  assign(xs, index_list(index_uni(3)), y);
-  EXPECT_FLOAT_EQ(y, xs(2));
+  assign(lhs_x, index_list(index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, lhs_x(2));
 
-  test_throw(xs, index_list(index_uni(0)), y);
-  test_throw(xs, index_list(index_uni(6)), y);
+  assign(lhs_x, index_list(index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, lhs_x(2));
+
+  test_throw(lhs_x, index_list(index_uni(0)), y);
+  test_throw(lhs_x, index_list(index_uni(6)), y);
 }
 
-TEST(ModelIndexing, lvalueRowVecUni) {
-  RowVectorXd xs(5);
-  xs << 0, 1, 2, 3, 4;
+TEST(model_indexing, assign_eigrowvec_scalar_uni_index) {
+  RowVectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
   double y = 13;
-  assign(xs, index_list(index_uni(3)), y);
-  EXPECT_FLOAT_EQ(y, xs(2));
-  test_throw(xs, index_list(index_uni(0)), y);
-  test_throw(xs, index_list(index_uni(6)), y);
+  assign(lhs_x, index_list(index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, lhs_x(2));
+  test_throw(lhs_x, index_list(index_uni(0)), y);
+  test_throw(lhs_x, index_list(index_uni(6)), y);
 }
 
-TEST(ModelIndexing, lvalueVecMulti) {
-  VectorXd xs(5);
-  xs << 0, 1, 2, 3, 4;
-  VectorXd ys(3);
-  ys << 10, 11, 12;
-  assign(xs, index_list(index_min(3)), ys);
-  EXPECT_FLOAT_EQ(ys(0), xs(2));
-  EXPECT_FLOAT_EQ(ys(1), xs(3));
-  EXPECT_FLOAT_EQ(ys(2), xs(4));
-  test_throw_ia(xs, index_list(index_min(0)), ys);
+TEST(model_indexing, assign_eigvec_eigvec_index_min) {
+  VectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
+  VectorXd rhs_y(3);
+  rhs_y << 10, 11, 12;
+  assign(lhs_x, index_list(index_min(3)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y(0), lhs_x(2));
+  EXPECT_FLOAT_EQ(rhs_y(1), lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(2), lhs_x(4));
+  test_throw_ia(lhs_x, index_list(index_min(0)), rhs_y);
 
-  xs << 0, 1, 2, 3, 4;
+  assign(lhs_x, index_list(index_min(3)), rhs_y.array() + 1.0);
+  EXPECT_FLOAT_EQ(rhs_y(0) + 1.0, lhs_x(2));
+  EXPECT_FLOAT_EQ(rhs_y(1) + 1.0, lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(2) + 1.0, lhs_x(4));
+}
+
+TEST(model_indexing, assign_eigvec_eigvec_index_multi) {
+  VectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
+  VectorXd rhs_y(3);
+  rhs_y << 10, 11, 12;
+
   vector<int> ns;
   ns.push_back(4);
   ns.push_back(1);
   ns.push_back(3);
-  assign(xs, index_list(index_multi(ns)), ys);
-  EXPECT_FLOAT_EQ(ys(0), xs(3));
-  EXPECT_FLOAT_EQ(ys(1), xs(0));
-  EXPECT_FLOAT_EQ(ys(2), xs(2));
+  assign(lhs_x, index_list(index_multi(ns)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y(0), lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(1), lhs_x(0));
+  EXPECT_FLOAT_EQ(rhs_y(2), lhs_x(2));
+
+  assign(lhs_x, index_list(index_multi(ns)), rhs_y.array() + 4);
+  EXPECT_FLOAT_EQ(rhs_y(0) + 4, lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(1) + 4, lhs_x(0));
+  EXPECT_FLOAT_EQ(rhs_y(2) + 4, lhs_x(2));
 
   ns[ns.size() - 1] = 0;
-  test_throw(xs, index_list(index_multi(ns)), ys);
+  test_throw(lhs_x, index_list(index_multi(ns)), rhs_y);
 
   ns[ns.size() - 1] = 10;
-  test_throw(xs, index_list(index_multi(ns)), ys);
+  test_throw(lhs_x, index_list(index_multi(ns)), rhs_y);
 
   ns[ns.size() - 1] = 3;
   ns.push_back(1);
-  test_throw_ia(xs, index_list(index_multi(ns)), ys);
+  test_throw_ia(lhs_x, index_list(index_multi(ns)), rhs_y);
 }
 
-TEST(ModelIndexing, lvalueRowVecMulti) {
-  RowVectorXd xs(5);
-  xs << 0, 1, 2, 3, 4;
-  RowVectorXd ys(3);
-  ys << 10, 11, 12;
-  assign(xs, index_list(index_min(3)), ys);
-  EXPECT_FLOAT_EQ(ys(0), xs(2));
-  EXPECT_FLOAT_EQ(ys(1), xs(3));
-  EXPECT_FLOAT_EQ(ys(2), xs(4));
-  test_throw_ia(xs, index_list(index_min(2)), ys);
-  test_throw_ia(xs, index_list(index_min(0)), ys);
+TEST(model_indexing, assign_eigrowvec_eigrowvec_index_min) {
+  RowVectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
+  RowVectorXd rhs_y(3);
+  rhs_y << 10, 11, 12;
+  assign(lhs_x, index_list(index_min(3)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y(0), lhs_x(2));
+  EXPECT_FLOAT_EQ(rhs_y(1), lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(2), lhs_x(4));
+  test_throw_ia(lhs_x, index_list(index_min(0)), rhs_y);
 
-  xs << 0, 1, 2, 3, 4;
+  assign(lhs_x, index_list(index_min(3)), rhs_y.array() + 1.0);
+  EXPECT_FLOAT_EQ(rhs_y(0) + 1.0, lhs_x(2));
+  EXPECT_FLOAT_EQ(rhs_y(1) + 1.0, lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(2) + 1.0, lhs_x(4));
+}
+
+TEST(model_indexing, assign_eigrowvec_eigrowvec_index_multi) {
+  RowVectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
+  RowVectorXd rhs_y(3);
+  rhs_y << 10, 11, 12;
+
   vector<int> ns;
   ns.push_back(4);
   ns.push_back(1);
   ns.push_back(3);
-  assign(xs, index_list(index_multi(ns)), ys);
-  EXPECT_FLOAT_EQ(ys(0), xs(3));
-  EXPECT_FLOAT_EQ(ys(1), xs(0));
-  EXPECT_FLOAT_EQ(ys(2), xs(2));
+  assign(lhs_x, index_list(index_multi(ns)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y(0), lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(1), lhs_x(0));
+  EXPECT_FLOAT_EQ(rhs_y(2), lhs_x(2));
+
+  assign(lhs_x, index_list(index_multi(ns)), rhs_y.array() + 4);
+  EXPECT_FLOAT_EQ(rhs_y(0) + 4, lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(1) + 4, lhs_x(0));
+  EXPECT_FLOAT_EQ(rhs_y(2) + 4, lhs_x(2));
 
   ns[ns.size() - 1] = 0;
-  test_throw(xs, index_list(index_multi(ns)), ys);
+  test_throw(lhs_x, index_list(index_multi(ns)), rhs_y);
 
   ns[ns.size() - 1] = 10;
-  test_throw(xs, index_list(index_multi(ns)), ys);
+  test_throw(lhs_x, index_list(index_multi(ns)), rhs_y);
 
   ns[ns.size() - 1] = 3;
   ns.push_back(1);
-  test_throw_ia(xs, index_list(index_multi(ns)), ys);
+  test_throw_ia(lhs_x, index_list(index_multi(ns)), rhs_y);
 }
 
-TEST(ModelIndexing, lvalueMatrixUni) {
+TEST(model_indexing, assign_eigmatrix_rowvec_uni_index) {
   MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
   RowVectorXd y(4);
   y << 10.0, 10.1, 10.2, 10.3;
 
-  assign(x, index_list(index_uni(3)), y);
+  assign(x, index_list(index_uni(3)), y.array() + 3);
   for (int j = 0; j < 4; ++j)
-    EXPECT_FLOAT_EQ(x(2, j), y(j));
+    EXPECT_FLOAT_EQ(x(2, j), y(j) + 3);
 
   test_throw(x, index_list(index_uni(0)), y);
   test_throw(x, index_list(index_uni(5)), y);
 }
 
-TEST(ModelIndexing, lvalueMatrixMulti) {
+TEST(model_indexing, assign_eigmatrix_eigmatrix_index_min) {
   MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
@@ -305,9 +370,17 @@ TEST(ModelIndexing, lvalueMatrixMulti) {
   y << 10.0, 10.1, 10.2, 10.3, 11.0, 11.1, 11.2, 11.3;
 
   assign(x, index_list(index_min(2)), y);
-  for (int i = 0; i < 2; ++i)
-    for (int j = 0; j < 4; ++j)
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 4; ++j) {
       EXPECT_FLOAT_EQ(y(i, j), x(i + 1, j));
+    }
+  }
+  assign(x, index_list(index_min(2)), y.transpose().transpose());
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_FLOAT_EQ(y(i, j), x(i + 1, j));
+    }
+  }
   test_throw_ia(x, index_list(index_min(1)), y);
 
   MatrixXd z(1, 2);
@@ -316,7 +389,7 @@ TEST(ModelIndexing, lvalueMatrixMulti) {
   test_throw_ia(x, index_list(index_min(2)), z);
 }
 
-TEST(ModelIndexing, lvalueMatrixUniUni) {
+TEST(model_indexing, assign_eigmatrix_scalar_index_uni) {
   MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
@@ -330,7 +403,7 @@ TEST(ModelIndexing, lvalueMatrixUniUni) {
   test_throw(x, index_list(index_uni(2), index_uni(5)), y);
 }
 
-TEST(ModelIndexing, lvalueMatrixUniMulti) {
+TEST(model_indexing, assign_eigmatrix_eigrowvec_uni_index_min_max_index) {
   MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
@@ -341,6 +414,11 @@ TEST(ModelIndexing, lvalueMatrixUniMulti) {
   EXPECT_FLOAT_EQ(y(0), x(1, 1));
   EXPECT_FLOAT_EQ(y(1), x(1, 2));
   EXPECT_FLOAT_EQ(y(2), x(1, 3));
+
+  assign(x, index_list(index_uni(2), index_min_max(2, 4)), y.array() + 2);
+  EXPECT_FLOAT_EQ(y(0) + 2, x(1, 1));
+  EXPECT_FLOAT_EQ(y(1) + 2, x(1, 2));
+  EXPECT_FLOAT_EQ(y(2) + 2, x(1, 3));
 
   test_throw(x, index_list(index_uni(0), index_min_max(2, 4)), y);
   test_throw(x, index_list(index_uni(5), index_min_max(2, 4)), y);
@@ -356,6 +434,11 @@ TEST(ModelIndexing, lvalueMatrixUniMulti) {
   EXPECT_FLOAT_EQ(y(1), x(2, 0));
   EXPECT_FLOAT_EQ(y(2), x(2, 2));
 
+  assign(x, index_list(index_uni(3), index_multi(ns)), y.array() + 2);
+  EXPECT_FLOAT_EQ(y(0) + 2, x(2, 3));
+  EXPECT_FLOAT_EQ(y(1) + 2, x(2, 0));
+  EXPECT_FLOAT_EQ(y(2) + 2, x(2, 2));
+
   ns[ns.size() - 1] = 0;
   test_throw(x, index_list(index_uni(3), index_multi(ns)), y);
 
@@ -366,7 +449,7 @@ TEST(ModelIndexing, lvalueMatrixUniMulti) {
   test_throw_ia(x, index_list(index_uni(3), index_multi(ns)), y);
 }
 
-TEST(ModelIndexing, lvalueMatrixMultiUni) {
+TEST(model_indexing, assign_eigmatrix_eigvec_min_max_index_uni_index) {
   MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
@@ -376,6 +459,10 @@ TEST(ModelIndexing, lvalueMatrixMultiUni) {
   assign(x, index_list(index_min_max(2, 3), index_uni(4)), y);
   EXPECT_FLOAT_EQ(y(0), x(1, 3));
   EXPECT_FLOAT_EQ(y(1), x(2, 3));
+
+  assign(x, index_list(index_min_max(2, 3), index_uni(4)), y.array() + 2);
+  EXPECT_FLOAT_EQ(y(0) + 2, x(1, 3));
+  EXPECT_FLOAT_EQ(y(1) + 2, x(2, 3));
 
   test_throw(x, index_list(index_min_max(2, 3), index_uni(0)), y);
   test_throw(x, index_list(index_min_max(2, 3), index_uni(5)), y);
@@ -389,6 +476,10 @@ TEST(ModelIndexing, lvalueMatrixMultiUni) {
   EXPECT_FLOAT_EQ(y(0), x(2, 2));
   EXPECT_FLOAT_EQ(y(1), x(0, 2));
 
+  assign(x, index_list(index_multi(ns), index_uni(3)), y.array() + 2);
+  EXPECT_FLOAT_EQ(y(0) + 2, x(2, 2));
+  EXPECT_FLOAT_EQ(y(1) + 2, x(0, 2));
+
   ns[ns.size() - 1] = 0;
   test_throw(x, index_list(index_multi(ns), index_uni(3)), y);
 
@@ -399,7 +490,7 @@ TEST(ModelIndexing, lvalueMatrixMultiUni) {
   test_throw_ia(x, index_list(index_multi(ns), index_uni(3)), y);
 }
 
-TEST(ModelIndexing, lvalueMatrixMultiMulti) {
+TEST(model_indexing, assign_eigmatrix_eigmatrix_min_max_index_min_index) {
   MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
@@ -417,8 +508,14 @@ TEST(ModelIndexing, lvalueMatrixMultiMulti) {
   test_throw_ia(x, index_list(index_min_max(2, 3), index_min(0)), y);
   test_throw_ia(x, index_list(index_min_max(2, 3), index_min(10)), y);
   test_throw_ia(x, index_list(index_min_max(1, 3), index_min(2)), y);
+}
 
+TEST(model_indexing, assign_eigmatrix_eigmatrix_multi_index_multi_index) {
+  MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  MatrixXd y(2, 3);
+  y << 10, 11, 12, 20, 21, 22;
   vector<int> ms;
   ms.push_back(3);
   ms.push_back(1);
@@ -435,6 +532,15 @@ TEST(ModelIndexing, lvalueMatrixMultiMulti) {
   EXPECT_FLOAT_EQ(y(1, 1), x(0, 2));
   EXPECT_FLOAT_EQ(y(1, 2), x(0, 0));
 
+  MatrixXd y2 = y.array() + 2;
+  assign(x, index_list(index_multi(ms), index_multi(ns)), y.array() + 2);
+  EXPECT_FLOAT_EQ(y2(0, 0), x(2, 1));
+  EXPECT_FLOAT_EQ(y2(0, 1), x(2, 2));
+  EXPECT_FLOAT_EQ(y2(0, 2), x(2, 0));
+  EXPECT_FLOAT_EQ(y2(1, 0), x(0, 1));
+  EXPECT_FLOAT_EQ(y2(1, 1), x(0, 2));
+  EXPECT_FLOAT_EQ(y2(1, 2), x(0, 0));
+
   ms[ms.size() - 1] = 0;
   test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
 
@@ -448,7 +554,7 @@ TEST(ModelIndexing, lvalueMatrixMultiMulti) {
   ns[ns.size() - 1] = 10;
   test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
 }
-TEST(ModelIndexing, doubleToVar) {
+TEST(model_indexing, assign_double_to_var) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::var;
@@ -458,18 +564,18 @@ TEST(ModelIndexing, doubleToVar) {
   using stan::model::nil_index_list;
   using std::vector;
 
-  vector<double> xs;
-  xs.push_back(1);
-  xs.push_back(2);
-  xs.push_back(3);
-  vector<vector<double> > xss;
-  xss.push_back(xs);
+  vector<double> lhs_x;
+  lhs_x.push_back(1);
+  lhs_x.push_back(2);
+  lhs_x.push_back(3);
+  vector<vector<double> > lhs_xs;
+  lhs_xs.push_back(lhs_x);
 
-  vector<var> ys(3);
-  vector<vector<var> > yss;
-  yss.push_back(ys);
+  vector<var> rhs_y(3);
+  vector<vector<var> > rhs_ys;
+  rhs_ys.push_back(rhs_y);
 
-  assign(yss, cons_list(index_omni(), nil_index_list()), xss, "foo");
+  assign(rhs_ys, cons_list(index_omni(), nil_index_list()), lhs_xs, "foo");
 
   // test both cases where matrix indexed by rows
   // case 1: double matrix with single multi-index on LHS, var matrix on RHS
@@ -484,22 +590,26 @@ TEST(ModelIndexing, doubleToVar) {
   is.push_back(2);
   is.push_back(3);
   assign(a, cons_list(index_multi(is), nil_index_list()), b);
-  for (int i = 0; i < 2; ++i)
-    for (int j = 0; j < 3; ++j)
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 3; ++j) {
       EXPECT_FLOAT_EQ(a(i + 1, j).val(), b(i, j));
+    }
+  }
 
   // case 2: double matrix with single multi-index on LHS, row vector
   // on RHS
   Matrix<var, Dynamic, Dynamic> c(4, 3);
-  for (int i = 0; i < 12; ++i)
+  for (int i = 0; i < 12; ++i) {
     c(i) = -(i + 1);
+  }
   Matrix<double, 1, Dynamic> d(3);
   d << 100, 101, 102;
   assign(c, cons_list(index_uni(2), nil_index_list()), d);
-  for (int j = 0; j < 3; ++j)
+  for (int j = 0; j < 3; ++j) {
     EXPECT_FLOAT_EQ(c(1, j).val(), d(j));
+  }
 }
-TEST(ModelIndexing, resultSizeNegIndexing) {
+TEST(model_indexing, assign_result_size_neg_index) {
   using stan::model::assign;
   using stan::model::cons_list;
   using stan::model::index_min_max;
@@ -516,7 +626,7 @@ TEST(ModelIndexing, resultSizeNegIndexing) {
   EXPECT_EQ(0, lhs.size());
 }
 
-TEST(modelIndexing, doubleToVarSimple) {
+TEST(model_indexing, assign_double_to_var_simple) {
   using stan::math::var;
   using stan::model::nil_index_list;
   typedef Eigen::MatrixXd mat_d;
@@ -526,6 +636,7 @@ TEST(modelIndexing, doubleToVarSimple) {
   a << 1, 2, 3, 4;
   mat_v b;
   assign(b, nil_index_list(), a);
-  for (int i = 0; i < a.size(); ++i)
+  for (int i = 0; i < a.size(); ++i) {
     EXPECT_FLOAT_EQ(a(i), b(i).val());
+  }
 }

--- a/src/test/unit/model/indexing/lvalue_test.cpp
+++ b/src/test/unit/model/indexing/lvalue_test.cpp
@@ -116,7 +116,6 @@ TEST(model_indexing, assign_stdvec_stdvec_min_index_max_index) {
   test_throw_ia(lhs_x, index_list(index_max(10)), rhs_y);
 }
 
-
 TEST(model_indexing, assign_stdvec_stdvec_multi_index) {
   vector<double> lhs_x;
   for (int i = 0; i < 10; ++i) {
@@ -568,11 +567,11 @@ TEST(model_indexing, assign_double_to_var) {
   lhs_x.push_back(1);
   lhs_x.push_back(2);
   lhs_x.push_back(3);
-  vector<vector<double> > lhs_xs;
+  vector<vector<double>> lhs_xs;
   lhs_xs.push_back(lhs_x);
 
   vector<var> rhs_y(3);
-  vector<vector<var> > rhs_ys;
+  vector<vector<var>> rhs_ys;
   rhs_ys.push_back(rhs_y);
 
   assign(rhs_ys, cons_list(index_omni(), nil_index_list()), lhs_xs, "foo");

--- a/src/test/unit/model/indexing/lvalue_test.cpp
+++ b/src/test/unit/model/indexing/lvalue_test.cpp
@@ -233,9 +233,6 @@ TEST(model_indexing, assign_eigvec_scalar_uni_index) {
   assign(lhs_x, index_list(index_uni(3)), y);
   EXPECT_FLOAT_EQ(y, lhs_x(2));
 
-  assign(lhs_x, index_list(index_uni(3)), y);
-  EXPECT_FLOAT_EQ(y, lhs_x(2));
-
   test_throw(lhs_x, index_list(index_uni(0)), y);
   test_throw(lhs_x, index_list(index_uni(6)), y);
 }

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -391,7 +391,7 @@ void vector_multi_test() {
   v << 0, 1, 2, 3, 4;
 
   T vi = rvalue(v, index_list(index_omni()));
-/*  EXPECT_EQ(5, vi.size());
+  EXPECT_EQ(5, vi.size());
   EXPECT_FLOAT_EQ(0, vi(0));
   EXPECT_FLOAT_EQ(2, vi(2));
   EXPECT_FLOAT_EQ(4, vi(4));
@@ -460,7 +460,7 @@ void vector_multi_test() {
 
   ns[ns.size() - 1] = 15;
   test_out_of_range(v, index_list(index_multi(ns)));
-*/}
+}
 
 TEST(model_indexing, rvalue_eigvec_multi) {
   vector_multi_test<Eigen::VectorXd>();

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -391,7 +391,7 @@ void vector_multi_test() {
   v << 0, 1, 2, 3, 4;
 
   T vi = rvalue(v, index_list(index_omni()));
-  EXPECT_EQ(5, vi.size());
+/*  EXPECT_EQ(5, vi.size());
   EXPECT_FLOAT_EQ(0, vi(0));
   EXPECT_FLOAT_EQ(2, vi(2));
   EXPECT_FLOAT_EQ(4, vi(4));
@@ -460,7 +460,7 @@ void vector_multi_test() {
 
   ns[ns.size() - 1] = 15;
   test_out_of_range(v, index_list(index_multi(ns)));
-}
+*/}
 
 TEST(model_indexing, rvalue_eigvec_multi) {
   vector_multi_test<Eigen::VectorXd>();

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -379,9 +379,7 @@ void vector_uni_test() {
   test_out_of_range(v, index_list(index_uni(20)));
 }
 
-TEST(model_indexing, rvalue_vector_uni) {
-   vector_uni_test<Eigen::VectorXd>();
- }
+TEST(model_indexing, rvalue_vector_uni) { vector_uni_test<Eigen::VectorXd>(); }
 
 TEST(model_indexing, rvalue_eigrowvec_uni) {
   vector_uni_test<Eigen::RowVectorXd>();
@@ -505,7 +503,6 @@ TEST(model_indexing, rvalue_eigmatrix_uni) {
 
   test_out_of_range(m, index_list(index_uni(0)));
   test_out_of_range(m, index_list(index_uni(15)));
-
 }
 
 TEST(model_indexing, rvalue_eigmatrix_multi) {
@@ -592,7 +589,6 @@ TEST(model_indexing, rvalue_eigmatrix_multi) {
   EXPECT_FLOAT_EQ(3.1, a(3, 1));
   EXPECT_FLOAT_EQ(3.2, a(3, 2));
 
-
   a = rvalue(m.array() + 2, index_list(index_omni()));
   EXPECT_EQ(4, a.rows());
   EXPECT_EQ(3, a.cols());
@@ -657,8 +653,9 @@ TEST(model_indexing, rvalue_eigmatrix_uni_uni) {
 
   for (int m = 0; m < 3; ++m) {
     for (int n = 0; n < 4; ++n) {
-      EXPECT_FLOAT_EQ(2 + m + n / 10.0, rvalue(x.array() + 2, index_list(index_uni(m + 1),
-                                                         index_uni(n + 1))));
+      EXPECT_FLOAT_EQ(2 + m + n / 10.0,
+                      rvalue(x.array() + 2,
+                             index_list(index_uni(m + 1), index_uni(n + 1))));
     }
   }
 

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -18,7 +18,7 @@ void test_out_of_range(const C& c, const I& idxs) {
   EXPECT_THROW(stan::model::rvalue(c, idxs), std::out_of_range);
 }
 
-TEST(ModelIndexing, rvalue_vector_nil) {
+TEST(model_indexing, rvalue_vector_nil) {
   std::vector<double> x;
   x.push_back(1.1);
   x.push_back(2.2);
@@ -29,7 +29,7 @@ TEST(ModelIndexing, rvalue_vector_nil) {
   EXPECT_FLOAT_EQ(2.2, rx[1]);
 }
 
-TEST(ModelIndexing, rvalue_vector_uni_nil) {
+TEST(model_indexing, rvalue_vector_uni_nil) {
   std::vector<double> x;
   x.push_back(1.1);
   x.push_back(2.2);
@@ -43,7 +43,7 @@ TEST(ModelIndexing, rvalue_vector_uni_nil) {
   test_out_of_range(x, index_list(index_uni(4)));
 }
 
-TEST(ModelIndexing, rvalue_vector_multi_nil) {
+TEST(model_indexing, rvalue_vector_multi_nil) {
   std::vector<double> x;
   x.push_back(1.1);
   x.push_back(2.2);
@@ -69,7 +69,7 @@ TEST(ModelIndexing, rvalue_vector_multi_nil) {
   test_out_of_range(x, index_list(index_multi(idxs)));
 }
 
-TEST(ModelIndexing, rvalue_vector_omni_nil) {
+TEST(model_indexing, rvalue_vector_omni_nil) {
   std::vector<double> y;
   std::vector<double> ry = rvalue(y, index_list(index_omni()));
   EXPECT_EQ(0U, y.size());
@@ -85,7 +85,7 @@ TEST(ModelIndexing, rvalue_vector_omni_nil) {
     EXPECT_FLOAT_EQ(x[n], rx[n]);
 }
 
-TEST(ModelIndexing, rvalue_vector_min_nil) {
+TEST(model_indexing, rvalue_vector_min_nil) {
   std::vector<double> x;
   x.push_back(1.1);
   x.push_back(2.2);
@@ -104,7 +104,7 @@ TEST(ModelIndexing, rvalue_vector_min_nil) {
   test_out_of_range(x, index_list(index_min(0)));
 }
 
-TEST(ModelIndexing, rvalue_vector_max_nil) {
+TEST(model_indexing, rvalue_vector_max_nil) {
   std::vector<double> x;
   x.push_back(1.1);
   x.push_back(2.2);
@@ -113,8 +113,9 @@ TEST(ModelIndexing, rvalue_vector_max_nil) {
   for (int k = 0; k < 3; ++k) {
     std::vector<double> rx = rvalue(x, index_list(index_max(k + 1)));
     EXPECT_FLOAT_EQ(k + 1, rx.size());
-    for (size_t n = 0; n < rx.size(); ++n)
+    for (size_t n = 0; n < rx.size(); ++n) {
       EXPECT_FLOAT_EQ(x[n], rx[n]);
+    }
   }
 
   std::vector<double> ry = rvalue(x, index_list(index_max(0)));
@@ -123,7 +124,7 @@ TEST(ModelIndexing, rvalue_vector_max_nil) {
   test_out_of_range(x, index_list(index_max(4)));
 }
 
-TEST(ModelIndexing, rvalue_vector_min_max_nil) {
+TEST(model_indexing, rvalue_vector_min_max_nil) {
   std::vector<double> x;
   x.push_back(1.1);
   x.push_back(2.2);
@@ -135,8 +136,9 @@ TEST(ModelIndexing, rvalue_vector_min_max_nil) {
       std::vector<double> rx
           = rvalue(x, index_list(index_min_max(mn + 1, mx + 1)));
       EXPECT_FLOAT_EQ(mx - mn + 1, rx.size());
-      for (int n = mn; n <= mx; ++n)
+      for (int n = mn; n <= mx; ++n) {
         EXPECT_FLOAT_EQ(x[n], rx[n - mn]);
+      }
     }
   }
 
@@ -144,7 +146,7 @@ TEST(ModelIndexing, rvalue_vector_min_max_nil) {
   test_out_of_range(x, index_list(index_min_max(2, 5)));
 }
 
-TEST(ModelIndexing, rvalue_doubless_uni_uni) {
+TEST(model_indexing, rvalue_vector_uni_uni) {
   using std::vector;
 
   vector<double> x0;
@@ -159,10 +161,12 @@ TEST(ModelIndexing, rvalue_doubless_uni_uni) {
   x.push_back(x0);
   x.push_back(x1);
 
-  for (int m = 0; m < 2; ++m)
-    for (int n = 0; n < 2; ++n)
+  for (int m = 0; m < 2; ++m) {
+    for (int n = 0; n < 2; ++n) {
       EXPECT_FLOAT_EQ(m + n / 10.0, rvalue(x, index_list(index_uni(m + 1),
                                                          index_uni(n + 1))));
+    }
+  }
 
   test_out_of_range(x, index_list(index_uni(0), index_uni(1)));
   test_out_of_range(x, index_list(index_uni(5), index_uni(1)));
@@ -170,7 +174,7 @@ TEST(ModelIndexing, rvalue_doubless_uni_uni) {
   test_out_of_range(x, index_list(index_uni(1), index_uni(5)));
 }
 
-TEST(ModelIndexing, rvalue_doubless_uni_multi) {
+TEST(model_indexing, rvalue_vector_vector_uni_multi) {
   using std::vector;
 
   vector<double> x0;
@@ -244,7 +248,7 @@ TEST(ModelIndexing, rvalue_doubless_uni_multi) {
   test_out_of_range(x, index_list(index_uni(1), index_multi(ns)));
 }
 
-TEST(ModelIndexing, rvalue_doubless_multi_uni) {
+TEST(model_indexing, rvalue_vector_multi_uni) {
   using std::vector;
 
   vector<double> x0;
@@ -323,7 +327,7 @@ TEST(ModelIndexing, rvalue_doubless_multi_uni) {
   test_out_of_range(x, index_list(index_multi(ns), index_uni(1)));
 }
 
-TEST(ModelIndexing, rvalue_doubless_multi_multi) {
+TEST(model_indexing, rvalue_vector_multi_multi) {
   using std::vector;
 
   vector<double> x0;
@@ -367,13 +371,19 @@ void vector_uni_test() {
   EXPECT_FLOAT_EQ(1, rvalue(v, index_list(index_uni(2))));
   EXPECT_FLOAT_EQ(2, rvalue(v, index_list(index_uni(3))));
 
+  EXPECT_FLOAT_EQ(2, rvalue(v.array() + 2, index_list(index_uni(1))));
+  EXPECT_FLOAT_EQ(3, rvalue(v.array() + 2, index_list(index_uni(2))));
+  EXPECT_FLOAT_EQ(4, rvalue(v.array() + 2, index_list(index_uni(3))));
+
   test_out_of_range(v, index_list(index_uni(0)));
   test_out_of_range(v, index_list(index_uni(20)));
 }
 
-TEST(ModelIndexing, rvalueVectorUni) { vector_uni_test<Eigen::VectorXd>(); }
+TEST(model_indexing, rvalue_vector_uni) {
+   vector_uni_test<Eigen::VectorXd>();
+ }
 
-TEST(ModelIndexing, rvalueRowVectorUni) {
+TEST(model_indexing, rvalue_eigrowvec_uni) {
   vector_uni_test<Eigen::RowVectorXd>();
 }
 
@@ -392,18 +402,35 @@ void vector_multi_test() {
   EXPECT_EQ(3, vi.size());
   EXPECT_FLOAT_EQ(2, vi(0));
   EXPECT_FLOAT_EQ(4, vi(2));
+
+  vi = rvalue(v.array() + 2, index_list(index_min(3)));
+  EXPECT_EQ(3, vi.size());
+  EXPECT_FLOAT_EQ(4, vi(0));
+  EXPECT_FLOAT_EQ(6, vi(2));
+
   test_out_of_range(v, index_list(index_min(0)));
 
   vi = rvalue(v, index_list(index_max(3)));
   EXPECT_EQ(3, vi.size());
   EXPECT_FLOAT_EQ(0, vi(0));
   EXPECT_FLOAT_EQ(2, vi(2));
+  vi = rvalue(v.array() + 2, index_list(index_max(3)));
+  EXPECT_EQ(3, vi.size());
+  EXPECT_FLOAT_EQ(2, vi(0));
+  EXPECT_FLOAT_EQ(4, vi(2));
+
   test_out_of_range(v, index_list(index_max(15)));
 
   vi = rvalue(v, index_list(index_min_max(2, 4)));
   EXPECT_EQ(3, vi.size());
   EXPECT_FLOAT_EQ(1, vi(0));
   EXPECT_FLOAT_EQ(3, vi(2));
+
+  vi = rvalue(v.array() + 2, index_list(index_min_max(2, 4)));
+  EXPECT_EQ(3, vi.size());
+  EXPECT_FLOAT_EQ(3, vi(0));
+  EXPECT_FLOAT_EQ(5, vi(2));
+
   test_out_of_range(v, index_list(index_min_max(0, 4)));
   test_out_of_range(v, index_list(index_min_max(2, 15)));
 
@@ -423,6 +450,13 @@ void vector_multi_test() {
   EXPECT_FLOAT_EQ(4.0, vi(4));
   EXPECT_FLOAT_EQ(3.0, vi(6));
 
+  vi = rvalue(v.array() + 2, index_list(index_multi(ns)));
+  EXPECT_EQ(7, vi.size());
+  EXPECT_FLOAT_EQ(5.0, vi(0));
+  EXPECT_FLOAT_EQ(3.0, vi(2));
+  EXPECT_FLOAT_EQ(6.0, vi(4));
+  EXPECT_FLOAT_EQ(5.0, vi(6));
+
   ns.push_back(0);
   test_out_of_range(v, index_list(index_multi(ns)));
 
@@ -430,13 +464,15 @@ void vector_multi_test() {
   test_out_of_range(v, index_list(index_multi(ns)));
 }
 
-TEST(ModelIndexing, rvalueVectorMulti) { vector_multi_test<Eigen::VectorXd>(); }
+TEST(model_indexing, rvalue_eigvec_multi) {
+  vector_multi_test<Eigen::VectorXd>();
+}
 
-TEST(ModelIndexing, rvalueRowVectorMulti) {
+TEST(model_indexing, rvalue_eigrowvec_multi) {
   vector_multi_test<Eigen::RowVectorXd>();
 }
 
-TEST(ModelIndexing, rvalueMatrixUni) {
+TEST(model_indexing, rvalue_eigmatrix_uni) {
   using Eigen::MatrixXd;
   using Eigen::RowVectorXd;
   using Eigen::VectorXd;
@@ -444,24 +480,35 @@ TEST(ModelIndexing, rvalueMatrixUni) {
   MatrixXd m(4, 3);
   m << 0.0, 0.1, 0.2, 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 3.0, 3.1, 3.2;
 
-  // FIXME
-
   RowVectorXd v = rvalue(m, index_list(index_uni(1)));
   EXPECT_EQ(3, v.size());
   EXPECT_FLOAT_EQ(0.0, v(0));
   EXPECT_FLOAT_EQ(0.1, v(1));
   EXPECT_FLOAT_EQ(0.2, v(2));
-  test_out_of_range(m, index_list(index_uni(0)));
-  test_out_of_range(m, index_list(index_uni(15)));
+
+  v = rvalue(m.array() + 2, index_list(index_uni(1)));
+  EXPECT_FLOAT_EQ(2.0, v(0));
+  EXPECT_FLOAT_EQ(2.1, v(1));
+  EXPECT_FLOAT_EQ(2.2, v(2));
 
   v = rvalue(m, index_list(index_uni(2)));
   EXPECT_EQ(3, v.size());
   EXPECT_FLOAT_EQ(1.0, v(0));
   EXPECT_FLOAT_EQ(1.1, v(1));
   EXPECT_FLOAT_EQ(1.2, v(2));
+
+  v = rvalue(m.array() + 2, index_list(index_uni(2)));
+  EXPECT_EQ(3, v.size());
+  EXPECT_FLOAT_EQ(3.0, v(0));
+  EXPECT_FLOAT_EQ(3.1, v(1));
+  EXPECT_FLOAT_EQ(3.2, v(2));
+
+  test_out_of_range(m, index_list(index_uni(0)));
+  test_out_of_range(m, index_list(index_uni(15)));
+
 }
 
-TEST(ModelIndexing, rvalueMatrixMulti) {
+TEST(model_indexing, rvalue_eigmatrix_multi) {
   using Eigen::MatrixXd;
   using Eigen::RowVectorXd;
   using Eigen::VectorXd;
@@ -478,6 +525,16 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(3.0, a(1, 0));
   EXPECT_FLOAT_EQ(3.1, a(1, 1));
   EXPECT_FLOAT_EQ(3.2, a(1, 2));
+
+  a = rvalue(m.array() + 2, index_list(index_min(3)));
+  EXPECT_EQ(2, a.rows());
+  EXPECT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(4.0, a(0, 0));
+  EXPECT_FLOAT_EQ(4.1, a(0, 1));
+  EXPECT_FLOAT_EQ(4.2, a(0, 2));
+  EXPECT_FLOAT_EQ(5.0, a(1, 0));
+  EXPECT_FLOAT_EQ(5.1, a(1, 1));
+  EXPECT_FLOAT_EQ(5.2, a(1, 2));
   test_out_of_range(m, index_list(index_min(0)));
 
   a = rvalue(m, index_list(index_max(2)));
@@ -489,6 +546,17 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(1.0, a(1, 0));
   EXPECT_FLOAT_EQ(1.1, a(1, 1));
   EXPECT_FLOAT_EQ(1.2, a(1, 2));
+
+  a = rvalue(m.array() + 2, index_list(index_max(2)));
+  EXPECT_EQ(2, a.rows());
+  EXPECT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(2.0, a(0, 0));
+  EXPECT_FLOAT_EQ(2.1, a(0, 1));
+  EXPECT_FLOAT_EQ(2.2, a(0, 2));
+  EXPECT_FLOAT_EQ(3.0, a(1, 0));
+  EXPECT_FLOAT_EQ(3.1, a(1, 1));
+  EXPECT_FLOAT_EQ(3.2, a(1, 2));
+
   test_out_of_range(m, index_list(index_max(15)));
 
   a = rvalue(m, index_list(index_min_max(2, 3)));
@@ -500,6 +568,17 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(2.0, a(1, 0));
   EXPECT_FLOAT_EQ(2.1, a(1, 1));
   EXPECT_FLOAT_EQ(2.2, a(1, 2));
+
+  a = rvalue(m.array() + 2, index_list(index_min_max(2, 3)));
+  EXPECT_EQ(2, a.rows());
+  EXPECT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(3.0, a(0, 0));
+  EXPECT_FLOAT_EQ(3.1, a(0, 1));
+  EXPECT_FLOAT_EQ(3.2, a(0, 2));
+  EXPECT_FLOAT_EQ(4.0, a(1, 0));
+  EXPECT_FLOAT_EQ(4.1, a(1, 1));
+  EXPECT_FLOAT_EQ(4.2, a(1, 2));
+
   test_out_of_range(m, index_list(index_min_max(0, 3)));
   test_out_of_range(m, index_list(index_min_max(2, 15)));
 
@@ -512,6 +591,17 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(3.0, a(3, 0));
   EXPECT_FLOAT_EQ(3.1, a(3, 1));
   EXPECT_FLOAT_EQ(3.2, a(3, 2));
+
+
+  a = rvalue(m.array() + 2, index_list(index_omni()));
+  EXPECT_EQ(4, a.rows());
+  EXPECT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(2.0, a(0, 0));
+  EXPECT_FLOAT_EQ(2.1, a(0, 1));
+  EXPECT_FLOAT_EQ(2.2, a(0, 2));
+  EXPECT_FLOAT_EQ(5.0, a(3, 0));
+  EXPECT_FLOAT_EQ(5.1, a(3, 1));
+  EXPECT_FLOAT_EQ(5.2, a(3, 2));
 
   std::vector<int> ns;
   ns.push_back(3);
@@ -534,6 +624,19 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(0.1, a(6, 1));
   EXPECT_FLOAT_EQ(0.2, a(6, 2));
 
+  a = rvalue(m.array() + 2, index_list(index_multi(ns)));
+  EXPECT_FLOAT_EQ(7, a.rows());
+  EXPECT_FLOAT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(4.0, a(0, 0));
+  EXPECT_FLOAT_EQ(4.1, a(0, 1));
+  EXPECT_FLOAT_EQ(4.2, a(0, 2));
+  EXPECT_FLOAT_EQ(5.0, a(5, 0));
+  EXPECT_FLOAT_EQ(5.1, a(5, 1));
+  EXPECT_FLOAT_EQ(5.2, a(5, 2));
+  EXPECT_FLOAT_EQ(2.0, a(6, 0));
+  EXPECT_FLOAT_EQ(2.1, a(6, 1));
+  EXPECT_FLOAT_EQ(2.2, a(6, 2));
+
   ns.push_back(0);
   test_out_of_range(m, index_list(index_multi(ns)));
 
@@ -541,76 +644,141 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   test_out_of_range(m, index_list(index_multi(ns)));
 }
 
-TEST(ModelIndexing, rvalueMatrixSingleSingle) {
+TEST(model_indexing, rvalue_eigmatrix_uni_uni) {
   Eigen::MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
-  for (int m = 0; m < 3; ++m)
-    for (int n = 0; n < 4; ++n)
+  for (int m = 0; m < 3; ++m) {
+    for (int n = 0; n < 4; ++n) {
       EXPECT_FLOAT_EQ(m + n / 10.0, rvalue(x, index_list(index_uni(m + 1),
                                                          index_uni(n + 1))));
+    }
+  }
+
+  for (int m = 0; m < 3; ++m) {
+    for (int n = 0; n < 4; ++n) {
+      EXPECT_FLOAT_EQ(2 + m + n / 10.0, rvalue(x.array() + 2, index_list(index_uni(m + 1),
+                                                         index_uni(n + 1))));
+    }
+  }
+
   test_out_of_range(x, index_list(index_uni(0), index_uni(1)));
   test_out_of_range(x, index_list(index_uni(0), index_uni(10)));
   test_out_of_range(x, index_list(index_uni(1), index_uni(0)));
   test_out_of_range(x, index_list(index_uni(1), index_uni(10)));
 }
 
-TEST(ModelIndexing, rvalueMatrixSingleMulti) {
+TEST(model_indexing, rvalue_eigmatrix_uni_multi) {
   Eigen::MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
   Eigen::RowVectorXd v = rvalue(x, index_list(index_uni(2), index_omni()));
   EXPECT_EQ(4, v.size());
-  for (int i = 0; i < 4; ++i)
+  for (int i = 0; i < 4; ++i) {
     EXPECT_FLOAT_EQ(v(i), x(1, i));
+  }
+
+  v = rvalue(x.array() + 2, index_list(index_uni(2), index_omni()));
+  EXPECT_EQ(4, v.size());
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_FLOAT_EQ(v(i), x(1, i) + 2);
+  }
+
   test_out_of_range(x, index_list(index_uni(0), index_omni()));
   test_out_of_range(x, index_list(index_uni(10), index_omni()));
 
   v = rvalue(x, index_list(index_uni(3), index_min(2)));
   EXPECT_EQ(3, v.size());
-  for (int i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i) {
     EXPECT_FLOAT_EQ(v(i), x(2, i + 1));
+  }
+
+  v = rvalue(x.array() + 2, index_list(index_uni(3), index_min(2)));
+  EXPECT_EQ(3, v.size());
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_FLOAT_EQ(v(i), x(2, i + 1) + 2);
+  }
+
   test_out_of_range(x, index_list(index_uni(0), index_min(2)));
   test_out_of_range(x, index_list(index_uni(1), index_min(0)));
 }
 
-TEST(ModelIndexing, rvalueMatrixMultiSingle) {
+TEST(model_indexing, rvalue_eigmatrix_multi_uni) {
   Eigen::MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
   Eigen::VectorXd v = rvalue(x, index_list(index_omni(), index_uni(2)));
   EXPECT_EQ(3, v.size());
-  for (int j = 0; j < 3; ++j)
+  for (int j = 0; j < 3; ++j) {
     EXPECT_FLOAT_EQ(j + 0.1, v(j));
+  }
+
+  v = rvalue(x.array() + 2, index_list(index_omni(), index_uni(2)));
+  EXPECT_EQ(3, v.size());
+  for (int j = 0; j < 3; ++j) {
+    EXPECT_FLOAT_EQ(j + 2.1, v(j));
+  }
+
   test_out_of_range(x, index_list(index_omni(), index_uni(0)));
   test_out_of_range(x, index_list(index_omni(), index_uni(20)));
 
   v = rvalue(x, index_list(index_min(2), index_uni(3)));
   EXPECT_EQ(2, v.size());
-  for (int j = 0; j < 2; ++j)
+  for (int j = 0; j < 2; ++j) {
     EXPECT_EQ(1 + j + 0.2, v(j));
+  }
+
+  v = rvalue(x.array() + 2, index_list(index_min(2), index_uni(3)));
+  EXPECT_EQ(2, v.size());
+  for (int j = 0; j < 2; ++j) {
+    EXPECT_EQ(1 + j + 2.2, v(j));
+  }
+
   test_out_of_range(x, index_list(index_min(0), index_uni(3)));
   test_out_of_range(x, index_list(index_min(2), index_uni(0)));
   test_out_of_range(x, index_list(index_min(2), index_uni(30)));
 }
 
-TEST(ModelIndexing, rvalueMatrixMultiMulti) {
+TEST(model_indexing, rvalue_eigmatrix_multi_multi) {
   Eigen::MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
   Eigen::MatrixXd y = rvalue(x, index_list(index_omni(), index_omni()));
   EXPECT_EQ(x.rows(), y.rows());
   EXPECT_EQ(x.cols(), y.cols());
-  for (int i = 0; i < x.rows(); ++i)
-    for (int j = 0; j < x.cols(); ++j)
+  for (int i = 0; i < x.rows(); ++i) {
+    for (int j = 0; j < x.cols(); ++j) {
       EXPECT_FLOAT_EQ(x(i, j), y(i, j));
+    }
+  }
+
+  y = rvalue(x.array() + 2, index_list(index_omni(), index_omni()));
+  EXPECT_EQ(x.rows(), y.rows());
+  EXPECT_EQ(x.cols(), y.cols());
+  for (int i = 0; i < x.rows(); ++i) {
+    for (int j = 0; j < x.cols(); ++j) {
+      EXPECT_FLOAT_EQ(x(i, j) + 2, y(i, j));
+    }
+  }
 
   y = rvalue(x, index_list(index_min(2), index_min(3)));
   EXPECT_EQ(2, y.rows());
   EXPECT_EQ(2, y.cols());
-  for (int i = 0; i < 2; ++i)
-    for (int j = 0; j < 2; ++j)
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 2; ++j) {
       EXPECT_FLOAT_EQ(i + 1 + (j + 2) / 10.0, y(i, j));
+    }
+  }
+
+  y = rvalue(x.array() + 2, index_list(index_min(2), index_min(3)));
+  EXPECT_EQ(2, y.rows());
+  EXPECT_EQ(2, y.cols());
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 2; ++j) {
+      EXPECT_FLOAT_EQ(2 + i + 1 + (j + 2) / 10.0, y(i, j));
+    }
+  }
+
   test_out_of_range(x, index_list(index_min(0), index_min(3)));
   test_out_of_range(x, index_list(index_min(2), index_min(0)));
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This allows `rvalue` and `assign` to take in generic eigen expressions. This uses a `const` [`Eigen::Ref`](https://eigen.tuxfamily.org/dox/classEigen_1_1Ref.html) on the rhs of `assign` and the input to `rvalue` so that eigen expressions sent into rvalue that need row or column access will first be evaluated. This allows `Eigen::Matrix` inputs to avoid a copy while eigen expressions will be evaluated 

This PR also makes one specialization for the case of `A[, col_index]` for grabbing a column of a matrix. It feels like this should be a regular thing people do and since we do col major index it feels like an easy slice to grab with `A.col()`

#### Intended Effect

Inputs to `rvalue` and `assign` can be more complex eigen expressions

#### How to Verify

Additional tests have been added to rvalue_test and lvalue_test that can be run from

```
./runTests.py ./src/test/unit/model/indexing/
```

This PR also cleans up the names of tests for `assign` to be more descriptive and names the assignee `lhs_x` and variable to be assigned `rhs_y`. I think this makes the test code easier to read 

#### Side Effects

Since everything is templated to remove dynamic. This should allow for Eigen expressions like `colvec * rowvec` to carry forward that the result is known to have 1x1 dims. Once the math library is templated to accept generic eigen expressions we can remove the `.eval()` in a few places here let the returns of `rvalue` be their `auto` deduced type

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
