### PR TITLE
Replace clock_t with std::chrono

### DIFF
--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -65,15 +65,13 @@ int fixed_param(Model& model, const stan::io::var_context& init,
   writer.write_sample_names(s, sampler, model);
   writer.write_diagnostic_names(s, sampler, model);
 
-  clock_t start = clock();
-
+  auto start = std::chrono::steady_clock::now();
   util::generate_transitions(sampler, num_samples, 0, num_samples, num_thin,
                              refresh, true, false, writer, s, model, rng,
                              interrupt, logger);
-  clock_t end = clock();
-
-  double sampleDeltaT = static_cast<double>(end - start) / CLOCKS_PER_SEC;
-  writer.write_timing(0.0, sampleDeltaT);
+  auto end = std::chrono::steady_clock::now();
+  std::chrono::duration<double> sample_delta_t = end-start;
+  writer.write_timing(0.0, sample_delta_t.count());
 
   return error_codes::OK;
 }

--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -72,7 +72,7 @@ int fixed_param(Model& model, const stan::io::var_context& init,
                              interrupt, logger);
   auto end = std::chrono::steady_clock::now();
   double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()/1000.0;
-  writer.write_timing(0.0, sample_delta_t.count());
+  writer.write_timing(0.0, sample_delta_t);
 
   return error_codes::OK;
 }

--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -71,7 +71,7 @@ int fixed_param(Model& model, const stan::io::var_context& init,
                              refresh, true, false, writer, s, model, rng,
                              interrupt, logger);
   auto end = std::chrono::steady_clock::now();
-  std::chrono::duration<double> sample_delta_t = end - start;
+  double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()/1000.0;
   writer.write_timing(0.0, sample_delta_t.count());
 
   return error_codes::OK;

--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -71,8 +71,10 @@ int fixed_param(Model& model, const stan::io::var_context& init,
                              refresh, true, false, writer, s, model, rng,
                              interrupt, logger);
   auto end = std::chrono::steady_clock::now();
-  double sample_delta_t = std::chrono::duration_cast
-    <std::chrono::milliseconds>(end - start).count()/1000.0;
+  double sample_delta_t
+      = std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+            .count()
+        / 1000.0;
   writer.write_timing(0.0, sample_delta_t);
 
   return error_codes::OK;

--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -11,6 +11,7 @@
 #include <stan/services/util/generate_transitions.hpp>
 #include <stan/services/util/create_rng.hpp>
 #include <stan/services/util/initialize.hpp>
+#include <chrono>
 #include <vector>
 
 namespace stan {

--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -70,7 +70,7 @@ int fixed_param(Model& model, const stan::io::var_context& init,
                              refresh, true, false, writer, s, model, rng,
                              interrupt, logger);
   auto end = std::chrono::steady_clock::now();
-  std::chrono::duration<double> sample_delta_t = end-start;
+  std::chrono::duration<double> sample_delta_t = end - start;
   writer.write_timing(0.0, sample_delta_t.count());
 
   return error_codes::OK;

--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -71,7 +71,8 @@ int fixed_param(Model& model, const stan::io::var_context& init,
                              refresh, true, false, writer, s, model, rng,
                              interrupt, logger);
   auto end = std::chrono::steady_clock::now();
-  double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()/1000.0;
+  double sample_delta_t = std::chrono::duration_cast
+    <std::chrono::milliseconds>(end - start).count()/1000.0;
   writer.write_timing(0.0, sample_delta_t);
 
   return error_codes::OK;

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -171,7 +171,7 @@ std::vector<double> initialize(Model& model, const stan::io::var_context& init,
       throw;
     }
     auto end = std::chrono::steady_clock::now();
-    std::chrono::duration<double> diff = end-start;
+    std::chrono::duration<double> diff = end - start;
     double deltaT = diff.count();
     if (log_prob_msg.str().length() > 0)
       logger.info(log_prob_msg);

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -172,8 +172,10 @@ std::vector<double> initialize(Model& model, const stan::io::var_context& init,
       throw;
     }
     auto end = std::chrono::steady_clock::now();
-    double deltaT = std::chrono::duration_cast
-     <std::chrono::milliseconds>(end -start).count()/1000.0;
+    double deltaT
+        = std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+              .count()
+          / 1000.0;
     if (log_prob_msg.str().length() > 0)
       logger.info(log_prob_msg);
 

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -8,6 +8,7 @@
 #include <stan/io/chained_var_context.hpp>
 #include <stan/model/log_prob_grad.hpp>
 #include <stan/math/prim.hpp>
+#include <chrono>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -172,8 +172,7 @@ std::vector<double> initialize(Model& model, const stan::io::var_context& init,
       throw;
     }
     auto end = std::chrono::steady_clock::now();
