### PR TITLE
cleanup includes of Eigen/*

### DIFF
--- a/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/model/gradient.hpp>
 #include <stan/model/log_prob_propto.hpp>
-#include <Eigen/Dense>
 #include <iostream>
 #include <limits>
 #include <stdexcept>

--- a/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp
@@ -7,7 +7,6 @@
 #include <stan/mcmc/hmc/hamiltonians/dense_e_point.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <boost/random/normal_distribution.hpp>
-#include <Eigen/Cholesky>
 
 namespace stan {
 namespace mcmc {

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -4,7 +4,6 @@
 #include <stan/callbacks/writer.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <boost/lexical_cast.hpp>
-#include <stan/math/prim/fun/Eigen.hpp>
 #include <string>
 #include <vector>
 

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -4,7 +4,7 @@
 #include <stan/callbacks/writer.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <boost/lexical_cast.hpp>
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <string>
 #include <vector>
 

--- a/src/stan/mcmc/hmc/integrators/impl_leapfrog.hpp
+++ b/src/stan/mcmc/hmc/integrators/impl_leapfrog.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MCMC_HMC_INTEGRATORS_IMPL_LEAPFROG_HPP
 #define STAN_MCMC_HMC_INTEGRATORS_IMPL_LEAPFROG_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/mcmc/hmc/integrators/base_leapfrog.hpp>
 
 namespace stan {

--- a/src/stan/model/indexing/deep_copy.hpp
+++ b/src/stan/model/indexing/deep_copy.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MODEL_INDEXING_DEEP_COPY_HPP
 #define STAN_MODEL_INDEXING_DEEP_COPY_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <vector>
 
 namespace stan {

--- a/src/stan/model/indexing/rvalue_return.hpp
+++ b/src/stan/model/indexing/rvalue_return.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MODEL_INDEXING_RVALUE_RETURN_HPP
 #define STAN_MODEL_INDEXING_RVALUE_RETURN_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/index_list.hpp>
 #include <vector>

--- a/src/stan/optimization/bfgs_update.hpp
+++ b/src/stan/optimization/bfgs_update.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_OPTIMIZATION_BFGS_UPDATE_HPP
 #define STAN_OPTIMIZATION_BFGS_UPDATE_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 
 namespace stan {
 namespace optimization {

--- a/src/stan/optimization/lbfgs_update.hpp
+++ b/src/stan/optimization/lbfgs_update.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_OPTIMIZATION_LBFGS_UPDATE_HPP
 #define STAN_OPTIMIZATION_LBFGS_UPDATE_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <boost/circular_buffer.hpp>
 #include <tuple>
 #include <vector>

--- a/src/stan/optimization/newton.hpp
+++ b/src/stan/optimization/newton.hpp
@@ -3,9 +3,7 @@
 
 #include <stan/model/grad_hess_log_prob.hpp>
 #include <stan/model/log_prob_grad.hpp>
-#include <Eigen/Dense>
-#include <Eigen/Cholesky>
-#include <Eigen/Eigenvalues>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <vector>
 
 namespace stan {

--- a/src/stan/services/sample/standalone_gqs.hpp
+++ b/src/stan/services/sample/standalone_gqs.hpp
@@ -8,7 +8,7 @@
 #include <stan/services/error_codes.hpp>
 #include <stan/services/util/create_rng.hpp>
 #include <stan/services/util/gq_writer.hpp>
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <boost/algorithm/string.hpp>
 #include <string>
 #include <vector>

--- a/src/stan/services/util/create_unit_e_dense_inv_metric.hpp
+++ b/src/stan/services/util/create_unit_e_dense_inv_metric.hpp
@@ -2,7 +2,7 @@
 #define STAN_SERVICES_UTIL_CREATE_UNIT_E_DENSE_INV_METRIC_HPP
 
 #include <stan/io/dump.hpp>
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <sstream>
 
 namespace stan {

--- a/src/stan/services/util/read_diag_inv_metric.hpp
+++ b/src/stan/services/util/read_diag_inv_metric.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/callbacks/logger.hpp>
 #include <stan/io/var_context.hpp>
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <limits>
 #include <sstream>
 #include <string>

--- a/src/test/unit/services/instrumented_callbacks.hpp
+++ b/src/test/unit/services/instrumented_callbacks.hpp
@@ -4,7 +4,7 @@
 #include <stan/callbacks/stream_writer.hpp>
 #include <stan/callbacks/writer.hpp>
 #include <stan/callbacks/interrupt.hpp>
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <map>
 #include <string>
 #include <iostream>

--- a/src/test/unit/util.hpp
+++ b/src/test/unit/util.hpp
@@ -1,10 +1,10 @@
-#ifndef TEST__UNIT__UTIL_HPP
-#define TEST__UNIT__UTIL_HPP
+#ifndef TEST_UNIT_UTIL_HPP
+#define TEST_UNIT_UTIL_HPP
 
 #include <stan/io/stan_csv_reader.hpp>
 
 #include <boost/algorithm/string.hpp>
-#include <Eigen/Dense>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <gtest/gtest.h>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

In some places, we directly include `<Eigen/...>` files. That is discouraged due to our implementations of .val() and .adj() in Math. This PR cleans that up in the Stan repo.

#### Intended Effect



#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
