### PR TITLE
Add recover_mem to log_prob_grad

### DIFF
--- a/src/stan/model/log_prob_propto.hpp
+++ b/src/stan/model/log_prob_propto.hpp
@@ -35,10 +35,10 @@ double log_prob_propto(const M& model, std::vector<double>& params_r,
   using stan::math::var;
   using std::vector;
   try {
-  vector<var> ad_params_r;
-  ad_params_r.reserve(model.num_params_r());
-  for (size_t i = 0; i < model.num_params_r(); ++i)
-    ad_params_r.push_back(params_r[i]);
+    vector<var> ad_params_r;
+    ad_params_r.reserve(model.num_params_r());
+    for (size_t i = 0; i < model.num_params_r(); ++i)
+      ad_params_r.push_back(params_r[i]);
     double lp = model
                     .template log_prob<true, jacobian_adjust_transform>(
                         ad_params_r, params_i, msgs)
@@ -83,9 +83,9 @@ double log_prob_propto(const M& model, Eigen::VectorXd& params_r,
     for (size_t i = 0; i < model.num_params_r(); ++i)
       ad_params_r.push_back(params_r(i));
     double lp = model
-             .template log_prob<true, jacobian_adjust_transform>(ad_params_r,
-                                                                 params_i, msgs)
-             .val();
+                    .template log_prob<true, jacobian_adjust_transform>(
+                        ad_params_r, params_i, msgs)
+                    .val();
     stan::math::recover_memory();
     return lp;
   } catch (std::exception& ex) {

--- a/src/stan/model/log_prob_propto.hpp
+++ b/src/stan/model/log_prob_propto.hpp
@@ -34,11 +34,11 @@ double log_prob_propto(const M& model, std::vector<double>& params_r,
                        std::vector<int>& params_i, std::ostream* msgs = 0) {
   using stan::math::var;
   using std::vector;
+  try {
   vector<var> ad_params_r;
   ad_params_r.reserve(model.num_params_r());
   for (size_t i = 0; i < model.num_params_r(); ++i)
     ad_params_r.push_back(params_r[i]);
-  try {
     double lp = model
                     .template log_prob<true, jacobian_adjust_transform>(
                         ad_params_r, params_i, msgs)
@@ -77,23 +77,21 @@ double log_prob_propto(const M& model, Eigen::VectorXd& params_r,
   using stan::math::var;
   using std::vector;
   vector<int> params_i(0);
-
-  double lp;
   try {
     vector<var> ad_params_r;
     ad_params_r.reserve(model.num_params_r());
     for (size_t i = 0; i < model.num_params_r(); ++i)
       ad_params_r.push_back(params_r(i));
-    lp = model
+    double lp = model
              .template log_prob<true, jacobian_adjust_transform>(ad_params_r,
                                                                  params_i, msgs)
              .val();
+    stan::math::recover_memory();
+    return lp;
   } catch (std::exception& ex) {
     stan::math::recover_memory();
     throw;
   }
-  stan::math::recover_memory();
-  return lp;
 }
 
 }  // namespace model


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes #2936 to make sure memory is recovered for log_prob_grad.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