-    std::chrono::duration<double> diff = end - start;
-    double deltaT = diff.count();
+    double deltaT = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()/1000.0;
     if (log_prob_msg.str().length() > 0)
       logger.info(log_prob_msg);
 

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -158,7 +158,7 @@ std::vector<double> initialize(Model& model, const stan::io::var_context& init,
     }
     std::stringstream log_prob_msg;
     std::vector<double> gradient;
-    clock_t start_check = clock();
+    auto start = std::chrono::steady_clock::now();
     try {
       // we evaluate this with propto=true since we're
       // evaluating with autodiff variables
@@ -170,9 +170,9 @@ std::vector<double> initialize(Model& model, const stan::io::var_context& init,
       logger.info(e.what());
       throw;
     }
-    clock_t end_check = clock();
-    double deltaT
-        = static_cast<double>(end_check - start_check) / CLOCKS_PER_SEC;
+    auto end = std::chrono::steady_clock::now();
+    std::chrono::duration<double> diff = end-start;
+    double deltaT = diff.count();
     if (log_prob_msg.str().length() > 0)
       logger.info(log_prob_msg);
 

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -172,7 +172,8 @@ std::vector<double> initialize(Model& model, const stan::io::var_context& init,
       throw;
     }
     auto end = std::chrono::steady_clock::now();
-    double deltaT = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()/1000.0;
+    double deltaT = std::chrono::duration_cast
+     <std::chrono::milliseconds>(end -start).count()/1000.0;
     if (log_prob_msg.str().length() > 0)
       logger.info(log_prob_msg);
 

--- a/src/stan/services/util/run_adaptive_sampler.hpp
+++ b/src/stan/services/util/run_adaptive_sampler.hpp
@@ -71,9 +71,8 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
   double warm_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(
                             end_warm - start_warm)
                             .count()
-                        / 1000.0
-
-                          sampler.disengage_adaptation();
+                        / 1000.0;
+  sampler.disengage_adaptation();
   writer.write_adapt_finish(sampler);
   sampler.write_sampler_state(sample_writer);
 
@@ -85,9 +84,8 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
   double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(
                               end_sample - start_sample)
                               .count()
-                          / 1000.0
-
-                            writer.write_timing(warm_delta_t, sample_delta_t);
+                          / 1000.0;
+  writer.write_timing(warm_delta_t, sample_delta_t);
 }
 }  // namespace util
 }  // namespace services

--- a/src/stan/services/util/run_adaptive_sampler.hpp
+++ b/src/stan/services/util/run_adaptive_sampler.hpp
@@ -5,7 +5,7 @@
 #include <stan/callbacks/writer.hpp>
 #include <stan/services/util/generate_transitions.hpp>
 #include <stan/services/util/mcmc_writer.hpp>
-#include <ctime>
+#include <chrono>
 #include <vector>
 
 namespace stan {

--- a/src/stan/services/util/run_adaptive_sampler.hpp
+++ b/src/stan/services/util/run_adaptive_sampler.hpp
@@ -68,7 +68,7 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
                              num_thin, refresh, save_warmup, true, writer, s,
                              model, rng, interrupt, logger);
   auto end_warm = std::chrono::steady_clock::now();
-  std::chrono::duration<double> warm_delta_t = end_warm - start_warm;
+  double warm_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end_warm - start_warm).count()/1000.0
 
   sampler.disengage_adaptation();
   writer.write_adapt_finish(sampler);
@@ -79,9 +79,9 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
   auto end_sample = std::chrono::steady_clock::now();
-  std::chrono::duration<double> sample_delta_t = end_sample - start_sample;
+  double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end_sample - start_sample).count()/1000.0
 
