### PR TITLE
cpplint: Harmonize with stan-dev/math

### DIFF
--- a/make/cpplint
+++ b/make/cpplint
@@ -1,13 +1,5 @@
-PYTHON2 ?= python
-# Check version because new distros have python to default to Python3
-PYTHON_VERSION := $(shell $(PYTHON2) -c "print(__import__('sys').version.split(' ' )[0].split('.')[0])")
-ifeq ($(PYTHON_VERSION),)
-  $(warning Python2 required by cpplint, but PYTHON2=$(PYTHON2) not found. See 'make help')
-endif
-ifeq ($(PYTHON_VERSION),3)
-  $(warning Python2 required by cpplint, but PYTHON2=$(PYTHON2) is Python3. See 'make help')
-endif
+PYTHON ?= python
 
 .PHONY: cpplint
 cpplint:
-	@$(PYTHON2) $(CPPLINT)/cpplint.py --output=vs7 --counting=detailed --root=src --extension=hpp,cpp --filter=-runtime/indentation_namespace,-readability/namespace,-legal/copyright,-whitespace/indent,-runtime/reference,-build/c++11 $(shell find src/stan -name '*.hpp' -o -name '*.cpp')
+	@$(PYTHON) $(CPPLINT)/cpplint.py --output=vs7 --counting=detailed --root=src --extension=hpp,cpp --filter=-runtime/indentation_namespace,-build/c++11,-readability/namespace,-legal/copyright,-whitespace/indent,-runtime/reference,-build/header_guard,-build/include_order,-build/include_what_you_use,-runtime/string,-build/namespaces $(shell find src/stan -name '*.hpp' -o -name '*.cpp')


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Updates `cpplint` so `python 2` is no longer required.

This change ONLY makes sense when https://github.com/stan-dev/math/pull/1871 has been merged.

#### Intended Effect

No more warnings about `python 2` while running `cpplint`

#### How to Verify

`make cpplint`

#### Side Effects

VERY dependent on this:

https://github.com/stan-dev/math/pull/1871

#### Documentation

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rohit Goswami <rg0swami[at]yahoo.com>

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)