### PR TITLE
Add slices for var matrices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ stan.kdev4
 
 # clangd compiler database
 compile_commands.json
+
+# gdb
+.gdb_history

--- a/src/stan/model/indexing/deep_copy.hpp
+++ b/src/stan/model/indexing/deep_copy.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MODEL_INDEXING_DEEP_COPY_HPP
 #define STAN_MODEL_INDEXING_DEEP_COPY_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim.hpp>
 #include <vector>
 
 namespace stan {
@@ -20,9 +20,19 @@ namespace model {
  * @param x Input value.
  * @return Constant reference to input.
  */
-template <typename T>
+template <typename T, require_stan_scalar_t<T>* = nullptr>
 inline const T& deep_copy(const T& x) {
   return x;
+}
+
+template <typename T, require_stan_scalar_t<T>* = nullptr>
+inline T& deep_copy(T& x) {
+  return x;
+}
+
+template <typename T, require_stan_scalar_t<T>* = nullptr>
+inline T deep_copy(T&& x) {
+  return std::forward<T>(x);
 }
 
 /**
@@ -39,10 +49,9 @@ inline const T& deep_copy(const T& x) {
  * @param a Input matrix, vector, or row vector.
  * @return Deep copy of input.
  */
-template <typename T, int R, int C>
-inline Eigen::Matrix<T, R, C> deep_copy(const Eigen::Matrix<T, R, C>& a) {
-  Eigen::Matrix<T, R, C> result(a);
-  return result;
+template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+inline plain_type_t<EigMat> deep_copy(EigMat&& a) {
+  return plain_type_t<EigMat>(std::forward<EigMat>(a));
 }
 
 /**
@@ -57,10 +66,9 @@ inline Eigen::Matrix<T, R, C> deep_copy(const Eigen::Matrix<T, R, C>& a) {
  * @param v Input vector.
  * @return Deep copy of input.
  */
-template <typename T>
-inline std::vector<T> deep_copy(const std::vector<T>& v) {
-  std::vector<T> result(v);
-  return result;
+template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+inline std::decay_t<StdVec> deep_copy(StdVec&& v) {
+  return {std::forward<StdVec>(v)};
 }
 
 }  // namespace model

--- a/src/stan/model/indexing/deep_copy.hpp
+++ b/src/stan/model/indexing/deep_copy.hpp
@@ -26,7 +26,6 @@ inline plain_type_t<T> deep_copy(T&& x) {
   return std::forward<T>(x);
 }
 
-
 }  // namespace model
 }  // namespace stan
 #endif

--- a/src/stan/model/indexing/deep_copy.hpp
+++ b/src/stan/model/indexing/deep_copy.hpp
@@ -16,60 +16,15 @@ namespace model {
  * copies.  The functions that call this overload recursively will
  * be doing the actual copies with assignment.
  *
- * @tparam T Type of scalar.
+ * @tparam T Any type.
  * @param x Input value.
- * @return Constant reference to input.
+ * @return Copy of input.
  */
-template <typename T, require_stan_scalar_t<T>* = nullptr>
-inline const T& deep_copy(const T& x) {
-  return x;
-}
-
-template <typename T, require_stan_scalar_t<T>* = nullptr>
-inline T& deep_copy(T& x) {
-  return x;
-}
-
-template <typename T, require_stan_scalar_t<T>* = nullptr>
-inline T deep_copy(T&& x) {
+template <typename T>
+inline plain_type_t<T> deep_copy(T&& x) {
   return std::forward<T>(x);
 }
 
-/**
- * Return a copy of the specified matrix, vector, or row
- * vector.  The return value is a copy in the sense that modifying
- * its contents will not affect the original matrix.
- *
- * <p>Warning:  This function assumes that the elements of the
- * matrix deep copy under assignment.
- *
- * @tparam T Scalar type.
- * @tparam R Row type specification.
- * @tparam C Column type specification.
- * @param a Input matrix, vector, or row vector.
- * @return Deep copy of input.
- */
-template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
-inline plain_type_t<EigMat> deep_copy(EigMat&& a) {
-  return plain_type_t<EigMat>(std::forward<EigMat>(a));
-}
-
-/**
- * Return a deep copy of the specified standard vector.  The
- * return value is a copy in the sense that modifying its contents
- * will not affect the original vector.
- *
- * <p>Warning:  This function assumes that the elements of the
- * vector deep copy under assignment.
- *
- * @tparam T Scalar type.
- * @param v Input vector.
- * @return Deep copy of input.
- */
-template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
-inline std::decay_t<StdVec> deep_copy(StdVec&& v) {
-  return {std::forward<StdVec>(v)};
-}
 
 }  // namespace model
 }  // namespace stan

--- a/src/stan/model/indexing/index.hpp
+++ b/src/stan/model/indexing/index.hpp
@@ -2,7 +2,7 @@
 #define STAN_MODEL_INDEXING_INDEX_HPP
 
 #include <vector>
-
+#include <stan/math/prim/meta.hpp>
 namespace stan {
 
 namespace model {
@@ -22,7 +22,7 @@ struct index_uni {
    *
    * @param n single index.
    */
-  explicit index_uni(int n) : n_(n) {}
+  explicit constexpr index_uni(int n) : n_(n) {}
 };
 
 // MULTIPLE INDEXING (does not reduce dimensionality)
@@ -39,7 +39,8 @@ struct index_multi {
    *
    * @param ns multiple indexes.
    */
-  explicit index_multi(const std::vector<int>& ns) : ns_(ns) {}
+  template <typename T, require_not_same_t<T, index_multi>* = nullptr>
+  explicit constexpr index_multi(T&& ns) : ns_(std::forward<T>(ns)) {}
 };
 
 /**
@@ -60,7 +61,7 @@ struct index_min {
    *
    * @param min minimum index (inclusive).
    */
-  explicit index_min(int min) : min_(min) {}
+  explicit constexpr index_min(int min) : min_(min) {}
 };
 
 /**
@@ -76,7 +77,7 @@ struct index_max {
    *
    * @param max maximum index (inclusive).
    */
-  explicit index_max(int max) : max_(max) {}
+  explicit constexpr index_max(int max) : max_(max) {}
 };
 
 /**

--- a/src/stan/model/indexing/index.hpp
+++ b/src/stan/model/indexing/index.hpp
@@ -95,7 +95,7 @@ struct index_min_max {
    * @param min minimum index (inclusive).
    * @param max maximum index (inclusive).
    */
-  explicit index_min_max(int min, int max) : min_(min), max_(max) {}
+  explicit constexpr index_min_max(int min, int max) : min_(min), max_(max) {}
 };
 
 }  // namespace model

