### PR TITLE
[NFC] base_hmc const accessor to _z

### DIFF
--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -15,6 +15,15 @@
 namespace stan {
 namespace mcmc {
 
+/**
+ * Base class for Hamiltonian samplers.
+ *
+ * @tparam Model The type of the Stan model.
+ * @tparam Hamiltonian The type of Hamiltonians over the (unconstrained)
+ * parameter space.
+ * @tparam Integrator The type of integrator (e.g. leapfrog).
+ * @tparam BaseRNG The type of random number generator.
+ */
 template <class Model, template <class, class> class Hamiltonian,
           template <class> class Integrator, class BaseRNG>
 class base_hmc : public base_mcmc {
@@ -132,7 +141,21 @@ class base_hmc : public base_mcmc {
     this->z_.ps_point::operator=(z_init);
   }
 
+  /**
+   * Gets the current point in the (unconstrained) parameter space.
+   *
+   * @return The current point in the (unconstrained) parameter space.
+   */
   typename Hamiltonian<Model, BaseRNG>::PointType& z() { return z_; }
+
+  /**
+   * Gets the current point in the (unconstrained) parameters space.
+   *
+   * @return The current point in the (unconstrained) parameters space.
+   */
+  const typename Hamiltonian<Model, BaseRNG>::PointType& z() const noexcept {
+    return z_;
+  }
 
   virtual void set_nominal_stepsize(double e) {
     if (e > 0)

--- a/src/test/unit/mcmc/hmc/base_hmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/base_hmc_test.cpp
@@ -46,6 +46,13 @@ TEST(McmcBaseHMC, point_construction) {
   EXPECT_EQ(static_cast<int>(q.size()), sampler.z().g.size());
 }
 
+TEST(McmcBaseHMC, point_access_from_const_hmc) {
+  rng_t base_rng(0);
+  const stan::mcmc::mock_hmc sampler(stan::mcmc::mock_model(2), base_rng);
+  EXPECT_EQ(2, sampler.z().q.size());
+  EXPECT_EQ(2, sampler.z().g.size());
+}
+
 TEST(McmcBaseHMC, seed) {
   rng_t base_rng(0);
 


### PR DESCRIPTION
#### Summary

Add a const accessor to `_z` in `src/stan/mcmc/hmc/base_hmc.hpp`

#### Intended Effect

Allow access in const contexts, useful for code integration with Stan as a library.

#### How to Verify

N/A

#### Side Effects

Shouldn't be any.

#### Documentation

N/A

#### Copyright and Licensing

K2DQ, LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