-  writer.write_timing(warm_delta_t.count(), sample_delta_t.count());
+  writer.write_timing(warm_delta_t, sample_delta_t);
 }
 }  // namespace util
 }  // namespace services

--- a/src/stan/services/util/run_adaptive_sampler.hpp
+++ b/src/stan/services/util/run_adaptive_sampler.hpp
@@ -68,10 +68,12 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
                              num_thin, refresh, save_warmup, true, writer, s,
                              model, rng, interrupt, logger);
   auto end_warm = std::chrono::steady_clock::now();
-  double warm_delta_t = std::chrono::duration_cast
-    <std::chrono::milliseconds>(end_warm - start_warm).count()/1000.0
+  double warm_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            end_warm - start_warm)
+                            .count()
+                        / 1000.0
 
-  sampler.disengage_adaptation();
+                          sampler.disengage_adaptation();
   writer.write_adapt_finish(sampler);
   sampler.write_sampler_state(sample_writer);
 
@@ -80,10 +82,12 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
   auto end_sample = std::chrono::steady_clock::now();
-  double sample_delta_t = std::chrono::duration_cast
-    <std::chrono::milliseconds>(end_sample - start_sample).count()/1000.0
+  double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              end_sample - start_sample)
+                              .count()
+                          / 1000.0
 
-  writer.write_timing(warm_delta_t, sample_delta_t);
+                            writer.write_timing(warm_delta_t, sample_delta_t);
 }
 }  // namespace util
 }  // namespace services

--- a/src/stan/services/util/run_adaptive_sampler.hpp
+++ b/src/stan/services/util/run_adaptive_sampler.hpp
@@ -68,7 +68,8 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
                              num_thin, refresh, save_warmup, true, writer, s,
                              model, rng, interrupt, logger);
   auto end_warm = std::chrono::steady_clock::now();
-  double warm_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end_warm - start_warm).count()/1000.0
+  double warm_delta_t = std::chrono::duration_cast
+    <std::chrono::milliseconds>(end_warm - start_warm).count()/1000.0
 
   sampler.disengage_adaptation();
   writer.write_adapt_finish(sampler);
@@ -79,7 +80,8 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
   auto end_sample = std::chrono::steady_clock::now();
-  double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end_sample - start_sample).count()/1000.0
+  double sample_delta_t = std::chrono::duration_cast
+    <std::chrono::milliseconds>(end_sample - start_sample).count()/1000.0
 
   writer.write_timing(warm_delta_t, sample_delta_t);
 }

--- a/src/stan/services/util/run_adaptive_sampler.hpp
+++ b/src/stan/services/util/run_adaptive_sampler.hpp
@@ -63,25 +63,25 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
   writer.write_sample_names(s, sampler, model);
   writer.write_diagnostic_names(s, sampler, model);
 
-  clock_t start = clock();
+  auto start_warm = std::chrono::steady_clock::now();
   util::generate_transitions(sampler, num_warmup, 0, num_warmup + num_samples,
                              num_thin, refresh, save_warmup, true, writer, s,
                              model, rng, interrupt, logger);
-  clock_t end = clock();
-  double warm_delta_t = static_cast<double>(end - start) / CLOCKS_PER_SEC;
+  auto end_warm = std::chrono::steady_clock::now();
+  std::chrono::duration<double> warm_delta_t = end_warm-start_warm;
 
   sampler.disengage_adaptation();
   writer.write_adapt_finish(sampler);
   sampler.write_sampler_state(sample_writer);
 
-  start = clock();
+  auto start_sample = std::chrono::steady_clock::now();
   util::generate_transitions(sampler, num_samples, num_warmup,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
-  end = clock();
-  double sample_delta_t = static_cast<double>(end - start) / CLOCKS_PER_SEC;
+  auto end_sample = std::chrono::steady_clock::now();
+  std::chrono::duration<double> sample_delta_t = end_sample-start_sample;
 
-  writer.write_timing(warm_delta_t, sample_delta_t);
+  writer.write_timing(warm_delta_t.count(), sample_delta_t.count());
 }
 }  // namespace util
 }  // namespace services

--- a/src/stan/services/util/run_adaptive_sampler.hpp
+++ b/src/stan/services/util/run_adaptive_sampler.hpp
@@ -68,7 +68,7 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
                              num_thin, refresh, save_warmup, true, writer, s,
                              model, rng, interrupt, logger);
   auto end_warm = std::chrono::steady_clock::now();
