### PR TITLE
Bugfix/2817 refactor runtest

### DIFF
--- a/runTests.py
+++ b/runTests.py
@@ -13,6 +13,7 @@ import time
 winsfx = ".exe"
 testsfx = "_test.cpp"
 
+
 def processCLIArgs():
     """
     Define and process the command line interface to the runTests.py script.
@@ -20,77 +21,93 @@ def processCLIArgs():
     cli_description = "Generate and run stan math library tests."
     cli_epilog = "See more information at: https://github.com/stan-dev/stan"
 
-    parser = ArgumentParser(description=cli_description,
-                            epilog=cli_epilog,
-                            formatter_class=RawTextHelpFormatter)
+    parser = ArgumentParser(
+        description=cli_description,
+        epilog=cli_epilog,
+        formatter_class=RawTextHelpFormatter,
+    )
 
     # Now define all the rules of the command line args and opts
-    parser.add_argument("-j", metavar="N", type=int, default=1,
-                        help="number of cores for make to use")
+    parser.add_argument(
+        "-j", metavar="N", type=int, default=1, help="number of cores for make to use"
+    )
 
     tests_help_msg = "The path(s) to the test case(s) to run.\n"
     tests_help_msg += "Example: 'src/test/unit', 'src/test/integration', and/or\n"
     tests_help_msg += "         'src/test/unit/version_test'"
-    parser.add_argument("tests", nargs="+", type=str,
-                        help=tests_help_msg)
-    parser.add_argument("-m", "--make-only", dest="make_only",
-                        action="store_true", help="Don't run tests, just try to make them.")
+    parser.add_argument("tests", nargs="+", type=str, help=tests_help_msg)
+    parser.add_argument(
+        "-m",
+        "--make-only",
+        dest="make_only",
+        action="store_true",
+        help="Don't run tests, just try to make them.",
+    )
     # And parse the command line against those rules
     return parser.parse_args()
 
 
 def stopErr(msg, returncode):
     """Report an error message to stderr and exit with a given code."""
-    sys.stderr.write('%s\n' % msg)
-    sys.stderr.write('exit now (%s)\n' % time.strftime('%x %X %Z'))
+    sys.stderr.write("%s\n" % msg)
+    sys.stderr.write("exit now (%s)\n" % time.strftime("%x %X %Z"))
     sys.exit(returncode)
 
 
 def isWin():
-    return (platform.system().lower().startswith("windows")
-            or os.name.lower().startswith("windows"))
+    return platform.system().lower().startswith(
+        "windows"
+    ) or os.name.lower().startswith("windows")
+
 
 batchSize = 24 if isWin() else 200
 
+
 def mungeName(name):
     """Set up the makefile target name"""
-    if (name.startswith("src") or name.startswith("./src")):
-        name = name.replace("src/","",1)
-    if (name.endswith(testsfx)):
-        name = name.replace(testsfx,"_test")
-        if (isWin()):
+    if name.startswith("src") or name.startswith("./src"):
+        name = name.replace("src/", "", 1)
+    if name.endswith(testsfx):
+        name = name.replace(testsfx, "_test")
+        if isWin():
             name += winsfx
-            name = name.replace("\\","/")
+            name = name.replace("\\", "/")
     return name
+
 
 def doCommand(command, exit_on_failure=True):
     """Run command as a shell command and report/exit on errors."""
     print("------------------------------------------------------------")
     print("%s" % command)
-    if isWin() and command.startswith('make '):
-      command = command.replace('make ', 'mingw32-make ')
+    if isWin() and command.startswith("make "):
+        command = command.replace("make ", "mingw32-make ")
     p1 = subprocess.Popen(command, shell=True)
     p1.wait()
-    if exit_on_failure and (not(p1.returncode is None) and not(p1.returncode == 0)):
-        stopErr('%s failed' % command, p1.returncode)
+    if exit_on_failure and (not (p1.returncode is None) and not (p1.returncode == 0)):
+        stopErr("%s failed" % command, p1.returncode)
+
 
 def modelDependencies(tests):
-    dependencies = {}
+    dependencies = []
     for filepath in tests:
         filepath = "src/" + filepath + ".cpp"
         if os.path.isfile(filepath) and filepath.endswith(testsfx):
             with open(filepath) as file:
                 test_file_content = file.read()
                 # look for TEST() and TEST_F()
-                matches = re.findall(r"#include <test/test-models/.*hpp>", test_file_content)                
+                matches = re.findall(
+                    r"#include <test/test-models/.*hpp>", test_file_content
+                )
                 for x in matches:
                     x = x.replace("#include <", "").replace(">", "")
-                    dependencies[x] = 1
-    return [x for x in dependencies]
+                    dependencies.append(x)
+    return dependencies
+
 
 def makeTest(name, j):
     """Run the make command for a given single test."""
-    doCommand('make -j%d %s' % (j or 1, name))
+    doCommand("make -j%d %s" % (j or 1, name))
+
 
 def runTest(name):
     executable = mungeName(name).replace("/", os.sep)
@@ -98,18 +115,22 @@ def runTest(name):
     command = '%s --gtest_output="xml:%s.xml"' % (executable, xml)
     doCommand(command)
 
+
 def findTests(base_path):
     folders = filter(os.path.isdir, base_path)
     nonfolders = list(set(base_path) - set(folders))
-    tests = nonfolders + [os.path.join(root, n)
-            for f in folders
-            for root, _, names in os.walk(f)
-            for n in names
-            if n.endswith(testsfx)]
+    tests = nonfolders + [
+        os.path.join(root, n)
+        for f in folders
+        for root, _, names in os.walk(f)
+        for n in names
+        if n.endswith(testsfx)
+    ]
     return map(mungeName, tests)
 
+
 def batched(tests):
-    return [tests[i:i + batchSize] for i in range(0, len(tests), batchSize)]
+    return [tests[i : i + batchSize] for i in range(0, len(tests), batchSize)]
 
 
 def main():
@@ -120,10 +141,10 @@ def main():
         stopErr("No matching tests found.", -1)
 
     for batch in batched(tests):
-        modelHpp = modelDependencies(batch)        
+        modelHpp = modelDependencies(batch)
         makeTest(" ".join(modelHpp), inputs.j)
         makeTest(" ".join(batch), inputs.j)
-    
+
     if not inputs.make_only:
         for t in tests:
             runTest(t)

--- a/runTests.py
+++ b/runTests.py
@@ -34,6 +34,8 @@ def processCLIArgs():
     tests_help_msg += "         'src/test/unit/version_test'"
     parser.add_argument("tests", nargs="+", type=str,
                         help=tests_help_msg)
+    parser.add_argument("-m", "--make-only", dest="make_only",
+                        action="store_true", help="Don't run tests, just try to make them.")
     # And parse the command line against those rules
     return parser.parse_args()
 
@@ -120,9 +122,10 @@ def main():
         modelHpp = modelDependencies(batch)        
         makeTest(" ".join(modelHpp), inputs.j)
         makeTest(" ".join(batch), inputs.j)
-
-    for t in tests:
-        runTest(t)
+    
+    if not inputs.make_only:
+        for t in tests:
+            runTest(t)
 
 
 if __name__ == "__main__":

--- a/runTests.py
+++ b/runTests.py
@@ -12,7 +12,6 @@ import time
 
 winsfx = ".exe"
 testsfx = "_test.cpp"
-batchSize = 200
 
 def processCLIArgs():
     """
