### PR TITLE
Cleanup the use of boost::

### DIFF
--- a/src/stan/analyze/mcmc/compute_effective_sample_size.hpp
+++ b/src/stan/analyze/mcmc/compute_effective_sample_size.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/analyze/mcmc/autocovariance.hpp>
 #include <stan/analyze/mcmc/split_chains.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <algorithm>
 #include <cmath>
 #include <vector>
@@ -51,7 +50,7 @@ inline double compute_effective_sample_size(std::vector<const double*> draws,
         draws[chain_idx], sizes[chain_idx]);
 
     for (int n = 0; n < num_draws; n++) {
-      if (!boost::math::isfinite(draw(n))) {
+      if (!std::isfinite(draw(n))) {
         return std::numeric_limits<double>::quiet_NaN();
       }
     }

--- a/src/stan/analyze/mcmc/compute_potential_scale_reduction.hpp
+++ b/src/stan/analyze/mcmc/compute_potential_scale_reduction.hpp
@@ -8,7 +8,6 @@
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <algorithm>
 #include <cmath>
 #include <vector>
@@ -49,7 +48,7 @@ inline double compute_potential_scale_reduction(
         draws[chain], sizes[chain]);
 
     for (int n = 0; n < num_draws; n++) {
-      if (!boost::math::isfinite(draw(n))) {
+      if (!std::isfinite(draw(n))) {
         return std::numeric_limits<double>::quiet_NaN();
       }
     }

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/io/var_context.hpp>
 #include <stan/math.hpp>
-#include <boost/throw_exception.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <map>
 #include <algorithm>

--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -5,11 +5,6 @@
 #include <stan/io/var_context.hpp>
 #include <stan/math/prim.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/throw_exception.hpp>
-#include <boost/type_traits/is_floating_point.hpp>
-#include <boost/type_traits/is_integral.hpp>
-#include <boost/type_traits/is_arithmetic.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <iostream>
 #include <limits>
 #include <map>
@@ -23,7 +18,6 @@
 namespace stan {
 namespace io {
 
-using Eigen::Dynamic;
 /**
  * Reads data from S-plus dump format.
  *
@@ -250,7 +244,7 @@ class dump_reader {
       d = boost::lexical_cast<size_t>(buf_);
     } catch (const boost::bad_lexical_cast& exc) {
       std::string msg = "value " + buf_ + " beyond array dimension range";
-      BOOST_THROW_EXCEPTION(std::invalid_argument(msg));
+      throw std::invalid_argument(msg);
     }
     return d;
   }
@@ -277,7 +271,7 @@ class dump_reader {
       n = boost::lexical_cast<int>(buf_);
     } catch (const boost::bad_lexical_cast& exc) {
       std::string msg = "value " + buf_ + " beyond int range";
-      BOOST_THROW_EXCEPTION(std::invalid_argument(msg));
+      throw std::invalid_argument(msg);
     }
     return n;
   }
@@ -290,7 +284,7 @@ class dump_reader {
         validate_zero_buf(buf_);
     } catch (const boost::bad_lexical_cast& exc) {
       std::string msg = "value " + buf_ + " beyond numeric range";
-      BOOST_THROW_EXCEPTION(std::invalid_argument(msg));
+      throw std::invalid_argument(msg);
     }
     return x;
   }
@@ -574,11 +568,11 @@ class dump_reader {
       bool okSyntax = scan_value();  // set stack_r_, stack_i_, dims_
       if (!okSyntax) {
         std::string msg = "syntax error";
-        BOOST_THROW_EXCEPTION(std::invalid_argument(msg));
+        throw std::invalid_argument(msg);
       }
     } catch (const std::invalid_argument& e) {
       std::string msg = "data " + name_ + " " + e.what();
-      BOOST_THROW_EXCEPTION(std::invalid_argument(msg));
+      throw std::invalid_argument(msg);
     }
     return true;
   }

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -103,7 +103,7 @@ class reader {
   inline int integer() {
     if (int_pos_ >= data_i_.size()) {
       throw std::runtime_error("no more integers to read.");
-    }      
+    }
     return data_i_[int_pos_++];
   }
 
@@ -131,9 +131,9 @@ class reader {
    * @return Next scalar value.
    */
   inline T scalar() {
-    if (pos_ >= data_r_.size()){
+    if (pos_ >= data_r_.size()) {
       throw std::runtime_error("no more scalars to read");
-    }      
+    }
     return data_r_[pos_++];
   }
 
@@ -323,7 +323,7 @@ class reader {
     int i = integer();
     if (!(i >= lb)) {
       throw std::runtime_error("required value greater than or equal to lb");
-    }      
+    } 
     return i;
   }
   /**
@@ -403,14 +403,13 @@ class reader {
     int i = integer();
     if (lb > ub) {
       throw std::runtime_error("lower bound must be less than or equal to ub");
-    }      
+    }
     if (!(i >= lb)) {
       throw std::runtime_error("required value greater than or equal to lb");
-    }      
+    }
     if (!(i <= ub)) {
       throw std::runtime_error("required value less than or equal to ub");
     }
-      
     return i;
   }
   /**

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_IO_READER_HPP
 #define STAN_IO_READER_HPP
 
-#include <boost/throw_exception.hpp>
 #include <stan/math/prim.hpp>
 #include <stdexcept>
 #include <string>
@@ -102,8 +101,9 @@ class reader {
    * @return Next integer value.
    */
   inline int integer() {
-    if (int_pos_ >= data_i_.size())
-      BOOST_THROW_EXCEPTION(std::runtime_error("no more integers to read."));
+    if (int_pos_ >= data_i_.size()) {
+      throw std::runtime_error("no more integers to read.");
+    }      
     return data_i_[int_pos_++];
   }
 
@@ -131,8 +131,9 @@ class reader {
    * @return Next scalar value.
    */
   inline T scalar() {
-    if (pos_ >= data_r_.size())
-      BOOST_THROW_EXCEPTION(std::runtime_error("no more scalars to read"));
+    if (pos_ >= data_r_.size()){
+      throw std::runtime_error("no more scalars to read");
+    }      
     return data_r_[pos_++];
   }
 
@@ -320,9 +321,9 @@ class reader {
    */
   inline int integer_lb(int lb) {
     int i = integer();
-    if (!(i >= lb))
-      BOOST_THROW_EXCEPTION(
-          std::runtime_error("required value greater than or equal to lb"));
+    if (!(i >= lb)) {
+      throw std::runtime_error("required value greater than or equal to lb");
+    }      
     return i;
   }
   /**
@@ -358,9 +359,9 @@ class reader {
    */
   inline int integer_ub(int ub) {
     int i = integer();
-    if (!(i <= ub))
-      BOOST_THROW_EXCEPTION(
-          std::runtime_error("required value less than or equal to ub"));
+    if (!(i <= ub)) {
+      throw std::runtime_error("required value less than or equal to ub");
+    }
     return i;
   }
   /**
@@ -400,15 +401,16 @@ class reader {
   inline int integer_lub(int lb, int ub) {
     // read first to make position deterministic [arbitrary choice]
     int i = integer();
-    if (lb > ub)
-      BOOST_THROW_EXCEPTION(
-          std::runtime_error("lower bound must be less than or equal to ub"));
-    if (!(i >= lb))
-      BOOST_THROW_EXCEPTION(
-          std::runtime_error("required value greater than or equal to lb"));
-    if (!(i <= ub))
-      BOOST_THROW_EXCEPTION(
-          std::runtime_error("required value less than or equal to ub"));
+    if (lb > ub) {
+      throw std::runtime_error("lower bound must be less than or equal to ub");
+    }      
+    if (!(i >= lb)) {
+      throw std::runtime_error("required value greater than or equal to lb");
+    }      
+    if (!(i <= ub)) {
+      throw std::runtime_error("required value less than or equal to ub");
+    }
+      
     return i;
   }
   /**

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -323,7 +323,7 @@ class reader {
     int i = integer();
     if (!(i >= lb)) {
       throw std::runtime_error("required value greater than or equal to lb");
-    } 
+    }
     return i;
   }
   /**

--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -5,8 +5,6 @@
 #include <stan/callbacks/writer.hpp>
 #include <stan/mcmc/base_mcmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/random/variate_generator.hpp>
 #include <boost/random/uniform_01.hpp>
 #include <cmath>
 #include <limits>
@@ -88,7 +86,7 @@ class base_hmc : public base_mcmc {
                              logger);
 
     double h = this->hamiltonian_.H(this->z_);
-    if (boost::math::isnan(h))
+    if (std::isnan(h))
       h = std::numeric_limits<double>::infinity();
 
     double delta_H = H0 - h;
@@ -107,7 +105,7 @@ class base_hmc : public base_mcmc {
                                logger);
 
       double h = this->hamiltonian_.H(this->z_);
-      if (boost::math::isnan(h))
+      if (std::isnan(h))
         h = std::numeric_limits<double>::infinity();
 
       double delta_H = H0 - h;

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -2,7 +2,6 @@
 #define STAN_MCMC_HMC_NUTS_BASE_NUTS_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/math/prim.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
@@ -257,7 +256,7 @@ class base_nuts : public base_hmc<Model, Hamiltonian, Integrator, BaseRNG> {
       ++n_leapfrog;
 
       double h = this->hamiltonian_.H(this->z_);
-      if (boost::math::isnan(h))
+      if (std::isnan(h))
         h = std::numeric_limits<double>::infinity();
 
       if ((h - H0) > this->max_deltaH_)

--- a/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/base_nuts_classic.hpp
@@ -2,7 +2,6 @@
 #define STAN_MCMC_HMC_NUTS_CLASSIC_BASE_NUTS_CLASSIC_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 #include <algorithm>
@@ -191,7 +190,7 @@ class base_nuts_classic
       z_propose = this->z_;
 
       double h = this->hamiltonian_.H(this->z_);
-      if (boost::math::isnan(h))
+      if (std::isnan(h))
         h = std::numeric_limits<double>::infinity();
 
       util.criterion = util.log_u + (h - util.H0) < this->max_delta_;

--- a/src/stan/mcmc/hmc/static/base_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/base_static_hmc.hpp
@@ -4,7 +4,6 @@
 #include <stan/callbacks/logger.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <limits>
 #include <string>
@@ -55,7 +54,7 @@ class base_static_hmc
                                logger);
 
     double h = this->hamiltonian_.H(this->z_);
-    if (boost::math::isnan(h))
+    if (std::isnan(h))
       h = std::numeric_limits<double>::infinity();
 
     double acceptProb = std::exp(H0 - h);

--- a/src/stan/mcmc/hmc/static_uniform/base_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/base_static_uniform.hpp
@@ -4,7 +4,6 @@
 #include <stan/callbacks/logger.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 #include <cmath>
 #include <limits>
@@ -55,7 +54,7 @@ class base_static_uniform
                                logger);
 
       double h = this->hamiltonian_.H(this->z_);
-      if (boost::math::isnan(h))
+      if (std::isnan(h))
         h = std::numeric_limits<double>::infinity();
 
       double prob = std::exp(H0 - h);
@@ -73,7 +72,7 @@ class base_static_uniform
                                logger);
 
       double h = this->hamiltonian_.H(this->z_);
-      if (boost::math::isnan(h))
+      if (std::isnan(h))
         h = std::numeric_limits<double>::infinity();
 
       double prob = std::exp(H0 - h);

--- a/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/base_xhmc.hpp
@@ -2,7 +2,6 @@
 #define STAN_MCMC_HMC_NUTS_BASE_XHMC_HPP
 
 #include <stan/callbacks/logger.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/mcmc/hmc/base_hmc.hpp>
 #include <stan/mcmc/hmc/hamiltonians/ps_point.hpp>
 #include <algorithm>
@@ -168,7 +167,7 @@ class base_xhmc : public base_hmc<Model, Hamiltonian, Integrator, BaseRNG> {
       ++n_leapfrog;
 
       double h = this->hamiltonian_.H(this->z_);
-      if (boost::math::isnan(h))
+      if (std::isnan(h))
         h = std::numeric_limits<double>::infinity();
 
       if ((h - H0) > this->max_deltaH_)

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -1,13 +1,12 @@
 #ifndef STAN_MODEL_INDEXING_LVALUE_HPP
 #define STAN_MODEL_INDEXING_LVALUE_HPP
 
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_same.hpp>
 #include <stan/math/prim.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/index_list.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>
 #include <stan/model/indexing/rvalue_index_size.hpp>
+#include <type_traits>
 #include <vector>
 
 namespace stan {
@@ -119,7 +118,7 @@ inline void assign(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
  * the indexed size.
  */
 template <typename T, typename I, typename U>
-inline typename boost::disable_if<boost::is_same<I, index_uni>, void>::type
+inline typename std::enable_if<!std::is_same<I, index_uni>::value, void>::type
 assign(Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
        const cons_index_list<I, nil_index_list>& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, 1>& y, const char* name = "ANON",
@@ -154,7 +153,7 @@ assign(Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
  * the indexed size.
  */
 template <typename T, typename I, typename U>
-inline typename boost::disable_if<boost::is_same<I, index_uni>, void>::type
+inline typename std::enable_if<!std::is_same<I, index_uni>::value, void>::type
 assign(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
        const cons_index_list<I, nil_index_list>& idxs,
        const Eigen::Matrix<U, 1, Eigen::Dynamic>& y, const char* name = "ANON",
@@ -219,7 +218,7 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and right-hand side matrix do not match.
  */
 template <typename T, typename I, typename U>
-inline typename boost::disable_if<boost::is_same<I, index_uni>, void>::type
+inline typename std::enable_if<!std::is_same<I, index_uni>::value, void>::type
 assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
        const cons_index_list<I, nil_index_list>& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,
@@ -285,7 +284,7 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and right-hand side row vector do not match.
  */
 template <typename T, typename I, typename U>
-inline typename boost::disable_if<boost::is_same<I, index_uni>, void>::type
+inline typename std::enable_if<!std::is_same<I, index_uni>::value, void>::type
 assign(
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idxs,
@@ -322,7 +321,7 @@ assign(
  * matrix and right-hand side vector do not match.
  */
 template <typename T, typename I, typename U>
-inline typename boost::disable_if<boost::is_same<I, index_uni>, void>::type
+inline typename std::enable_if<!std::is_same<I, index_uni>::value, void>::type
 assign(
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idxs,
@@ -360,8 +359,8 @@ assign(
  * matrix and value matrix do not match.
  */
 template <typename T, typename I1, typename I2, typename U>
-inline typename boost::disable_if_c<boost::is_same<I1, index_uni>::value
-                                        || boost::is_same<I2, index_uni>::value,
+inline typename std::enable_if_t<std::is_same<I1, index_uni>::value
+                                        || std::is_same<I2, index_uni>::value,
                                     void>::type
 assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
@@ -441,7 +440,7 @@ inline void assign(std::vector<T>& x, const cons_index_list<index_uni, L>& idxs,
  * the recursive tail assignment dimensions do not match.
  */
 template <typename T, typename I, typename L, typename U>
-typename boost::disable_if<boost::is_same<I, index_uni>, void>::
+typename std::enable_if<std::is_same<I, index_uni>::value, void>::
     type inline assign(std::vector<T>& x, const cons_index_list<I, L>& idxs,
                        const std::vector<U>& y, const char* name = "ANON",
                        int depth = 0) {

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -360,8 +360,8 @@ assign(
  */
 template <typename T, typename I1, typename I2, typename U>
 inline typename std::enable_if_t<std::is_same<I1, index_uni>::value
-                                        || std::is_same<I2, index_uni>::value,
-                                    void>::type
+                                     || std::is_same<I2, index_uni>::value,
+                                 void>::type
 assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -118,7 +118,7 @@ inline void assign(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
  * the indexed size.
  */
 template <typename T, typename I, typename U>
-inline typename std::enable_if<!std::is_same<I, index_uni>::value, void>::type
+inline typename std::enable_if_t<!std::is_same<I, index_uni>::value>::type
 assign(Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
        const cons_index_list<I, nil_index_list>& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, 1>& y, const char* name = "ANON",
@@ -153,7 +153,7 @@ assign(Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
  * the indexed size.
  */
 template <typename T, typename I, typename U>
-inline typename std::enable_if<!std::is_same<I, index_uni>::value, void>::type
+inline typename std::enable_if_t<!std::is_same<I, index_uni>::value>::type
 assign(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
        const cons_index_list<I, nil_index_list>& idxs,
        const Eigen::Matrix<U, 1, Eigen::Dynamic>& y, const char* name = "ANON",
@@ -218,7 +218,7 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and right-hand side matrix do not match.
  */
 template <typename T, typename I, typename U>
-inline typename std::enable_if<!std::is_same<I, index_uni>::value, void>::type
+inline typename std::enable_if_t<!std::is_same<I, index_uni>::value>::type
 assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
        const cons_index_list<I, nil_index_list>& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,
@@ -284,7 +284,7 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and right-hand side row vector do not match.
  */
 template <typename T, typename I, typename U>
-inline typename std::enable_if<!std::is_same<I, index_uni>::value, void>::type
+inline typename std::enable_if_t<!std::is_same<I, index_uni>::value>::type
 assign(
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idxs,
@@ -321,7 +321,7 @@ assign(
  * matrix and right-hand side vector do not match.
  */
 template <typename T, typename I, typename U>
-inline typename std::enable_if<!std::is_same<I, index_uni>::value, void>::type
+inline typename std::enable_if_t<!std::is_same<I, index_uni>::value>::type
 assign(
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idxs,
@@ -359,9 +359,8 @@ assign(
  * matrix and value matrix do not match.
  */
 template <typename T, typename I1, typename I2, typename U>
-inline typename std::enable_if_t<std::is_same<I1, index_uni>::value
-                                     || std::is_same<I2, index_uni>::value,
-                                 void>::type
+inline typename std::enable_if_t<!std::is_same<I1, index_uni>::value
+                                     && !std::is_same<I2, index_uni>::value>::type
 assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,
@@ -440,7 +439,7 @@ inline void assign(std::vector<T>& x, const cons_index_list<index_uni, L>& idxs,
  * the recursive tail assignment dimensions do not match.
  */
 template <typename T, typename I, typename L, typename U>
-typename std::enable_if<std::is_same<I, index_uni>::value, void>::
+typename std::enable_if_t<!std::is_same<I, index_uni>::value>::
     type inline assign(std::vector<T>& x, const cons_index_list<I, L>& idxs,
                        const std::vector<U>& y, const char* name = "ANON",
                        int depth = 0) {

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -118,7 +118,7 @@ inline void assign(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
  * the indexed size.
  */
 template <typename T, typename I, typename U>
-inline typename std::enable_if_t<!std::is_same<I, index_uni>::value>::type
+inline std::enable_if_t<!std::is_same<I, index_uni>::value>
 assign(Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
        const cons_index_list<I, nil_index_list>& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, 1>& y, const char* name = "ANON",
@@ -153,7 +153,7 @@ assign(Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
  * the indexed size.
  */
 template <typename T, typename I, typename U>
-inline typename std::enable_if_t<!std::is_same<I, index_uni>::value>::type
+inline std::enable_if_t<!std::is_same<I, index_uni>::value>
 assign(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
        const cons_index_list<I, nil_index_list>& idxs,
        const Eigen::Matrix<U, 1, Eigen::Dynamic>& y, const char* name = "ANON",
@@ -218,7 +218,7 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and right-hand side matrix do not match.
  */
 template <typename T, typename I, typename U>
-inline typename std::enable_if_t<!std::is_same<I, index_uni>::value>::type
+inline std::enable_if_t<!std::is_same<I, index_uni>::value>
 assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
        const cons_index_list<I, nil_index_list>& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,
@@ -284,7 +284,7 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and right-hand side row vector do not match.
  */
 template <typename T, typename I, typename U>
-inline typename std::enable_if_t<!std::is_same<I, index_uni>::value>::type
+inline std::enable_if_t<!std::is_same<I, index_uni>::value>
 assign(
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idxs,
@@ -321,7 +321,7 @@ assign(
  * matrix and right-hand side vector do not match.
  */
 template <typename T, typename I, typename U>
-inline typename std::enable_if_t<!std::is_same<I, index_uni>::value>::type
+inline std::enable_if_t<!std::is_same<I, index_uni>::value>
 assign(
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idxs,
@@ -359,8 +359,8 @@ assign(
  * matrix and value matrix do not match.
  */
 template <typename T, typename I1, typename I2, typename U>
-inline typename std::enable_if_t<!std::is_same<I1, index_uni>::value
-                                 && !std::is_same<I2, index_uni>::value>::type
+inline std::enable_if_t<!std::is_same<I1, index_uni>::value
+                                 && !std::is_same<I2, index_uni>::value>
 assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,
@@ -439,8 +439,8 @@ inline void assign(std::vector<T>& x, const cons_index_list<index_uni, L>& idxs,
  * the recursive tail assignment dimensions do not match.
  */
 template <typename T, typename I, typename L, typename U>
-typename std::enable_if_t<!std::is_same<I, index_uni>::value>::
-    type inline assign(std::vector<T>& x, const cons_index_list<I, L>& idxs,
+std::enable_if_t<!std::is_same<I, index_uni>::value>
+ inline assign(std::vector<T>& x, const cons_index_list<I, L>& idxs,
                        const std::vector<U>& y, const char* name = "ANON",
                        int depth = 0) {
   int x_idx_size = rvalue_index_size(idxs.head_, x.size());

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -360,7 +360,7 @@ assign(
  */
 template <typename T, typename I1, typename I2, typename U>
 inline typename std::enable_if_t<!std::is_same<I1, index_uni>::value
-                                && !std::is_same<I2, index_uni>::value>::type
+                                 && !std::is_same<I2, index_uni>::value>::type
 assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -360,7 +360,7 @@ assign(
  */
 template <typename T, typename I1, typename I2, typename U>
 inline typename std::enable_if_t<!std::is_same<I1, index_uni>::value
-                                     && !std::is_same<I2, index_uni>::value>::type
+                                && !std::is_same<I2, index_uni>::value>::type
 assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -118,11 +118,11 @@ inline void assign(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
  * the indexed size.
  */
 template <typename T, typename I, typename U>
-inline std::enable_if_t<!std::is_same<I, index_uni>::value>
-assign(Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
-       const cons_index_list<I, nil_index_list>& idxs,
-       const Eigen::Matrix<U, Eigen::Dynamic, 1>& y, const char* name = "ANON",
-       int depth = 0) {
+inline std::enable_if_t<!std::is_same<I, index_uni>::value> assign(
+    Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
+    const cons_index_list<I, nil_index_list>& idxs,
+    const Eigen::Matrix<U, Eigen::Dynamic, 1>& y, const char* name = "ANON",
+    int depth = 0) {
   math::check_size_match("vector[multi] assign sizes", "lhs",
                          rvalue_index_size(idxs.head_, x.size()), name,
                          y.size());
@@ -153,11 +153,11 @@ assign(Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
  * the indexed size.
  */
 template <typename T, typename I, typename U>
-inline std::enable_if_t<!std::is_same<I, index_uni>::value>
-assign(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
-       const cons_index_list<I, nil_index_list>& idxs,
-       const Eigen::Matrix<U, 1, Eigen::Dynamic>& y, const char* name = "ANON",
-       int depth = 0) {
+inline std::enable_if_t<!std::is_same<I, index_uni>::value> assign(
+    Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
+    const cons_index_list<I, nil_index_list>& idxs,
+    const Eigen::Matrix<U, 1, Eigen::Dynamic>& y, const char* name = "ANON",
+    int depth = 0) {
   math::check_size_match("row_vector[multi] assign sizes", "lhs",
                          rvalue_index_size(idxs.head_, x.size()), name,
                          y.size());
@@ -218,11 +218,11 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and right-hand side matrix do not match.
  */
 template <typename T, typename I, typename U>
-inline std::enable_if_t<!std::is_same<I, index_uni>::value>
-assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
-       const cons_index_list<I, nil_index_list>& idxs,
-       const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,
-       const char* name = "ANON", int depth = 0) {
+inline std::enable_if_t<!std::is_same<I, index_uni>::value> assign(
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
+    const cons_index_list<I, nil_index_list>& idxs,
+    const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,
+    const char* name = "ANON", int depth = 0) {
   int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
   math::check_size_match("matrix[multi] assign row sizes", "lhs", x_idx_rows,
                          name, y.rows());
@@ -284,8 +284,7 @@ void assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * matrix and right-hand side row vector do not match.
  */
 template <typename T, typename I, typename U>
-inline std::enable_if_t<!std::is_same<I, index_uni>::value>
-assign(
+inline std::enable_if_t<!std::is_same<I, index_uni>::value> assign(
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idxs,
     const Eigen::Matrix<U, 1, Eigen::Dynamic>& y, const char* name = "ANON",
@@ -321,8 +320,7 @@ assign(
  * matrix and right-hand side vector do not match.
  */
 template <typename T, typename I, typename U>
-inline std::enable_if_t<!std::is_same<I, index_uni>::value>
-assign(
+inline std::enable_if_t<!std::is_same<I, index_uni>::value> assign(
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idxs,
     const Eigen::Matrix<U, Eigen::Dynamic, 1>& y, const char* name = "ANON",
@@ -360,7 +358,7 @@ assign(
  */
 template <typename T, typename I1, typename I2, typename U>
 inline std::enable_if_t<!std::is_same<I1, index_uni>::value
-                                 && !std::is_same<I2, index_uni>::value>
+                        && !std::is_same<I2, index_uni>::value>
 assign(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
        const Eigen::Matrix<U, Eigen::Dynamic, Eigen::Dynamic>& y,
@@ -439,10 +437,9 @@ inline void assign(std::vector<T>& x, const cons_index_list<index_uni, L>& idxs,
  * the recursive tail assignment dimensions do not match.
  */
 template <typename T, typename I, typename L, typename U>
-std::enable_if_t<!std::is_same<I, index_uni>::value>
- inline assign(std::vector<T>& x, const cons_index_list<I, L>& idxs,
-                       const std::vector<U>& y, const char* name = "ANON",
-                       int depth = 0) {
+std::enable_if_t<!std::is_same<I, index_uni>::value> inline assign(
+    std::vector<T>& x, const cons_index_list<I, L>& idxs,
+    const std::vector<U>& y, const char* name = "ANON", int depth = 0) {
   int x_idx_size = rvalue_index_size(idxs.head_, x.size());
   math::check_size_match("vector[multi,...] assign sizes", "lhs", x_idx_size,
                          name, y.size());

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -92,8 +92,8 @@ inline T rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
  * @return Result of indexing vector.
  */
 template <typename T, typename I>
-inline typename std::enable_if<!std::is_same<I, index_uni>::value,
-                               Eigen::Matrix<T, Eigen::Dynamic, 1> >::type
+inline std::enable_if_t<!std::is_same<I, index_uni>::value,
+                               Eigen::Matrix<T, Eigen::Dynamic, 1> >
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
        int depth = 0) {
@@ -123,8 +123,8 @@ rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
  * @return Result of indexing vector.
  */
 template <typename T, typename I>
-inline typename std::enable_if<!std::is_same<I, index_uni>::value,
-                               Eigen::Matrix<T, 1, Eigen::Dynamic> >::type
+inline std::enable_if_t<!std::is_same<I, index_uni>::value,
+                               Eigen::Matrix<T, 1, Eigen::Dynamic> >
 rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
        int depth = 0) {
@@ -176,9 +176,9 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I>
-inline typename std::enable_if<
+inline std::enable_if_t<
     !std::is_same<I, index_uni>::value,
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >::type
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
        int depth = 0) {
@@ -234,8 +234,8 @@ inline T rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I>
-inline typename std::enable_if<!std::is_same<I, index_uni>::value,
-                               Eigen::Matrix<T, 1, Eigen::Dynamic> >::type
+inline std::enable_if_t<!std::is_same<I, index_uni>::value,
+                               Eigen::Matrix<T, 1, Eigen::Dynamic> >
 rvalue(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idx,
@@ -262,8 +262,8 @@ rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I>
-inline typename std::enable_if<std::is_same<I, index_uni>::value,
-                               Eigen::Matrix<T, Eigen::Dynamic, 1> >::type
+inline std::enable_if_t<std::is_same<I, index_uni>::value,
+                               Eigen::Matrix<T, Eigen::Dynamic, 1> >
 rvalue(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idx,
@@ -296,9 +296,9 @@ rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I1, typename I2>
-inline typename std::enable_if_t<
-    std::is_same<I1, index_uni>::value || std::is_same<I2, index_uni>::value,
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >::type
+inline std::enable_if_t<
+    !std::is_same<I1, index_uni>::value && !std::is_same<I2, index_uni>::value,
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idx,
        const char* name = "ANON", int depth = 0) {

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -1,14 +1,13 @@
 #ifndef STAN_MODEL_INDEXING_RVALUE_HPP
 #define STAN_MODEL_INDEXING_RVALUE_HPP
 
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_same.hpp>
 #include <stan/math/prim.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/index_list.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>
 #include <stan/model/indexing/rvalue_index_size.hpp>
 #include <stan/model/indexing/rvalue_return.hpp>
+#include <type_traits>
 #include <vector>
 
 namespace stan {
@@ -93,7 +92,7 @@ inline T rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
  * @return Result of indexing vector.
  */
 template <typename T, typename I>
-inline typename boost::disable_if<boost::is_same<I, index_uni>,
+inline typename std::enable_if<std::is_same<I, index_uni>::value,
                                   Eigen::Matrix<T, Eigen::Dynamic, 1> >::type
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
@@ -124,7 +123,7 @@ rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
  * @return Result of indexing vector.
  */
 template <typename T, typename I>
-inline typename boost::disable_if<boost::is_same<I, index_uni>,
+inline typename std::enable_if<std::is_same<I, index_uni>::value,
                                   Eigen::Matrix<T, 1, Eigen::Dynamic> >::type
 rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
@@ -177,8 +176,8 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I>
-inline typename boost::disable_if<
-    boost::is_same<I, index_uni>,
+inline typename std::enable_if<
+    std::is_same<I, index_uni>::value,
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >::type
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
@@ -235,7 +234,7 @@ inline T rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I>
-inline typename boost::disable_if<boost::is_same<I, index_uni>,
+inline typename std::enable_if<std::is_same<I, index_uni>::value,
                                   Eigen::Matrix<T, 1, Eigen::Dynamic> >::type
 rvalue(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
@@ -263,7 +262,7 @@ rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I>
-inline typename boost::disable_if<boost::is_same<I, index_uni>,
+inline typename std::enable_if<std::is_same<I, index_uni>::value,
                                   Eigen::Matrix<T, Eigen::Dynamic, 1> >::type
 rvalue(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
@@ -297,9 +296,9 @@ rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I1, typename I2>
-inline typename boost::disable_if_c<
-    boost::is_same<I1, index_uni>::value
-        || boost::is_same<I2, index_uni>::value,
+inline typename std::enable_if_t<
+    std::is_same<I1, index_uni>::value
+        || std::is_same<I2, index_uni>::value,
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >::type
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idx,

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -92,7 +92,7 @@ inline T rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
  * @return Result of indexing vector.
  */
 template <typename T, typename I>
-inline typename std::enable_if<std::is_same<I, index_uni>::value,
+inline typename std::enable_if<!std::is_same<I, index_uni>::value,
                                Eigen::Matrix<T, Eigen::Dynamic, 1> >::type
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
@@ -123,7 +123,7 @@ rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
  * @return Result of indexing vector.
  */
 template <typename T, typename I>
-inline typename std::enable_if<std::is_same<I, index_uni>::value,
+inline typename std::enable_if<!std::is_same<I, index_uni>::value,
                                Eigen::Matrix<T, 1, Eigen::Dynamic> >::type
 rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
@@ -177,7 +177,7 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> rvalue(
  */
 template <typename T, typename I>
 inline typename std::enable_if<
-    std::is_same<I, index_uni>::value,
+    !std::is_same<I, index_uni>::value,
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >::type
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
@@ -234,7 +234,7 @@ inline T rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I>
-inline typename std::enable_if<std::is_same<I, index_uni>::value,
+inline typename std::enable_if<!std::is_same<I, index_uni>::value,
                                Eigen::Matrix<T, 1, Eigen::Dynamic> >::type
 rvalue(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -93,7 +93,7 @@ inline T rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
  */
 template <typename T, typename I>
 inline typename std::enable_if<std::is_same<I, index_uni>::value,
-                                  Eigen::Matrix<T, Eigen::Dynamic, 1> >::type
+                               Eigen::Matrix<T, Eigen::Dynamic, 1> >::type
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
        int depth = 0) {
@@ -124,7 +124,7 @@ rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
  */
 template <typename T, typename I>
 inline typename std::enable_if<std::is_same<I, index_uni>::value,
-                                  Eigen::Matrix<T, 1, Eigen::Dynamic> >::type
+                               Eigen::Matrix<T, 1, Eigen::Dynamic> >::type
 rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
        int depth = 0) {
@@ -235,7 +235,7 @@ inline T rvalue(
  */
 template <typename T, typename I>
 inline typename std::enable_if<std::is_same<I, index_uni>::value,
-                                  Eigen::Matrix<T, 1, Eigen::Dynamic> >::type
+                               Eigen::Matrix<T, 1, Eigen::Dynamic> >::type
 rvalue(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idx,
@@ -263,7 +263,7 @@ rvalue(
  */
 template <typename T, typename I>
 inline typename std::enable_if<std::is_same<I, index_uni>::value,
-                                  Eigen::Matrix<T, Eigen::Dynamic, 1> >::type
+                               Eigen::Matrix<T, Eigen::Dynamic, 1> >::type
 rvalue(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idx,
@@ -297,8 +297,7 @@ rvalue(
  */
 template <typename T, typename I1, typename I2>
 inline typename std::enable_if_t<
-    std::is_same<I1, index_uni>::value
-        || std::is_same<I2, index_uni>::value,
+    std::is_same<I1, index_uni>::value || std::is_same<I2, index_uni>::value,
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >::type
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idx,

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -261,7 +261,7 @@ rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I>
-inline std::enable_if_t<std::is_same<I, index_uni>::value,
+inline std::enable_if_t<!std::is_same<I, index_uni>::value,
                         Eigen::Matrix<T, Eigen::Dynamic, 1> >
 rvalue(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -93,7 +93,7 @@ inline T rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
  */
 template <typename T, typename I>
 inline std::enable_if_t<!std::is_same<I, index_uni>::value,
-                               Eigen::Matrix<T, Eigen::Dynamic, 1> >
+                        Eigen::Matrix<T, Eigen::Dynamic, 1> >
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
        int depth = 0) {
@@ -124,7 +124,7 @@ rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
  */
 template <typename T, typename I>
 inline std::enable_if_t<!std::is_same<I, index_uni>::value,
-                               Eigen::Matrix<T, 1, Eigen::Dynamic> >
+                        Eigen::Matrix<T, 1, Eigen::Dynamic> >
 rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
        int depth = 0) {
@@ -176,9 +176,8 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I>
-inline std::enable_if_t<
-    !std::is_same<I, index_uni>::value,
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
+inline std::enable_if_t<!std::is_same<I, index_uni>::value,
+                        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
        const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
        int depth = 0) {
@@ -235,7 +234,7 @@ inline T rvalue(
  */
 template <typename T, typename I>
 inline std::enable_if_t<!std::is_same<I, index_uni>::value,
-                               Eigen::Matrix<T, 1, Eigen::Dynamic> >
+                        Eigen::Matrix<T, 1, Eigen::Dynamic> >
 rvalue(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idx,
@@ -263,7 +262,7 @@ rvalue(
  */
 template <typename T, typename I>
 inline std::enable_if_t<std::is_same<I, index_uni>::value,
-                               Eigen::Matrix<T, Eigen::Dynamic, 1> >
+                        Eigen::Matrix<T, Eigen::Dynamic, 1> >
 rvalue(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idx,
@@ -296,9 +295,9 @@ rvalue(
  * @return Result of indexing matrix.
  */
 template <typename T, typename I1, typename I2>
-inline std::enable_if_t<
-    !std::is_same<I1, index_uni>::value && !std::is_same<I2, index_uni>::value,
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
+inline std::enable_if_t<!std::is_same<I1, index_uni>::value
+                            && !std::is_same<I2, index_uni>::value,
+                        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
 rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idx,
        const char* name = "ANON", int depth = 0) {

--- a/src/stan/model/model_header.hpp
+++ b/src/stan/model/model_header.hpp
@@ -15,7 +15,6 @@
 #include <stan/model/indexing.hpp>
 #include <stan/services/util/create_rng.hpp>
 
-#include <boost/exception/all.hpp>
 #include <boost/random/additive_combine.hpp>
 #include <boost/random/linear_congruential.hpp>
 

--- a/src/stan/optimization/bfgs.hpp
+++ b/src/stan/optimization/bfgs.hpp
@@ -7,7 +7,6 @@
 #include <stan/optimization/bfgs_linesearch.hpp>
 #include <stan/optimization/bfgs_update.hpp>
 #include <stan/optimization/lbfgs_update.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
@@ -323,7 +322,7 @@ class ModelAdaptor {
       return 1;
     }
 
-    if (boost::math::isfinite(f)) {
+    if (std::isfinite(f)) {
       return 0;
     } else {
       if (_msgs)
@@ -357,7 +356,7 @@ class ModelAdaptor {
 
     g.resize(_g.size());
     for (size_t i = 0; i < _g.size(); i++) {
-      if (!boost::math::isfinite(_g[i])) {
+      if (!std::isfinite(_g[i])) {
         if (_msgs)
           *_msgs << "Error evaluating model log probability: "
                     "Non-finite gradient."
@@ -367,7 +366,7 @@ class ModelAdaptor {
       g[i] = -_g[i];
     }
 
-    if (boost::math::isfinite(f)) {
+    if (std::isfinite(f)) {
       return 0;
     } else {
       if (_msgs)

--- a/src/stan/optimization/bfgs_linesearch.hpp
+++ b/src/stan/optimization/bfgs_linesearch.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_OPTIMIZATION_BFGS_LINESEARCH_HPP
 #define STAN_OPTIMIZATION_BFGS_LINESEARCH_HPP
 
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
@@ -134,7 +133,7 @@ int WolfLSZoom(Scalar &alpha, XType &newX, Scalar &newF, XType &newDF,
         d2 = -d2;
       alpha
           = ahi - (ahi - alo) * (ahiDFp + d2 - d1) / (ahiDFp - aloDFp + 2 * d2);
-      if (!boost::math::isfinite(alpha)
+      if (!std::isfinite(alpha)
           || alpha < std::min(alo, ahi) + 0.01 * std::fabs(alo - ahi)
           || alpha > std::max(alo, ahi) - 0.01 * std::fabs(alo - ahi))
         alpha = 0.5 * (alo + ahi);

--- a/src/stan/optimization/lbfgs_update.hpp
+++ b/src/stan/optimization/lbfgs_update.hpp
@@ -2,8 +2,8 @@
 #define STAN_OPTIMIZATION_LBFGS_UPDATE_HPP
 
 #include <Eigen/Dense>
-#include <boost/tuple/tuple.hpp>
 #include <boost/circular_buffer.hpp>
+#include <tuple>
 #include <vector>
 
 namespace stan {
@@ -19,7 +19,7 @@ class LBFGSUpdate {
   typedef Eigen::Matrix<Scalar, DimAtCompile, 1> VectorT;
   typedef Eigen::Matrix<Scalar, DimAtCompile, DimAtCompile> HessianT;
   // NOLINTNEXTLINE(build/include_what_you_use)
-  typedef boost::tuple<Scalar, VectorT, VectorT> UpdateT;
+  typedef std::tuple<Scalar, VectorT, VectorT> UpdateT;
 
   explicit LBFGSUpdate(size_t L = 5) : _buf(L) {}
 
@@ -57,7 +57,7 @@ class LBFGSUpdate {
     Scalar invskyk = 1.0 / skyk;
     _gammak = skyk / yk.squaredNorm();
     _buf.push_back();
-    _buf.back() = boost::tie(invskyk, yk, sk);
+    _buf.back() = std::tie(invskyk, yk, sk);
 
     return B0fact;
   }
@@ -81,9 +81,9 @@ class LBFGSUpdate {
     for (buf_rit = _buf.rbegin(), alpha_rit = alphas.rbegin();
          buf_rit != _buf.rend(); buf_rit++, alpha_rit++) {
       Scalar alpha;
-      const Scalar &rhoi(boost::get<0>(*buf_rit));
-      const VectorT &yi(boost::get<1>(*buf_rit));
-      const VectorT &si(boost::get<2>(*buf_rit));
+      const Scalar &rhoi(std::get<0>(*buf_rit));
+      const VectorT &yi(std::get<1>(*buf_rit));
+      const VectorT &si(std::get<2>(*buf_rit));
 
       alpha = rhoi * si.dot(pk);
       pk -= alpha * yi;
@@ -93,9 +93,9 @@ class LBFGSUpdate {
     for (buf_it = _buf.begin(), alpha_it = alphas.begin(); buf_it != _buf.end();
          buf_it++, alpha_it++) {
       Scalar beta;
-      const Scalar &rhoi(boost::get<0>(*buf_it));
-      const VectorT &yi(boost::get<1>(*buf_it));
-      const VectorT &si(boost::get<2>(*buf_it));
+      const Scalar &rhoi(std::get<0>(*buf_it));
+      const VectorT &yi(std::get<1>(*buf_it));
+      const VectorT &si(std::get<2>(*buf_it));
 
       beta = rhoi * yi.dot(pk);
       pk += (*alpha_it - beta) * si;

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -146,7 +146,7 @@ std::vector<double> initialize(Model& model, const stan::io::var_context& init,
       logger.info(e.what());
       throw;
     }
-    if (!boost::math::isfinite(log_prob)) {
+    if (!std::isfinite(log_prob)) {
       logger.info("Rejecting initial value:");
       logger.info(
           "  Log probability evaluates to log(0),"
@@ -176,7 +176,7 @@ std::vector<double> initialize(Model& model, const stan::io::var_context& init,
     if (log_prob_msg.str().length() > 0)
       logger.info(log_prob_msg);
 
-    bool gradient_ok = boost::math::isfinite(stan::math::sum(gradient));
+    bool gradient_ok = std::isfinite(stan::math::sum(gradient));
 
     if (!gradient_ok) {
       logger.info("Rejecting initial value:");


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is part of a wider cleanup to address stan-dev/cmdstan#863

Replaces: 

- `boost::math::isfinite` with `std::isfinite`
- changes `BOOST_THROW_EXCEPTION(std::invalid_argument(msg));` to `throw std::invalid_argument(msg);`
- boost::math::isnan(h) with std::isnan(h) 
- disable_if with std::enable_if
- cleans up unused headers

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
