### PR TITLE
Use stanc3 for standalone functions tests and run Win integration tests on merges only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -249,6 +249,13 @@ pipeline {
                 }
                 stage('Integration Windows') {
                     agent { label 'windows' }
+                    when { 
+                        expression { 
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ) &&
+                            !skipRemainingStages 
+                        }
+                    }
                     steps {
                         deleteDirWin()
                             unstash 'StanSetup'

--- a/make/tests
+++ b/make/tests
@@ -78,6 +78,8 @@ src/test/%.d : INC_FIRST = -I $(if $(STAN),$(STAN)/src,src) -I $(if $(STAN),$(ST
 src/test/%.d : INC += $(INC_GTEST)
 src/test/%.d : DEPTARGETS = -MT $(patsubst src/test/%.d,test/%.o,$@) -MT $@
 
+ifdef STANC2
+
 ## this is for the $(STANC_TEMPLATE_INSTANTIATION) files
 src/stan/%.d : DEPTARGETS = -MT test/test-models/stanc2$(EXE) -MT $(patsubst src/%.d,test/%.o,$@) -MT $@
 
@@ -113,7 +115,7 @@ STANC_TESTS := $(patsubst src/%.cpp,%$(EXE),$(STANC_TESTS_HEADERS))
 # add additional dependency to libstanc.a
 $(STANC_TESTS_O) : test/libstanc.a
 $(STANC_TESTS) : LDLIBS += $(LDLIBS_STANC)
-
+endif
 
 ############################################################
 ##
@@ -233,9 +235,9 @@ $(patsubst src/%.stan,%.hpp,$(TEST_MODELS)) : test/test-models/%.hpp : src/test/
 # Generate C++ from Stan standalone functions
 ##
 TEST_FUNCTIONS = $(call findfiles,src/test/test-models,*.stanfuncs)
-$(patsubst src/%.stanfuncs,%.hpp,$(TEST_FUNCTIONS)) : test/test-models/%.hpp : src/test/test-models/%.stanfuncs test/test-models/stanc2$(EXE)
+$(patsubst src/%.stanfuncs,%.hpp,$(TEST_FUNCTIONS)) : test/test-models/%.hpp : src/test/test-models/%.stanfuncs $(TEST_STANC)
 	@mkdir -p $(dir $@)
-	$(WINE) test/test-models/stanc2$(EXE) $< --o=$@
+	$(WINE) $(TEST_STANC) --standalone-functions $< --o=$@
 
 ##
 # src/test/unit/lang/stanc_helper_test.cpp requires files to be read-only.

--- a/make/tests
+++ b/make/tests
@@ -78,8 +78,6 @@ src/test/%.d : INC_FIRST = -I $(if $(STAN),$(STAN)/src,src) -I $(if $(STAN),$(ST
 src/test/%.d : INC += $(INC_GTEST)
 src/test/%.d : DEPTARGETS = -MT $(patsubst src/test/%.d,test/%.o,$@) -MT $@
 
-ifdef STANC2
-
 ## this is for the $(STANC_TEMPLATE_INSTANTIATION) files
 src/stan/%.d : DEPTARGETS = -MT test/test-models/stanc2$(EXE) -MT $(patsubst src/%.d,test/%.o,$@) -MT $@
 
@@ -115,7 +113,6 @@ STANC_TESTS := $(patsubst src/%.cpp,%$(EXE),$(STANC_TESTS_HEADERS))
 # add additional dependency to libstanc.a
 $(STANC_TESTS_O) : test/libstanc.a
 $(STANC_TESTS) : LDLIBS += $(LDLIBS_STANC)
-endif
 
 ############################################################
 ##

--- a/src/test/integration/standalone_functions_test.cpp
+++ b/src/test/integration/standalone_functions_test.cpp
@@ -1,0 +1,14 @@
+#include <gtest/gtest.h>
+#include <test/test-models/good-standalone-functions/basic.hpp>
+
+TEST(standalone_functions, int_only_multiplication) {
+  EXPECT_EQ(int_only_multiplication(2,5), 10);
+  EXPECT_NEAR(my_log1p_exp(1), 1.3132, 1E-4);
+  Eigen::Matrix<double, -1, 1> a(6), correct(6), res(6);
+  a << 1,2,3,4,5,6;
+  res = my_vector_mul_by_5(a);
+  correct << 5,10,15,20,25,30;
+  for(int i = 0; i< a.size(); i++) {
+    EXPECT_EQ(res(i), correct(i));
+  }
+}

--- a/src/test/integration/standalone_functions_test.cpp
+++ b/src/test/integration/standalone_functions_test.cpp
@@ -2,13 +2,13 @@
 #include <test/test-models/good-standalone-functions/basic.hpp>
 
 TEST(standalone_functions, int_only_multiplication) {
-  EXPECT_EQ(int_only_multiplication(2,5), 10);
+  EXPECT_EQ(int_only_multiplication(2, 5), 10);
   EXPECT_NEAR(my_log1p_exp(1), 1.3132, 1E-4);
   Eigen::Matrix<double, -1, 1> a(6), correct(6), res(6);
-  a << 1,2,3,4,5,6;
+  a << 1, 2, 3, 4, 5, 6;
   res = my_vector_mul_by_5(a);
-  correct << 5,10,15,20,25,30;
-  for(int i = 0; i< a.size(); i++) {
+  correct << 5, 10, 15, 20, 25, 30;
+  for (int i = 0; i < a.size(); i++) {
     EXPECT_EQ(res(i), correct(i));
   }
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR does a few minor things: 
- after https://github.com/stan-dev/stanc3/pull/524 we can run standalone functions tests in this repo with stanc3. This PR fixes the makefile logic to use stanc3 for those tests as well. stanc2 is no longer used for tests in /stan
- adds a test that uses a standalone function compiled with stanc. Previously we only checked that the models compile.
- changes the Windows Integration Jenkins stage to only run on merges to develop/master. This test can run for 4 hours if used on a non-AWS machine and the likelihood of Unix integration tests passing and this one failing are slim.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar, Uni. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