-  std::chrono::duration<double> warm_delta_t = end_warm-start_warm;
+  std::chrono::duration<double> warm_delta_t = end_warm - start_warm;
 
   sampler.disengage_adaptation();
   writer.write_adapt_finish(sampler);
@@ -79,7 +79,7 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
   auto end_sample = std::chrono::steady_clock::now();
-  std::chrono::duration<double> sample_delta_t = end_sample-start_sample;
+  std::chrono::duration<double> sample_delta_t = end_sample - start_sample;
 
   writer.write_timing(warm_delta_t.count(), sample_delta_t.count());
 }

--- a/src/stan/services/util/run_sampler.hpp
+++ b/src/stan/services/util/run_sampler.hpp
@@ -56,9 +56,8 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
   double warm_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(
                             end_warm - start_warm)
                             .count()
-                        / 1000.0
-
-                          writer.write_adapt_finish(sampler);
+                        / 1000.0;
+  writer.write_adapt_finish(sampler);
   sampler.write_sampler_state(sample_writer);
 
   auto start_sample = std::chrono::steady_clock::now();
@@ -69,9 +68,8 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
   double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(
                               end_sample - start_sample)
                               .count()
-                          / 1000.0
-
-                            writer.write_timing(warm_delta_t, sample_delta_t);
+                          / 1000.0;
+  writer.write_timing(warm_delta_t, sample_delta_t);
 }
 }  // namespace util
 }  // namespace services

--- a/src/stan/services/util/run_sampler.hpp
+++ b/src/stan/services/util/run_sampler.hpp
@@ -53,7 +53,8 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
                              num_thin, refresh, save_warmup, true, writer, s,
                              model, rng, interrupt, logger);
   auto end_warm = std::chrono::steady_clock::now();
-  double warm_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end_warm - start_warm).count()/1000.0
+  double warm_delta_t = std::chrono::duration_cast
+    <std::chrono::milliseconds>(end_warm - start_warm).count()/1000.0
 
   writer.write_adapt_finish(sampler);
   sampler.write_sampler_state(sample_writer);
@@ -63,7 +64,8 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
   auto end_sample = std::chrono::steady_clock::now();
-  double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end_sample - start_sample).count()/1000.0
+  double sample_delta_t = std::chrono::duration_cast
+    <std::chrono::milliseconds>(end_sample - start_sample).count()/1000.0
 
   writer.write_timing(warm_delta_t, sample_delta_t);
 }

--- a/src/stan/services/util/run_sampler.hpp
+++ b/src/stan/services/util/run_sampler.hpp
@@ -53,7 +53,7 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
                              num_thin, refresh, save_warmup, true, writer, s,
                              model, rng, interrupt, logger);
   auto end_warm = std::chrono::steady_clock::now();
-  std::chrono::duration<double> warm_delta_t = end_warm - start_warm;
+  double warm_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end_warm - start_warm).count()/1000.0
 
   writer.write_adapt_finish(sampler);
   sampler.write_sampler_state(sample_writer);
@@ -63,9 +63,9 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
   auto end_sample = std::chrono::steady_clock::now();
-  std::chrono::duration<double> sample_delta_t = end_sample - start_sample;
+  double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end_sample - start_sample).count()/1000.0
 
-  writer.write_timing(warm_delta_t.count(), sample_delta_t.count());
+  writer.write_timing(warm_delta_t, sample_delta_t);
 }
 }  // namespace util
 }  // namespace services

--- a/src/stan/services/util/run_sampler.hpp
+++ b/src/stan/services/util/run_sampler.hpp
@@ -4,7 +4,7 @@
 #include <stan/callbacks/logger.hpp>
 #include <stan/services/util/generate_transitions.hpp>
 #include <stan/services/util/mcmc_writer.hpp>
