### PR TITLE
Add validate_dims in array_var_context

### DIFF
--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -2,6 +2,7 @@
 #define STAN_IO_ARRAY_VAR_CONTEXT_HPP
 
 #include <stan/io/var_context.hpp>
+#include <stan/io/validate_dims.hpp>
 #include <stan/math.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <map>
@@ -350,48 +351,7 @@ class array_var_context : public var_context {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
-    bool is_int_type = base_type == "int";
-    if (is_int_type) {
-      if (!contains_i(name)) {
-        std::stringstream msg;
-        msg << (contains_r(name) ? "int variable contained non-int values"
-                                 : "variable does not exist")
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; base type=" << base_type;
-        throw std::runtime_error(msg.str());
-      }
-    } else {
-      if (!contains_r(name)) {
-        std::stringstream msg;
-        msg << "variable does not exist"
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; base type=" << base_type;
-        throw std::runtime_error(msg.str());
-      }
-    }
-    std::vector<size_t> dims = dims_r(name);
-    if (dims.size() != dims_declared.size()) {
-      std::stringstream msg;
-      msg << "mismatch in number dimensions declared and found in context"
-          << "; processing stage=" << stage << "; variable name=" << name
-          << "; dims declared=";
-      dims_msg(msg, dims_declared);
-      msg << "; dims found=";
-      dims_msg(msg, dims);
-      throw std::runtime_error(msg.str());
-    }
-    for (size_t i = 0; i < dims.size(); ++i) {
-      if (dims_declared[i] != dims[i]) {
-        std::stringstream msg;
-        msg << "mismatch in dimension declared and found in context"
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; position=" << i << "; dims declared=";
-        dims_msg(msg, dims_declared);
-        msg << "; dims found=";
-        dims_msg(msg, dims);
-        throw std::runtime_error(msg.str());
-      }
-    }
+    validate_dims(*this, stage, name, base_type, dims_declared);
   }
 
   /**

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -349,7 +349,50 @@ class array_var_context : public var_context {
    */
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
-                     const std::vector<size_t>& dims_declared) const {}
+                     const std::vector<size_t>& dims_declared) const {
+    bool is_int_type = base_type == "int";
+    if (is_int_type) {
+      if (!contains_i(name)) {
+        std::stringstream msg;
+        msg << (contains_r(name) ? "int variable contained non-int values"
+                                 : "variable does not exist")
+            << "; processing stage=" << stage << "; variable name=" << name
+            << "; base type=" << base_type;
+        throw std::runtime_error(msg.str());
+      }
+    } else {
+      if (!contains_r(name)) {
+        std::stringstream msg;
+        msg << "variable does not exist"
+            << "; processing stage=" << stage << "; variable name=" << name
+            << "; base type=" << base_type;
+        throw std::runtime_error(msg.str());
+      }
+    }
+    std::vector<size_t> dims = dims_r(name);
+    if (dims.size() != dims_declared.size()) {
+      std::stringstream msg;
+      msg << "mismatch in number dimensions declared and found in context"
+          << "; processing stage=" << stage << "; variable name=" << name
+          << "; dims declared=";
+      dims_msg(msg, dims_declared);
+      msg << "; dims found=";
+      dims_msg(msg, dims);
+      throw std::runtime_error(msg.str());
+    }
+    for (size_t i = 0; i < dims.size(); ++i) {
+      if (dims_declared[i] != dims[i]) {
+        std::stringstream msg;
+        msg << "mismatch in dimension declared and found in context"
+            << "; processing stage=" << stage << "; variable name=" << name
+            << "; position=" << i << "; dims declared=";
+        dims_msg(msg, dims_declared);
+        msg << "; dims found=";
+        dims_msg(msg, dims);
+        throw std::runtime_error(msg.str());
+      }
+    }
+  }
 
   /**
    * Return a list of the names of the floating point variables in

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -351,7 +351,7 @@ class array_var_context : public var_context {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
-    validate_dims(*this, stage, name, base_type, dims_declared);
+    stan::io::validate_dims(*this, stage, name, base_type, dims_declared);
   }
 
   /**

--- a/src/stan/io/chained_var_context.hpp
+++ b/src/stan/io/chained_var_context.hpp
@@ -2,6 +2,7 @@
 #define STAN_IO_CHAINED_VAR_CONTEXT_HPP
 
 #include <stan/io/var_context.hpp>
+#include <stan/io/validate_dims.hpp>
 #include <string>
 #include <vector>
 
@@ -72,7 +73,9 @@ class chained_var_context : public var_context {
    */
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
-                     const std::vector<size_t>& dims_declared) const {}
+                     const std::vector<size_t>& dims_declared) const {
+    validate_dims(*this, stage, name, base_type, dims_declared);
+  }
 };
 }  // namespace io
 }  // namespace stan