--- a/src/stan/model/indexing/index_list.hpp
+++ b/src/stan/model/indexing/index_list.hpp
@@ -18,8 +18,8 @@ struct nil_index_list {};
  */
 template <typename H, typename T>
 struct cons_index_list {
-  H head_;
-  T tail_;
+  std::decay_t<H> head_;
+  std::decay_t<T> tail_;
 
   /**
    * Construct a non-empty index list with the specified index for
@@ -36,7 +36,7 @@ struct cons_index_list {
 // factory-like function does type inference for I and T
 template <typename I, typename T>
 inline constexpr auto cons_list(I&& idx1, T&& t) {
-  return cons_index_list<I, T>(std::forward<I>(idx1), std::forward<T>(t));
+  return cons_index_list<std::decay_t<I>, std::decay_t<T>>(std::forward<I>(idx1), std::forward<T>(t));
 }
 
 inline constexpr auto index_list() { return nil_index_list(); }

--- a/src/stan/model/indexing/index_list.hpp
+++ b/src/stan/model/indexing/index_list.hpp
@@ -1,6 +1,9 @@
 #ifndef STAN_MODEL_INDEXING_INDEX_LIST_HPP
 #define STAN_MODEL_INDEXING_INDEX_LIST_HPP
 
+#include <utility>
+#include <type_traits>
+
 namespace stan {
 namespace model {
 

--- a/src/stan/model/indexing/index_list.hpp
+++ b/src/stan/model/indexing/index_list.hpp
@@ -18,8 +18,8 @@ struct nil_index_list {};
  */
 template <typename H, typename T>
 struct cons_index_list {
-  const H head_;
-  const T tail_;
+  H head_;
+  T tail_;
 
   /**
    * Construct a non-empty index list with the specified index for
@@ -28,34 +28,32 @@ struct cons_index_list {
    * @param head Index for head.
    * @param tail Index list for tail.
    */
-  explicit cons_index_list(const H& head, const T& tail)
-      : head_(head), tail_(tail) {}
+  template <typename Head, typename Tail>
+  explicit constexpr cons_index_list(Head&& head, Tail&& tail)
+      : head_(std::forward<Head>(head)), tail_(std::forward<Tail>(tail)) {}
 };
 
 // factory-like function does type inference for I and T
 template <typename I, typename T>
-inline cons_index_list<I, T> cons_list(const I& idx1, const T& t) {
-  return cons_index_list<I, T>(idx1, t);
+inline constexpr auto cons_list(I&& idx1, T&& t) {
+  return cons_index_list<I, T>(std::forward<I>(idx1), std::forward<T>(t));
 }
 
-inline nil_index_list index_list() { return nil_index_list(); }
+inline constexpr auto index_list() { return nil_index_list(); }
 
 template <typename I>
-inline cons_index_list<I, nil_index_list> index_list(const I& idx) {
-  return cons_list(idx, index_list());
+inline constexpr auto index_list(I&& idx) {
+  return cons_list(std::forward<I>(idx), index_list());
 }
 
 template <typename I1, typename I2>
-inline cons_index_list<I1, cons_index_list<I2, nil_index_list> > index_list(
-    const I1& idx1, const I2& idx2) {
-  return cons_list(idx1, index_list(idx2));
+inline constexpr auto index_list(I1&& idx1, I2&& idx2) {
+  return cons_list(std::forward<I1>(idx1), index_list(std::forward<I2>(idx2)));
 }
 
 template <typename I1, typename I2, typename I3>
-inline cons_index_list<
-    I1, cons_index_list<I2, cons_index_list<I3, nil_index_list> > >
-index_list(const I1& idx1, const I2& idx2, const I3& idx3) {
-  return cons_list(idx1, index_list(idx2, idx3));
+inline constexpr auto index_list(I1&& idx1, I2&& idx2, I3&& idx3) {
+  return cons_list(std::forward<I1>(idx1), index_list(std::forward<I2>(idx2), std::forward<I3>(idx3)));
 }
 
 }  // namespace model

--- a/src/stan/model/indexing/index_list.hpp
+++ b/src/stan/model/indexing/index_list.hpp
@@ -39,21 +39,21 @@ inline constexpr auto cons_list(I&& idx1, T&& t) {
   return cons_index_list<std::decay_t<I>, std::decay_t<T>>(std::forward<I>(idx1), std::forward<T>(t));
 }
 
+/**
+ * Expansion stop for index_list returning back a `nul_index_list`
+ */
 inline constexpr auto index_list() { return nil_index_list(); }
 
-template <typename I>
-inline constexpr auto index_list(I&& idx) {
-  return cons_list(std::forward<I>(idx), index_list());
-}
-
-template <typename I1, typename I2>
-inline constexpr auto index_list(I1&& idx1, I2&& idx2) {
-  return cons_list(std::forward<I1>(idx1), index_list(std::forward<I2>(idx2)));
-}
-
-template <typename I1, typename I2, typename I3>
-inline constexpr auto index_list(I1&& idx1, I2&& idx2, I3&& idx3) {
-  return cons_list(std::forward<I1>(idx1), index_list(std::forward<I2>(idx2), std::forward<I3>(idx3)));
+/**
+ * @tparam I1 First index type
+ * @tparam I2 Parameter pack of index types.
+ * @param idx1 First index to construct the cons_index_list.
+ * @param idx2 A parameter pack expanded and recursivly called into
+ *  `index_list()`
+ */
+template <typename I1, typename... I2>
+inline constexpr auto index_list(I1&& idx1, I2&&... idx2) {
+  return cons_list(std::forward<I1>(idx1), index_list(std::forward<I2>(idx2)...));
 }
 
 }  // namespace model

--- a/src/stan/model/indexing/index_list.hpp
+++ b/src/stan/model/indexing/index_list.hpp
@@ -36,7 +36,8 @@ struct cons_index_list {
 // factory-like function does type inference for I and T
 template <typename I, typename T>
 inline constexpr auto cons_list(I&& idx1, T&& t) {
-  return cons_index_list<std::decay_t<I>, std::decay_t<T>>(std::forward<I>(idx1), std::forward<T>(t));
+  return cons_index_list<std::decay_t<I>, std::decay_t<T>>(
+      std::forward<I>(idx1), std::forward<T>(t));
 }
 
 /**
@@ -53,7 +54,8 @@ inline constexpr auto index_list() { return nil_index_list(); }
  */
 template <typename I1, typename... I2>
 inline constexpr auto index_list(I1&& idx1, I2&&... idx2) {
-  return cons_list(std::forward<I1>(idx1), index_list(std::forward<I2>(idx2)...));
+  return cons_list(std::forward<I1>(idx1),
+                   index_list(std::forward<I2>(idx2)...));
 }
 
 }  // namespace model

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -146,7 +146,7 @@ inline void assign(Vec1& x, const cons_index_list<index_min_max, nil_index_list>
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename Mat, typename RowVec, require_eigen_matrix_t<Mat>* = nullptr,
+template <typename Mat, typename RowVec, require_eigen_matrix_dynamic_t<Mat>* = nullptr,
  require_eigen_row_vector_t<RowVec>* = nullptr>
 inline void assign(Mat& x,
             const cons_index_list<index_uni, nil_index_list>& idxs,
@@ -177,7 +177,7 @@ inline void assign(Mat& x,
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename Mat, typename ColVec, require_eigen_matrix_t<Mat>* = nullptr,
+template <typename Mat, typename ColVec, require_eigen_matrix_dynamic_t<Mat>* = nullptr,
  require_eigen_col_vector_t<ColVec>* = nullptr>
 inline void assign(Mat& x,
             const cons_index_list<index_omni, cons_index_list<index_uni, nil_index_list>>& idxs,
@@ -207,7 +207,7 @@ inline void assign(Mat& x,
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename Mat, typename RowVec, require_eigen_matrix_t<Mat>* = nullptr,
+template <typename Mat, typename RowVec, require_eigen_matrix_dynamic_t<Mat>* = nullptr,
  require_eigen_row_vector_t<RowVec>* = nullptr>
 inline void assign(Mat& x,
             const cons_index_list<index_uni, cons_index_list<index_omni, nil_index_list>>& idxs,
@@ -237,7 +237,7 @@ inline void assign(Mat& x,
  * matrix and right-hand side matrix do not match.
  */
 template <typename Mat1, typename I, typename Mat2,
-  require_all_eigen_matrix_t<Mat2, Mat2>* = nullptr,
+  require_all_eigen_matrix_dynamic_t<Mat2, Mat2>* = nullptr,
   require_not_same_t<I, index_uni>* = nullptr>
 inline void assign(Mat1& x, const cons_index_list<I, nil_index_list>& idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
@@ -255,7 +255,7 @@ inline void assign(Mat1& x, const cons_index_list<I, nil_index_list>& idxs,
 }
 
 template <typename Mat1, typename Mat2,
-  require_all_eigen_matrix_t<Mat2, Mat2>* = nullptr>
+  require_all_eigen_matrix_dynamic_t<Mat2, Mat2>* = nullptr>
 inline void assign(Mat1& x,
    const cons_index_list<index_min_max, cons_index_list<index_min_max, nil_index_list>>& idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
@@ -302,7 +302,7 @@ inline void assign(Mat1& x,
  * @param[in] depth Indexing depth (default 0).
  * @throw std::out_of_range If either of the indices are out of bounds.
  */
-template <typename Mat, typename U, require_eigen_matrix_t<Mat>* = nullptr>
+template <typename Mat, typename U, require_eigen_matrix_dynamic_t<Mat>* = nullptr>
 inline void assign(Mat& x,
             const cons_index_list<
                 index_uni, cons_index_list<index_uni, nil_index_list> >& idxs,
@@ -334,7 +334,7 @@ inline void assign(Mat& x,
  * matrix and right-hand side row vector do not match.
  */
 template <typename Mat, typename I, typename Vec,
-  require_eigen_matrix_t<Mat>* = nullptr,
+  require_eigen_matrix_dynamic_t<Mat>* = nullptr,
   require_eigen_row_vector_t<Vec>* = nullptr,
   require_not_same_t<I, index_uni>* = nullptr>
 inline void assign(Mat& x,
@@ -373,7 +373,7 @@ inline void assign(Mat& x,
  * matrix and right-hand side vector do not match.
  */
 template <typename Mat, typename I, typename ColVec,
-  require_eigen_matrix_t<Mat>* = nullptr,
+  require_eigen_matrix_dynamic_t<Mat>* = nullptr,
   require_eigen_col_vector_t<ColVec>* = nullptr,
   require_not_same_t<I, index_uni>* = nullptr>
 inline void assign(Mat& x,
@@ -412,7 +412,7 @@ inline void assign(Mat& x,
  * matrix and value matrix do not match.
  */
 template <typename Mat1, typename I1, typename I2, typename Mat2,
- require_all_eigen_matrix_t<Mat1, Mat2>* = nullptr,
+ require_all_eigen_matrix_dynamic_t<Mat1, Mat2>* = nullptr,
  require_all_not_same_t<index_uni, I1, I2>* = nullptr>
 inline void assign(Mat1& x,
        const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -66,8 +66,7 @@ inline void assign(std::vector<T>& x, const nil_index_list& /* idxs */,
  * @param[in] depth Indexing depth (default 0).
  * @throw std::out_of_range If the index is out of bounds.
  */
-template <typename Vec1, typename U,
- require_eigen_vector_t<Vec1>* = nullptr>
+template <typename Vec1, typename U, require_eigen_vector_t<Vec1>* = nullptr>
 inline void assign(Vec1& x,
                    const cons_index_list<index_uni, nil_index_list>& idxs,
                    const U& y, const char* name = "ANON", int depth = 0) {
@@ -94,11 +93,11 @@ inline void assign(Vec1& x,
  * the indexed size.
  */
 template <typename Vec1, typename Vec2, typename I,
-  require_all_eigen_vector_t<Vec1, Vec2>* = nullptr,
-  require_not_same_t<I, index_uni>* = nullptr>
+          require_all_eigen_vector_t<Vec1, Vec2>* = nullptr,
+          require_not_same_t<I, index_uni>* = nullptr>
 inline void assign(Vec1& x, const cons_index_list<I, nil_index_list>& idxs,
-  const Vec2& y, const char* name = "ANON", int depth = 0) {
-    const auto& y_ref = stan::math::to_ref(y);
+                   const Vec2& y, const char* name = "ANON", int depth = 0) {
+  const auto& y_ref = stan::math::to_ref(y);
   math::check_size_match("vector[multi] assign sizes", "lhs",
                          rvalue_index_size(idxs.head_, x.size()), name,
                          y_ref.size());
@@ -110,15 +109,18 @@ inline void assign(Vec1& x, const cons_index_list<I, nil_index_list>& idxs,
 }
 
 template <typename Vec1, typename Vec2, typename I,
-  require_all_eigen_vector_t<Vec1, Vec2>* = nullptr>
-inline void assign(Vec1& x, const cons_index_list<index_min_max, nil_index_list>& idxs,
-  const Vec2& y, const char* name = "ANON", int depth = 0) {
-    const auto& y_ref = stan::math::to_ref(y);
+          require_all_eigen_vector_t<Vec1, Vec2>* = nullptr>
+inline void assign(Vec1& x,
+                   const cons_index_list<index_min_max, nil_index_list>& idxs,
+                   const Vec2& y, const char* name = "ANON", int depth = 0) {
+  const auto& y_ref = stan::math::to_ref(y);
   math::check_size_match("vector[multi] assign sizes", "lhs",
                          rvalue_index_size(idxs.head_, x.size()), name,
                          y_ref.size());
-  math::check_range("vector[min_max] min assign", name, x.size(), idxs.head_.min_);
-  math::check_range("vector[min_max] max assign", name, x.size(), idxs.head_.max_);
+  math::check_range("vector[min_max] min assign", name, x.size(),
+                    idxs.head_.min_);
+  math::check_range("vector[min_max] max assign", name, x.size(),
+                    idxs.head_.max_);
   if (idxs.head_.min_ <= idxs.head_.max_) {
     x.segment(idxs.head_.min_ - 1, idxs.head_.max_ - 1) = y;
     return;
@@ -146,18 +148,17 @@ inline void assign(Vec1& x, const cons_index_list<index_min_max, nil_index_list>
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename Mat, typename RowVec, require_eigen_matrix_dynamic_t<Mat>* = nullptr,
- require_eigen_row_vector_t<RowVec>* = nullptr>
+template <typename Mat, typename RowVec,
+          require_eigen_matrix_dynamic_t<Mat>* = nullptr,
+          require_eigen_row_vector_t<RowVec>* = nullptr>
 inline void assign(Mat& x,
-            const cons_index_list<index_uni, nil_index_list>& idxs,
-            const RowVec& y,
-            const char* name = "ANON", int depth = 0) {
+                   const cons_index_list<index_uni, nil_index_list>& idxs,
+                   const RowVec& y, const char* name = "ANON", int depth = 0) {
   math::check_size_match("matrix[uni] assign sizes", "lhs", x.cols(), name,
                          y.cols());
   math::check_range("matrix[uni] assign range", name, x.rows(), idxs.head_.n_);
   x.row(idxs.head_.n_ - 1) = y;
 }
-
 
 /**
  * Assign the specified Eigen matrix at the specified single index
@@ -177,15 +178,18 @@ inline void assign(Mat& x,
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename Mat, typename ColVec, require_eigen_matrix_dynamic_t<Mat>* = nullptr,
- require_eigen_col_vector_t<ColVec>* = nullptr>
-inline void assign(Mat& x,
-            const cons_index_list<index_omni, cons_index_list<index_uni, nil_index_list>>& idxs,
-            const ColVec& y,
-            const char* name = "ANON", int depth = 0) {
+template <typename Mat, typename ColVec,
+          require_eigen_matrix_dynamic_t<Mat>* = nullptr,
+          require_eigen_col_vector_t<ColVec>* = nullptr>
+inline void assign(
+    Mat& x,
+    const cons_index_list<index_omni,
+                          cons_index_list<index_uni, nil_index_list>>& idxs,
+    const ColVec& y, const char* name = "ANON", int depth = 0) {
   math::check_size_match("matrix[uni] assign sizes", "lhs", x.rows(), name,
                          y.rows());
-  math::check_range("matrix[uni] assign range", name, x.cols(), idxs.tail_.head_.n_);
+  math::check_range("matrix[uni] assign range", name, x.cols(),
+                    idxs.tail_.head_.n_);
   x.col(idxs.tail_.head_.n_ - 1) = y;
 }
 
@@ -207,12 +211,14 @@ inline void assign(Mat& x,
  * @throw std::invalid_argument If the number of columns in the row
  * vector and matrix do not match.
  */
-template <typename Mat, typename RowVec, require_eigen_matrix_dynamic_t<Mat>* = nullptr,
- require_eigen_row_vector_t<RowVec>* = nullptr>
-inline void assign(Mat& x,
-            const cons_index_list<index_uni, cons_index_list<index_omni, nil_index_list>>& idxs,
-            const RowVec& y,
-            const char* name = "ANON", int depth = 0) {
+template <typename Mat, typename RowVec,
+          require_eigen_matrix_dynamic_t<Mat>* = nullptr,
+          require_eigen_row_vector_t<RowVec>* = nullptr>
+inline void assign(
+    Mat& x,
+    const cons_index_list<index_uni,
+                          cons_index_list<index_omni, nil_index_list>>& idxs,
+    const RowVec& y, const char* name = "ANON", int depth = 0) {
   math::check_size_match("matrix[uni] assign sizes", "lhs", x.cols(), name,
                          y.cols());
   x.row(idxs.head_.n_ - 1) = y;
@@ -237,10 +243,10 @@ inline void assign(Mat& x,
  * matrix and right-hand side matrix do not match.
  */
 template <typename Mat1, typename I, typename Mat2,
-  require_all_eigen_matrix_dynamic_t<Mat2, Mat2>* = nullptr,
-  require_not_same_t<I, index_uni>* = nullptr>
+          require_all_eigen_matrix_dynamic_t<Mat2, Mat2>* = nullptr,
+          require_not_same_t<I, index_uni>* = nullptr>
 inline void assign(Mat1& x, const cons_index_list<I, nil_index_list>& idxs,
-    const Mat2& y, const char* name = "ANON", int depth = 0) {
+                   const Mat2& y, const char* name = "ANON", int depth = 0) {
   const int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
   const auto& y_ref = stan::math::to_ref(y);
   math::check_size_match("matrix[multi] assign row sizes", "lhs", x_idx_rows,
@@ -255,9 +261,11 @@ inline void assign(Mat1& x, const cons_index_list<I, nil_index_list>& idxs,
 }
 
 template <typename Mat1, typename Mat2,
-  require_all_eigen_matrix_dynamic_t<Mat2, Mat2>* = nullptr>
-inline void assign(Mat1& x,
-   const cons_index_list<index_min_max, cons_index_list<index_min_max, nil_index_list>>& idxs,
+          require_all_eigen_matrix_dynamic_t<Mat2, Mat2>* = nullptr>
+inline void assign(
+    Mat1& x,
+    const cons_index_list<index_min_max,
+                          cons_index_list<index_min_max, nil_index_list>>& idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
   const int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
   const int x_idx_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
@@ -266,26 +274,39 @@ inline void assign(Mat1& x,
   math::check_size_match("matrix[multi] assign col sizes", "lhs", x_idx_cols,
                          name, y.cols());
   if (idxs.head_.min_ <= idxs.head_.max_) {
-   if (idxs.tail_.head_.min_ <= idxs.tail_.head_.max_) {
-     x.block(idxs.head_.min_ - 1, idxs.tail_.head_.min_ - 1, idxs.head_.max_ - 1, idxs.tail_.head_.max_ - 1) = y;
-     return;
-   } else {
-     x.block(idxs.head_.min_ - 1, idxs.tail_.head_.max_ - 1, idxs.head_.max_ - 1, idxs.tail_.head_.min_ - 1).colwise().reverse() = y;
-     return;
-   }
+    if (idxs.tail_.head_.min_ <= idxs.tail_.head_.max_) {
+      x.block(idxs.head_.min_ - 1, idxs.tail_.head_.min_ - 1,
+              idxs.head_.max_ - 1, idxs.tail_.head_.max_ - 1)
+          = y;
+      return;
+    } else {
+      x.block(idxs.head_.min_ - 1, idxs.tail_.head_.max_ - 1,
+              idxs.head_.max_ - 1, idxs.tail_.head_.min_ - 1)
+          .colwise()
+          .reverse()
+          = y;
+      return;
+    }
   } else {
-   if (idxs.tail_.head_.min_ <= idxs.tail_.head_.max_) {
-     x.block(idxs.head_.max_ - 1, idxs.tail_.head_.min_ - 1, idxs.head_.min_ - 1, idxs.tail_.head_.max_ - 1).rowwise().reverse() = y;
-     return;
-   } else {
-     x.block(idxs.head_.max_ - 1, idxs.tail_.head_.max_ - 1, idxs.head_.min_ - 1, idxs.tail_.head_.min_ - 1).rowwise().reverse().colwise().reverse() = y;
-     return;
-   }
+    if (idxs.tail_.head_.min_ <= idxs.tail_.head_.max_) {
+      x.block(idxs.head_.max_ - 1, idxs.tail_.head_.min_ - 1,
+              idxs.head_.min_ - 1, idxs.tail_.head_.max_ - 1)
+          .rowwise()
+          .reverse()
+          = y;
+      return;
+    } else {
+      x.block(idxs.head_.max_ - 1, idxs.tail_.head_.max_ - 1,
+              idxs.head_.min_ - 1, idxs.tail_.head_.min_ - 1)
+          .rowwise()
+          .reverse()
+          .colwise()
+          .reverse()
+          = y;
+      return;
+    }
   }
-
 }
-
-
 
 /**
  * Assign the specified Eigen matrix at the specified pair of
@@ -302,11 +323,13 @@ inline void assign(Mat1& x,
  * @param[in] depth Indexing depth (default 0).
  * @throw std::out_of_range If either of the indices are out of bounds.
  */
-template <typename Mat, typename U, require_eigen_matrix_dynamic_t<Mat>* = nullptr>
-inline void assign(Mat& x,
-            const cons_index_list<
-                index_uni, cons_index_list<index_uni, nil_index_list> >& idxs,
-            const U& y, const char* name = "ANON", int depth = 0) {
+template <typename Mat, typename U,
+          require_eigen_matrix_dynamic_t<Mat>* = nullptr>
+inline void assign(
+    Mat& x,
+    const cons_index_list<index_uni,
+                          cons_index_list<index_uni, nil_index_list>>& idxs,
+    const U& y, const char* name = "ANON", int depth = 0) {
   const int m = idxs.head_.n_;
   const int n = idxs.tail_.head_.n_;
   math::check_range("matrix[uni,uni] assign range", name, x.rows(), m);
@@ -334,13 +357,13 @@ inline void assign(Mat& x,
  * matrix and right-hand side row vector do not match.
  */
 template <typename Mat, typename I, typename Vec,
-  require_eigen_matrix_dynamic_t<Mat>* = nullptr,
-  require_eigen_row_vector_t<Vec>* = nullptr,
-  require_not_same_t<I, index_uni>* = nullptr>
-inline void assign(Mat& x,
-    const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idxs,
-    const Vec& y, const char* name = "ANON",
-    int depth = 0) {
+          require_eigen_matrix_dynamic_t<Mat>* = nullptr,
+          require_eigen_row_vector_t<Vec>* = nullptr,
+          require_not_same_t<I, index_uni>* = nullptr>
+inline void assign(
+    Mat& x,
+    const cons_index_list<index_uni, cons_index_list<I, nil_index_list>>& idxs,
+    const Vec& y, const char* name = "ANON", int depth = 0) {
   const auto& y_ref = stan::math::to_ref(y);
   const int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
   math::check_size_match("matrix[uni,multi] assign sizes", "lhs", x_idxs_cols,
@@ -373,11 +396,12 @@ inline void assign(Mat& x,
  * matrix and right-hand side vector do not match.
  */
 template <typename Mat, typename I, typename ColVec,
-  require_eigen_matrix_dynamic_t<Mat>* = nullptr,
-  require_eigen_col_vector_t<ColVec>* = nullptr,
-  require_not_same_t<I, index_uni>* = nullptr>
-inline void assign(Mat& x,
-  const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idxs,
+          require_eigen_matrix_dynamic_t<Mat>* = nullptr,
+          require_eigen_col_vector_t<ColVec>* = nullptr,
+          require_not_same_t<I, index_uni>* = nullptr>
+inline void assign(
+    Mat& x,
+    const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idxs,
     const ColVec& y, const char* name = "ANON", int depth = 0) {
   const int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
   const auto& y_ref = stan::math::to_ref(y);
@@ -412,12 +436,12 @@ inline void assign(Mat& x,
  * matrix and value matrix do not match.
  */
 template <typename Mat1, typename I1, typename I2, typename Mat2,
- require_all_eigen_matrix_dynamic_t<Mat1, Mat2>* = nullptr,
- require_all_not_same_t<index_uni, I1, I2>* = nullptr>
-inline void assign(Mat1& x,
-       const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idxs,
-       const Mat2& y,
-       const char* name = "ANON", int depth = 0) {
+          require_all_eigen_matrix_dynamic_t<Mat1, Mat2>* = nullptr,
+          require_all_not_same_t<index_uni, I1, I2>* = nullptr>
+inline void assign(
+    Mat1& x,
+    const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idxs,
+    const Mat2& y, const char* name = "ANON", int depth = 0) {
   const int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
   const int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
   const auto& y_ref = stan::math::to_ref(y);
@@ -462,7 +486,8 @@ inline void assign(Mat1& x,
 template <typename T, typename L, typename U>
 inline void assign(std::vector<T>& x, const cons_index_list<index_uni, L>& idxs,
                    const U& y, const char* name = "ANON", int depth = 0) {
-  math::check_range("vector[uni,...] assign range", name, x.size(), idxs.head_.n_);
+  math::check_range("vector[uni,...] assign range", name, x.size(),
+                    idxs.head_.n_);
   assign(x[idxs.head_.n_ - 1], idxs.tail_, y, name, depth + 1);
 }
 
@@ -492,9 +517,10 @@ inline void assign(std::vector<T>& x, const cons_index_list<index_uni, L>& idxs,
  * the recursive tail assignment dimensions do not match.
  */
 template <typename T, typename I, typename L, typename U,
- require_not_same_t<I, index_uni>* = nullptr>
+          require_not_same_t<I, index_uni>* = nullptr>
 inline void assign(std::vector<T>& x, const cons_index_list<I, L>& idxs,
-    const std::vector<U>& y, const char* name = "ANON", int depth = 0) {
+                   const std::vector<U>& y, const char* name = "ANON",
+                   int depth = 0) {
   int x_idx_size = rvalue_index_size(idxs.head_, x.size());
   math::check_size_match("vector[multi,...] assign sizes", "lhs", x_idx_size,
                          name, y.size());

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -42,13 +42,13 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
  * @param[in] name name of lvalue variable (default "ANON").
  * @param[in] depth indexing depth (default 0).
  */
-template <typename T, typename U>
+template <typename T, typename U, require_std_vector_t<U>* = nullptr>
 inline void assign(std::vector<T>& x, const nil_index_list& /* idxs */,
-                   const std::vector<U>& y, const char* name = "ANON",
+                   U&& y, const char* name = "ANON",
                    int depth = 0) {
   x.resize(y.size());
   for (size_t i = 0; i < y.size(); ++i)
-    assign(x[i], nil_index_list(), y[i], name, depth + 1);
+    assign(x[i], nil_index_list(), std::forward<U>(y)[i], name, depth + 1);
 }
 
 /**

--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -42,7 +42,8 @@ inline void assign(T& x, const nil_index_list& /* idxs */, U&& y,
  * @param[in] name name of lvalue variable (default "ANON").
  * @param[in] depth indexing depth (default 0).
  */
-template <typename T, typename U, require_std_vector_t<U>* = nullptr>
+template <typename T, typename U, require_std_vector_t<U>* = nullptr,
+  require_not_same_t<T, value_type_t<U>>* = nullptr>
 inline void assign(std::vector<T>& x, const nil_index_list& /* idxs */,
                    U&& y, const char* name = "ANON",
                    int depth = 0) {

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -37,7 +37,7 @@ inline T rvalue(T&& c, const nil_index_list& /*idx*/, const char* /*name*/ = "",
  * Return the result of indexing a type without taking a subset. Mostly used as
  * an intermediary rvalue function when doing multiple subsets.
  *
- * Types:  type[,] : type
+ * Types:  type[omni] : type
  *
  * @tparam T Any type.
  * @param[in] an object.
@@ -228,7 +228,7 @@ inline auto rvalue(const EigMat& a,
                    const cons_index_list<index_uni, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[uni] indexing", name, a.rows(), idx.head_.n_);
-  return a.row(idx.head_.n_ - 1);
+  return a.row(idx.head_.n_ - 1).eval();
 }
 
 /**
@@ -686,7 +686,7 @@ inline auto rvalue(const EigMat& a,
   math::check_range("matrix[multi] indexing", name, a.rows(),
                     idx.head_.min_ - 1);
   return a.block(idx.head_.min_ - 1, 0, a.rows() - (idx.head_.min_ - 1),
-                 a.cols());
+                 a.cols()).eval();
 }
 
 /**
@@ -732,7 +732,7 @@ inline auto rvalue(const EigMat& a,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),
                     idx.head_.max_ - 1);
-  return a.block(0, 0, idx.head_.max_, a.cols());
+  return a.block(0, 0, idx.head_.max_, a.cols()).eval();
 }
 
 /**
@@ -1040,9 +1040,8 @@ inline auto rvalue(StdVec&& c,
  */
 template <typename StdVec, typename I, typename L,
           require_std_vector_t<StdVec>* = nullptr>
-inline rvalue_return_t<std::decay_t<StdVec>, cons_index_list<I, L>> rvalue(
-    StdVec&& c, const cons_index_list<I, L>& idx, const char* name = "ANON",
-    int depth = 0) {
+inline auto rvalue(StdVec&& c, const cons_index_list<I, L>& idx,
+   const char* name = "ANON", int depth = 0) {
   rvalue_return_t<std::decay_t<StdVec>, cons_index_list<I, L>> result;
   const int index_size = rvalue_index_size(idx.head_, c.size());
   if (index_size > 0) {

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -88,7 +88,7 @@ inline T rvalue(
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
-    const EigMat& a,
+    EigMat&& a,
     const cons_index_list<index_uni,
                           cons_index_list<index_omni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -112,7 +112,7 @@ inline auto rvalue(
 template <typename VarMat,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    const VarMat& a,
+    VarMat&& a,
     const cons_index_list<index_uni,
                           cons_index_list<index_omni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -135,7 +135,7 @@ inline auto rvalue(
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
-    const EigMat& a,
+    EigMat&& a,
     const cons_index_list<index_omni,
                           cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -159,7 +159,7 @@ inline auto rvalue(
 template <typename VarMat,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    const VarMat& a,
+    VarMat&& a,
     const cons_index_list<index_omni,
                           cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -181,7 +181,7 @@ inline auto rvalue(
  * @return Result of indexing vector.
  */
 template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
-inline auto&& rvalue(const EigVec& v,
+inline auto&& rvalue(EigVec&& v,
                      const cons_index_list<index_uni, nil_index_list>& idx,
                      const char* name = "ANON", int depth = 0) {
   math::check_range("vector[single] indexing", name, v.size(), idx.head_.n_);
@@ -203,7 +203,7 @@ inline auto&& rvalue(const EigVec& v,
  * @return Result of indexing vector.
  */
 template <typename VarVec, require_var_vt<is_eigen_vector, VarVec>* = nullptr>
-inline auto rvalue(const VarVec& v,
+inline auto rvalue(VarVec&& v,
                    const cons_index_list<index_uni, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("vector[single] indexing", name, v.size(), idx.head_.n_);
@@ -224,7 +224,7 @@ inline auto rvalue(const VarVec& v,
  * @return Result of indexing matrix.
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
-inline auto rvalue(const EigMat& a,
+inline auto rvalue(EigMat&& a,
                    const cons_index_list<index_uni, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[uni] indexing", name, a.rows(), idx.head_.n_);
@@ -246,7 +246,7 @@ inline auto rvalue(const EigMat& a,
  */
 template <typename VarMat,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
-inline auto rvalue(const VarMat& a,
+inline auto rvalue(VarMat&& a,
                    const cons_index_list<index_uni, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("varmatrix[uni] indexing", name, a.rows(), idx.head_.n_);
@@ -268,7 +268,7 @@ inline auto rvalue(const VarMat& a,
  */
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
 inline auto& rvalue(
-    const EigMat& a,
+    EigMat&& a,
     const cons_index_list<index_uni,
                           cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -296,7 +296,7 @@ inline auto& rvalue(
 template <typename VarMat,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    const VarMat& a,
+    VarMat&& a,
     const cons_index_list<index_uni,
                           cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -325,7 +325,7 @@ inline auto rvalue(
 template <typename EigMat, typename I,
           require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
-    const EigMat& a,
+    EigMat&& a,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
@@ -351,7 +351,7 @@ inline auto rvalue(
 template <typename VarMat, typename I,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    const VarMat& a,
+    VarMat&& a,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
@@ -377,7 +377,7 @@ inline auto rvalue(
 template <typename EigMat, typename I,
           require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, 1> rvalue(
-    const EigMat& a,
+    EigMat&& a,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   const int m = idx.tail_.head_.n_;
@@ -403,7 +403,7 @@ inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, 1> rvalue(
 template <typename VarMat, typename I,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    const VarMat& a,
+    VarMat&& a,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   const int m = idx.tail_.head_.n_;
@@ -425,7 +425,7 @@ inline auto rvalue(
  * @return Result of indexing vector.
  */
 template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
-inline auto rvalue(const EigVec& v,
+inline auto rvalue(EigVec&& v,
                    const cons_index_list<index_min_max, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("vector[min_max] min indexing", name, v.size(),
@@ -457,7 +457,7 @@ inline auto rvalue(const EigVec& v,
  */
 template <typename VarVec, require_var_vt<is_eigen_vector, VarVec>* = nullptr>
 inline std::decay_t<VarVec> rvalue(
-    const VarVec& v, const cons_index_list<index_min_max, nil_index_list>& idx,
+    VarVec&& v, const cons_index_list<index_min_max, nil_index_list>& idx,
     const char* name = "ANON", int depth = 0) {
   math::check_range("var_vector[min_max] min indexing", name, v.size(),
                     idx.head_.min_);
@@ -488,7 +488,7 @@ inline std::decay_t<VarVec> rvalue(
  * @return Result of indexing matrix.
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
-inline EigMat rvalue(const EigMat& a,
+inline EigMat rvalue(EigMat&& a,
                      const cons_index_list<index_min_max, nil_index_list>& idx,
                      const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),
@@ -524,7 +524,7 @@ inline EigMat rvalue(const EigMat& a,
 template <typename VarMat,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline std::decay_t<VarMat> rvalue(
-    const VarMat& a, const cons_index_list<index_min_max, nil_index_list>& idx,
+    VarMat&& a, const cons_index_list<index_min_max, nil_index_list>& idx,
     const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),
                     idx.head_.min_ - 1);
@@ -556,7 +556,7 @@ inline std::decay_t<VarMat> rvalue(
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
-    const EigMat& mat,
+    EigMat&& mat,
     const cons_index_list<index_min_max,
                           cons_index_list<index_min_max, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -620,7 +620,7 @@ inline auto rvalue(
 template <typename VarMat,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline VarMat rvalue(
-    const VarMat& mat,
+    VarMat&& mat,
     const cons_index_list<index_min_max,
                           cons_index_list<index_min_max, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -680,7 +680,7 @@ inline VarMat rvalue(
  * @return Result of indexing matrix.
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
-inline auto rvalue(const EigMat& a,
+inline auto rvalue(EigMat&& a,
                    const cons_index_list<index_min, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),
@@ -705,7 +705,7 @@ inline auto rvalue(const EigMat& a,
  */
 template <typename VarMat,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
-inline auto rvalue(const VarMat& a,
+inline auto rvalue(VarMat&& a,
                    const cons_index_list<index_min, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),
@@ -728,7 +728,7 @@ inline auto rvalue(const VarMat& a,
  * @return Result of indexing matrix.
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
-inline auto rvalue(const EigMat& a,
+inline auto rvalue(EigMat&& a,
                    const cons_index_list<index_max, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),
@@ -751,7 +751,7 @@ inline auto rvalue(const EigMat& a,
  */
 template <typename VarMat,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
-inline auto rvalue(const VarMat& a,
+inline auto rvalue(VarMat&& a,
                    const cons_index_list<index_max, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),
@@ -776,7 +776,7 @@ inline auto rvalue(const VarMat& a,
 template <typename EigVec, typename I,
           require_eigen_vector_t<EigVec>* = nullptr>
 inline plain_type_t<EigVec> rvalue(
-    const EigVec& v, const cons_index_list<I, nil_index_list>& idx,
+    EigVec&& v, const cons_index_list<I, nil_index_list>& idx,
     const char* name = "ANON", int depth = 0) {
   const int size = rvalue_index_size(idx.head_, v.size());
   const auto& v_ref = stan::math::to_ref(v);
@@ -806,7 +806,7 @@ inline plain_type_t<EigVec> rvalue(
 template <typename VarVec, typename I,
           require_var_vt<is_eigen_vector, VarVec>* = nullptr>
 inline stan::math::var_value<plain_type_t<value_type_t<VarVec>>> rvalue(
-    const VarVec& v, const cons_index_list<I, nil_index_list>& idx,
+    VarVec&& v, const cons_index_list<I, nil_index_list>& idx,
     const char* name = "ANON", int depth = 0) {
   const int size = rvalue_index_size(idx.head_, v.size());
   using var_plain_type = plain_type_t<value_type_t<VarVec>>;
@@ -843,7 +843,7 @@ inline stan::math::var_value<plain_type_t<value_type_t<VarVec>>> rvalue(
  */
 template <typename EigMat, typename I,
           require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
-inline auto rvalue(const EigMat& a,
+inline auto rvalue(EigMat&& a,
                    const cons_index_list<I, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   const int n_rows = rvalue_index_size(idx.head_, a.rows());
@@ -873,7 +873,7 @@ inline auto rvalue(const EigMat& a,
  */
 template <typename VarMat,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
-inline auto rvalue(const VarMat& a,
+inline auto rvalue(VarMat&& a,
                    const cons_index_list<index_multi, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   const int n_rows = rvalue_index_size(idx.head_, a.rows());
@@ -908,7 +908,7 @@ inline auto rvalue(const VarMat& a,
 template <typename EigMat, typename I1, typename I2,
           require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline plain_type_t<EigMat> rvalue(
-    const EigMat& a,
+    EigMat&& a,
     const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   const auto& a_ref = stan::math::to_ref(a);
@@ -945,7 +945,7 @@ inline plain_type_t<EigMat> rvalue(
 template <typename VarMat, typename I1, typename I2,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    const VarMat& a,
+    VarMat&& a,
     const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   const int rows = rvalue_index_size(idx.head_, a.rows());

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -56,11 +56,11 @@ inline T rvalue(
 /**
  * Return the result of indexing a type without taking a subset
  *
- * Types:  type[,] : type
+ * Types:  type[omni, omni] : type
  *
  * @tparam T Any type.
  * @param[in] an object.
- * @param[in] idx Index consisting of one omni-index.
+ * @param[in] idx Index consisting of two omni-indices.
  * @param[in] name String form of expression being evaluated.
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
@@ -81,7 +81,7 @@ inline T rvalue(
  *
  * Types:  mat[single,] : rowvec
  *
- * @tparam T Scalar type.
+ * @tparam EigMat An eigen matrix
  * @param[in] a Eigen matrix.
  * @param[in] idx Index consisting of one uni-index.
  * @param[in] name String form of expression being evaluated.
@@ -98,9 +98,21 @@ inline auto rvalue(
   return a.row(idx.head_.n_ - 1).eval();
 }
 
+/**
+ * Return the result of indexing the specified var matrix with a
+ * sequence consisting of one single index, returning a row vector.
+ *
+ * Types:  mat[single,] : rowvec
+ *
+ * @tparam VarMat a `var_value` with underlying eigen matrix type.
+ * @param[in] a Eigen matrix.
+ * @param[in] idx Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
-inline auto rvalue(
-    VarMat&& a,
+inline auto rvalue(const VarMat& a,
     const cons_index_list<index_uni,
                           cons_index_list<index_omni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -112,9 +124,9 @@ inline auto rvalue(
  * Return the result of indexing the specified Eigen matrix with a
  * sequence consisting of one single index, returning a vector.
  *
- * Types:  mat[,single] : rowvec
+ * Types:  mat[,single] : vec
  *
- * @tparam T Scalar type.
+ * @tparam EigMat An eigen matrix
  * @param[in] a Eigen matrix.
  * @param[in] idx Index consisting of one uni-index.
  * @param[in] name String form of expression being evaluated.
@@ -122,8 +134,7 @@ inline auto rvalue(
  * @return Result of indexing matrix.
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
-inline auto rvalue(
-    const EigMat& a,
+inline auto rvalue(const EigMat& a,
     const cons_index_list<index_omni,
                           cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -131,9 +142,22 @@ inline auto rvalue(
   return a.col(idx.tail_.head_.n_ - 1).eval();
 }
 
+/**
+ * Return the result of indexing the specified var matrix with a
+ * sequence consisting of one single index, returning a vector.
+ *
+ * Types:  mat[,single] : vec
+ *
+ * @tparam VarMat a `var_value` with underlying eigen matrix type.
+ * @param[in] a Eigen matrix.
+ * @param[in] idx Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    VarMat&& a,
+    const VarMat& a,
     const cons_index_list<index_omni,
                           cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -147,7 +171,7 @@ inline auto rvalue(
  *
  * Types:  vec[single] : scal
  *
- * @tparam T Scalar type.
+ * @tparam EigVec An eigen vector
  * @param[in] v Vector being indexed.
  * @param[in] idx One single index.
  * @param[in] name String form of expression being evaluated.
@@ -163,8 +187,21 @@ inline auto&& rvalue(const EigVec& v,
   return v_ref.coeffRef(idx.head_.n_ - 1);
 }
 
-template <typename VarMat, require_var_vt<is_eigen_vector, VarMat>* = nullptr>
-inline auto rvalue(VarMat&& v,
+/**
+ * Return the result of indexing the specified Eigen vector with a
+ * sequence containing one single index, returning a scalar.
+ *
+ * Types:  vec[single] : scal
+ *
+ * @tparam VarVec a `var_value` with underlying vector type.
+ * @param[in] v Vector being indexed.
+ * @param[in] idx One single index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing vector.
+ */
+template <typename VarVec, require_var_vt<is_eigen_vector, VarVec>* = nullptr>
+inline auto rvalue(const VarVec& v,
                    const cons_index_list<index_uni, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("vector[single] indexing", name, v.size(), idx.head_.n_);
@@ -177,7 +214,7 @@ inline auto rvalue(VarMat&& v,
  *
  * Types:  mat[single] : rowvec
  *
- * @tparam T Scalar type.
+ * @tparam EigMat An eigen matrix
  * @param[in] a Eigen matrix.
  * @param[in] idx Index consisting of one uni-index.
  * @param[in] name String form of expression being evaluated.
@@ -192,8 +229,21 @@ inline auto rvalue(const EigMat& a,
   return a.row(idx.head_.n_ - 1);
 }
 
+/**
+ * Return the result of indexing the specified var matrix with a
+ * sequence consisting of one single index, returning a row vector.
+ *
+ * Types:  mat[single] : rowvec
+ *
+ * @tparam VarMat a `var_value` with underlying matrix type.
+ * @param[in] a var matrix
+ * @param[in] idx Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
-inline auto rvalue(VarMat&& a,
+inline auto rvalue(const VarMat& a,
                    const cons_index_list<index_uni, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("varmatrix[uni] indexing", name, a.rows(), idx.head_.n_);
@@ -207,7 +257,7 @@ inline auto rvalue(VarMat&& a,
  *
  * Types:  mat[single,single] : scalar
  *
- * @tparam T Scalar type.
+ * @tparam EigMat An eigen type
  * @param[in] a Matrix to index.
  * @param[in] idx Pair of single indexes.
  * @param[in] name String form of expression being evaluated.
@@ -215,7 +265,7 @@ inline auto rvalue(VarMat&& a,
  * @return Result of indexing matrix.
  */
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
-inline auto&& rvalue(
+inline auto& rvalue(
     const EigMat& a,
     const cons_index_list<index_uni,
                           cons_index_list<index_uni, nil_index_list>>& idx,
@@ -228,9 +278,22 @@ inline auto&& rvalue(
   return a_ref.coeffRef(idx.head_.n_ - 1, idx.tail_.head_.n_ - 1);
 }
 
+/**
+ * Return the result of indexing the specified var matrix with a
+ * sequence consisting of two single indexes, returning a scalar.
+ *
+ * Types:  mat[single, single] : scalar
+ *
+ * @tparam VarMat a `var_value` with underlying matrix type.
+ * @param[in] a Matrix to index.
+ * @param[in] idx Pair of single indexes.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    VarMat&& a,
+    const VarMat& a,
     const cons_index_list<index_uni,
                           cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -246,9 +309,9 @@ inline auto rvalue(
  * sequence consisting of a single index and multiple index,
  * returning a row vector.
  *
- * Types:  mat[single,multiple] : row vector
+ * Types:  mat[single, multiple] : row vector
  *
- * @tparam T Scalar type.
+ * @tparam EigMat An eigen matrix
  * @tparam I Type of multiple index.
  * @param[in] a Matrix to index.
  * @param[in] idx Pair of single index and multiple index.
@@ -267,24 +330,40 @@ inline auto rvalue(
   return rvalue(a.row(m - 1), idx.tail_);
 }
 
+/**
+ * Return the result of indexing the specified var matrix with a
+ * sequence consisting of a single index and multiple index,
+ * returning a row vector.
+ *
+ * Types:  mat[single, multiple] : row vector
+ *
+ * @tparam VarMat a `var_value` with underlying matrix type.
+ * @tparam I Type of multiple index.
+ * @param[in] a Matrix to index.
+ * @param[in] idx Pair of single index and multiple index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename VarMat, typename I,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    VarMat&& a,
+    const VarMat& a,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   int m = idx.head_.n_;
   math::check_range("matrix[uni,multi] indexing, row", name, a.rows(), m);
   return rvalue(a.row(m - 1), idx.tail_);
 }
+
 /**
  * Return the result of indexing the specified Eigen matrix with a
  * sequence consisting of a multiple index and a single index,
  * returning a vector.
  *
- * Types:  mat[multiple,single] : vector
+ * Types:  mat[multiple, single] : vector
  *
- * @tparam T Scalar type.
+ * @tparam EigMat An eigen matrix
  * @tparam I Type of multiple index.
  * @param[in] a Matrix to index.
  * @param[in] idx Pair multiple index and single index.
@@ -303,10 +382,25 @@ inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, 1> rvalue(
   return rvalue(a.col(m - 1), index_list(idx.head_));
 }
 
+/**
+ * Return the result of indexing the specified var matrix with a
+ * sequence consisting of a multiple index and a single index,
+ * returning a vector.
+ *
+ * Types:  mat[multiple, single] : vector
+ *
+ * @tparam VarMat a `var_value` with underlying matrix type.
+ * @tparam I Type of multiple index.
+ * @param[in] a Matrix to index.
+ * @param[in] idx Pair multiple index and single index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename VarMat, typename I,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    VarMat&& a,
+    const VarMat& a,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   const int m = idx.tail_.head_.n_;
@@ -315,12 +409,12 @@ inline auto rvalue(
 }
 
 /**
- * Return the result of indexing the specified Eigen vector with a
- * sequence containing one single index, returning a scalar.
+ * Return the result of indexing the specified Eigen vector min_max index,
+ *  returning a vector
  *
- * Types:  vec[single] : scal
+ * Types:  vec[min_max] : vector
  *
- * @tparam T Scalar type.
+ * @tparam EigVec An eigen vector
  * @param[in] v Vector being indexed.
  * @param[in] idx One single index.
  * @param[in] name String form of expression being evaluated.
@@ -345,9 +439,22 @@ inline auto rvalue(const EigVec& v,
   }
 }
 
-template <typename VarMat, require_var_vt<is_eigen_vector, VarMat>* = nullptr>
-inline std::decay_t<VarMat> rvalue(
-    VarMat&& v, const cons_index_list<index_min_max, nil_index_list>& idx,
+/**
+ * Return the result of indexing the specified var vector min_max index,
+ *  returning a vector
+ *
+ * Types:  vec[min_max] : vector
+ *
+ * @tparam VarVec a `var_value` with underlying vector type.
+ * @param[in] v Vector being indexed.
+ * @param[in] idx One single index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing vector.
+ */
+template <typename VarVec, require_var_vt<is_eigen_vector, VarVec>* = nullptr>
+inline std::decay_t<VarVec> rvalue(
+    const VarVec& v, const cons_index_list<index_min_max, nil_index_list>& idx,
     const char* name = "ANON", int depth = 0) {
   math::check_range("var_vector[min_max] min indexing", name, v.size(),
                     idx.head_.min_);
@@ -363,6 +470,20 @@ inline std::decay_t<VarMat> rvalue(
   }
 }
 
+/**
+ * Return the result of indexing the specified Eigen matrix with a
+ * min_max_index returning a block from max to min.
+ *
+ * Types:  mat[min_max] : matrix
+ *
+ * @tparam EigMat An eigen matrix
+ * @tparam I Type of multiple index.
+ * @param[in] a Matrix to index.
+ * @param[in] idx Pair multiple index and single index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline EigMat rvalue(const EigMat& a,
                      const cons_index_list<index_min_max, nil_index_list>& idx,
@@ -381,9 +502,23 @@ inline EigMat rvalue(const EigMat& a,
   }
 }
 
+/**
+ * Return the result of indexing the specified var matrix with a
+ * min_max_index returning a block from max to min.
+ *
+ * Types:  mat[min_max] : matrix
+ *
+ * @tparam VarMat a `var_value` with underlying matrix type.
+ * @tparam I Type of multiple index.
+ * @param[in] a Matrix to index.
+ * @param[in] idx Pair multiple index and single index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline std::decay_t<VarMat> rvalue(
-    VarMat&& a, const cons_index_list<index_min_max, nil_index_list>& idx,
+    const VarMat& a, const cons_index_list<index_min_max, nil_index_list>& idx,
     const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),
                     idx.head_.min_ - 1);
@@ -401,12 +536,12 @@ inline std::decay_t<VarMat> rvalue(
 }
 
 /**
- * Return the result of indexing the specified Eigen matrix with a
- * sequence consisting of one single index, returning a row vector.
+ * Return the result of indexing the specified Eigen matrix with two min_max
+ * indices, returning back a block of the Eigen matrix.
  *
- * Types:  mat[single,] : rowvec
+ * Types:  mat[min_max, min_max] : matrix
  *
- * @tparam T Scalar type.
+ * @tparam EigMat An eigen matrix
  * @param[in] a Eigen matrix.
  * @param[in] idx Index consisting of one uni-index.
  * @param[in] name String form of expression being evaluated.
@@ -463,9 +598,22 @@ inline auto rvalue(
   }
 }
 
+/**
+ * Return the result of indexing the specified var matrix with two min_max
+ * indices, returning back a block of the Eigen matrix.
+ *
+ * Types:  mat[min_max, min_max] : matrix
+ *
+ * @tparam VarMat a `var_value` with underlying matrix type.
+ * @param[in] a Eigen matrix.
+ * @param[in] idx Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline VarMat rvalue(
-    VarMat&& mat,
+    const VarMat& mat,
     const cons_index_list<index_min_max,
                           cons_index_list<index_min_max, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -509,6 +657,19 @@ inline VarMat rvalue(
   }
 }
 
+/**
+ * Return the result of indexing the specified Eigen matrix with a min index
+ * returning back a block of rows min:N and all cols
+ *
+ * Types:  mat[min:] : matrix
+ *
+ * @tparam EigMat An eigen matrix
+ * @param[in] a Eigen matrix.
+ * @param[in] idx Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(const EigMat& a,
                    const cons_index_list<index_min, nil_index_list>& idx,
@@ -519,6 +680,42 @@ inline auto rvalue(const EigMat& a,
                  a.cols());
 }
 
+/**
+ * Return the result of indexing the specified var matrix with a min index
+ * returning back a block of rows min:N and all cols
+ *
+ * Types:  mat[min:] : matrix
+ *
+ * @tparam VarMat a `var_value` with underlying matrix type.
+ * @param[in] a Eigen matrix.
+ * @param[in] idx Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+inline auto rvalue(const VarMat& a,
+                   const cons_index_list<index_min, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[multi] indexing", name, a.rows(),
+                    idx.head_.min_ - 1);
+  return a.block(idx.head_.min_ - 1, 0, a.rows() - (idx.head_.min_ - 1),
+                 a.cols());
+}
+
+/**
+ * Return the result of indexing the specified Eigen matrix with a max index
+ * returning back a block of rows 1:max and all columns
+ *
+ * Types:  mat[:max] : matrix
+ *
+ * @tparam EigMat An eigen matrix
+ * @param[in] a Eigen matrix.
+ * @param[in] idx Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(const EigMat& a,
                    const cons_index_list<index_max, nil_index_list>& idx,
@@ -528,18 +725,21 @@ inline auto rvalue(const EigMat& a,
   return a.block(0, 0, idx.head_.max_, a.cols());
 }
 
+/**
+ * Return the result of indexing the specified var matrix with a max index
+ * returning back a block of rows 1:max and all columns
+ *
+ * Types:  mat[:max] : matrix
+ *
+ * @tparam VarMat a `var_value` with underlying matrix type.
+ * @param[in] a Eigen matrix.
+ * @param[in] idx Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
-inline auto rvalue(VarMat&& a,
-                   const cons_index_list<index_min, nil_index_list>& idx,
-                   const char* name = "ANON", int depth = 0) {
-  math::check_range("matrix[multi] indexing", name, a.rows(),
-                    idx.head_.min_ - 1);
-  return a.block(idx.head_.min_ - 1, 0, a.rows() - (idx.head_.min_ - 1),
-                 a.cols());
-}
-
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
-inline auto rvalue(VarMat&& a,
+inline auto rvalue(const VarMat& a,
                    const cons_index_list<index_max, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),
@@ -553,7 +753,7 @@ inline auto rvalue(VarMat&& a,
  *
  * Types: vec[multiple] : vec
  *
- * @tparam T Scalar type.
+ * @tparam EigMat An eigen vector
  * @tparam I Multi-index type.
  * @param[in] v Eigen vector.
  * @param[in] idx Index consisting of one multi-index.
@@ -577,13 +777,27 @@ inline plain_type_t<EigVec> rvalue(
   return a;
 }
 
-template <typename VarMat, typename I,
-          require_var_vt<is_eigen_vector, VarMat>* = nullptr>
-inline stan::math::var_value<plain_type_t<value_type_t<VarMat>>> rvalue(
-    VarMat&& v, const cons_index_list<I, nil_index_list>& idx,
+/**
+ * Return the result of indexing the specified Eigen vector with a
+ * sequence containing one multiple index, returning a vector.
+ *
+ * Types: vec[multiple] : vec
+ *
+ * @tparam VarVec a `var_value` with underlying vector type.
+ * @tparam I Multi-index type.
+ * @param[in] v Eigen vector.
+ * @param[in] idx Index consisting of one multi-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing vector.
+ */
+template <typename VarVec, typename I,
+          require_var_vt<is_eigen_vector, VarVec>* = nullptr>
+inline stan::math::var_value<plain_type_t<value_type_t<VarVec>>> rvalue(
+    const VarVec& v, const cons_index_list<I, nil_index_list>& idx,
     const char* name = "ANON", int depth = 0) {
   const int size = rvalue_index_size(idx.head_, v.size());
-  using var_plain_type = plain_type_t<value_type_t<VarMat>>;
+  using var_plain_type = plain_type_t<value_type_t<VarVec>>;
   arena_t<var_plain_type> a(size);
   arena_t<std::vector<int>> index_vec;
   for (int i = 0; i < size; ++i) {
@@ -595,31 +809,11 @@ inline stan::math::var_value<plain_type_t<value_type_t<VarMat>>> rvalue(
   stan::math::var_value<var_plain_type> ret_a(a);
   stan::math::reverse_pass_callback([index_vec, v, ret_a]() mutable {
     for (int i = 0; i < index_vec.size(); ++i) {
-      v.adj()(index_vec[i]) += ret_a.adj()(i);
+      v.adj().coeffRef(index_vec[i]) += ret_a.adj().coeffRef(i);
     }
   });
   return ret_a;
 }
-
-
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
-inline auto rvalue(VarMat&& a,
-                   const cons_index_list<index_multi, nil_index_list>& idx,
-                   const char* name = "ANON", int depth = 0) {
-  const int n_rows = rvalue_index_size(idx.head_, a.rows());
-  plain_type_t<value_type_t<VarMat>> b(n_rows, a.cols());
-  for (int i = 0; i < n_rows; ++i) {
-    const int n = rvalue_at(i, idx.head_);
-    math::check_range("matrix[multi] indexing", name, a.rows(), n);
-    b.row(i) = a.val().row(n - 1);
-  }
-  stan::math::var_value<value_type_t<VarMat>> a_ret(b);
-  stan::math::reverse_pass_callback([a, a_ret]() {
-    a.vi_->adj_ += a_ret.vi_->adj_;
-  });
-  return a_ret;
-}
-
 
 /**
  * Return the result of indexing the specified Eigen matrix with a
@@ -627,7 +821,7 @@ inline auto rvalue(VarMat&& a,
  *
  * Types:  mat[multiple] : mat
  *
- * @tparam T Scalar type.
+ * @tparam EigMat An eigen matrix
  * @tparam I Type of multiple index.
  * @param[in] a Matrix to index.
  * @param[in] idx Index consisting of single multiple index.
@@ -652,13 +846,47 @@ inline auto rvalue(const EigMat& a,
 }
 
 /**
+ * Return the result of indexing the specified var matrix with a
+ * sequence containing one multiple index, returning a vector.
+ *
+ * Types: matrix[multiple] : matrix
+ *
+ * @tparam VarMat a `var_value` with underlying matrix type.
+ * @tparam I Multi-index type.
+ * @param[in] v Eigen vector.
+ * @param[in] idx Index consisting of one multi-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing vector.
+ */
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+inline auto rvalue(const VarMat& a,
+                   const cons_index_list<index_multi, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
+  const int n_rows = rvalue_index_size(idx.head_, a.rows());
+  using var_plain_type = plain_type_t<value_type_t<VarMat>>;
+  arena_t<var_plain_type> b(n_rows, a.cols());
+  for (int i = 0; i < n_rows; ++i) {
+    const int n = rvalue_at(i, idx.head_);
+    math::check_range("matrix[multi] indexing", name, a.rows(), n);
+    b.row(i) = a.val().row(n - 1);
+  }
+  stan::math::var_value<var_plain_type> a_ret(b);
+  stan::math::reverse_pass_callback([a, a_ret]() {
+    a.vi_->adj_ += a_ret.vi_->adj_;
+  });
+  return a_ret;
+}
+
+
+/**
  * Return the result of indexing the specified Eigen matrix with a
  * sequence consisting of a pair o multiple indexes, returning a
  * a matrix.
  *
  * Types:  mat[multiple,multiple] : mat
  *
- * @tparam T Scalar type.
+ * @tparam EigMat An eigen matrix
  * @tparam I Type of multiple index.
  * @param[in] a Matrix to index.
  * @param[in] idx Pair of multiple indexes.
@@ -688,15 +916,31 @@ inline plain_type_t<EigMat> rvalue(
   return c;
 }
 
+/**
+ * Return the result of indexing the specified var matrix with a
+ * sequence consisting of a pair o multiple indexes, returning a
+ * a matrix.
+ *
+ * Types:  mat[multiple,multiple] : mat
+ *
+ * @tparam VarMat a `var_value` with underlying matrix type.
+ * @tparam I Type of multiple index.
+ * @param[in] a Matrix to index.
+ * @param[in] idx Pair of multiple indexes.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
 template <typename VarMat, typename I1, typename I2,
           require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
-    VarMat&& a,
+    const VarMat& a,
     const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
   const int rows = rvalue_index_size(idx.head_, a.rows());
   const int cols = rvalue_index_size(idx.tail_.head_, a.cols());
-  plain_type_t<value_type_t<VarMat>> c(rows, cols);
+  using var_plain_type = plain_type_t<value_type_t<VarMat>>;
+  arena_t<plain_type_t<var_plain_type>> c(rows, cols);
   arena_t<std::vector<int>> m_slice;
   arena_t<std::vector<int>> n_slice;
   for (int j = 0; j < cols; ++j) {
@@ -710,7 +954,7 @@ inline auto rvalue(
       n_slice.push_back(n - 1);
     }
   }
-  stan::math::var_value<plain_type_t<value_type_t<VarMat>>> a_ret(c);
+  stan::math::var_value<var_plain_type> a_ret(c);
   stan::math::reverse_pass_callback([cols, rows, m_slice, n_slice, a,
                                      a_ret]() mutable {
     for (int j = 0; j < cols; ++j) {
@@ -744,6 +988,27 @@ inline auto rvalue(StdVec&& c, const cons_index_list<index_uni, L>& idx,
   const int n = idx.head_.n_;
   math::check_range("array[uni,...] index", name, c.size(), n);
   return rvalue(c[n - 1], idx.tail_, name, depth + 1);
+}
+
+/**
+ * Return the result of indexing the specified array with
+ * a single index.
+ *
+ * Types:  std::vector<T>[single] : T
+ *
+ * @tparam StdVec a standard vector
+ * @param[in] c Container of list elements.
+ * @param[in] idx Index list beginning with single index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing array.
+ */
+template <typename StdVec, typename L, require_std_vector_t<StdVec>* = nullptr>
+inline auto rvalue(StdVec&& c, const cons_index_list<index_uni, nil_index_list>& idx,
+                   const char* name = "ANON", int depth = 0) {
+  const int n = idx.head_.n_;
+  math::check_range("array[uni,...] index", name, c.size(), n);
+  return std::forward<StdVec>(c)[n - 1];
 }
 
 /**

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -74,6 +74,7 @@ inline T rvalue(
   return std::forward<T>(a);
 }
 
+
 /**
  * Return the result of indexing the specified Eigen matrix with a
  * sequence consisting of one single index, returning a row vector.
@@ -87,7 +88,7 @@ inline T rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename EigMat, require_eigen_matrix_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
     const EigMat& a,
     const cons_index_list<index_uni,
@@ -97,7 +98,7 @@ inline auto rvalue(
   return a.row(idx.head_.n_ - 1).eval();
 }
 
-template <typename VarMat, require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
     VarMat&& a,
     const cons_index_list<index_uni,
@@ -120,7 +121,7 @@ inline auto rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename EigMat, require_eigen_matrix_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
     const EigMat& a,
     const cons_index_list<index_omni,
@@ -130,7 +131,7 @@ inline auto rvalue(
   return a.col(idx.tail_.head_.n_ - 1).eval();
 }
 
-template <typename VarMat, require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
     VarMat&& a,
     const cons_index_list<index_omni,
@@ -183,7 +184,7 @@ inline auto rvalue(VarMat&& v,
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename EigMat, require_eigen_matrix_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(const EigMat& a,
                    const cons_index_list<index_uni, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -191,7 +192,7 @@ inline auto rvalue(const EigMat& a,
   return a.row(idx.head_.n_ - 1);
 }
 
-template <typename VarMat, require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(VarMat&& a,
                    const cons_index_list<index_uni, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -227,7 +228,7 @@ inline auto&& rvalue(
   return a_ref.coeffRef(idx.head_.n_ - 1, idx.tail_.head_.n_ - 1);
 }
 
-template <typename VarMat, require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
     VarMat&& a,
     const cons_index_list<index_uni,
@@ -256,7 +257,7 @@ inline auto rvalue(
  * @return Result of indexing matrix.
  */
 template <typename EigMat, typename I,
-          require_eigen_matrix_t<EigMat>* = nullptr>
+          require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
     const EigMat& a,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list>>& idx,
@@ -267,7 +268,7 @@ inline auto rvalue(
 }
 
 template <typename VarMat, typename I,
-          require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
     VarMat&& a,
     const cons_index_list<index_uni, cons_index_list<I, nil_index_list>>& idx,
@@ -292,7 +293,7 @@ inline auto rvalue(
  * @return Result of indexing matrix.
  */
 template <typename EigMat, typename I,
-          require_eigen_matrix_t<EigMat>* = nullptr>
+          require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, 1> rvalue(
     const EigMat& a,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idx,
@@ -303,7 +304,7 @@ inline Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, 1> rvalue(
 }
 
 template <typename VarMat, typename I,
-          require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
     VarMat&& a,
     const cons_index_list<I, cons_index_list<index_uni, nil_index_list>>& idx,
@@ -362,7 +363,7 @@ inline std::decay_t<VarMat> rvalue(
   }
 }
 
-template <typename EigMat, require_eigen_matrix_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline EigMat rvalue(const EigMat& a,
                      const cons_index_list<index_min_max, nil_index_list>& idx,
                      const char* name = "ANON", int depth = 0) {
@@ -376,13 +377,11 @@ inline EigMat rvalue(const EigMat& a,
   } else {
     return a
         .block(idx.head_.max_ - 1, 0, idx.head_.min_ - (idx.head_.max_ - 1),
-               a.cols())
-        .rowwise()
-        .reverse();
+               a.cols()).rowwise().reverse();
   }
 }
 
-template <typename VarMat, require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline std::decay_t<VarMat> rvalue(
     VarMat&& a, const cons_index_list<index_min_max, nil_index_list>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -397,8 +396,7 @@ inline std::decay_t<VarMat> rvalue(
     return a
         .block(idx.head_.max_ - 1, 0, idx.head_.min_ - (idx.head_.max_ - 1),
                a.cols())
-        .rowwise()
-        .reverse();
+        .rowwise_reverse();
   }
 }
 
@@ -415,7 +413,7 @@ inline std::decay_t<VarMat> rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename EigMat, require_eigen_matrix_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
     const EigMat& mat,
     const cons_index_list<index_min_max,
@@ -459,16 +457,13 @@ inline auto rvalue(
           .block(idx.head_.max_ - 1, idx.tail_.head_.max_ - 1,
                  idx.head_.min_ - (idx.head_.max_ - 1),
                  idx.tail_.head_.min_ - (idx.tail_.head_.max_ - 1))
-          .rowwise()
-          .reverse()
-          .colwise()
           .reverse()
           .eval();
     }
   }
 }
 
-template <typename VarMat, require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline VarMat rvalue(
     VarMat&& mat,
     const cons_index_list<index_min_max,
@@ -494,9 +489,7 @@ inline VarMat rvalue(
           .block(idx.head_.min_ - 1, idx.tail_.head_.max_ - 1,
                  idx.head_.max_ - (idx.head_.min_ - 1),
                  idx.tail_.head_.min_ - (idx.tail_.head_.max_ - 1))
-          .colwise()
-          .reverse()
-          .eval();
+          .colwise_reverse().eval();
     }
   } else {
     if (idx.tail_.head_.min_ <= idx.tail_.head_.max_) {
@@ -504,24 +497,19 @@ inline VarMat rvalue(
           .block(idx.head_.max_ - 1, idx.tail_.head_.min_ - 1,
                  idx.head_.min_ - (idx.head_.max_ - 1),
                  idx.tail_.head_.max_ - (idx.tail_.head_.min_ - 1))
-          .rowwise()
-          .reverse()
-          .eval();
+          .rowwise_reverse().eval();
     } else {
       return mat
           .block(idx.head_.max_ - 1, idx.tail_.head_.max_ - 1,
                  idx.head_.min_ - (idx.head_.max_ - 1),
                  idx.tail_.head_.min_ - (idx.tail_.head_.max_ - 1))
-          .rowwise()
-          .reverse()
-          .colwise()
           .reverse()
           .eval();
     }
   }
 }
 
-template <typename EigMat, require_eigen_matrix_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(const EigMat& a,
                    const cons_index_list<index_min, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -531,7 +519,7 @@ inline auto rvalue(const EigMat& a,
                  a.cols());
 }
 
-template <typename EigMat, require_eigen_matrix_t<EigMat>* = nullptr>
+template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(const EigMat& a,
                    const cons_index_list<index_max, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -540,7 +528,7 @@ inline auto rvalue(const EigMat& a,
   return a.block(0, 0, idx.head_.max_, a.cols());
 }
 
-template <typename VarMat, require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(VarMat&& a,
                    const cons_index_list<index_min, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -550,7 +538,7 @@ inline auto rvalue(VarMat&& a,
                  a.cols());
 }
 
-template <typename VarMat, require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(VarMat&& a,
                    const cons_index_list<index_max, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -595,7 +583,8 @@ inline stan::math::var_value<plain_type_t<value_type_t<VarMat>>> rvalue(
     VarMat&& v, const cons_index_list<I, nil_index_list>& idx,
     const char* name = "ANON", int depth = 0) {
   const int size = rvalue_index_size(idx.head_, v.size());
-  arena_t<value_type_t<VarMat>> a(size);
+  using var_plain_type = plain_type_t<value_type_t<VarMat>>;
+  arena_t<var_plain_type> a(size);
   arena_t<std::vector<int>> index_vec;
   for (int i = 0; i < size; ++i) {
     const int n = rvalue_at(i, idx.head_);
@@ -603,7 +592,7 @@ inline stan::math::var_value<plain_type_t<value_type_t<VarMat>>> rvalue(
     a.coeffRef(i) = v.val().coeffRef(n - 1);
     index_vec.push_back(n - 1);
   }
-  stan::math::var_value<plain_type_t<value_type_t<VarMat>>> ret_a(a);
+  stan::math::var_value<var_plain_type> ret_a(a);
   stan::math::reverse_pass_callback([index_vec, v, ret_a]() mutable {
     for (int i = 0; i < index_vec.size(); ++i) {
       v.adj()(index_vec[i]) += ret_a.adj()(i);
@@ -613,7 +602,7 @@ inline stan::math::var_value<plain_type_t<value_type_t<VarMat>>> rvalue(
 }
 
 
-template <typename VarMat, require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(VarMat&& a,
                    const cons_index_list<index_multi, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -647,7 +636,7 @@ inline auto rvalue(VarMat&& a,
  * @return Result of indexing matrix.
  */
 template <typename EigMat, typename I,
-          require_eigen_matrix_t<EigMat>* = nullptr>
+          require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(const EigMat& a,
                    const cons_index_list<I, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -678,7 +667,7 @@ inline auto rvalue(const EigMat& a,
  * @return Result of indexing matrix.
  */
 template <typename EigMat, typename I1, typename I2,
-          require_eigen_matrix_t<EigMat>* = nullptr>
+          require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
 inline plain_type_t<EigMat> rvalue(
     const EigMat& a,
     const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idx,
@@ -700,7 +689,7 @@ inline plain_type_t<EigMat> rvalue(
 }
 
 template <typename VarMat, typename I1, typename I2,
-          require_var_vt<is_eigen_matrix, VarMat>* = nullptr>
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
     VarMat&& a,
     const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idx,

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -488,9 +488,9 @@ inline std::decay_t<VarVec> rvalue(
  * @return Result of indexing matrix.
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
-inline plain_type_t<EigMat> rvalue(EigMat&& a,
-                     const cons_index_list<index_min_max, nil_index_list>& idx,
-                     const char* name = "ANON", int depth = 0) {
+inline plain_type_t<EigMat> rvalue(
+    EigMat&& a, const cons_index_list<index_min_max, nil_index_list>& idx,
+    const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),
                     idx.head_.min_ - 1);
   math::check_range("matrix[multi] indexing", name, a.rows(),

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -488,7 +488,7 @@ inline std::decay_t<VarVec> rvalue(
  * @return Result of indexing matrix.
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
-inline EigMat rvalue(EigMat&& a,
+inline plain_type_t<EigMat> rvalue(EigMat&& a,
                      const cons_index_list<index_min_max, nil_index_list>& idx,
                      const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[multi] indexing", name, a.rows(),

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -28,8 +28,8 @@ namespace model {
  * @return Input value.
  */
 template <typename T>
-inline T rvalue(T&& c, const nil_index_list& /*idx*/,
-                             const char* /*name*/ = "", int /*depth*/ = 0) {
+inline T rvalue(T&& c, const nil_index_list& /*idx*/, const char* /*name*/ = "",
+                int /*depth*/ = 0) {
   return std::forward<T>(c);
 }
 
@@ -47,9 +47,8 @@ inline T rvalue(T&& c, const nil_index_list& /*idx*/,
  * @return Result of indexing matrix.
  */
 template <typename T>
-inline T rvalue(
-    T&& a, const cons_index_list<index_omni, nil_index_list>& idx,
-    const char* name = "ANON", int depth = 0) {
+inline T rvalue(T&& a, const cons_index_list<index_omni, nil_index_list>& idx,
+                const char* name = "ANON", int depth = 0) {
   return std::forward<T>(a);
 }
 
@@ -73,7 +72,6 @@ inline T rvalue(
     const char* name = "ANON", int depth = 0) {
   return std::forward<T>(a);
 }
-
 
 /**
  * Return the result of indexing the specified Eigen matrix with a
@@ -111,8 +109,10 @@ inline auto rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
-inline auto rvalue(const VarMat& a,
+template <typename VarMat,
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+inline auto rvalue(
+    const VarMat& a,
     const cons_index_list<index_uni,
                           cons_index_list<index_omni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -134,7 +134,8 @@ inline auto rvalue(const VarMat& a,
  * @return Result of indexing matrix.
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr>
-inline auto rvalue(const EigMat& a,
+inline auto rvalue(
+    const EigMat& a,
     const cons_index_list<index_omni,
                           cons_index_list<index_uni, nil_index_list>>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -155,7 +156,8 @@ inline auto rvalue(const EigMat& a,
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+template <typename VarMat,
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
     const VarMat& a,
     const cons_index_list<index_omni,
@@ -242,14 +244,14 @@ inline auto rvalue(const EigMat& a,
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+template <typename VarMat,
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(const VarMat& a,
                    const cons_index_list<index_uni, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("varmatrix[uni] indexing", name, a.rows(), idx.head_.n_);
   return a.row(idx.head_.n_ - 1);
 }
-
 
 /**
  * Return the result of indexing the specified Eigen matrix with a
@@ -291,7 +293,8 @@ inline auto& rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+template <typename VarMat,
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(
     const VarMat& a,
     const cons_index_list<index_uni,
@@ -498,7 +501,9 @@ inline EigMat rvalue(const EigMat& a,
   } else {
     return a
         .block(idx.head_.max_ - 1, 0, idx.head_.min_ - (idx.head_.max_ - 1),
-               a.cols()).rowwise().reverse();
+               a.cols())
+        .rowwise()
+        .reverse();
   }
 }
 
@@ -516,7 +521,8 @@ inline EigMat rvalue(const EigMat& a,
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+template <typename VarMat,
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline std::decay_t<VarMat> rvalue(
     const VarMat& a, const cons_index_list<index_min_max, nil_index_list>& idx,
     const char* name = "ANON", int depth = 0) {
@@ -611,7 +617,8 @@ inline auto rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+template <typename VarMat,
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline VarMat rvalue(
     const VarMat& mat,
     const cons_index_list<index_min_max,
@@ -637,7 +644,8 @@ inline VarMat rvalue(
           .block(idx.head_.min_ - 1, idx.tail_.head_.max_ - 1,
                  idx.head_.max_ - (idx.head_.min_ - 1),
                  idx.tail_.head_.min_ - (idx.tail_.head_.max_ - 1))
-          .colwise_reverse().eval();
+          .colwise_reverse()
+          .eval();
     }
   } else {
     if (idx.tail_.head_.min_ <= idx.tail_.head_.max_) {
@@ -645,7 +653,8 @@ inline VarMat rvalue(
           .block(idx.head_.max_ - 1, idx.tail_.head_.min_ - 1,
                  idx.head_.min_ - (idx.head_.max_ - 1),
                  idx.tail_.head_.max_ - (idx.tail_.head_.min_ - 1))
-          .rowwise_reverse().eval();
+          .rowwise_reverse()
+          .eval();
     } else {
       return mat
           .block(idx.head_.max_ - 1, idx.tail_.head_.max_ - 1,
@@ -693,7 +702,8 @@ inline auto rvalue(const EigMat& a,
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+template <typename VarMat,
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(const VarMat& a,
                    const cons_index_list<index_min, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -738,7 +748,8 @@ inline auto rvalue(const EigMat& a,
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+template <typename VarMat,
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(const VarMat& a,
                    const cons_index_list<index_max, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -859,7 +870,8 @@ inline auto rvalue(const EigMat& a,
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing vector.
  */
-template <typename VarMat, require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
+template <typename VarMat,
+          require_var_vt<is_eigen_matrix_dynamic, VarMat>* = nullptr>
 inline auto rvalue(const VarMat& a,
                    const cons_index_list<index_multi, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
@@ -872,12 +884,10 @@ inline auto rvalue(const VarMat& a,
     b.row(i) = a.val().row(n - 1);
   }
   stan::math::var_value<var_plain_type> a_ret(b);
-  stan::math::reverse_pass_callback([a, a_ret]() {
-    a.vi_->adj_ += a_ret.vi_->adj_;
-  });
+  stan::math::reverse_pass_callback(
+      [a, a_ret]() { a.vi_->adj_ += a_ret.vi_->adj_; });
   return a_ret;
 }
-
 
 /**
  * Return the result of indexing the specified Eigen matrix with a
@@ -1004,7 +1014,8 @@ inline auto rvalue(StdVec&& c, const cons_index_list<index_uni, L>& idx,
  * @return Result of indexing array.
  */
 template <typename StdVec, typename L, require_std_vector_t<StdVec>* = nullptr>
-inline auto rvalue(StdVec&& c, const cons_index_list<index_uni, nil_index_list>& idx,
+inline auto rvalue(StdVec&& c,
+                   const cons_index_list<index_uni, nil_index_list>& idx,
                    const char* name = "ANON", int depth = 0) {
   const int n = idx.head_.n_;
   math::check_range("array[uni,...] index", name, c.size(), n);

--- a/src/stan/model/indexing/rvalue_at.hpp
+++ b/src/stan/model/indexing/rvalue_at.hpp
@@ -40,7 +40,9 @@ inline constexpr int rvalue_at(int n, const index_omni& idx) { return n + 1; }
  * @param[in] idx Index (from 1)
  * @return Underlying index position (from 1).
  */
-inline constexpr int rvalue_at(int n, const index_min& idx) { return idx.min_ + n; }
+inline constexpr int rvalue_at(int n, const index_min& idx) {
+  return idx.min_ + n;
+}
 
 /**
  * Return the index in the underlying array corresponding to the
@@ -64,7 +66,9 @@ inline constexpr int rvalue_at(int n, const index_max& idx) { return n + 1; }
  * @param[in] idx Index (from 1).
  * @return Underlying index position (from 1).
  */
-inline constexpr int rvalue_at(int n, const index_min_max& idx) { return idx.min_ + n; }
+inline constexpr int rvalue_at(int n, const index_min_max& idx) {
+  return idx.min_ + n;
+}
 
 }  // namespace model
 }  // namespace stan

--- a/src/stan/model/indexing/rvalue_at.hpp
+++ b/src/stan/model/indexing/rvalue_at.hpp
@@ -28,7 +28,7 @@ inline int rvalue_at(int n, const index_multi& idx) { return idx.ns_[n]; }
  * @param[in] idx Index (from 1).
  * @return Underlying index position (from 1).
  */
-inline int rvalue_at(int n, const index_omni& idx) { return n + 1; }
+inline constexpr int rvalue_at(int n, const index_omni& idx) { return n + 1; }
 
 /**
  * Return the index in the underlying array corresponding to the
@@ -40,7 +40,7 @@ inline int rvalue_at(int n, const index_omni& idx) { return n + 1; }
  * @param[in] idx Index (from 1)
  * @return Underlying index position (from 1).
  */
-inline int rvalue_at(int n, const index_min& idx) { return idx.min_ + n; }
+inline constexpr int rvalue_at(int n, const index_min& idx) { return idx.min_ + n; }
 
 /**
  * Return the index in the underlying array corresponding to the
@@ -52,7 +52,7 @@ inline int rvalue_at(int n, const index_min& idx) { return idx.min_ + n; }
  * @param[in] idx Index (from 1).
  * @return Underlying index position (from 1).
  */
-inline int rvalue_at(int n, const index_max& idx) { return n + 1; }
+inline constexpr int rvalue_at(int n, const index_max& idx) { return n + 1; }
 
 /**
  * Return the index in the underlying array corresponding to the
@@ -64,7 +64,7 @@ inline int rvalue_at(int n, const index_max& idx) { return n + 1; }
  * @param[in] idx Index (from 1).
  * @return Underlying index position (from 1).
  */
-inline int rvalue_at(int n, const index_min_max& idx) { return idx.min_ + n; }
+inline constexpr int rvalue_at(int n, const index_min_max& idx) { return idx.min_ + n; }
 
 }  // namespace model
 }  // namespace stan

--- a/src/stan/model/indexing/rvalue_index_size.hpp
+++ b/src/stan/model/indexing/rvalue_index_size.hpp
@@ -28,7 +28,9 @@ inline int rvalue_index_size(const index_multi& idx, int size) {
  * @param[in] size Size of container.
  * @return Size of result.
  */
-inline constexpr int rvalue_index_size(const index_omni& idx, int size) { return size; }
+inline constexpr int rvalue_index_size(const index_omni& idx, int size) {
+  return size;
+}
 
 /**
  * Return size of specified min index for specified size of

--- a/src/stan/model/indexing/rvalue_index_size.hpp
+++ b/src/stan/model/indexing/rvalue_index_size.hpp
@@ -28,7 +28,7 @@ inline int rvalue_index_size(const index_multi& idx, int size) {
  * @param[in] size Size of container.
  * @return Size of result.
  */
-inline int rvalue_index_size(const index_omni& idx, int size) { return size; }
+inline constexpr int rvalue_index_size(const index_omni& idx, int size) { return size; }
 
 /**
  * Return size of specified min index for specified size of
@@ -38,7 +38,7 @@ inline int rvalue_index_size(const index_omni& idx, int size) { return size; }
  * @param[in] size Size of container.
  * @return Size of result.
  */
-inline int rvalue_index_size(const index_min& idx, int size) {
+inline constexpr int rvalue_index_size(const index_min& idx, int size) {
   return size - idx.min_ + 1;
 }
 
@@ -49,7 +49,7 @@ inline int rvalue_index_size(const index_min& idx, int size) {
  * @param[in] size Size of container (ignored).
  * @return Size of result.
  */
-inline int rvalue_index_size(const index_max& idx, int size) {
+inline constexpr int rvalue_index_size(const index_max& idx, int size) {
   return idx.max_;
 }
 
@@ -61,7 +61,7 @@ inline int rvalue_index_size(const index_max& idx, int size) {
  * @param[in] size Size of container (ignored).
  * @return Size of result.
  */
-inline int rvalue_index_size(const index_min_max& idx, int size) {
+inline constexpr int rvalue_index_size(const index_min_max& idx, int size) {
   return (idx.max_ < idx.min_) ? 0 : (idx.max_ - idx.min_ + 1);
 }
 

--- a/src/stan/model/indexing/rvalue_return.hpp
+++ b/src/stan/model/indexing/rvalue_return.hpp
@@ -195,6 +195,25 @@ struct rvalue_return<std::vector<C>, cons_index_list<I, L> > {
 
 /**
  * Template specialization for a standard vector whose index list
+ * starts with a multiple index.
+ *
+ * @tparam C Element type for standard vector (container or
+ * scalar).
+ * @tparam I Multiple index type.
+ * @tparam L Following index types.
+ */
+template <typename C, typename I, typename L>
+struct rvalue_return<std::vector<stan::math::var_value<C>>, cons_index_list<I, L> > {
+  /**
+   * Return type is calculated recursively as a standard vector of
+   * the rvalue return for the element type C and following index
+   * types L.
+   */
+  typedef std::vector<stan::math::var_value<typename rvalue_return<C, L>::type>> type;
+};
+
+/**
+ * Template specialization for a standard vector whose index list
  * starts with a single index.
  *
  * @tparam C Element type for standard vector (container or
@@ -208,6 +227,23 @@ struct rvalue_return<std::vector<C>, cons_index_list<index_uni, L> > {
    * for the element type C and following index types L.
    */
   typedef typename rvalue_return<C, L>::type type;
+};
+
+/**
+ * Template specialization for a standard vector whose index list
+ * starts with a single index.
+ *
+ * @tparam C Element type for standard vector (container or
+ * scalar).
+ * @tparam L Following index types.
+ */
+template <typename C, typename L>
+struct rvalue_return<std::vector<stan::math::var_value<C>>, cons_index_list<index_uni, L> > {
+  /**
+   * Return type is calculated recursively as the rvalue return
+   * for the element type C and following index types L.
+   */
+  typedef stan::math::var_value<typename rvalue_return<C, L>::type> type;
 };
 
 template <typename... Ts>

--- a/src/stan/model/indexing/rvalue_return.hpp
+++ b/src/stan/model/indexing/rvalue_return.hpp
@@ -1,7 +1,8 @@
 #ifndef STAN_MODEL_INDEXING_RVALUE_RETURN_HPP
 #define STAN_MODEL_INDEXING_RVALUE_RETURN_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim.hpp>
+#include <stan/math/rev/core/var.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/index_list.hpp>
 #include <vector>

--- a/src/stan/model/indexing/rvalue_return.hpp
+++ b/src/stan/model/indexing/rvalue_return.hpp
@@ -56,7 +56,7 @@ struct rvalue_return<C, nil_index_list> {
  */
 template <typename T, typename I, int R, int C>
 struct rvalue_return<Eigen::Matrix<T, R, C>,
-                     cons_index_list<I, nil_index_list> > {
+                     cons_index_list<I, nil_index_list>> {
   /**
    * Return type is the matrix container type.
    */
@@ -71,7 +71,7 @@ struct rvalue_return<Eigen::Matrix<T, R, C>,
  */
 template <typename T>
 struct rvalue_return<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>,
-                     cons_index_list<index_uni, nil_index_list> > {
+                     cons_index_list<index_uni, nil_index_list>> {
   /**
    * Return type is row vector.
    */
@@ -86,7 +86,7 @@ struct rvalue_return<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>,
  */
 template <typename T>
 struct rvalue_return<Eigen::Matrix<T, Eigen::Dynamic, 1>,
-                     cons_index_list<index_uni, nil_index_list> > {
+                     cons_index_list<index_uni, nil_index_list>> {
   /**
    * Return type is scalar type of vector.
    */
@@ -101,7 +101,7 @@ struct rvalue_return<Eigen::Matrix<T, Eigen::Dynamic, 1>,
  */
 template <typename T>
 struct rvalue_return<Eigen::Matrix<T, 1, Eigen::Dynamic>,
-                     cons_index_list<index_uni, nil_index_list> > {
+                     cons_index_list<index_uni, nil_index_list>> {
   /**
    * Return type is scalar type of row vector.
    */
@@ -117,9 +117,8 @@ struct rvalue_return<Eigen::Matrix<T, 1, Eigen::Dynamic>,
  * @tparam I2 Type of second multiple index.
  */
 template <typename T, typename I1, typename I2>
-struct rvalue_return<
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>,
-    cons_index_list<I1, cons_index_list<I2, nil_index_list> > > {
+struct rvalue_return<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>,
+                     cons_index_list<I1, cons_index_list<I2, nil_index_list>>> {
   /**
    * Return type is matrix container type.
    */
@@ -136,7 +135,7 @@ struct rvalue_return<
 template <typename T, typename I>
 struct rvalue_return<
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>,
-    cons_index_list<I, cons_index_list<index_uni, nil_index_list> > > {
+    cons_index_list<I, cons_index_list<index_uni, nil_index_list>>> {
   /**
    * Return type is vector with same scalar type as matrix container.
    */
@@ -153,7 +152,7 @@ struct rvalue_return<
 template <typename T, typename I>
 struct rvalue_return<
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>,
-    cons_index_list<index_uni, cons_index_list<I, nil_index_list> > > {
+    cons_index_list<index_uni, cons_index_list<I, nil_index_list>>> {
   /**
    * Return type is row vector with same scalar type as matrix container.
    */
@@ -169,7 +168,7 @@ struct rvalue_return<
 template <typename T>
 struct rvalue_return<
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>,
-    cons_index_list<index_uni, cons_index_list<index_uni, nil_index_list> > > {
+    cons_index_list<index_uni, cons_index_list<index_uni, nil_index_list>>> {
   /**
    * Return type is scalar type of matrix.
    */
@@ -186,7 +185,7 @@ struct rvalue_return<
  * @tparam L Following index types.
  */
 template <typename C, typename I, typename L>
-struct rvalue_return<std::vector<C>, cons_index_list<I, L> > {
+struct rvalue_return<std::vector<C>, cons_index_list<I, L>> {
   /**
    * Return type is calculated recursively as a standard vector of
    * the rvalue return for the element type C and following index
@@ -205,13 +204,15 @@ struct rvalue_return<std::vector<C>, cons_index_list<I, L> > {
  * @tparam L Following index types.
  */
 template <typename C, typename I, typename L>
-struct rvalue_return<std::vector<stan::math::var_value<C>>, cons_index_list<I, L> > {
+struct rvalue_return<std::vector<stan::math::var_value<C>>,
+                     cons_index_list<I, L>> {
   /**
    * Return type is calculated recursively as a standard vector of
    * the rvalue return for the element type C and following index
    * types L.
    */
-  typedef std::vector<stan::math::var_value<typename rvalue_return<C, L>::type>> type;
+  typedef std::vector<stan::math::var_value<typename rvalue_return<C, L>::type>>
+      type;
 };
 
 /**
@@ -223,7 +224,7 @@ struct rvalue_return<std::vector<stan::math::var_value<C>>, cons_index_list<I, L
  * @tparam L Following index types.
  */
 template <typename C, typename L>
-struct rvalue_return<std::vector<C>, cons_index_list<index_uni, L> > {
+struct rvalue_return<std::vector<C>, cons_index_list<index_uni, L>> {
   /**
    * Return type is calculated recursively as the rvalue return
    * for the element type C and following index types L.
@@ -240,7 +241,8 @@ struct rvalue_return<std::vector<C>, cons_index_list<index_uni, L> > {
  * @tparam L Following index types.
  */
 template <typename C, typename L>
-struct rvalue_return<std::vector<stan::math::var_value<C>>, cons_index_list<index_uni, L> > {
+struct rvalue_return<std::vector<stan::math::var_value<C>>,
+                     cons_index_list<index_uni, L>> {
   /**
    * Return type is calculated recursively as the rvalue return
    * for the element type C and following index types L.

--- a/src/stan/model/indexing/rvalue_return.hpp
+++ b/src/stan/model/indexing/rvalue_return.hpp
@@ -22,7 +22,7 @@ namespace model {
  * @tparam C Type of container or scalar.
  * @tparam L Type of index list.
  */
-template <typename C, typename L>
+template <typename C, typename L, typename = void>
 struct rvalue_return {};
 
 /**
@@ -209,6 +209,9 @@ struct rvalue_return<std::vector<C>, cons_index_list<index_uni, L> > {
    */
   typedef typename rvalue_return<C, L>::type type;
 };
+
+template <typename... Ts>
+using rvalue_return_t = typename rvalue_return<std::decay_t<Ts>...>::type;
 
 }  // namespace model
 }  // namespace stan


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds specializations for the indexing for `var<mat>` and general Eigen matrices. There were a lot of times that eigen matrices were being subset using the default multi-index overload. But we can specialize a handful of these for Eigen matrices to get back more efficient slices. This will also work nicely when we can start returning expressions as sub setting can continue passing around expressions.

This PR looks very big, though all the changes are essentially in `rvalue.hpp` and the tests for `rvalue.hpp`. There's also a bit of code duplication in some places because we don't have a type trait to detect whether we have a var matrix or matrix of dynamic types vs. a var vector or vector.  If this is too much to review I'm happy to break this up into smaller PRs over the different indexing types. I could also break this up to do the indexing for `var<matrix>` in one PR and the indexing for `matrix<var>` in another

#### Intended Effect

This should make vector style indexing more efficient

#### How to Verify

Tests were added in the indexing folder for the rvalue specializations. Additional tests were added for checking that reverse min_max indices are correct

```
./runTests.py -j32 ./src/test/unit/model/indexing/
```

#### Side Effects

#### Documentation

Docs added for the `var<mat>` and `mat<var>` `rvalue()` specializations

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