-#include <ctime>
+#include <chrono>
 #include <vector>
 
 namespace stan {

--- a/src/stan/services/util/run_sampler.hpp
+++ b/src/stan/services/util/run_sampler.hpp
@@ -48,24 +48,24 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
   writer.write_sample_names(s, sampler, model);
   writer.write_diagnostic_names(s, sampler, model);
 
-  clock_t start = clock();
+  auto start_warm = std::chrono::steady_clock::now();
   util::generate_transitions(sampler, num_warmup, 0, num_warmup + num_samples,
                              num_thin, refresh, save_warmup, true, writer, s,
                              model, rng, interrupt, logger);
-  clock_t end = clock();
-  double warm_delta_t = static_cast<double>(end - start) / CLOCKS_PER_SEC;
+  auto end_warm = std::chrono::steady_clock::now();
+  std::chrono::duration<double> warm_delta_t = end_warm-start_warm;
 
   writer.write_adapt_finish(sampler);
   sampler.write_sampler_state(sample_writer);
 
-  start = clock();
+  auto start_sample = std::chrono::steady_clock::now();
   util::generate_transitions(sampler, num_samples, num_warmup,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
-  end = clock();
-  double sample_delta_t = static_cast<double>(end - start) / CLOCKS_PER_SEC;
+  auto end_sample = std::chrono::steady_clock::now();
+  std::chrono::duration<double> sample_delta_t = end_warm-start_warm;
 
-  writer.write_timing(warm_delta_t, sample_delta_t);
+  writer.write_timing(warm_delta_t.count(), sample_delta_t.count());
 }
 }  // namespace util
 }  // namespace services

--- a/src/stan/services/util/run_sampler.hpp
+++ b/src/stan/services/util/run_sampler.hpp
@@ -53,10 +53,12 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
                              num_thin, refresh, save_warmup, true, writer, s,
                              model, rng, interrupt, logger);
   auto end_warm = std::chrono::steady_clock::now();
-  double warm_delta_t = std::chrono::duration_cast
-    <std::chrono::milliseconds>(end_warm - start_warm).count()/1000.0
+  double warm_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            end_warm - start_warm)
+                            .count()
+                        / 1000.0
 
-  writer.write_adapt_finish(sampler);
+                          writer.write_adapt_finish(sampler);
   sampler.write_sampler_state(sample_writer);
 
   auto start_sample = std::chrono::steady_clock::now();
@@ -64,10 +66,12 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
   auto end_sample = std::chrono::steady_clock::now();
-  double sample_delta_t = std::chrono::duration_cast
-    <std::chrono::milliseconds>(end_sample - start_sample).count()/1000.0
+  double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              end_sample - start_sample)
+                              .count()
+                          / 1000.0
 
-  writer.write_timing(warm_delta_t, sample_delta_t);
+                            writer.write_timing(warm_delta_t, sample_delta_t);
 }
 }  // namespace util
 }  // namespace services

--- a/src/stan/services/util/run_sampler.hpp
+++ b/src/stan/services/util/run_sampler.hpp
@@ -63,7 +63,7 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
   auto end_sample = std::chrono::steady_clock::now();
-  std::chrono::duration<double> sample_delta_t = end_warm - start_warm;
+  std::chrono::duration<double> sample_delta_t = end_sample - start_sample;
 
   writer.write_timing(warm_delta_t.count(), sample_delta_t.count());
 }

--- a/src/stan/services/util/run_sampler.hpp
+++ b/src/stan/services/util/run_sampler.hpp
@@ -53,7 +53,7 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
                              num_thin, refresh, save_warmup, true, writer, s,
                              model, rng, interrupt, logger);
   auto end_warm = std::chrono::steady_clock::now();
-  std::chrono::duration<double> warm_delta_t = end_warm-start_warm;
+  std::chrono::duration<double> warm_delta_t = end_warm - start_warm;
 
   writer.write_adapt_finish(sampler);
   sampler.write_sampler_state(sample_writer);
@@ -63,7 +63,7 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
                              num_warmup + num_samples, num_thin, refresh, true,
                              false, writer, s, model, rng, interrupt, logger);
   auto end_sample = std::chrono::steady_clock::now();
-  std::chrono::duration<double> sample_delta_t = end_warm-start_warm;
+  std::chrono::duration<double> sample_delta_t = end_warm - start_warm;
 
   writer.write_timing(warm_delta_t.count(), sample_delta_t.count());
 }

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -13,12 +13,13 @@
 #include <boost/circular_buffer.hpp>
 #include <boost/lexical_cast.hpp>
 #include <algorithm>