--- a/src/stan/io/chained_var_context.hpp
+++ b/src/stan/io/chained_var_context.hpp
@@ -74,7 +74,7 @@ class chained_var_context : public var_context {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
-    validate_dims(*this, stage, name, base_type, dims_declared);
+    stan::io::validate_dims(*this, stage, name, base_type, dims_declared);
   }
 };
 }  // namespace io

--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -2,6 +2,7 @@
 #define STAN_IO_DUMP_HPP
 
 #include <stan/io/validate_zero_buf.hpp>
+#include <stan/io/validate_dims.hpp>
 #include <stan/io/var_context.hpp>
 #include <stan/math/prim.hpp>
 #include <boost/lexical_cast.hpp>
@@ -773,48 +774,7 @@ class dump : public stan::io::var_context {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
-    bool is_int_type = base_type == "int";
-    if (is_int_type) {
-      if (!contains_i(name)) {
-        std::stringstream msg;
-        msg << (contains_r(name) ? "int variable contained non-int values"
-                                 : "variable does not exist")
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; base type=" << base_type;
-        throw std::runtime_error(msg.str());
-      }
-    } else {
-      if (!contains_r(name)) {
-        std::stringstream msg;
-        msg << "variable does not exist"
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; base type=" << base_type;
-        throw std::runtime_error(msg.str());
-      }
-    }
-    std::vector<size_t> dims = dims_r(name);
-    if (dims.size() != dims_declared.size()) {
-      std::stringstream msg;
-      msg << "mismatch in number dimensions declared and found in context"
-          << "; processing stage=" << stage << "; variable name=" << name
-          << "; dims declared=";
-      dims_msg(msg, dims_declared);
-      msg << "; dims found=";
-      dims_msg(msg, dims);
-      throw std::runtime_error(msg.str());
-    }
-    for (size_t i = 0; i < dims.size(); ++i) {
-      if (dims_declared[i] != dims[i]) {
-        std::stringstream msg;
-        msg << "mismatch in dimension declared and found in context"
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; position=" << i << "; dims declared=";
-        dims_msg(msg, dims_declared);
-        msg << "; dims found=";
-        dims_msg(msg, dims);
-        throw std::runtime_error(msg.str());
-      }
-    }
+    validate_dims(*this, stage, name, base_type, dims_declared);
   }
 
   /**

--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -774,7 +774,7 @@ class dump : public stan::io::var_context {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
-    validate_dims(*this, stage, name, base_type, dims_declared);
+    stan::io::validate_dims(*this, stage, name, base_type, dims_declared);
   }
 
   /**

--- a/src/stan/io/empty_var_context.hpp
+++ b/src/stan/io/empty_var_context.hpp
@@ -93,7 +93,7 @@ class empty_var_context : public var_context {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
-    validate_dims(*this, stage, name, base_type, dims_declared); 
+    stan::io::validate_dims(*this, stage, name, base_type, dims_declared); 
   }
 
   /**

--- a/src/stan/io/empty_var_context.hpp
+++ b/src/stan/io/empty_var_context.hpp
@@ -2,6 +2,7 @@
 #define STAN_IO_EMPTY_VAR_CONTEXT_HPP
 
 #include <stan/io/var_context.hpp>
+#include <stan/io/validate_dims.hpp>
 #include <string>
 #include <vector>
 
@@ -91,7 +92,9 @@ class empty_var_context : public var_context {
    */
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
-                     const std::vector<size_t>& dims_declared) const {}
+                     const std::vector<size_t>& dims_declared) const {
+    validate_dims(*this, stage, name, base_type, dims_declared); 
+  }
 
   /**
    * Fill a list of the names of the floating point variables in

--- a/src/stan/io/empty_var_context.hpp
+++ b/src/stan/io/empty_var_context.hpp
@@ -93,7 +93,7 @@ class empty_var_context : public var_context {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
-    stan::io::validate_dims(*this, stage, name, base_type, dims_declared); 
+    stan::io::validate_dims(*this, stage, name, base_type, dims_declared);
   }
 
   /**

--- a/src/stan/io/random_var_context.hpp
+++ b/src/stan/io/random_var_context.hpp
@@ -2,6 +2,7 @@
 #define STAN_IO_RANDOM_VAR_CONTEXT_HPP
 
 #include <stan/io/var_context.hpp>
+#include <stan/io/validate_dims.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
 #include <algorithm>
 #include <limits>
@@ -191,7 +192,9 @@ class random_var_context : public var_context {
    */
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
-                     const std::vector<size_t>& dims_declared) const {}
+                     const std::vector<size_t>& dims_declared) const {
+    validate_dims(*this, stage, name, base_type, dims_declared); 
+  }
 
   /**
    * Return the random initialization on the unconstrained scale.

--- a/src/stan/io/random_var_context.hpp
+++ b/src/stan/io/random_var_context.hpp
@@ -193,7 +193,7 @@ class random_var_context : public var_context {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
-    validate_dims(*this, stage, name, base_type, dims_declared); 
+    stan::io::validate_dims(*this, stage, name, base_type, dims_declared); 
   }
 
   /**

--- a/src/stan/io/random_var_context.hpp
+++ b/src/stan/io/random_var_context.hpp
@@ -193,7 +193,7 @@ class random_var_context : public var_context {
   void validate_dims(const std::string& stage, const std::string& name,
                      const std::string& base_type,
                      const std::vector<size_t>& dims_declared) const {
-    stan::io::validate_dims(*this, stage, name, base_type, dims_declared); 
+    stan::io::validate_dims(*this, stage, name, base_type, dims_declared);
   }
 
   /**

--- a/src/stan/io/validate_dims.hpp
+++ b/src/stan/io/validate_dims.hpp
@@ -27,8 +27,8 @@ namespace io {
     if (is_int_type) {
       if (!context.contains_i(name)) {
         std::stringstream msg;
-        msg << (context.contains_r(name) ? "int variable contained non-int values"
-                                 : "variable does not exist")
+        msg << (context.contains_r(name) ?
+           "int variable contained non-int values" : "variable does not exist")
             << "; processing stage=" << stage << "; variable name=" << name
             << "; base type=" << base_type;
         throw std::runtime_error(msg.str());

--- a/src/stan/io/validate_dims.hpp
+++ b/src/stan/io/validate_dims.hpp
@@ -19,7 +19,7 @@ namespace io {
  * @throw std::runtime_error if mismatch between declared
  *        dimensions and dimensions found in context.
  */