@@ -50,6 +49,8 @@ def stopErr(msg, returncode):
 def isWin():
     return (platform.system().lower().startswith("windows")
             or os.name.lower().startswith("windows"))
+
+batchSize = 24 if isWin() else 200
 
 def mungeName(name):
     """Set up the makefile target name"""

--- a/runTests.py
+++ b/runTests.py
@@ -1,35 +1,128 @@
 #!/usr/bin/python
 
-"""
-replacement for runtest target in Makefile
-"""
-
+from __future__ import print_function
+from argparse import ArgumentParser, RawTextHelpFormatter
 import os
 import os.path
 import platform
-import sys
+import re
 import subprocess
+import sys
 import time
-import imp
-mathRunTests = imp.load_source('runTests',
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-            "lib", "stan_math", "runTests.py"))
 
-# set up good makefile target name
+winsfx = ".exe"
+testsfx = "_test.cpp"
+batchSize = 200
+
+def processCLIArgs():
+    """
+    Define and process the command line interface to the runTests.py script.
+    """
+    cli_description = "Generate and run stan math library tests."
+    cli_epilog = "See more information at: https://github.com/stan-dev/stan"
+
+    parser = ArgumentParser(description=cli_description,
+                            epilog=cli_epilog,
+                            formatter_class=RawTextHelpFormatter)
+
+    # Now define all the rules of the command line args and opts
+    parser.add_argument("-j", metavar="N", type=int, default=1,
+                        help="number of cores for make to use")
+
+    tests_help_msg = "The path(s) to the test case(s) to run.\n"
+    tests_help_msg += "Example: 'src/test/unit', 'src/test/integration', and/or\n"
+    tests_help_msg += "         'src/test/unit/version_test'"
+    parser.add_argument("tests", nargs="+", type=str,
+                        help=tests_help_msg)
+    # And parse the command line against those rules
+    return parser.parse_args()
+
+
+def stopErr(msg, returncode):
+    """Report an error message to stderr and exit with a given code."""
+    sys.stderr.write('%s\n' % msg)
+    sys.stderr.write('exit now (%s)\n' % time.strftime('%x %X %Z'))
+    sys.exit(returncode)
+
+
+def isWin():
+    return (platform.system().lower().startswith("windows")
+            or os.name.lower().startswith("windows"))
+
 def mungeName(name):
