### PR TITLE
std:: int overloads test model

### DIFF
--- a/src/test/test-models/good/int_overloads.stan
+++ b/src/test/test-models/good/int_overloads.stan
@@ -27,8 +27,10 @@ transformed data {
   transformed_data_real = log10(d_int);
   transformed_data_real = log10(d_real);
 
-  transformed_data_real = pow(d_int);
-  transformed_data_real = pow(d_real);
+  transformed_data_real = pow(d_int, d_int);
+  transformed_data_real = pow(d_real, d_int);
+  transformed_data_real = pow(d_int, d_real);
+  transformed_data_real = pow(d_real, d_real);
   transformed_data_real = sqrt(d_int);
   transformed_data_real = sqrt(d_real);
   transformed_data_real = cbrt(d_int);
@@ -46,6 +48,10 @@ transformed data {
   transformed_data_real = acos(d_real);
   transformed_data_real = atan(d_int);
   transformed_data_real = atan(d_real);
+  transformed_data_real = atan2(d_int, d_int);
+  transformed_data_real = atan2(d_real, d_int);
+  transformed_data_real = atan2(d_int, d_real);
+  transformed_data_real = atan2(d_real, d_real);
 
   transformed_data_real = sinh(d_int);
   transformed_data_real = sinh(d_real);
@@ -96,95 +102,51 @@ parameters {
   real p_real;
   real y_p;
 }
-model {
-  y ~ normal(0,1);
-}
 
 transformed parameters {
   real transformed_param_real;
 
-  transformed_param_real = abs(d_int);
-  transformed_param_real = abs(d_real);
-  transformed_param_real = fabs(d_int);
-  transformed_param_real = fabs(d_real);
+  transformed_param_real = abs(p_real);
+  transformed_param_real = fabs(p_real);
 
-  transformed_param_real = exp(d_int);
-  transformed_param_real = exp(d_real);
-  transformed_param_real = exp2(d_int);
-  transformed_param_real = exp2(d_real);
-  transformed_param_real = expm1(d_int);
-  transformed_param_real = expm1(d_real);
-  transformed_param_real = log(d_int);
-  transformed_param_real = log(d_real);
-  transformed_param_real = log1p(d_int);
-  transformed_param_real = log1p(d_real);
-  transformed_param_real = log2(d_int);
-  transformed_param_real = log2(d_real);
-  transformed_param_real = log10(d_int);
-  transformed_param_real = log10(d_real);
+  transformed_param_real = exp(p_real);
+  transformed_param_real = exp2(p_real);
+  transformed_param_real = expm1(p_real);
+  transformed_param_real = log(p_real);
+  transformed_param_real = log1p(p_real);
+  transformed_param_real = log2(p_real);
+  transformed_param_real = log10(p_real);
 
-  transformed_param_real = pow(d_int);
-  transformed_param_real = pow(d_real);
-  transformed_param_real = sqrt(d_int);
-  transformed_param_real = sqrt(d_real);
-  transformed_param_real = cbrt(d_int);
-  transformed_param_real = cbrt(d_real);
+  transformed_param_real = pow(d_int, p_real);
+  transformed_param_real = pow(p_real, d_int);
+  transformed_param_real = pow(p_real, p_real);
+  transformed_param_real = sqrt(p_real);
+  transformed_param_real = cbrt(p_real);
 
-  transformed_param_real = sin(d_int);
-  transformed_param_real = sin(d_real);
-  transformed_param_real = cos(d_int);
-  transformed_param_real = cos(d_real);
-  transformed_param_real = tan(d_int);
-  transformed_param_real = tan(d_real);
-  transformed_param_real = asin(d_int);
-  transformed_param_real = asin(d_real);
-  transformed_param_real = acos(d_int);
-  transformed_param_real = acos(d_real);
-  transformed_param_real = atan(d_int);
-  transformed_param_real = atan(d_real);
+  transformed_param_real = sin(p_real);
+  transformed_param_real = cos(p_real);
+  transformed_param_real = tan(p_real);
+  transformed_param_real = asin(p_real);
+  transformed_param_real = acos(p_real);
+  transformed_param_real = atan(p_real);
 
-  transformed_param_real = sinh(d_int);
-  transformed_param_real = sinh(d_real);
-  transformed_param_real = cosh(d_int);
-  transformed_param_real = cosh(d_real);
-  transformed_param_real = tanh(d_int);
-  transformed_param_real = tanh(d_real);
-  transformed_param_real = asinh(d_int);
-  transformed_param_real = asinh(d_real);
-  transformed_param_real = acosh(d_int);
-  transformed_param_real = acosh(d_real);
-  transformed_param_real = atanh(d_int);
-  transformed_param_real = atanh(d_real);
+  transformed_param_real = sinh(p_real);
+  transformed_param_real = cosh(p_real);
+  transformed_param_real = tanh(p_real);
+  transformed_param_real = asinh(p_real);
+  transformed_param_real = acosh(p_real);
+  transformed_param_real = atanh(p_real);
 
-  transformed_param_real = erf(d_int);
-  transformed_param_real = erf(d_real);
-  transformed_param_real = erfc(d_int);
-  transformed_param_real = erfc(d_real);
-  transformed_param_real = tgamma(d_int);
-  transformed_param_real = tgamma(d_real);
+  transformed_param_real = erf(p_real);
+  transformed_param_real = erfc(p_real);
+  transformed_param_real = tgamma(p_real);
 
-  transformed_param_real = ceil(d_int);
-  transformed_param_real = ceil(d_real);
-  transformed_param_real = floor(d_int);
-  transformed_param_real = floor(d_real);
-  transformed_param_real = trunc(d_int);
-  transformed_param_real = trunc(d_real);
-  transformed_param_real = round(d_int);
-  transformed_param_real = round(d_real);
+  transformed_param_real = ceil(p_real);
+  transformed_param_real = floor(p_real);
+  transformed_param_real = trunc(p_real);
+  transformed_param_real = round(p_real);
 
-  transformed_param_real = inv(d_int);
-  transformed_param_real = inv(d_real);
-  transformed_param_real = inv_sqrt(d_int);
-  transformed_param_real = inv_sqrt(d_real);
-  transformed_param_real = inv_square(d_int);
-  transformed_param_real = inv_square(d_real);
-  transformed_param_real = sqrt(d_int);
-  transformed_param_real = sqrt(d_real);
-  transformed_param_real = tan(d_int);
-  transformed_param_real = tan(d_real);
-  transformed_param_real = tanh(d_int);
-  transformed_param_real = tanh(d_real);
-  transformed_param_real = trigamma(d_int);
+  transformed_param_real = trigamma(p_real);
   transformed_param_real = trigamma(d_real);
 
 }

--- a/src/test/test-models/good/int_overloads.stan
+++ b/src/test/test-models/good/int_overloads.stan
@@ -81,19 +81,6 @@ transformed data {
   transformed_data_real = trunc(d_real);
   transformed_data_real = round(d_int);
   transformed_data_real = round(d_real);
-
-  transformed_data_real = inv(d_int);
-  transformed_data_real = inv(d_real);
-  transformed_data_real = inv_sqrt(d_int);
-  transformed_data_real = inv_sqrt(d_real);
-  transformed_data_real = inv_square(d_int);
-  transformed_data_real = inv_square(d_real);
-  transformed_data_real = sqrt(d_int);
-  transformed_data_real = sqrt(d_real);
-  transformed_data_real = tan(d_int);
-  transformed_data_real = tan(d_real);
-  transformed_data_real = tanh(d_int);
-  transformed_data_real = tanh(d_real);
   transformed_data_real = trigamma(d_int);
   transformed_data_real = trigamma(d_real);
 }

--- a/src/test/test-models/good/int_overloads.stan
+++ b/src/test/test-models/good/int_overloads.stan
@@ -1,0 +1,194 @@
+data { 
+  int d_int;
+  real d_real;
+}
+
+transformed data {
+  int transformed_data_int;
+  real transformed_data_real;
+
+  transformed_data_real = abs(d_int);
+  transformed_data_real = abs(d_real);
+  transformed_data_real = fabs(d_int);
+  transformed_data_real = fabs(d_real);
+
+  transformed_data_real = exp(d_int);
+  transformed_data_real = exp(d_real);
+  transformed_data_real = exp2(d_int);
+  transformed_data_real = exp2(d_real);
+  transformed_data_real = expm1(d_int);
+  transformed_data_real = expm1(d_real);
+  transformed_data_real = log(d_int);
+  transformed_data_real = log(d_real);
+  transformed_data_real = log1p(d_int);
+  transformed_data_real = log1p(d_real);
+  transformed_data_real = log2(d_int);
+  transformed_data_real = log2(d_real);
+  transformed_data_real = log10(d_int);
+  transformed_data_real = log10(d_real);
+
+  transformed_data_real = pow(d_int);
+  transformed_data_real = pow(d_real);
+  transformed_data_real = sqrt(d_int);
+  transformed_data_real = sqrt(d_real);
+  transformed_data_real = cbrt(d_int);
+  transformed_data_real = cbrt(d_real);
+
+  transformed_data_real = sin(d_int);
+  transformed_data_real = sin(d_real);
+  transformed_data_real = cos(d_int);
+  transformed_data_real = cos(d_real);
+  transformed_data_real = tan(d_int);
+  transformed_data_real = tan(d_real);
+  transformed_data_real = asin(d_int);
+  transformed_data_real = asin(d_real);
+  transformed_data_real = acos(d_int);
+  transformed_data_real = acos(d_real);
+  transformed_data_real = atan(d_int);
+  transformed_data_real = atan(d_real);
+
+  transformed_data_real = sinh(d_int);
+  transformed_data_real = sinh(d_real);
+  transformed_data_real = cosh(d_int);
+  transformed_data_real = cosh(d_real);
+  transformed_data_real = tanh(d_int);
+  transformed_data_real = tanh(d_real);
+  transformed_data_real = asinh(d_int);
+  transformed_data_real = asinh(d_real);
+  transformed_data_real = acosh(d_int);
+  transformed_data_real = acosh(d_real);
+  transformed_data_real = atanh(d_int);
+  transformed_data_real = atanh(d_real);
+
+  transformed_data_real = erf(d_int);
+  transformed_data_real = erf(d_real);
+  transformed_data_real = erfc(d_int);
+  transformed_data_real = erfc(d_real);
+  transformed_data_real = tgamma(d_int);
+  transformed_data_real = tgamma(d_real);
+
+  transformed_data_real = ceil(d_int);
+  transformed_data_real = ceil(d_real);
+  transformed_data_real = floor(d_int);
+  transformed_data_real = floor(d_real);
+  transformed_data_real = trunc(d_int);
+  transformed_data_real = trunc(d_real);
+  transformed_data_real = round(d_int);
+  transformed_data_real = round(d_real);
+
+  transformed_data_real = inv(d_int);
+  transformed_data_real = inv(d_real);
+  transformed_data_real = inv_sqrt(d_int);
+  transformed_data_real = inv_sqrt(d_real);
+  transformed_data_real = inv_square(d_int);
+  transformed_data_real = inv_square(d_real);
+  transformed_data_real = sqrt(d_int);
+  transformed_data_real = sqrt(d_real);
+  transformed_data_real = tan(d_int);
+  transformed_data_real = tan(d_real);
+  transformed_data_real = tanh(d_int);
+  transformed_data_real = tanh(d_real);
+  transformed_data_real = trigamma(d_int);
+  transformed_data_real = trigamma(d_real);
+}
+
+parameters {
+  real p_real;
+  real y_p;
+}
+model {
+  y ~ normal(0,1);
+}
+
+transformed parameters {
+  real transformed_param_real;
+
+  transformed_param_real = abs(d_int);
+  transformed_param_real = abs(d_real);
+  transformed_param_real = fabs(d_int);
+  transformed_param_real = fabs(d_real);
+
+  transformed_param_real = exp(d_int);
+  transformed_param_real = exp(d_real);
+  transformed_param_real = exp2(d_int);
+  transformed_param_real = exp2(d_real);
+  transformed_param_real = expm1(d_int);
+  transformed_param_real = expm1(d_real);
+  transformed_param_real = log(d_int);
+  transformed_param_real = log(d_real);
+  transformed_param_real = log1p(d_int);
+  transformed_param_real = log1p(d_real);
+  transformed_param_real = log2(d_int);
+  transformed_param_real = log2(d_real);
+  transformed_param_real = log10(d_int);
+  transformed_param_real = log10(d_real);
+
+  transformed_param_real = pow(d_int);
+  transformed_param_real = pow(d_real);
+  transformed_param_real = sqrt(d_int);
+  transformed_param_real = sqrt(d_real);
+  transformed_param_real = cbrt(d_int);
+  transformed_param_real = cbrt(d_real);
+
+  transformed_param_real = sin(d_int);
+  transformed_param_real = sin(d_real);
+  transformed_param_real = cos(d_int);
+  transformed_param_real = cos(d_real);
+  transformed_param_real = tan(d_int);
+  transformed_param_real = tan(d_real);
+  transformed_param_real = asin(d_int);
+  transformed_param_real = asin(d_real);
+  transformed_param_real = acos(d_int);
+  transformed_param_real = acos(d_real);
+  transformed_param_real = atan(d_int);
+  transformed_param_real = atan(d_real);
+
+  transformed_param_real = sinh(d_int);
+  transformed_param_real = sinh(d_real);
+  transformed_param_real = cosh(d_int);
+  transformed_param_real = cosh(d_real);
+  transformed_param_real = tanh(d_int);
+  transformed_param_real = tanh(d_real);
+  transformed_param_real = asinh(d_int);
+  transformed_param_real = asinh(d_real);
+  transformed_param_real = acosh(d_int);
+  transformed_param_real = acosh(d_real);
+  transformed_param_real = atanh(d_int);
+  transformed_param_real = atanh(d_real);
+
+  transformed_param_real = erf(d_int);
+  transformed_param_real = erf(d_real);
+  transformed_param_real = erfc(d_int);
+  transformed_param_real = erfc(d_real);
+  transformed_param_real = tgamma(d_int);
+  transformed_param_real = tgamma(d_real);
+
+  transformed_param_real = ceil(d_int);
+  transformed_param_real = ceil(d_real);
+  transformed_param_real = floor(d_int);
+  transformed_param_real = floor(d_real);
+  transformed_param_real = trunc(d_int);
+  transformed_param_real = trunc(d_real);
+  transformed_param_real = round(d_int);
+  transformed_param_real = round(d_real);
+
+  transformed_param_real = inv(d_int);
+  transformed_param_real = inv(d_real);
+  transformed_param_real = inv_sqrt(d_int);
+  transformed_param_real = inv_sqrt(d_real);
+  transformed_param_real = inv_square(d_int);
+  transformed_param_real = inv_square(d_real);
+  transformed_param_real = sqrt(d_int);
+  transformed_param_real = sqrt(d_real);
+  transformed_param_real = tan(d_int);
+  transformed_param_real = tan(d_real);
+  transformed_param_real = tanh(d_int);
+  transformed_param_real = tanh(d_real);
+  transformed_param_real = trigamma(d_int);
+  transformed_param_real = trigamma(d_real);
+
+}
+
+model {  
+  y_p ~ normal(0,1);
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x ] Declare copyright holder and open-source license: see below

#### Summary

Adding a model that will test fun(int) and fun(real) for all functions that mirror the std:: cmath functions. 

This is added to test the changes in https://github.com/stan-dev/math/pull/1765

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
