### PR TITLE
Bugfix/841-cmdstan: Add option of reading in csv without fixing indexed names

### DIFF
--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -175,7 +175,7 @@ class stan_csv_reader {
   }  // read_metadata
 
   static bool read_header(std::istream& in, std::vector<std::string>& header,
-                          std::ostream* out) {
+                          std::ostream* out, bool prettify_name = true) {
     std::string line;
 
     if (in.peek() != 'l')
@@ -192,7 +192,7 @@ class stan_csv_reader {
       boost::trim(token);
 
       int pos = token.find('.');
-      if (pos > 0) {
+      if (pos > 0 && prettify_name) {
         token.replace(pos, 1, "[");
         std::replace(token.begin(), token.end(), '.', ',');
         token += "]";


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Currently, CSV reader always reads in the header and then prettifies the indexed names:

y.1 becomes y[1], y.1.1 becomes y[1,1] and so on. 

For standalone generated quantities in cmdstan where we read in a CSV we want to have the option of not prettifying: this caused a bug of matching y.1 and y[1] which threw a mismatch.

This PR adds the option of not prettifying and is a prerequisite for https://github.com/stan-dev/cmdstan/pull/900 that will fix https://github.com/stan-dev/cmdstan/issues/841


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Rok Češnovar, Univ. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