+    """Set up the makefile target name"""
     if (name.startswith("src") or name.startswith("./src")):
         name = name.replace("src/","",1)
-    if (name.endswith(mathRunTests.testsfx)):
-        name = name.replace(mathRunTests.testsfx,"_test")
-        if (mathRunTests.isWin()):
-            name += mathRunTests.winsfx
+    if (name.endswith(testsfx)):
+        name = name.replace(testsfx,"_test")
+        if (isWin()):
+            name += winsfx
             name = name.replace("\\","/")
     return name
 
+def doCommand(command, exit_on_failure=True):
+    """Run command as a shell command and report/exit on errors."""
+    print("------------------------------------------------------------")
+    print("%s" % command)
+    if isWin() and command.startswith('make '):
+      command = command.replace('make ', 'mingw32-make ')
+    p1 = subprocess.Popen(command, shell=True)
+    p1.wait()
+    if exit_on_failure and (not(p1.returncode is None) and not(p1.returncode == 0)):
+        stopErr('%s failed' % command, p1.returncode)
+
+def modelDependencies(tests):
+    dependencies = {}
+    for filepath in tests:
+        filepath = "src/" + filepath + ".cpp"
+        if os.path.isfile(filepath) and filepath.endswith(testsfx):
+            with open(filepath) as file:
+                test_file_content = file.read()
+                # look for TEST() and TEST_F()
+                matches = re.findall(r"#include <test/test-models/.*hpp>", test_file_content)                
+                for x in matches:
+                    x = x.replace("#include <", "").replace(">", "")
+                    dependencies[x] = 1
+    return [x for x in dependencies]
+
+def makeTest(name, j):
+    """Run the make command for a given single test."""
+    doCommand('make -j%d %s' % (j or 1, name))
+
+def runTest(name):
+    executable = mungeName(name).replace("/", os.sep)
+    xml = mungeName(name).replace(winsfx, "")
+    command = '%s --gtest_output="xml:%s.xml"' % (executable, xml)
+    doCommand(command)
+
+def findTests(base_path):
+    folders = filter(os.path.isdir, base_path)
+    nonfolders = list(set(base_path) - set(folders))
+    tests = nonfolders + [os.path.join(root, n)
+            for f in folders
+            for root, _, names in os.walk(f)
+            for n in names
+            if n.endswith(testsfx)]
+    return map(mungeName, tests)
+
+def batched(tests):
+    return [tests[i:i + batchSize] for i in range(0, len(tests), batchSize)]
+
 
 def main():
-    mathRunTests.mungeName = mungeName
-    mathRunTests.main()
+    inputs = processCLIArgs()
+
+    tests = findTests(inputs.tests)
+    if not tests:
+        stopErr("No matching tests found.", -1)
+
+    for batch in batched(tests):
+        modelHpp = modelDependencies(batch)        
+        makeTest(" ".join(modelHpp), inputs.j)
+        makeTest(" ".join(batch), inputs.j)
+
+    for t in tests:
+        runTest(t)
 
 
 if __name__ == "__main__":

--- a/src/test/unit/util_test.cpp
+++ b/src/test/unit/util_test.cpp
@@ -2,13 +2,14 @@
 #include <test/unit/util.hpp>
 
 TEST(TestUnitUtil, streams) {
+  stan::test::capture_std_streams();
   std::cout << "foo";
   std::cerr << "bar";
-  stan::test::capture_std_streams();
   EXPECT_EQ("foo", stan::test::cout_ss.str());
   EXPECT_EQ("bar", stan::test::cerr_ss.str());
 
   stan::test::reset_std_streams();
+  stan::test::capture_std_streams();
   EXPECT_EQ("", stan::test::cout_ss.str());
   EXPECT_EQ("", stan::test::cerr_ss.str());
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is another attempt to fix #2817. This time I refactored the runTests.py python script, not relying on makefiles. 

So this might not be the most makefile-ish way of doing this. It does make it easier to understand (at least for me) and I think that makes it more "maintainable" in the future.

Before running tests, the script checks which model .hpp files need to be built and builds them using make. The runTests is heavily based on the math runTests.py as it was before. 

The way it was done before, was a bit weird. For example `runTests.py -h` printed
```
Generate and run stan math library tests.
...
See more information at: https://github.com/stan-dev/math
```
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar, University of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
