### PR TITLE
[WIP] Add `using std::pow` to model code generator (Issue #1809 in math)

### DIFF
--- a/src/stan/lang/generator/generate_usings.hpp
+++ b/src/stan/lang/generator/generate_usings.hpp
@@ -20,7 +20,7 @@ void generate_usings(std::ostream& o) {
   generate_using("std::string", o);
   generate_using("std::stringstream", o);
   generate_using("std::vector", o);
-  generate_using("std::log", o);
+  generate_using("std::pow", o);
   generate_using("stan::io::dump", o);
   generate_using("stan::math::lgamma", o);
   generate_using("stan::model::prob_grad", o);

--- a/src/stan/lang/generator/generate_usings.hpp
+++ b/src/stan/lang/generator/generate_usings.hpp
@@ -20,6 +20,7 @@ void generate_usings(std::ostream& o) {
   generate_using("std::string", o);
   generate_using("std::stringstream", o);
   generate_using("std::vector", o);
+  generate_using("std::log", o);
   generate_using("stan::io::dump", o);
   generate_using("stan::math::lgamma", o);
   generate_using("stan::model::prob_grad", o);


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is an alternate fix to https://github.com/stan-dev/math/pull/1810.

Work in progress, don't merge. It shouldn't work with mingw as it is anyway.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