+#include <chrono>
 #include <limits>
 #include <numeric>
 #include <ostream>
-#include <vector>
 #include <queue>
 #include <string>
+#include <vector>
 
 namespace stan {
 
@@ -387,7 +388,7 @@ class advi {
            << delta_elbo_ave << "  " << std::setw(15) << std::fixed
            << std::setprecision(3) << delta_elbo_med;
         auto end = std::chrono::steady_clock::now();
-        std::chrono::duration<double> delta_t = end_warm - start_warm;
+        std::chrono::duration<double> delta_t = end - start;
 
         std::vector<double> print_vector;
         print_vector.clear();

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -388,7 +388,8 @@ class advi {
            << delta_elbo_ave << "  " << std::setw(15) << std::fixed
            << std::setprecision(3) << delta_elbo_med;
         auto end = std::chrono::steady_clock::now();
-        double delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()/1000.0
+        double delta_t = std::chrono::duration_cast
+          <std::chrono::milliseconds>(end - start).count()/1000.0
 
         std::vector<double> print_vector;
         print_vector.clear();

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -391,10 +391,8 @@ class advi {
         double delta_t
             = std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
                   .count()
-              / 1000.0
-
-              std::vector<double>
-                  print_vector;
+              / 1000.0;
+        std::vector<double> print_vector;
         print_vector.clear();
         print_vector.push_back(iter_counter);
         print_vector.push_back(delta_t);

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -388,12 +388,12 @@ class advi {
            << delta_elbo_ave << "  " << std::setw(15) << std::fixed
            << std::setprecision(3) << delta_elbo_med;
         auto end = std::chrono::steady_clock::now();
-        std::chrono::duration<double> delta_t = end - start;
+        double delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()/1000.0
 
         std::vector<double> print_vector;
         print_vector.clear();
         print_vector.push_back(iter_counter);
-        print_vector.push_back(delta_t.count());
+        print_vector.push_back(delta_t);
         print_vector.push_back(elbo);
         diagnostic_writer(print_vector);
 

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -388,10 +388,13 @@ class advi {
            << delta_elbo_ave << "  " << std::setw(15) << std::fixed
            << std::setprecision(3) << delta_elbo_med;
         auto end = std::chrono::steady_clock::now();
-        double delta_t = std::chrono::duration_cast
-          <std::chrono::milliseconds>(end - start).count()/1000.0
+        double delta_t
+            = std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+                  .count()
+              / 1000.0
 
-        std::vector<double> print_vector;
+              std::vector<double>
+                  print_vector;
         print_vector.clear();
         print_vector.push_back(iter_counter);
         print_vector.push_back(delta_t);

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -387,7 +387,7 @@ class advi {
            << delta_elbo_ave << "  " << std::setw(15) << std::fixed
            << std::setprecision(3) << delta_elbo_med;
         auto end = std::chrono::steady_clock::now();
-        std::chrono::duration<double> delta_t = end_warm-start_warm;
+        std::chrono::duration<double> delta_t = end_warm - start_warm;
 
         std::vector<double> print_vector;
         print_vector.clear();

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -347,9 +347,7 @@ class advi {
         "   notes ");
 
     // Timing variables
-    clock_t start = clock();
-    clock_t end;
-    double delta_t;
+    auto start = std::chrono::steady_clock::now();
 
     // Main loop
     bool do_more_iterations = true;
@@ -388,14 +386,13 @@ class advi {
            << std::setw(16) << std::fixed << std::setprecision(3)
            << delta_elbo_ave << "  " << std::setw(15) << std::fixed
            << std::setprecision(3) << delta_elbo_med;
-
-        end = clock();
-        delta_t = static_cast<double>(end - start) / CLOCKS_PER_SEC;
+        auto end = std::chrono::steady_clock::now();
+        std::chrono::duration<double> delta_t = end_warm-start_warm;
 
         std::vector<double> print_vector;
         print_vector.clear();
         print_vector.push_back(iter_counter);
-        print_vector.push_back(delta_t);
+        print_vector.push_back(delta_t.count());
         print_vector.push_back(elbo);
         diagnostic_writer(print_vector);
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes #2921 by replacing clock_t with std::chrono::steady_clock

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