-void validate_dims(const stan::io::var_context& context,
+inline void validate_dims(const stan::io::var_context& context,
                    const std::string& stage, const std::string& name,
                    const std::string& base_type,
                    const std::vector<size_t>& dims_declared) {

--- a/src/stan/io/validate_dims.hpp
+++ b/src/stan/io/validate_dims.hpp
@@ -20,9 +20,9 @@ namespace io {
  *        dimensions and dimensions found in context.
  */
 inline void validate_dims(const stan::io::var_context& context,
-                   const std::string& stage, const std::string& name,
-                   const std::string& base_type,
-                   const std::vector<size_t>& dims_declared) {
+                          const std::string& stage, const std::string& name,
+                          const std::string& base_type,
+                          const std::vector<size_t>& dims_declared) {
   bool is_int_type = base_type == "int";
   if (is_int_type) {
     if (!context.contains_i(name)) {

--- a/src/stan/io/validate_dims.hpp
+++ b/src/stan/io/validate_dims.hpp
@@ -1,0 +1,73 @@
+#ifndef STAN_IO_VALIDATE_DIMS_HPP
+#define STAN_IO_VALIDATE_DIMS_HPP
+
+#include <stan/io/var_context.hpp>
+#include <string>
+#include <vector>
+
+namespace stan {
+namespace io {
+
+  /**
+   * Check variable dimensions against variable declaration.
+   *
+   * @param context The var context to check.
+   * @param stage stan program processing stage
+   * @param name variable name
+   * @param base_type declared stan variable type
+   * @param dims variable dimensions
+   * @throw std::runtime_error if mismatch between declared
+   *        dimensions and dimensions found in context.
+   */
+  void validate_dims(const stan::io::var_context& context,
+                     const std::string& stage, const std::string& name,
+                     const std::string& base_type,
+                     const std::vector<size_t>& dims_declared) {
+    bool is_int_type = base_type == "int";
+    if (is_int_type) {
+      if (!context.contains_i(name)) {
+        std::stringstream msg;
+        msg << (context.contains_r(name) ? "int variable contained non-int values"
+                                 : "variable does not exist")
+            << "; processing stage=" << stage << "; variable name=" << name
+            << "; base type=" << base_type;
+        throw std::runtime_error(msg.str());
+      }
+    } else {
+      if (!context.contains_r(name)) {
+        std::stringstream msg;
+        msg << "variable does not exist"
+            << "; processing stage=" << stage << "; variable name=" << name
+            << "; base type=" << base_type;
+        throw std::runtime_error(msg.str());
+      }
+    }
+    std::vector<size_t> dims = context.dims_r(name);
+    if (dims.size() != dims_declared.size()) {
+      std::stringstream msg;
+      msg << "mismatch in number dimensions declared and found in context"
+          << "; processing stage=" << stage << "; variable name=" << name
+          << "; dims declared=";
+      context.dims_msg(msg, dims_declared);
+      msg << "; dims found=";
+      context.dims_msg(msg, dims);
+      throw std::runtime_error(msg.str());
+    }
+    for (size_t i = 0; i < dims.size(); ++i) {
+      if (dims_declared[i] != dims[i]) {
+        std::stringstream msg;
+        msg << "mismatch in dimension declared and found in context"
+            << "; processing stage=" << stage << "; variable name=" << name
+            << "; position=" << i << "; dims declared=";
+        context.dims_msg(msg, dims_declared);
+        msg << "; dims found=";
+        context.dims_msg(msg, dims);
+        throw std::runtime_error(msg.str());
+      }
+    }
+  }
+
+
+}  // namespace io
+}  // namespace stan
+#endif

--- a/src/stan/io/validate_dims.hpp
+++ b/src/stan/io/validate_dims.hpp
@@ -8,65 +8,64 @@
 namespace stan {
 namespace io {
 
-  /**
-   * Check variable dimensions against variable declaration.
-   *
-   * @param context The var context to check.
-   * @param stage stan program processing stage
-   * @param name variable name
-   * @param base_type declared stan variable type
-   * @param dims variable dimensions
-   * @throw std::runtime_error if mismatch between declared
-   *        dimensions and dimensions found in context.
-   */
-  void validate_dims(const stan::io::var_context& context,
-                     const std::string& stage, const std::string& name,
-                     const std::string& base_type,
-                     const std::vector<size_t>& dims_declared) {
-    bool is_int_type = base_type == "int";
-    if (is_int_type) {
-      if (!context.contains_i(name)) {
-        std::stringstream msg;
-        msg << (context.contains_r(name) ?
-           "int variable contained non-int values" : "variable does not exist")
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; base type=" << base_type;
-        throw std::runtime_error(msg.str());
-      }
-    } else {
-      if (!context.contains_r(name)) {
-        std::stringstream msg;
-        msg << "variable does not exist"
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; base type=" << base_type;
-        throw std::runtime_error(msg.str());
-      }
-    }
-    std::vector<size_t> dims = context.dims_r(name);
-    if (dims.size() != dims_declared.size()) {
+/**
+ * Check variable dimensions against variable declaration.
+ *
+ * @param context The var context to check.
+ * @param stage stan program processing stage
+ * @param name variable name
+ * @param base_type declared stan variable type
+ * @param dims variable dimensions
+ * @throw std::runtime_error if mismatch between declared
+ *        dimensions and dimensions found in context.
+ */
+void validate_dims(const stan::io::var_context& context,
+                   const std::string& stage, const std::string& name,
+                   const std::string& base_type,
+                   const std::vector<size_t>& dims_declared) {
+  bool is_int_type = base_type == "int";
+  if (is_int_type) {
+    if (!context.contains_i(name)) {
       std::stringstream msg;
-      msg << "mismatch in number dimensions declared and found in context"
+      msg << (context.contains_r(name) ? "int variable contained non-int values"
+                                       : "variable does not exist")
           << "; processing stage=" << stage << "; variable name=" << name
-          << "; dims declared=";
+          << "; base type=" << base_type;
+      throw std::runtime_error(msg.str());
+    }
+  } else {
+    if (!context.contains_r(name)) {
+      std::stringstream msg;
+      msg << "variable does not exist"
+          << "; processing stage=" << stage << "; variable name=" << name
+          << "; base type=" << base_type;
+      throw std::runtime_error(msg.str());
+    }
+  }
+  std::vector<size_t> dims = context.dims_r(name);
+  if (dims.size() != dims_declared.size()) {
+    std::stringstream msg;
+    msg << "mismatch in number dimensions declared and found in context"
+        << "; processing stage=" << stage << "; variable name=" << name
+        << "; dims declared=";
+    context.dims_msg(msg, dims_declared);
+    msg << "; dims found=";
+    context.dims_msg(msg, dims);
+    throw std::runtime_error(msg.str());
+  }
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (dims_declared[i] != dims[i]) {
+      std::stringstream msg;
+      msg << "mismatch in dimension declared and found in context"
+          << "; processing stage=" << stage << "; variable name=" << name
+          << "; position=" << i << "; dims declared=";
       context.dims_msg(msg, dims_declared);
       msg << "; dims found=";
       context.dims_msg(msg, dims);
       throw std::runtime_error(msg.str());
     }
-    for (size_t i = 0; i < dims.size(); ++i) {
-      if (dims_declared[i] != dims[i]) {
-        std::stringstream msg;
-        msg << "mismatch in dimension declared and found in context"
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; position=" << i << "; dims declared=";
-        context.dims_msg(msg, dims_declared);
-        msg << "; dims found=";
-        context.dims_msg(msg, dims);
-        throw std::runtime_error(msg.str());
-      }
-    }
   }
-
+}
 
 }  // namespace io
 }  // namespace stan

--- a/src/test/unit/io/array_var_context_test.cpp
+++ b/src/test/unit/io/array_var_context_test.cpp
@@ -214,29 +214,23 @@ TEST(array_var_context, invalid_context_validate) {
   std::vector<std::string> names;
   stan::io::array_var_context avc(names, a, dims);
   // invalid - empty
-  EXPECT_THROW(
-    bernoulli_model_namespace::bernoulli_model(avc, 0, &std::cout),
-    std::runtime_error
-  );
+  EXPECT_THROW(bernoulli_model_namespace::bernoulli_model(avc, 0, &std::cout),
+               std::runtime_error);
   // invalid - missing N and y
   a.push_back(0);
   std::vector<size_t> scalar_dim;
   dims.push_back(scalar_dim);
   names.push_back("K");
   stan::io::array_var_context avc1(names, a, dims);
-  EXPECT_THROW(
-    bernoulli_model_namespace::bernoulli_model(avc1, 0, &std::cout),
-    std::runtime_error
-  );
+  EXPECT_THROW(bernoulli_model_namespace::bernoulli_model(avc1, 0, &std::cout),
+               std::runtime_error);
   // invalid - missing y
   a.push_back(1);
   dims.push_back(scalar_dim);
   names.push_back("N");
   stan::io::array_var_context avc2(names, a, dims);
-  EXPECT_THROW(
-    bernoulli_model_namespace::bernoulli_model(avc2, 0, &std::cout),
-    std::runtime_error
-  );
+  EXPECT_THROW(bernoulli_model_namespace::bernoulli_model(avc2, 0, &std::cout),
+               std::runtime_error);
   // OK
   a.push_back(1);
   std::vector<size_t> arr_dim;
@@ -244,5 +238,6 @@ TEST(array_var_context, invalid_context_validate) {
   dims.push_back(arr_dim);
   names.push_back("y");
   stan::io::array_var_context avc3(names, a, dims);
-  EXPECT_NO_THROW(bernoulli_model_namespace::bernoulli_model(avc3, 0, &std::cout));
+  EXPECT_NO_THROW(
+      bernoulli_model_namespace::bernoulli_model(avc3, 0, &std::cout));
 }

--- a/src/test/unit/io/array_var_context_test.cpp
+++ b/src/test/unit/io/array_var_context_test.cpp
@@ -3,6 +3,7 @@
 #include <stan/io/array_var_context.hpp>
 #include <gtest/gtest.h>
 #include <boost/math/special_functions/fpclassify.hpp>
+#include <test/test-models/good/services/bernoulli.hpp>
 #include <Eigen/Dense>
 
 TEST(array_var_context, ctor_int) {
@@ -205,4 +206,43 @@ TEST(array_var_context, invalid_input2) {
     return;
   }
   FAIL();
+}
+
+TEST(array_var_context, invalid_context_validate) {
+  std::vector<int> a;
+  std::vector<std::vector<size_t> > dims;
+  std::vector<std::string> names;
+  stan::io::array_var_context avc(names, a, dims);
+  // invalid - empty
+  EXPECT_THROW(
+    bernoulli_model_namespace::bernoulli_model(avc, 0, &std::cout),
+    std::runtime_error
+  );
+  // invalid - missing N and y
+  a.push_back(0);
+  std::vector<size_t> scalar_dim;
+  dims.push_back(scalar_dim);
+  names.push_back("K");
+  stan::io::array_var_context avc1(names, a, dims);
+  EXPECT_THROW(
+    bernoulli_model_namespace::bernoulli_model(avc1, 0, &std::cout),
+    std::runtime_error
+  );
+  // invalid - missing y
+  a.push_back(1);
+  dims.push_back(scalar_dim);
+  names.push_back("N");
+  stan::io::array_var_context avc2(names, a, dims);
+  EXPECT_THROW(
+    bernoulli_model_namespace::bernoulli_model(avc2, 0, &std::cout),
+    std::runtime_error
+  );
+  // OK
+  a.push_back(1);
+  std::vector<size_t> arr_dim;
+  arr_dim.push_back(1);
+  dims.push_back(arr_dim);
+  names.push_back("y");
+  stan::io::array_var_context avc3(names, a, dims);
+  EXPECT_NO_THROW(bernoulli_model_namespace::bernoulli_model(avc3, 0, &std::cout));
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes #2948 

array_var_context used by rstan and pystan has an empty validate_dims function: https://github.com/stan-dev/stan/blob/develop/src/stan/io/array_var_context.hpp 

This PR adds the code from https://github.com/stan-dev/stan/blob/develop/src/stan/io/dump.hpp#L773
and tests.

In order to verify comment out the added code in validate_dims and run the array_var_context_test. It will segfault.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Rok Češnovar, Univ. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
