### PR TITLE
Add SFINAE for vector types to assign

### DIFF
--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -46,7 +46,7 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U y,
  */
 template <typename T, typename U,
           typename = require_all_not_stan_scalar_t<U, T>,
-          typename = require_all_not_std_vector_t<U, T>>
+          typename = require_any_t<is_not_std_vector_t<U, T>, is_same_vt<U, T>>>
 inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
                    const char* name = "ANON", int depth = 0) {
   x = std::forward<U>(y);

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -63,7 +63,8 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
  * @param[in] name name of lvalue variable (default "ANON").
  * @param[in] depth indexing depth (default 0).
  */
-template <typename Vec1, typename Vec2, typename = require_all_std_vector_t<Vec1, Vec2>>
+template <typename Vec1, typename Vec2,
+ typename = require_all_std_vector_t<Vec1, Vec2>>
 inline void assign(Vec1&& x, const nil_index_list& /* idxs */,
                    Vec2&& y, const char* name = "ANON",
                    int depth = 0) {

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -64,10 +64,9 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
  * @param[in] depth indexing depth (default 0).
  */
 template <typename Vec1, typename Vec2,
- typename = require_all_std_vector_t<Vec1, Vec2>>
-inline void assign(Vec1&& x, const nil_index_list& /* idxs */,
-                   Vec2&& y, const char* name = "ANON",
-                   int depth = 0) {
+          typename = require_all_std_vector_t<Vec1, Vec2>>
+inline void assign(Vec1&& x, const nil_index_list& /* idxs */, Vec2&& y,
+                   const char* name = "ANON", int depth = 0) {
   x.resize(y.size());
   for (size_t i = 0; i < y.size(); ++i) {
     assign(x[i], nil_index_list(), y[i], name, depth + 1);

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -45,7 +45,8 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U y,
  * @param[in] depth Indexing depth (default 0; ignored
  */
 template <typename T, typename U,
-          typename = require_all_not_stan_scalar_t<U, T>>
+          typename = require_all_not_stan_scalar_t<U, T>,
+          typename = require_all_not_std_vector_t<U, T>>
 inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
                    const char* name = "ANON", int depth = 0) {
   x = std::forward<U>(y);
@@ -62,9 +63,9 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
  * @param[in] name name of lvalue variable (default "ANON").
  * @param[in] depth indexing depth (default 0).
  */
-template <typename T, typename U>
-inline void assign(std::vector<T>& x, const nil_index_list& /* idxs */,
-                   const std::vector<U>& y, const char* name = "ANON",
+template <typename Vec1, typename Vec2, typename = require_all_std_vector_t<Vec1, Vec2>>
+inline void assign(Vec1&& x, const nil_index_list& /* idxs */,
+                   Vec2&& y, const char* name = "ANON",
                    int depth = 0) {
   x.resize(y.size());
   for (size_t i = 0; i < y.size(); ++i) {

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -57,7 +57,8 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
  * standard vector lvalue.
  *
  * @tparam Vec1 vector type to be assigned to
- * @tparam Vec2 vector type that must be assignable to `Vec1`
+ * @tparam Vec2 vector type with scalar that must be assignable to scalar out
+ *  `Vec1`.
  * @param[in] x lvalue variable
  * @param[in] y rvalue variable
  * @param[in] name name of lvalue variable (default "ANON").

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -56,8 +56,8 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
  * Assign the specified standard vector rvalue to the specified
  * standard vector lvalue.
  *
- * @tparam T lvalue container element type
- * @tparam U rvalue container element type, which must be assignable to `T`
+ * @tparam Vec1 vector type to be assigned to
+ * @tparam Vec2 vector type that must be assignable to `Vec1`
  * @param[in] x lvalue variable
  * @param[in] y rvalue variable
  * @param[in] name name of lvalue variable (default "ANON").

--- a/src/test/unit/model/indexing/lvalue_test.cpp
+++ b/src/test/unit/model/indexing/lvalue_test.cpp
@@ -622,7 +622,17 @@ TEST(model_indexing, assign_result_size_neg_index) {
   EXPECT_EQ(0, lhs.size());
 }
 
-TEST(model_indexing, assign_double_to_var_simple) {
+TEST(model_indexing, assign_double_to_var_scalar) {
+  using stan::math::var;
+  using stan::model::nil_index_list;
+  double a = 5;
+  var b;
+  assign(b, nil_index_list(), a);
+    EXPECT_FLOAT_EQ(a, b.val());
+}
+
+
+TEST(model_indexing, assign_double_to_var_matrix) {
   using stan::math::var;
   using stan::model::nil_index_list;
   typedef Eigen::MatrixXd mat_d;
@@ -634,5 +644,21 @@ TEST(model_indexing, assign_double_to_var_simple) {
   assign(b, nil_index_list(), a);
   for (int i = 0; i < a.size(); ++i) {
     EXPECT_FLOAT_EQ(a(i), b(i).val());
+  }
+}
+
+
+TEST(model_indexing, assign_double_to_var_vector) {
+  using stan::math::var;
+  using stan::model::nil_index_list;
+
+  std::vector<double> a(2);
+  for (int i = 0; i < a.size(); i++) {
+    a[i] = static_cast<double>(i);
+  }
+  std::vector<stan::math::var> b(2);
+  assign(b, nil_index_list(), a);
+  for (int i = 0; i < a.size(); ++i) {
+    EXPECT_FLOAT_EQ(a[i], b[i].val());
   }
 }

--- a/src/test/unit/model/indexing/lvalue_test.cpp
+++ b/src/test/unit/model/indexing/lvalue_test.cpp
@@ -628,9 +628,8 @@ TEST(model_indexing, assign_double_to_var_scalar) {
   double a = 5;
   var b;
   assign(b, nil_index_list(), a);
-    EXPECT_FLOAT_EQ(a, b.val());
+  EXPECT_FLOAT_EQ(a, b.val());
 }
-
 
 TEST(model_indexing, assign_double_to_var_matrix) {
   using stan::math::var;
@@ -646,7 +645,6 @@ TEST(model_indexing, assign_double_to_var_matrix) {
     EXPECT_FLOAT_EQ(a(i), b(i).val());
   }
 }
-
 
 TEST(model_indexing, assign_double_to_var_vector) {
   using stan::math::var;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: Steve Bronder

#### Summary

Fixes `assign` so that `assign(std::vector<var>, ..., std::vector<double>, nil_index_list)` dispatches to the correct overload

#### Intended Effect

Fixes: https://github.com/stan-dev/stanc3/issues/471

#### How to Verify

Added tests for vector of doubles to var in `index/lvalue_test.cpp`

```bash
./runTests.py -j12 ./src/test/unit/model/indexing/
```

#### Side Effects

None

#### Documentation

Update docs

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
