### PR TITLE
Add overloads of rvalue() for efficient slicing

### DIFF
--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -351,8 +351,7 @@ template <
 inline void assign(Mat1&& x,
                    const cons_index_list<index_min, nil_index_list>& idxs,
                    const Mat2& y, const char* name = "ANON", int depth = 0) {
-  const auto start_row = idxs.head_.min_ - 1;
-  const auto row_size = x.rows() - start_row;
+  const auto row_size = x.rows() - (idxs.head_.min_ - 1);
   stan::math::check_range("matrix[min] assign range", name, x.rows(), row_size);
   stan::math::check_size_match("matrix[min] assign row sizes", "lhs", row_size,
                                name, y.rows());
@@ -794,7 +793,7 @@ inline void assign(
     const Mat2& y, const char* name = "ANON", int depth = 0) {
   stan::math::check_size_match("matrix[..., max] assign col size", "lhs",
                                idxs.tail_.head_.max_, name, y.cols());
-  assign(x.leftCols(idxs.tail_.head_.max_ - 1), index_list(idxs.head_), y, name,
+  assign(x.leftCols(idxs.tail_.head_.max_), index_list(idxs.head_), y, name,
          depth + 1);
 }
 

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -349,7 +349,7 @@ inline auto rvalue(EigMat&& x,
 
 /**
  * Return the result of indexing an Eigen matrix with two min_max
- * indices, returning back a block of the Eigen matrix.
+ * indices, returning back a block of an Eigen matrix.
  *
  * Types:  mat[min_max, min_max] : matrix
  *

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -2,11 +2,12 @@
 #define STAN_MODEL_INDEXING_RVALUE_HPP
 
 #include <stan/math/prim.hpp>
+#include <stan/math/rev.hpp>
+#include <stan/model/indexing/deep_copy.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/index_list.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>
 #include <stan/model/indexing/rvalue_index_size.hpp>
-#include <stan/model/indexing/rvalue_return.hpp>
 #include <type_traits>
 #include <vector>
 
@@ -14,7 +15,32 @@ namespace stan {
 
 namespace model {
 
-// all indexing from 1
+/**
+ * Indexing Notes:
+ * The different index types:
+ * index_uni - A single cell.
+ * index_multi - Access multiple cells.
+ * index_omni - A no-op for all indices along a dimension.
+ * index_min - index from min:N
+ * index_max - index from 1:max
+ * index_min_max - index from min:max
+ * nil_index_list - no-op
+ * The order of the overloads are
+ * vector / row_vector:
+ *  - all index overloads
+ * matrix:
+ *  - all row index overloads
+ *    - Return a subset of rows.
+ *  - column/row overloads
+ *    - overload on both the row and column indices.
+ *  - column overloads
+ *    - These take a subset of columns and then call the row slice rvalue
+ *       over the column subset.
+ * Std vector:
+ *  - single element and elementwise overloads
+ *  - General overload for nested std vectors.
+ */
+
 
 /**
  * Return the result of indexing a specified value with
@@ -23,172 +49,359 @@ namespace model {
  * Types:  T[] : T
  *
  * @tparam T Scalar type.
- * @param[in] c Value to index.
+ * @param[in] x Value to index.
  * @return Input value.
  */
 template <typename T>
-inline T rvalue(const T& c, const nil_index_list& /*idx*/,
-                const char* /*name*/ = "", int /*depth*/ = 0) {
-  return c;
+inline T rvalue(T&& x, const nil_index_list& /*idx*/, const char* /*name*/ = "",
+                int /*depth*/ = 0) {
+  return std::forward<T>(x);
 }
 
 /**
- * Return the result of indexing the specified Eigen vector with a
- * sequence containing one single index, returning a scalar.
+ * Return the result of indexing a type without taking a subset. Mostly used as
+ * an intermediary rvalue function when doing multiple subsets.
  *
- * Types:  vec[single] : scal
+ * Types:  type[omni] : type
  *
- * @tparam T Scalar type.
+ * @tparam T Any type.
+ * @param[in] x an object.
+ * @param[in] idxs Index consisting of one omni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
+template <typename T>
+inline T rvalue(T&& x, const cons_index_list<index_omni, nil_index_list>& idxs,
+                const char* name = "ANON", int depth = 0) {
+  return std::forward<T>(x);
+}
+
+/**
+ * Return the result of indexing a type without taking a subset
+ *
+ * Types:  type[omni, omni] : type
+ *
+ * @tparam T Any type.
+ * @param[in] x an object.
+ * @param[in] idxs Index consisting of two omni-indices.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
+template <typename T>
+inline T rvalue(T&& x,
+    const cons_index_list<index_omni,
+                          cons_index_list<index_omni, nil_index_list>>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  return std::forward<T>(x);
+}
+
+/**
+ * Return a single element of an Eigen Vector.
+ *
+ * Types:  vec[uni] : scal
+ *
+ * @tparam EigVec An eigen vector
  * @param[in] v Vector being indexed.
- * @param[in] idx One single index.
+ * @param[in] idxs One single index.
  * @param[in] name String form of expression being evaluated.
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing vector.
  */
-template <typename T>
-inline T rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
-                const cons_index_list<index_uni, nil_index_list>& idx,
-                const char* name = "ANON", int depth = 0) {
-  int ones_idx = idx.head_.n_;
-  math::check_range("vector[single] indexing", name, v.size(), ones_idx);
-  return v.coeff(ones_idx - 1);
+template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
+inline auto rvalue(EigVec&& v,
+                   const cons_index_list<index_uni, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+  using stan::math::to_ref;
+  math::check_range("vector[uni] indexing", name, v.size(), idxs.head_.n_);
+  return v.coeff(idxs.head_.n_ - 1);
 }
 
 /**
- * Return the result of indexing the specified Eigen row vector
- * with a sequence containing one single index, returning a
- * scalar.
+ * Return a non-contiguous subset of elements in a vector.
  *
- * Types:  rowvec[single] : scal
+ * Types:  vec[multi] : vec
  *
- * @tparam T Scalar type.
- * @param[in] rv Row vector being indexed.
- * @param[in] idx One single index in list.
- * @param[in] name String form of expression being evaluated.
- * @param[in] depth Depth of indexing dimension.
- * @return Result of indexing row vector.
+ * @tparam Vec Eigen type with either dynamic rows or columns, but not both.
+ * @param[in] x Eigen vector type.
+ * @param[in] idxs Sequence of integers.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the value size isn't the same as
+ * the indexed size.
  */
-template <typename T>
-inline T rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
-                const cons_index_list<index_uni, nil_index_list>& idx,
-                const char* name = "ANON", int depth = 0) {
-  int n = idx.head_.n_;
-  math::check_range("row_vector[single] indexing", name, rv.size(), n);
-  return rv.coeff(n - 1);
-}
-
-/**
- * Return the result of indexing the specified Eigen vector with a
- * sequence containing one multiple index, returning a vector.
- *
- * Types: vec[multiple] : vec
- *
- * @tparam T Scalar type.
- * @tparam I Multi-index type.
- * @param[in] v Eigen vector.
- * @param[in] idx Index consisting of one multi-index.
- * @param[in] name String form of expression being evaluated.
- * @param[in] depth Depth of indexing dimension.
- * @return Result of indexing vector.
- */
-template <typename T, typename I>
-inline std::enable_if_t<!std::is_same<I, index_uni>::value,
-                        Eigen::Matrix<T, Eigen::Dynamic, 1> >
-rvalue(const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
-       const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
-       int depth = 0) {
-  int size = rvalue_index_size(idx.head_, v.size());
-  Eigen::Matrix<T, Eigen::Dynamic, 1> a(size);
-  for (int i = 0; i < size; ++i) {
-    int n = rvalue_at(i, idx.head_);
-    math::check_range("vector[multi] indexing", name, v.size(), n);
-    a(i) = v.coeff(n - 1);
+template <typename Vec, require_eigen_vector_t<Vec>* = nullptr>
+inline plain_type_t<Vec> rvalue(Vec&& v, const cons_index_list<index_multi, nil_index_list>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  const auto v_size = v.size();
+  const auto& v_ref = stan::math::to_ref(v);
+  plain_type_t<Vec> ret_v(idxs.head_.ns_.size());
+  for (int i = 0; i < idxs.head_.ns_.size(); ++i) {
+    math::check_range("vector[multi] indexing", name, v_ref.size(),
+                      idxs.head_.ns_[i]);
+    ret_v.coeffRef(i) = v_ref.coeff(idxs.head_.ns_[i] - 1);
   }
-  return a;
+  return ret_v;
 }
 
 /**
- * Return the result of indexing the specified Eigen row vector
- * with a sequence containing one multiple index, returning a row
- * vector.
+ * Return a range of an Eigen vector
  *
- * Types:  row_vec[multiple] : rowvec
+ * Types:  vec[min_max] : vector
  *
- * @tparam T Scalar type.
- * @tparam I Multi-index type.
- * @param[in] rv Eigen row vector.
- * @param[in] idx Index consisting of one multi-index.
+ * @tparam EigVec An eigen vector
+ * @param[in] v Vector being indexed.
+ * @param[in] idxs One single index.
  * @param[in] name String form of expression being evaluated.
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing vector.
  */
-template <typename T, typename I>
-inline std::enable_if_t<!std::is_same<I, index_uni>::value,
-                        Eigen::Matrix<T, 1, Eigen::Dynamic> >
-rvalue(const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv,
-       const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
-       int depth = 0) {
-  int size = rvalue_index_size(idx.head_, rv.size());
-  Eigen::Matrix<T, 1, Eigen::Dynamic> a(size);
-  for (int i = 0; i < size; ++i) {
-    int n = rvalue_at(i, idx.head_);
-    math::check_range("row_vector[multi] indexing", name, rv.size(), n);
-    a(i) = rv.coeff(n - 1);
+template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
+inline auto rvalue(EigVec&& v,
+                   const cons_index_list<index_min_max, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+  math::check_range("vector[min_max] min indexing", name, v.size(),
+                    idxs.head_.min_);
+  math::check_range("vector[min_max] max indexing", name, v.size(),
+                    idxs.head_.max_);
+  if (idxs.head_.is_ascending()) {
+    return v.segment(idxs.head_.min_ - 1, idxs.head_.max_ - (idxs.head_.min_ - 1))
+        .eval();
+  } else {
+    return v.segment(idxs.head_.max_ - 1, idxs.head_.min_ - (idxs.head_.max_ - 1))
+        .reverse()
+        .eval();
   }
-  return a;
 }
 
 /**
- * Return the result of indexing the specified Eigen matrix with a
+ * Return a tail slice of a vector
+ *
+ * Types:  vector[min:N] : vector
+ *
+ * @tparam Vec Eigen type with either dynamic rows or columns, but not both.
+ * @param[in] x vector
+ * @param[in] idxs An index.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ */
+template <typename Vec, require_eigen_vector_t<Vec>* = nullptr>
+inline auto rvalue(Vec&& x,
+                   const cons_index_list<index_min, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+  stan::math::check_range("vector[min] indexing range", name, x.size(),
+                          idxs.head_.min_);
+  return x.tail(x.size() - idxs.head_.min_ + 1).eval();
+}
+
+/**
+ * Return a head slice of a vector
+ *
+ * Types:  vector[1:max] <- vector
+ *
+ * @tparam Vec Eigen type with either dynamic rows or columns, but not both.
+ * @param[in] x Eigen vector type.
+ * @param[in] idxs An index.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ */
+template <typename Vec,
+          require_all_eigen_vector_t<Vec>* = nullptr>
+inline auto rvalue(Vec&& x,
+                   const cons_index_list<index_max, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+  stan::math::check_range("vector[min] indexing range", name, x.size(),
+                          idxs.head_.max_);
+  return x.head(idxs.head_.max_).eval();
+}
+
+/**
+ * Return the result of indexing the Eigen matrix with a
  * sequence consisting of one single index, returning a row vector.
  *
- * Types:  mat[single] : rowvec
+ * Types:  mat[uni] : rowvec
  *
- * @tparam T Scalar type.
- * @param[in] a Eigen matrix.
- * @param[in] idx Index consisting of one uni-index.
+ * @tparam EigMat An eigen matrix
+ * @param[in] x Eigen matrix.
+ * @param[in] idxs Index consisting of one uni-index.
  * @param[in] name String form of expression being evaluated.
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename T>
-inline Eigen::Matrix<T, 1, Eigen::Dynamic> rvalue(
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
-    const cons_index_list<index_uni, nil_index_list>& idx,
-    const char* name = "ANON", int depth = 0) {
-  int n = idx.head_.n_;
-  math::check_range("matrix[uni] indexing", name, a.rows(), n);
-  return a.row(n - 1);
+template <typename EigMat,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline auto rvalue(EigMat&& x,
+                   const cons_index_list<index_uni, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[uni] indexing", name, x.rows(), idxs.head_.n_);
+  return x.row(idxs.head_.n_ - 1).eval();
 }
 
 /**
- * Return the result of indexing the specified Eigen matrix with a
- * sequence consisting of a one multiple index, returning a matrix.
+ * Return the specified Eigen matrix at the specified multi index.
  *
- * Types:  mat[multiple] : mat
+ * Types:  mat[multi] = mat
  *
- * @tparam T Scalar type.
- * @tparam I Type of multiple index.
- * @param[in] a Matrix to index.
- * @param[in] idx Index consisting of single multiple index.
+ * @tparam EigMat Eigen type with dynamic rows and columns.
+ * @param[in] x Eigen type
+ * @param[in] idxs An indexing from the start of the container up to
+ * the specified maximum index (inclusive).
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ */
+template <typename EigMat,
+          stan::internal::require_all_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline plain_type_t<EigMat> rvalue(
+    EigMat&& x, const cons_index_list<index_multi, nil_index_list>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  const auto& x_ref = stan::math::to_ref(x);
+  plain_type_t<EigMat> x_ret(idxs.head_.ns_.size(), x.cols());
+  for (int i = 0; i < idxs.head_.ns_.size(); ++i) {
+    const int n = idxs.head_.ns_[i];
+    math::check_range("matrix[multi] subset range", name, x_ref.rows(), n);
+    x_ret.row(i) = x_ref.row(n - 1);
+  }
+  return x_ret;
+}
+
+/**
+ * Return the result of indexing the Eigen matrix with a min index
+ * returning back a block of rows min:N and all cols
+ *
+ * Types:  mat[min:N] : matrix
+ *
+ * @tparam EigMat An eigen matrix
+ * @param[in] x Eigen matrix.
+ * @param[in] idxs Index consisting of one uni-index.
  * @param[in] name String form of expression being evaluated.
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename T, typename I>
-inline std::enable_if_t<!std::is_same<I, index_uni>::value,
-                        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
-rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
-       const cons_index_list<I, nil_index_list>& idx, const char* name = "ANON",
-       int depth = 0) {
-  int n_rows = rvalue_index_size(idx.head_, a.rows());
-  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> b(n_rows, a.cols());
-  for (int i = 0; i < n_rows; ++i) {
-    int n = rvalue_at(i, idx.head_);
-    math::check_range("matrix[multi] indexing", name, a.rows(), n);
-    b.row(i) = a.row(n - 1);
+template <typename EigMat,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline auto rvalue(EigMat&& x,
+                   const cons_index_list<index_min, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+ const auto row_size = x.rows() - (idxs.head_.min_ - 1);
+  math::check_range("matrix[min] indexing", name, x.rows(), idxs.head_.min_);
+  return x.bottomRows(row_size).eval();
+}
+
+/**
+ * Return the Eigen matrix at the specified max index
+ *
+ * Types:  mat[:max] = mat
+ *
+ * @tparam EigMat Eigen type with dynamic rows and columns.
+ * @param[in] x Eigen type
+ * @param[in] idxs An indexing from the start of the container up to
+ * the specified maximum index (inclusive).
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ */
+template <typename EigMat,
+          stan::internal::require_all_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline auto rvalue(EigMat&& x,
+                   const cons_index_list<index_max, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[max] indexing range", name, x.cols(),
+                    idxs.head_.max_);
+  return x.topRows(idxs.head_.max_).eval();
+}
+
+/**
+ * Return the Eigen matrix at the specified min_max index.
+ *
+ * Types:  mat[min_max] = mat
+ *
+ * @tparam EigMat Eigen type with dynamic rows and columns.
+ * @param[in] x Eigen type
+ * @param[in] idxs An indexing from the start of the container up to
+ * the specified maximum index (inclusive).
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ */
+template <typename EigMat,
+          stan::internal::require_all_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline auto rvalue(EigMat&& x,
+                   const cons_index_list<index_min_max, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[min_max] max row indexing", name, x.rows(),
+                    idxs.head_.max_);
+  math::check_range("matrix[min_max] min row indexing", name, x.rows(),
+                    idxs.head_.min_);
+  if (idxs.head_.is_ascending()) {
+    return x.middleRows(idxs.head_.min_ - 1, idxs.head_.max_ - 1).eval();
+  } else {
+    return x.middleRows(idxs.head_.max_ - 1, idxs.head_.min_ - 1).colwise().reverse().eval();
   }
-  return b;
+}
+
+/**
+ * Return the result of indexing an Eigen matrix with two min_max
+ * indices, returning back a block of the Eigen matrix.
+ *
+ * Types:  mat[min_max, min_max] : matrix
+ *
+ * @tparam EigMat An eigen matrix
+ * @param[in] x Eigen matrix.
+ * @param[in] idxs Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
+template <typename EigMat,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline auto rvalue(
+    EigMat&& x,
+    const cons_index_list<index_min_max,
+                          cons_index_list<index_min_max, nil_index_list>>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[min_max, min_max] min row indexing", name,
+                    x.rows(), idxs.head_.min_);
+  math::check_range("matrix[min_max, min_max] max row indexing", name,
+                    x.rows(), idxs.head_.max_);
+  math::check_range("matrix[min_max, min_max] min column indexing", name,
+                    x.cols(), idxs.tail_.head_.min_);
+  math::check_range("matrix[min_max, min_max] max column indexing", name,
+                    x.cols(), idxs.tail_.head_.max_);
+  if (idxs.head_.is_ascending()) {
+    if (idxs.tail_.head_.is_ascending()) {
+      return x.block(idxs.head_.min_ - 1, idxs.tail_.head_.min_ - 1,
+                 idxs.head_.max_ - (idxs.head_.min_ - 1),
+                 idxs.tail_.head_.max_ - (idxs.tail_.head_.min_ - 1))
+          .eval();
+    } else {
+      return x.block(idxs.head_.min_ - 1, idxs.tail_.head_.max_ - 1,
+                 idxs.head_.max_ - (idxs.head_.min_ - 1),
+                 idxs.tail_.head_.min_ - (idxs.tail_.head_.max_ - 1))
+          .rowwise()
+          .reverse()
+          .eval();
+    }
+  } else {
+    if (idxs.tail_.head_.is_ascending()) {
+      return x.block(idxs.head_.max_ - 1, idxs.tail_.head_.min_ - 1,
+                 idxs.head_.min_ - (idxs.head_.max_ - 1),
+                 idxs.tail_.head_.max_ - (idxs.tail_.head_.min_ - 1))
+          .colwise()
+          .reverse()
+          .eval();
+    } else {
+      return x.block(idxs.head_.max_ - 1, idxs.tail_.head_.max_ - 1,
+                 idxs.head_.min_ - (idxs.head_.max_ - 1),
+                 idxs.tail_.head_.min_ - (idxs.tail_.head_.max_ - 1))
+          .reverse()
+          .eval();
+    }
+  }
 }
 
 /**
@@ -197,124 +410,297 @@ rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
  *
  * Types:  mat[single,single] : scalar
  *
- * @tparam T Scalar type.
- * @param[in] a Matrix to index.
- * @param[in] idx Pair of single indexes.
+ * @tparam EigMat An eigen type
+ * @param[in] x Matrix to index.
+ * @param[in] idxs Pair of single indexes.
  * @param[in] name String form of expression being evaluated.
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename T>
-inline T rvalue(
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
+template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+inline auto rvalue(
+    EigMat&& x,
     const cons_index_list<index_uni,
-                          cons_index_list<index_uni, nil_index_list> >& idx,
+                          cons_index_list<index_uni, nil_index_list>>& idxs,
     const char* name = "ANON", int depth = 0) {
-  int m = idx.head_.n_;
-  int n = idx.tail_.head_.n_;
-  math::check_range("matrix[uni,uni] indexing, row", name, a.rows(), m);
-  math::check_range("matrix[uni,uni] indexing, col", name, a.cols(), n);
-  return a.coeff(m - 1, n - 1);
+  math::check_range("matrix[uni,uni] indexing, row", name, x.rows(),
+                    idxs.head_.n_);
+  math::check_range("matrix[uni,uni] indexing, col", name, x.cols(),
+                    idxs.tail_.head_.n_);
+  return x.coeff(idxs.head_.n_ - 1, idxs.tail_.head_.n_ - 1);
 }
 
 /**
- * Return the result of indexing the specified Eigen matrix with a
- * sequence consisting of a single index and multiple index,
- * returning a row vector.
+ * Random access to a vector's cells to a row of an eigen matrix.
  *
- * Types:  mat[single,multiple] : row vector
+ * Types:  mat[uni, multi] = vector
  *
- * @tparam T Scalar type.
- * @tparam I Type of multiple index.
- * @param[in] a Matrix to index.
- * @param[in] idx Pair of single index and multiple index.
- * @param[in] name String form of expression being evaluated.
- * @param[in] depth Depth of indexing dimension.
- * @return Result of indexing matrix.
+ * @tparam EigMat Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix to index.
+ * @param[in] idxs Pair of multiple indexes (from 1).
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
  */
-template <typename T, typename I>
-inline std::enable_if_t<!std::is_same<I, index_uni>::value,
-                        Eigen::Matrix<T, 1, Eigen::Dynamic> >
-rvalue(
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
-    const cons_index_list<index_uni, cons_index_list<I, nil_index_list> >& idx,
+template <typename EigMat,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline Eigen::Matrix<value_type_t<EigMat>, 1, -1> rvalue(
+    EigMat&& x,
+    const cons_index_list<index_uni,
+                          cons_index_list<index_multi, nil_index_list>>& idxs,
     const char* name = "ANON", int depth = 0) {
-  int m = idx.head_.n_;
-  math::check_range("matrix[uni,multi] indexing, row", name, a.rows(), m);
-  Eigen::Matrix<T, 1, Eigen::Dynamic> r = a.row(m - 1);
-  return rvalue(r, idx.tail_);
-}
-
-/**
- * Return the result of indexing the specified Eigen matrix with a
- * sequence consisting of a multiple index and a single index,
- * returning a vector.
- *
- * Types:  mat[multiple,single] : vector
- *
- * @tparam T Scalar type.
- * @tparam I Type of multiple index.
- * @param[in] a Matrix to index.
- * @param[in] idx Pair multiple index and single index.
- * @param[in] name String form of expression being evaluated.
- * @param[in] depth Depth of indexing dimension.
- * @return Result of indexing matrix.
- */
-template <typename T, typename I>
-inline std::enable_if_t<!std::is_same<I, index_uni>::value,
-                        Eigen::Matrix<T, Eigen::Dynamic, 1> >
-rvalue(
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
-    const cons_index_list<I, cons_index_list<index_uni, nil_index_list> >& idx,
-    const char* name = "ANON", int depth = 0) {
-  int rows = rvalue_index_size(idx.head_, a.rows());
-  Eigen::Matrix<T, Eigen::Dynamic, 1> c(rows);
-  for (int i = 0; i < rows; ++i) {
-    int m = rvalue_at(i, idx.head_);
-    int n = idx.tail_.head_.n_;
-    math::check_range("matrix[multi,uni] index row", name, a.rows(), m);
-    math::check_range("matrix[multi,uni] index col", name, a.cols(), n);
-    c(i) = a.coeff(m - 1, n - 1);
+  math::check_range("matrix[uni, multi] index range", name, x.cols(),
+                    idxs.head_.n_);
+  const auto& x_ref = stan::math::to_ref(x);
+  Eigen::Matrix<value_type_t<EigMat>, 1, -1> x_ret(1,
+                                                   idxs.tail_.head_.ns_.size());
+  for (int i = 0; i < idxs.tail_.head_.ns_.size(); ++i) {
+    math::check_range("matrix[uni, multi] index range", name, x.cols(),
+                      idxs.tail_.head_.ns_[i]);
+    x_ret.coeffRef(i)
+        = x_ref.coeff(idxs.head_.n_ - 1, idxs.tail_.head_.ns_[i] - 1);
   }
-  return c;
+  return x_ret;
+}
+
+/**
+ * Random access of a matrix column with a multi index on the row.
+ * Types:  mat[multi, uni] = vector
+ *
+ * @tparam EigMat Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix to index.
+ * @param[in] idxs Pair of multiple indexes (from 1).
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ */
+template <typename EigMat,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline Eigen::Matrix<value_type_t<EigMat>, -1, 1> rvalue(
+    EigMat&& x,
+    const cons_index_list<index_multi,
+                          cons_index_list<index_uni, nil_index_list>>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[multi, uni] rvalue range", name, x.cols(),
+                    idxs.tail_.head_.n_);
+  const auto& x_ref = stan::math::to_ref(x);
+  Eigen::Matrix<value_type_t<EigMat>, -1, 1> x_ret(idxs.head_.ns_.size(), 1);
+  for (int i = 0; i < idxs.head_.ns_.size(); ++i) {
+    math::check_range("matrix[multi, uni] rvalue range", name, x_ref.rows(),
+                      idxs.head_.ns_[i]);
+    x_ret.coeffRef(i)
+        = x_ref.coeffRef(idxs.head_.ns_[i] - 1, idxs.tail_.head_.n_ - 1);
+  }
+  return x_ret;
 }
 
 /**
  * Return the result of indexing the specified Eigen matrix with a
- * sequence consisting of a pair o multiple indexes, returning a
+ * sequence consisting of a pair of multiple indexes, returning a
  * a matrix.
  *
- * Types:  mat[multiple,multiple] : mat
+ * Types:  mat[multi, multi] : mat
  *
- * @tparam T Scalar type.
- * @tparam I Type of multiple index.
- * @param[in] a Matrix to index.
- * @param[in] idx Pair of multiple indexes.
+ * @tparam EigMat An eigen matrix
+ * @param[in] x Matrix to index.
+ * @param[in] idxs Pair of multiple indexes.
  * @param[in] name String form of expression being evaluated.
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing matrix.
  */
-template <typename T, typename I1, typename I2>
-inline std::enable_if_t<!std::is_same<I1, index_uni>::value
-                            && !std::is_same<I2, index_uni>::value,
-                        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
-rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
-       const cons_index_list<I1, cons_index_list<I2, nil_index_list> >& idx,
-       const char* name = "ANON", int depth = 0) {
-  int rows = rvalue_index_size(idx.head_, a.rows());
-  int cols = rvalue_index_size(idx.tail_.head_, a.cols());
-  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> c(rows, cols);
+template <typename EigMat,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline plain_type_t<EigMat> rvalue(
+    EigMat&& x,
+    const cons_index_list<index_multi,
+                          cons_index_list<index_multi, nil_index_list>>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  const auto& x_ref = stan::math::to_ref(x);
+  const int rows = idxs.head_.ns_.size();
+  const int cols = idxs.tail_.head_.ns_.size();
+  plain_type_t<EigMat> x_ret(rows, cols);
   for (int j = 0; j < cols; ++j) {
     for (int i = 0; i < rows; ++i) {
-      int m = rvalue_at(i, idx.head_);
-      int n = rvalue_at(j, idx.tail_.head_);
-      math::check_range("matrix[multi,multi] row index", name, a.rows(), m);
-      math::check_range("matrix[multi,multi] col index", name, a.cols(), n);
-      c(i, j) = a.coeff(m - 1, n - 1);
+      const int m = idxs.head_.ns_[i];
+      const int n = idxs.tail_.head_.ns_[j];
+      math::check_range("matrix[multi,multi] row index", name, x_ref.rows(), m);
+      math::check_range("matrix[multi,multi] col index", name, x_ref.cols(), n);
+      x_ret.coeffRef(i, j) = x_ref.coeff(m - 1, n - 1);
     }
   }
-  return c;
+  return x_ret;
 }
+
+/**
+ * Return the result of indexing the specified Eigen matrix with a
+ * sequence consisting of one single index.
+ *
+ * Types:  mat[Idx, uni] : vec
+ *
+ * @tparam EigMat Eigen type with dynamic rows and columns.
+ * @param[in] x Eigen matrix.
+ * @param[in] idxs Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ */
+template <typename EigMat, typename Idx,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline auto rvalue(
+    EigMat&& x,
+    const cons_index_list<Idx, cons_index_list<index_uni, nil_index_list>>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[..., uni] indexing", name, x.cols(),
+                    idxs.tail_.head_.n_);
+  return deep_copy(rvalue(x.col(idxs.tail_.head_.n_ - 1), index_list(idxs.head_),
+                          name, depth + 1));
+}
+
+/**
+ * Return the result of indexing the specified Eigen matrix with a
+ * sequence consisting of multi index.
+ *
+ * Types:  mat[Idx, multi] : vec
+ *
+ * @tparam EigMat An eigen matrix
+ * @param[in] x Eigen matrix.
+ * @param[in] idxs Index consisting of one uni-index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
+template <typename EigMat, typename Idx,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr,
+          require_not_same_t<std::decay_t<Idx>, index_uni>* = nullptr>
+inline plain_type_t<EigMat> rvalue(
+    EigMat&& x,
+    const cons_index_list<Idx, cons_index_list<index_multi, nil_index_list>>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  const auto& x_ref = stan::math::to_ref(x);
+  const int rows = rvalue_index_size(idxs.head_, x_ref.rows());
+  const int cols = rvalue_index_size(idxs.tail_.head_, x_ref.cols());
+  plain_type_t<EigMat> x_ret(rows, idxs.tail_.head_.ns_.size());
+  for (int j = 0; j < idxs.tail_.head_.ns_.size(); ++j) {
+    const int n = idxs.tail_.head_.ns_[j];
+    math::check_range("matrix[..., multi] col index", name, x_ref.cols(), n);
+    x_ret.col(j)
+        = rvalue(x_ref.col(n - 1), index_list(idxs.head_), name, depth + 1);
+  }
+  return x_ret;
+}
+
+/**
+ * Return the Eigen matrix with all columns and a slice of rows.
+ *
+ * Types:  mat[Idx, omni] = mat
+ *
+ * @tparam EigMat Eigen type with dynamic rows and columns.
+ * @param[in] x Eigen type
+ * @param[in] idxs Pair of multiple indexes (from 1).
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ */
+template <typename EigMat, typename Idx,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline auto rvalue(
+    EigMat&& x,
+    const cons_index_list<Idx, cons_index_list<index_omni, nil_index_list>>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  return deep_copy(rvalue(std::forward<EigMat>(x), index_list(idxs.head_), name, depth + 1));
+}
+
+/**
+ * Return the Eigen matrix at the specified min
+ * index to the specified matrix value.
+ *
+ * Types:  mat[Idx, min] = mat
+ *
+ * @tparam EigMat Eigen type with dynamic rows and columns.
+ * @tparam Idx An index.
+ * @param[in] x Eigen type
+ * @param[in] idxs Container holding a row index and an index from a minimum
+ * index (inclusive) to the end of a container.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ */
+template <typename EigMat, typename Idx,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline auto rvalue(
+    EigMat&& x,
+    const cons_index_list<Idx, cons_index_list<index_min, nil_index_list>>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  const auto col_size = x.cols() - (idxs.tail_.head_.min_ - 1);
+  math::check_range("matrix[..., min] indexing", name, x.cols(),
+                    idxs.tail_.head_.min_);
+  return deep_copy(rvalue(x.rightCols(col_size),
+                          index_list(idxs.head_), name, depth + 1));
+}
+
+/**
+ * Return the Eigen matrix at the specified max index
+ *
+ * Types:  mat[Idx, max] = mat
+ *
+ * @tparam EigMat Eigen type with dynamic rows and columns.
+ * @tparam Idx An index.
+ * @param[in] x Eigen type
+ * @param[in] idxs Index holding a row index and an index from the start of the
+ * container up to the specified maximum index (inclusive).
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ */
+template <typename EigMat, typename Idx,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline auto rvalue(
+    EigMat&& x,
+    const cons_index_list<Idx, cons_index_list<index_max, nil_index_list>>& idxs,
+    const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[..., max] indexing", name, x.cols(),
+                    idxs.tail_.head_.max_);
+  return deep_copy(rvalue(x.leftCols(idxs.tail_.head_.max_),
+                          index_list(idxs.head_), name, depth + 1));
+}
+
+/**
+ * Return the result of indexing the specified Eigen matrix with a
+ * min_max_index returning a block from min to max.
+ *
+ * Types:  mat[Idx, min_max] : matrix
+ *
+ * @tparam EigMat An eigen matrix
+ * @tparam Idx Type of index.
+ * @param[in] x Matrix to index.
+ * @param[in] idxs Pair multiple index and single index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing matrix.
+ */
+template <typename EigMat, typename Idx,
+          stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
+inline auto rvalue(
+    EigMat&& x,
+    const cons_index_list<Idx, cons_index_list<index_min_max, nil_index_list>>&
+        idxs,
+    const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[..., min_max] indexing", name, x.rows(),
+                    idxs.tail_.head_.min_);
+  math::check_range("matrix[..., min_max] indexing", name, x.rows(),
+                    idxs.tail_.head_.max_);
+  if (idxs.tail_.head_.is_ascending()) {
+    const auto col_start = idxs.tail_.head_.min_ - 1;
+    return deep_copy(
+        rvalue(x.middleCols(col_start, idxs.tail_.head_.max_ - col_start),
+               index_list(idxs.head_), name, depth + 1));
+  } else {
+    const auto col_start = idxs.tail_.head_.max_ - 1;
+    return deep_copy(
+        rvalue(x.middleCols(col_start, idxs.tail_.head_.min_ - col_start).rowwise().reverse(),
+               index_list(idxs.head_), name, depth + 1));
+  }
+}
+
 
 /**
  * Return the result of indexing the specified array with
@@ -322,24 +708,42 @@ rvalue(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& a,
  * determined recursively.  Note that arrays are represented as
  * standard library vectors.
  *
- * Types:  std::vector<T>[single | L] : T[L]
+ * Types:  std::vector<T>[single | Idx] : T[Idx]
  *
  * @tparam T Type of list elements.
- * @tparam L Index list type for indexes after first index.
- * @param[in] c Container of list elements.
- * @param[in] idx Index list beginning with single index.
+ * @tparam Idx Index list type for indexes after first index.
+ * @param[in] v Container of list elements.
+ * @param[in] idxs Index list beginning with single index.
  * @param[in] name String form of expression being evaluated.
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing array.
  */
-template <typename T, typename L>
-inline
-    typename rvalue_return<std::vector<T>, cons_index_list<index_uni, L> >::type
-    rvalue(const std::vector<T>& c, const cons_index_list<index_uni, L>& idx,
-           const char* name = "ANON", int depth = 0) {
-  int n = idx.head_.n_;
-  math::check_range("array[uni,...] index", name, c.size(), n);
-  return rvalue(c[n - 1], idx.tail_, name, depth + 1);
+template <typename StdVec, typename Idx, require_std_vector_t<StdVec>* = nullptr>
+inline auto rvalue(StdVec&& v, const cons_index_list<index_uni, Idx>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+  math::check_range("array[uni, ...] index", name, v.size(), idxs.head_.n_);
+  return rvalue(v[idxs.head_.n_ - 1], idxs.tail_, name, depth + 1);
+}
+
+/**
+ * Return the result of indexing the specified array with
+ * a single index.
+ *
+ * Types:  std::vector<T>[single] : T
+ *
+ * @tparam StdVec a standard vector
+ * @param[in] c Container of list elements.
+ * @param[in] idxs Index list beginning with single index.
+ * @param[in] name String form of expression being evaluated.
+ * @param[in] depth Depth of indexing dimension.
+ * @return Result of indexing array.
+ */
+template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+inline auto rvalue(StdVec&& v,
+                   const cons_index_list<index_uni, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+  math::check_range("array[uni, ...] index", name, v.size(), idxs.head_.n_);
+  return v[idxs.head_.n_ - 1];
 }
 
 /**
@@ -348,25 +752,32 @@ inline
  * determined recursively.  Note that arrays are represented as
  * standard library vectors.
  *
- * Types:  std::vector<T>[multiple | L] : std::vector<T[L]>
+ * Types:  std::vector<T>[Idx1, Idx2] : std::vector<T>[Idx2]
  *
  * @tparam T Type of list elements.
- * @tparam L Index list type for indexes after first index.
- * @param[in] c Container of list elements.
- * @param[in] idx Index list beginning with multiple index.
+ * @tparam Idx1 Index list type for first index.
+ * @tparam Idx2 Index list type for second index index.
+ * @param[in] v Container of list elements.
+ * @param[in] idxs Index list beginning with multiple index.
  * @param[in] name String form of expression being evaluated.
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing array.
  */
-template <typename T, typename I, typename L>
-inline typename rvalue_return<std::vector<T>, cons_index_list<I, L> >::type
-rvalue(const std::vector<T>& c, const cons_index_list<I, L>& idx,
-       const char* name = "ANON", int depth = 0) {
-  typename rvalue_return<std::vector<T>, cons_index_list<I, L> >::type result;
-  for (int i = 0; i < rvalue_index_size(idx.head_, c.size()); ++i) {
-    int n = rvalue_at(i, idx.head_);
-    math::check_range("array[multi,...] index", name, c.size(), n);
-    result.push_back(rvalue(c[n - 1], idx.tail_, name, depth + 1));
+template <typename StdVec, typename Idx1, typename Idx2,
+          require_std_vector_t<StdVec>* = nullptr>
+inline auto rvalue(StdVec&& v, const cons_index_list<Idx1, Idx2>& idxs,
+                   const char* name = "ANON", int depth = 0) {
+  using inner_type = plain_type_t<decltype(
+      rvalue(v[rvalue_at(0, idxs.head_) - 1], idxs.tail_))>;
+  std::vector<inner_type> result;
+  const int index_size = rvalue_index_size(idxs.head_, v.size());
+  if (index_size > 0) {
+    result.reserve(index_size);
+  }
+  for (int i = 0; i < index_size; ++i) {
+    const int n = rvalue_at(i, idxs.head_);
+    math::check_range("array[..., ...] index", name, v.size(), n);
+    result.emplace_back(rvalue(v[n - 1], idxs.tail_, name, depth + 1));
   }
   return result;
 }

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -41,7 +41,6 @@ namespace model {
  *  - General overload for nested std vectors.
  */
 
-
 /**
  * Return the result of indexing a specified value with
  * a nil index list, which just returns the value.
@@ -90,7 +89,8 @@ inline T rvalue(T&& x, const cons_index_list<index_omni, nil_index_list>& idxs,
  * @return Result of indexing matrix.
  */
 template <typename T>
-inline T rvalue(T&& x,
+inline T rvalue(
+    T&& x,
     const cons_index_list<index_omni,
                           cons_index_list<index_omni, nil_index_list>>& idxs,
     const char* name = "ANON", int depth = 0) {
@@ -133,7 +133,8 @@ inline auto rvalue(EigVec&& v,
  * the indexed size.
  */
 template <typename Vec, require_eigen_vector_t<Vec>* = nullptr>
-inline plain_type_t<Vec> rvalue(Vec&& v, const cons_index_list<index_multi, nil_index_list>& idxs,
+inline plain_type_t<Vec> rvalue(
+    Vec&& v, const cons_index_list<index_multi, nil_index_list>& idxs,
     const char* name = "ANON", int depth = 0) {
   const auto v_size = v.size();
   const auto& v_ref = stan::math::to_ref(v);
@@ -163,9 +164,9 @@ inline auto rvalue(EigVec&& v,
                    const cons_index_list<index_min_max, nil_index_list>& idxs,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("vector[min_max] min indexing", name, v.size(),
-                   idxs.head_.min_);
+                    idxs.head_.min_);
   math::check_range("vector[min_max] max indexing", name, v.size(),
-                   idxs.head_.max_);
+                    idxs.head_.max_);
   if (idxs.head_.is_ascending()) {
     const auto slice_start = idxs.head_.min_ - 1;
     const auto slice_size = idxs.head_.max_ - slice_start;
@@ -210,8 +211,7 @@ inline auto rvalue(Vec&& x,
  * @param[in] depth Indexing depth (default 0).
  * @throw std::out_of_range If any of the indices are out of bounds.
  */
-template <typename Vec,
-          require_all_eigen_vector_t<Vec>* = nullptr>
+template <typename Vec, require_all_eigen_vector_t<Vec>* = nullptr>
 inline auto rvalue(Vec&& x,
                    const cons_index_list<index_max, nil_index_list>& idxs,
                    const char* name = "ANON", int depth = 0) {
@@ -288,7 +288,7 @@ template <typename EigMat,
 inline auto rvalue(EigMat&& x,
                    const cons_index_list<index_min, nil_index_list>& idxs,
                    const char* name = "ANON", int depth = 0) {
- const auto row_size = x.rows() - (idxs.head_.min_ - 1);
+  const auto row_size = x.rows() - (idxs.head_.min_ - 1);
   math::check_range("matrix[min] indexing", name, x.rows(), row_size);
   return x.bottomRows(row_size).eval();
 }
@@ -311,8 +311,7 @@ template <typename EigMat,
 inline auto rvalue(EigMat&& x,
                    const cons_index_list<index_max, nil_index_list>& idxs,
                    const char* name = "ANON", int depth = 0) {
-  math::check_range("matrix[max] indexing", name, x.cols(),
-                    idxs.head_.max_);
+  math::check_range("matrix[max] indexing", name, x.cols(), idxs.head_.max_);
   return x.topRows(idxs.head_.max_).eval();
 }
 
@@ -334,14 +333,17 @@ template <typename EigMat,
 inline auto rvalue(EigMat&& x,
                    const cons_index_list<index_min_max, nil_index_list>& idxs,
                    const char* name = "ANON", int depth = 0) {
-   math::check_range("matrix[min_max] max row indexing", name, x.rows(),
-                     idxs.head_.max_);
-   math::check_range("matrix[min_max] min row indexing", name, x.rows(),
-                     idxs.head_.min_);
+  math::check_range("matrix[min_max] max row indexing", name, x.rows(),
+                    idxs.head_.max_);
+  math::check_range("matrix[min_max] min row indexing", name, x.rows(),
+                    idxs.head_.min_);
   if (idxs.head_.is_ascending()) {
     return x.middleRows(idxs.head_.min_ - 1, idxs.head_.max_ - 1).eval();
   } else {
-    return x.middleRows(idxs.head_.max_ - 1, idxs.head_.min_ - 1).colwise().reverse().eval();
+    return x.middleRows(idxs.head_.max_ - 1, idxs.head_.min_ - 1)
+        .colwise()
+        .reverse()
+        .eval();
   }
 }
 
@@ -365,22 +367,24 @@ inline auto rvalue(
     const cons_index_list<index_min_max,
                           cons_index_list<index_min_max, nil_index_list>>& idxs,
     const char* name = "ANON", int depth = 0) {
-  math::check_range("matrix[min_max, min_max] min row indexing", name,
-                    x.rows(), idxs.head_.min_);
-  math::check_range("matrix[min_max, min_max] max row indexing", name,
-                    x.rows(), idxs.head_.max_);
+  math::check_range("matrix[min_max, min_max] min row indexing", name, x.rows(),
+                    idxs.head_.min_);
+  math::check_range("matrix[min_max, min_max] max row indexing", name, x.rows(),
+                    idxs.head_.max_);
   math::check_range("matrix[min_max, min_max] min column indexing", name,
                     x.cols(), idxs.tail_.head_.min_);
   math::check_range("matrix[min_max, min_max] max column indexing", name,
                     x.cols(), idxs.tail_.head_.max_);
   if (idxs.head_.is_ascending()) {
     if (idxs.tail_.head_.is_ascending()) {
-      return x.block(idxs.head_.min_ - 1, idxs.tail_.head_.min_ - 1,
+      return x
+          .block(idxs.head_.min_ - 1, idxs.tail_.head_.min_ - 1,
                  idxs.head_.max_ - (idxs.head_.min_ - 1),
                  idxs.tail_.head_.max_ - (idxs.tail_.head_.min_ - 1))
           .eval();
     } else {
-      return x.block(idxs.head_.min_ - 1, idxs.tail_.head_.max_ - 1,
+      return x
+          .block(idxs.head_.min_ - 1, idxs.tail_.head_.max_ - 1,
                  idxs.head_.max_ - (idxs.head_.min_ - 1),
                  idxs.tail_.head_.min_ - (idxs.tail_.head_.max_ - 1))
           .rowwise()
@@ -389,14 +393,16 @@ inline auto rvalue(
     }
   } else {
     if (idxs.tail_.head_.is_ascending()) {
-      return x.block(idxs.head_.max_ - 1, idxs.tail_.head_.min_ - 1,
+      return x
+          .block(idxs.head_.max_ - 1, idxs.tail_.head_.min_ - 1,
                  idxs.head_.min_ - (idxs.head_.max_ - 1),
                  idxs.tail_.head_.max_ - (idxs.tail_.head_.min_ - 1))
           .colwise()
           .reverse()
           .eval();
     } else {
-      return x.block(idxs.head_.max_ - 1, idxs.tail_.head_.max_ - 1,
+      return x
+          .block(idxs.head_.max_ - 1, idxs.tail_.head_.max_ - 1,
                  idxs.head_.min_ - (idxs.head_.max_ - 1),
                  idxs.tail_.head_.min_ - (idxs.tail_.head_.max_ - 1))
           .reverse()
@@ -548,12 +554,13 @@ template <typename EigMat, typename Idx,
           stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
     EigMat&& x,
-    const cons_index_list<Idx, cons_index_list<index_uni, nil_index_list>>& idxs,
+    const cons_index_list<Idx, cons_index_list<index_uni, nil_index_list>>&
+        idxs,
     const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[..., uni] indexing", name, x.cols(),
                     idxs.tail_.head_.n_);
-  return deep_copy(rvalue(x.col(idxs.tail_.head_.n_ - 1), index_list(idxs.head_),
-                          name, depth + 1));
+  return deep_copy(rvalue(x.col(idxs.tail_.head_.n_ - 1),
+                          index_list(idxs.head_), name, depth + 1));
 }
 
 /**
@@ -574,7 +581,8 @@ template <typename EigMat, typename Idx,
           require_not_same_t<std::decay_t<Idx>, index_uni>* = nullptr>
 inline plain_type_t<EigMat> rvalue(
     EigMat&& x,
-    const cons_index_list<Idx, cons_index_list<index_multi, nil_index_list>>& idxs,
+    const cons_index_list<Idx, cons_index_list<index_multi, nil_index_list>>&
+        idxs,
     const char* name = "ANON", int depth = 0) {
   const auto& x_ref = stan::math::to_ref(x);
   const int rows = rvalue_index_size(idxs.head_, x_ref.rows());
@@ -605,9 +613,11 @@ template <typename EigMat, typename Idx,
           stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
     EigMat&& x,
-    const cons_index_list<Idx, cons_index_list<index_omni, nil_index_list>>& idxs,
+    const cons_index_list<Idx, cons_index_list<index_omni, nil_index_list>>&
+        idxs,
     const char* name = "ANON", int depth = 0) {
-  return deep_copy(rvalue(std::forward<EigMat>(x), index_list(idxs.head_), name, depth + 1));
+  return deep_copy(
+      rvalue(std::forward<EigMat>(x), index_list(idxs.head_), name, depth + 1));
 }
 
 /**
@@ -629,13 +639,14 @@ template <typename EigMat, typename Idx,
           stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
     EigMat&& x,
-    const cons_index_list<Idx, cons_index_list<index_min, nil_index_list>>& idxs,
+    const cons_index_list<Idx, cons_index_list<index_min, nil_index_list>>&
+        idxs,
     const char* name = "ANON", int depth = 0) {
   const auto col_size = x.cols() - (idxs.tail_.head_.min_ - 1);
   math::check_range("matrix[..., min] indexing", name, x.cols(),
                     idxs.tail_.head_.min_);
-  return deep_copy(rvalue(x.rightCols(col_size),
-                          index_list(idxs.head_), name, depth + 1));
+  return deep_copy(
+      rvalue(x.rightCols(col_size), index_list(idxs.head_), name, depth + 1));
 }
 
 /**
@@ -657,7 +668,8 @@ template <typename EigMat, typename Idx,
           stan::internal::require_eigen_dense_dynamic_t<EigMat>* = nullptr>
 inline auto rvalue(
     EigMat&& x,
-    const cons_index_list<Idx, cons_index_list<index_max, nil_index_list>>& idxs,
+    const cons_index_list<Idx, cons_index_list<index_max, nil_index_list>>&
+        idxs,
     const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[..., max] indexing", name, x.cols(),
                     idxs.tail_.head_.max_);
@@ -698,11 +710,12 @@ inline auto rvalue(
   } else {
     const auto col_start = idxs.tail_.head_.max_ - 1;
     return deep_copy(
-        rvalue(x.middleCols(col_start, idxs.tail_.head_.min_ - col_start).rowwise().reverse(),
+        rvalue(x.middleCols(col_start, idxs.tail_.head_.min_ - col_start)
+                   .rowwise()
+                   .reverse(),
                index_list(idxs.head_), name, depth + 1));
   }
 }
-
 
 /**
  * Return the result of indexing the specified array with
@@ -720,7 +733,8 @@ inline auto rvalue(
  * @param[in] depth Depth of indexing dimension.
  * @return Result of indexing array.
  */
-template <typename StdVec, typename Idx, require_std_vector_t<StdVec>* = nullptr>
+template <typename StdVec, typename Idx,
+          require_std_vector_t<StdVec>* = nullptr>
 inline auto rvalue(StdVec&& v, const cons_index_list<index_uni, Idx>& idxs,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("array[uni, ...] index", name, v.size(), idxs.head_.n_);
@@ -784,7 +798,8 @@ inline auto rvalue(StdVec&& v, const cons_index_list<Idx1, Idx2>& idxs,
     const int n = rvalue_at(i, idxs.head_);
     math::check_range("array[..., ...] index", name, v.size(), n);
     if (std::is_rvalue_reference<StdVec>::value) {
-      result.emplace_back(rvalue(std::move(v[n - 1]), idxs.tail_, name, depth + 1));
+      result.emplace_back(
+          rvalue(std::move(v[n - 1]), idxs.tail_, name, depth + 1));
     } else {
       result.emplace_back(rvalue(v[n - 1], idxs.tail_, name, depth + 1));
     }

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -89,11 +89,11 @@ inline T rvalue(T&& x, const cons_index_list<index_omni, nil_index_list>& idxs,
  * @return Result of evaluating the expression.
  */
 template <typename T, require_not_plain_type_t<T>* = nullptr>
-inline auto rvalue(T&& x, const cons_index_list<index_omni, nil_index_list>& idxs,
-                const char* name = "ANON", int depth = 0) {
+inline auto rvalue(T&& x,
+                   const cons_index_list<index_omni, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
   return x.eval();
 }
-
 
 /**
  * Return the result of indexing a type without taking a subset

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -288,7 +288,7 @@ inline auto rvalue(EigMat&& x,
                    const cons_index_list<index_min, nil_index_list>& idxs,
                    const char* name = "ANON", int depth = 0) {
  const auto row_size = x.rows() - (idxs.head_.min_ - 1);
-  math::check_range("matrix[min] indexing", name, x.rows(), idxs.head_.min_);
+  math::check_range("matrix[min] indexing", name, x.rows(), row_size);
   return x.bottomRows(row_size).eval();
 }
 

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -433,7 +433,7 @@ inline auto rvalue(
 /**
  * Return a scalar from an Eigen matrix
  *
- * Types:  matrix[single,single] : scalar
+ * Types:  matrix[uni,uni] : scalar
  *
  * @tparam EigMat An eigen type
  * @param[in] x Matrix to index.
@@ -740,7 +740,7 @@ inline auto rvalue(
  * determined recursively.  Note that arrays are represented as
  * standard library vectors.
  *
- * Types:  std::vector<T>[single | Idx] : T[Idx]
+ * Types:  std::vector<T>[uni | Idx] : T[Idx]
  *
  * @tparam T Type of list elements.
  * @tparam Idx Index list type for indexes after first index.
@@ -766,7 +766,7 @@ inline auto rvalue(StdVec&& v, const cons_index_list<index_uni, Idx>& idxs,
  * Return the result of indexing the specified array with
  * a single index.
  *
- * Types:  std::vector<T>[single] : T
+ * Types:  std::vector<T>[uni] : T
  *
  * @tparam StdVec a standard vector
  * @param[in] c Container of list elements.

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -2,6 +2,7 @@
 #include <stdexcept>
 #include <vector>
 #include <stan/model/indexing/rvalue.hpp>
+#include <stan/math.hpp>
 #include <gtest/gtest.h>
 
 using stan::model::cons_index_list;
@@ -14,7 +15,7 @@ using stan::model::index_uni;
 using stan::model::nil_index_list;
 
 template <typename C, typename I>
-void test_out_of_range(const C& c, const I& idxs) {
+void test_out_of_range(C&& c, I&& idxs) {
   EXPECT_THROW(stan::model::rvalue(c, idxs), std::out_of_range);
 }
 
@@ -104,6 +105,20 @@ TEST(ModelIndexing, rvalue_vector_min_nil) {
   test_out_of_range(x, index_list(index_min(0)));
 }
 
+TEST(ModelIndexing, rvalue_eigen_vector_min_nil) {
+  Eigen::VectorXd x(3);
+  x << 1.1, 2.2, 3.3;
+  for (int k = 1; k < 4; ++k) {
+    auto rx = rvalue(x, index_list(index_min(k)));
+    EXPECT_FLOAT_EQ(3 - k + 1, rx.size());
+    for (size_t n = 0; n < rx.size(); ++n)
+      EXPECT_FLOAT_EQ(x[n + k - 1], rx[n]);
+  }
+
+  test_out_of_range(x, index_list(index_min(7)));
+  test_out_of_range(x, index_list(index_min(0)));
+}
+
 TEST(ModelIndexing, rvalue_vector_max_nil) {
   std::vector<double> x;
   x.push_back(1.1);
@@ -119,6 +134,22 @@ TEST(ModelIndexing, rvalue_vector_max_nil) {
 
   std::vector<double> ry = rvalue(x, index_list(index_max(0)));
   EXPECT_EQ(0U, ry.size());
+
+  test_out_of_range(x, index_list(index_max(4)));
+}
+
+TEST(ModelIndexing, rvalue_eigen_vector_max_nil) {
+  Eigen::VectorXd x(3);
+  x << 1.1, 2.2, 3.3;
+
+  for (int k = 1; k < 4; ++k) {
+    auto rx = rvalue(x, index_list(index_max(k)));
+    EXPECT_FLOAT_EQ(k, rx.size());
+    for (size_t n = 0; n < rx.size(); ++n)
+      EXPECT_FLOAT_EQ(x[n], rx[n]);
+  }
+
+  test_out_of_range(x, index_list(index_max(0)));
 
   test_out_of_range(x, index_list(index_max(4)));
 }
@@ -144,6 +175,38 @@ TEST(ModelIndexing, rvalue_vector_min_max_nil) {
   test_out_of_range(x, index_list(index_min_max(2, 5)));
 }
 
+TEST(ModelIndexing, rvalue_eigenvec_min_max_nil) {
+  Eigen::Matrix<double, -1, 1> x(4);
+  x(0) = 1.1;
+  x(1) = 2.2;
+  x(2) = 3.3;
+  x(3) = 4.4;
+  // min > max
+  for (int mn = 0; mn < 4; ++mn) {
+    for (int mx = mn; mx < 4; ++mx) {
+      Eigen::Matrix<double, -1, 1> rx
+          = rvalue(x, index_list(index_min_max(mn + 1, mx + 1)));
+      EXPECT_FLOAT_EQ(mx - mn + 1, rx.size());
+      for (int n = mn; n <= mx; ++n)
+        EXPECT_FLOAT_EQ(x[n], rx[n - mn]);
+    }
+  }
+
+  // max > min
+  for (int mn = 3; mn > -1; --mn) {
+    for (int mx = mn; mx > -1; --mx) {
+      Eigen::Matrix<double, -1, 1> rx
+          = rvalue(x, index_list(index_min_max(mn + 1, mx + 1)));
+      EXPECT_FLOAT_EQ(mn - mx + 1, rx.size());
+      for (int n = mn; n <= mx; ++n)
+        EXPECT_FLOAT_EQ(x[n], rx[n - mn]);
+    }
+  }
+
+  test_out_of_range(x, index_list(index_min_max(0, 2)));
+  test_out_of_range(x, index_list(index_min_max(2, 5)));
+}
+
 TEST(ModelIndexing, rvalue_doubless_uni_uni) {
   using std::vector;
 
@@ -155,7 +218,7 @@ TEST(ModelIndexing, rvalue_doubless_uni_uni) {
   x1.push_back(1.0);
   x1.push_back(1.1);
 
-  vector<vector<double> > x;
+  vector<vector<double>> x;
   x.push_back(x0);
   x.push_back(x1);
 
@@ -188,7 +251,7 @@ TEST(ModelIndexing, rvalue_doubless_uni_multi) {
   x2.push_back(2.1);
   x2.push_back(2.2);
 
-  vector<vector<double> > x;
+  vector<vector<double>> x;
   x.push_back(x0);
   x.push_back(x1);
   x.push_back(x2);
@@ -244,6 +307,71 @@ TEST(ModelIndexing, rvalue_doubless_uni_multi) {
   test_out_of_range(x, index_list(index_uni(1), index_multi(ns)));
 }
 
+TEST(ModelIndexing, rvalue_doubless_uni_multi_eigen) {
+  Eigen::MatrixXd x(3, 3);
+  x << 0.0, 0.1, 0.2, 1.0, 1.1, 1.2, 2.0, 2.1, 2.2;
+  Eigen::VectorXd y = rvalue(x, index_list(index_uni(1), index_min(2)));
+  EXPECT_EQ(2, y.size());
+  EXPECT_FLOAT_EQ(0.1, y[0]);
+  EXPECT_FLOAT_EQ(0.2, y[1]);
+  test_out_of_range(x, index_list(index_uni(0), index_min(2)));
+  test_out_of_range(x, index_list(index_uni(1), index_min(0)));
+
+  y = rvalue(x, index_list(index_uni(2), index_max(2)));
+  EXPECT_EQ(2, y.size());
+  EXPECT_FLOAT_EQ(1.0, y[0]);
+  EXPECT_FLOAT_EQ(1.1, y[1]);
+  test_out_of_range(x, index_list(index_uni(0), index_max(2)));
+  test_out_of_range(x, index_list(index_uni(1), index_max(15)));
+
+  y = rvalue(x, index_list(index_uni(2), index_min_max(2, 3)));
+  EXPECT_EQ(2, y.size());
+  EXPECT_FLOAT_EQ(1.1, y[0]);
+  EXPECT_FLOAT_EQ(1.2, y[1]);
+  test_out_of_range(x, index_list(index_uni(0), index_min_max(2, 3)));
+  test_out_of_range(x, index_list(index_uni(10), index_min_max(2, 3)));
+  test_out_of_range(x, index_list(index_uni(1), index_min_max(0, 3)));
+  test_out_of_range(x, index_list(index_uni(1), index_min_max(2, 15)));
+
+  y = rvalue(x, index_list(index_uni(2), index_min_max(2, 2)));
+  EXPECT_EQ(1, y.size());
+  EXPECT_FLOAT_EQ(1.1, y[0]);
+
+  y = rvalue(x, index_list(index_uni(3), index_omni()));
+  EXPECT_EQ(3, y.size());
+  EXPECT_FLOAT_EQ(2.0, y[0]);
+  EXPECT_FLOAT_EQ(2.1, y[1]);
+  EXPECT_FLOAT_EQ(2.2, y[2]);
+  test_out_of_range(x, index_list(index_uni(0), index_omni()));
+
+  std::vector<int> ns;
+  ns.push_back(3);
+  ns.push_back(1);
+  y = rvalue(x, index_list(index_uni(1), index_multi(ns)));
+  EXPECT_EQ(2, y.size());
+  EXPECT_FLOAT_EQ(0.2, y[0]);
+  EXPECT_FLOAT_EQ(0.0, y[1]);
+  test_out_of_range(x, index_list(index_uni(0), index_multi(ns)));
+  test_out_of_range(x, index_list(index_uni(10), index_multi(ns)));
+
+  ns.push_back(0);
+  test_out_of_range(x, index_list(index_uni(1), index_multi(ns)));
+
+  ns[ns.size() - 1] = 20;
+  test_out_of_range(x, index_list(index_uni(1), index_multi(ns)));
+}
+
+TEST(ModelIndexing, rvalue_doubless_minmax_minmax_eigen) {
+  Eigen::MatrixXd x(3, 3);
+  x << 0.0, 0.1, 0.2, 1.0, 1.1, 1.2, 2.0, 2.1, 2.2;
+  Eigen::VectorXd y = rvalue(x, index_list(index_uni(1), index_min(2)));
+  EXPECT_EQ(2, y.size());
+  EXPECT_FLOAT_EQ(0.1, y[0]);
+  EXPECT_FLOAT_EQ(0.2, y[1]);
+  test_out_of_range(x, index_list(index_uni(0), index_min(2)));
+  test_out_of_range(x, index_list(index_uni(1), index_min(0)));
+}
+
 TEST(ModelIndexing, rvalue_doubless_multi_uni) {
   using std::vector;
 
@@ -262,12 +390,72 @@ TEST(ModelIndexing, rvalue_doubless_multi_uni) {
   x2.push_back(2.1);
   x2.push_back(2.2);
 
-  vector<vector<double> > x;
+  vector<vector<double>> x;
   x.push_back(x0);
   x.push_back(x1);
   x.push_back(x2);
 
   vector<double> y = rvalue(x, index_list(index_min(2), index_uni(1)));
+  EXPECT_EQ(2, y.size());
+  EXPECT_FLOAT_EQ(1.0, y[0]);
+  EXPECT_FLOAT_EQ(2.0, y[1]);
+  test_out_of_range(x, index_list(index_min(0), index_uni(1)));
+  test_out_of_range(x, index_list(index_min(2), index_uni(0)));
+  test_out_of_range(x, index_list(index_min(2), index_uni(10)));
+
+  y = rvalue(x, index_list(index_max(2), index_uni(3)));
+  EXPECT_EQ(2, y.size());
+  EXPECT_FLOAT_EQ(0.2, y[0]);
+  EXPECT_FLOAT_EQ(1.2, y[1]);
+  test_out_of_range(x, index_list(index_max(10), index_uni(3)));
+  test_out_of_range(x, index_list(index_max(2), index_uni(0)));
+  test_out_of_range(x, index_list(index_max(2), index_uni(15)));
+
+  y = rvalue(x, index_list(index_min_max(2, 3), index_uni(2)));
+  EXPECT_EQ(2, y.size());
+  EXPECT_FLOAT_EQ(1.1, y[0]);
+  EXPECT_FLOAT_EQ(2.1, y[1]);
+  test_out_of_range(x, index_list(index_min_max(0, 3), index_uni(2)));
+  test_out_of_range(x, index_list(index_min_max(2, 15), index_uni(2)));
+  test_out_of_range(x, index_list(index_min_max(2, 3), index_uni(0)));
+  test_out_of_range(x, index_list(index_min_max(2, 3), index_uni(10)));
+
+  y = rvalue(x, index_list(index_min_max(2, 2), index_uni(2)));
+  EXPECT_EQ(1, y.size());
+  EXPECT_FLOAT_EQ(1.1, y[0]);
+  test_out_of_range(x, index_list(index_min_max(0, 2), index_uni(2)));
+  test_out_of_range(x, index_list(index_min_max(2, 12), index_uni(2)));
+  test_out_of_range(x, index_list(index_min_max(2, 2), index_uni(0)));
+  test_out_of_range(x, index_list(index_min_max(2, 2), index_uni(15)));
+
+  y = rvalue(x, index_list(index_omni(), index_uni(3)));
+  EXPECT_EQ(3, y.size());
+  EXPECT_FLOAT_EQ(0.2, y[0]);
+  EXPECT_FLOAT_EQ(1.2, y[1]);
+  EXPECT_FLOAT_EQ(2.2, y[2]);
+  test_out_of_range(x, index_list(index_omni(), index_uni(0)));
+  test_out_of_range(x, index_list(index_omni(), index_uni(10)));
+
+  vector<int> ns;
+  ns.push_back(3);
+  ns.push_back(1);
+  y = rvalue(x, index_list(index_multi(ns), index_uni(1)));
+  EXPECT_EQ(2, y.size());
+  EXPECT_FLOAT_EQ(2.0, y[0]);
+  EXPECT_FLOAT_EQ(0.0, y[1]);
+
+  ns.push_back(0);
+  test_out_of_range(x, index_list(index_multi(ns), index_uni(1)));
+
+  ns[ns.size() - 1] = 15;
+  test_out_of_range(x, index_list(index_multi(ns), index_uni(1)));
+}
+
+TEST(ModelIndexing, rvalue_doubless_multi_uni_eigen) {
+  using std::vector;
+  Eigen::MatrixXd x(3, 3);
+  x << 0.0, 0.1, 0.2, 1.0, 1.1, 1.2, 2.0, 2.1, 2.2;
+  Eigen::VectorXd y = rvalue(x, index_list(index_min(2), index_uni(1)));
   EXPECT_EQ(2, y.size());
   EXPECT_FLOAT_EQ(1.0, y[0]);
   EXPECT_FLOAT_EQ(2.0, y[1]);
@@ -341,12 +529,12 @@ TEST(ModelIndexing, rvalue_doubless_multi_multi) {
   x2.push_back(2.1);
   x2.push_back(2.2);
 
-  vector<vector<double> > x;
+  vector<vector<double>> x;
   x.push_back(x0);
   x.push_back(x1);
   x.push_back(x2);
 
-  vector<vector<double> > y = rvalue(x, index_list(index_max(2), index_min(2)));
+  vector<vector<double>> y = rvalue(x, index_list(index_max(2), index_min(2)));
   EXPECT_EQ(2, y.size());
   EXPECT_EQ(2, y[0].size());
   EXPECT_EQ(2, y[1].size());
@@ -354,6 +542,22 @@ TEST(ModelIndexing, rvalue_doubless_multi_multi) {
   EXPECT_FLOAT_EQ(0.2, y[0][1]);
   EXPECT_FLOAT_EQ(1.1, y[1][0]);
   EXPECT_FLOAT_EQ(1.2, y[1][1]);
+  test_out_of_range(x, index_list(index_max(20), index_min(2)));
+  test_out_of_range(x, index_list(index_max(2), index_min(0)));
+}
+
+TEST(ModelIndexing, rvalue_doubless_multi_multi_eigen) {
+  Eigen::MatrixXd x(3, 3);
+  x << 0.0, 0.1, 0.2, 1.0, 1.1, 1.2, 2.0, 2.1, 2.2;
+
+  Eigen::MatrixXd y = rvalue(x, index_list(index_max(2), index_min(2)));
+  EXPECT_EQ(4, y.size());
+  EXPECT_EQ(2, y.rows());
+  EXPECT_EQ(2, y.cols());
+  EXPECT_FLOAT_EQ(0.1, y(0, 0));
+  EXPECT_FLOAT_EQ(0.2, y(0, 1));
+  EXPECT_FLOAT_EQ(1.1, y(1, 0));
+  EXPECT_FLOAT_EQ(1.2, y(1, 1));
   test_out_of_range(x, index_list(index_max(20), index_min(2)));
   test_out_of_range(x, index_list(index_max(2), index_min(0)));
 }
@@ -366,6 +570,10 @@ void vector_uni_test() {
   EXPECT_FLOAT_EQ(0, rvalue(v, index_list(index_uni(1))));
   EXPECT_FLOAT_EQ(1, rvalue(v, index_list(index_uni(2))));
   EXPECT_FLOAT_EQ(2, rvalue(v, index_list(index_uni(3))));
+
+  EXPECT_FLOAT_EQ(2, rvalue(v.array() + 2, index_list(index_uni(1))));
+  EXPECT_FLOAT_EQ(3, rvalue(v.array() + 2, index_list(index_uni(2))));
+  EXPECT_FLOAT_EQ(4, rvalue(v.array() + 2, index_list(index_uni(3))));
 
   test_out_of_range(v, index_list(index_uni(0)));
   test_out_of_range(v, index_list(index_uni(20)));
@@ -394,11 +602,21 @@ void vector_multi_test() {
   EXPECT_FLOAT_EQ(4, vi(2));
   test_out_of_range(v, index_list(index_min(0)));
 
+  vi = rvalue(v.array() + 2, index_list(index_min(3)));
+  EXPECT_EQ(3, vi.size());
+  EXPECT_FLOAT_EQ(4, vi(0));
+  EXPECT_FLOAT_EQ(6, vi(2));
+
   vi = rvalue(v, index_list(index_max(3)));
   EXPECT_EQ(3, vi.size());
   EXPECT_FLOAT_EQ(0, vi(0));
   EXPECT_FLOAT_EQ(2, vi(2));
   test_out_of_range(v, index_list(index_max(15)));
+
+  vi = rvalue(v.array() + 2, index_list(index_max(3)));
+  EXPECT_EQ(3, vi.size());
+  EXPECT_FLOAT_EQ(2, vi(0));
+  EXPECT_FLOAT_EQ(4, vi(2));
 
   vi = rvalue(v, index_list(index_min_max(2, 4)));
   EXPECT_EQ(3, vi.size());
@@ -406,6 +624,11 @@ void vector_multi_test() {
   EXPECT_FLOAT_EQ(3, vi(2));
   test_out_of_range(v, index_list(index_min_max(0, 4)));
   test_out_of_range(v, index_list(index_min_max(2, 15)));
+
+  vi = rvalue(v.array() + 2, index_list(index_min_max(2, 4)));
+  EXPECT_EQ(3, vi.size());
+  EXPECT_FLOAT_EQ(3, vi(0));
+  EXPECT_FLOAT_EQ(5, vi(2));
 
   std::vector<int> ns;
   ns.push_back(4);
@@ -422,6 +645,13 @@ void vector_multi_test() {
   EXPECT_FLOAT_EQ(1.0, vi(2));
   EXPECT_FLOAT_EQ(4.0, vi(4));
   EXPECT_FLOAT_EQ(3.0, vi(6));
+
+  vi = rvalue(v.array() + 2, index_list(index_multi(ns)));
+  EXPECT_EQ(7, vi.size());
+  EXPECT_FLOAT_EQ(5.0, vi(0));
+  EXPECT_FLOAT_EQ(3.0, vi(2));
+  EXPECT_FLOAT_EQ(6.0, vi(4));
+  EXPECT_FLOAT_EQ(5.0, vi(6));
 
   ns.push_back(0);
   test_out_of_range(v, index_list(index_multi(ns)));
@@ -443,9 +673,6 @@ TEST(ModelIndexing, rvalueMatrixUni) {
 
   MatrixXd m(4, 3);
   m << 0.0, 0.1, 0.2, 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 3.0, 3.1, 3.2;
-
-  // FIXME
-
   RowVectorXd v = rvalue(m, index_list(index_uni(1)));
   EXPECT_EQ(3, v.size());
   EXPECT_FLOAT_EQ(0.0, v(0));
@@ -454,11 +681,22 @@ TEST(ModelIndexing, rvalueMatrixUni) {
   test_out_of_range(m, index_list(index_uni(0)));
   test_out_of_range(m, index_list(index_uni(15)));
 
+  v = rvalue(m.array() + 2, index_list(index_uni(1)));
+  EXPECT_FLOAT_EQ(2.0, v(0));
+  EXPECT_FLOAT_EQ(2.1, v(1));
+  EXPECT_FLOAT_EQ(2.2, v(2));
+
   v = rvalue(m, index_list(index_uni(2)));
   EXPECT_EQ(3, v.size());
   EXPECT_FLOAT_EQ(1.0, v(0));
   EXPECT_FLOAT_EQ(1.1, v(1));
   EXPECT_FLOAT_EQ(1.2, v(2));
+
+  v = rvalue(m.array() + 2, index_list(index_uni(2)));
+  EXPECT_EQ(3, v.size());
+  EXPECT_FLOAT_EQ(3.0, v(0));
+  EXPECT_FLOAT_EQ(3.1, v(1));
+  EXPECT_FLOAT_EQ(3.2, v(2));
 }
 
 TEST(ModelIndexing, rvalueMatrixMulti) {
@@ -480,6 +718,16 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(3.2, a(1, 2));
   test_out_of_range(m, index_list(index_min(0)));
 
+  a = rvalue(m.array() + 2, index_list(index_min(3)));
+  EXPECT_EQ(2, a.rows());
+  EXPECT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(4.0, a(0, 0));
+  EXPECT_FLOAT_EQ(4.1, a(0, 1));
+  EXPECT_FLOAT_EQ(4.2, a(0, 2));
+  EXPECT_FLOAT_EQ(5.0, a(1, 0));
+  EXPECT_FLOAT_EQ(5.1, a(1, 1));
+  EXPECT_FLOAT_EQ(5.2, a(1, 2));
+
   a = rvalue(m, index_list(index_max(2)));
   EXPECT_EQ(2, a.rows());
   EXPECT_EQ(3, a.cols());
@@ -491,6 +739,16 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(1.2, a(1, 2));
   test_out_of_range(m, index_list(index_max(15)));
 
+  a = rvalue(m.array() + 2, index_list(index_max(2)));
+  EXPECT_EQ(2, a.rows());
+  EXPECT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(2.0, a(0, 0));
+  EXPECT_FLOAT_EQ(2.1, a(0, 1));
+  EXPECT_FLOAT_EQ(2.2, a(0, 2));
+  EXPECT_FLOAT_EQ(3.0, a(1, 0));
+  EXPECT_FLOAT_EQ(3.1, a(1, 1));
+  EXPECT_FLOAT_EQ(3.2, a(1, 2));
+
   a = rvalue(m, index_list(index_min_max(2, 3)));
   EXPECT_EQ(2, a.rows());
   EXPECT_EQ(3, a.cols());
@@ -500,10 +758,78 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(2.0, a(1, 0));
   EXPECT_FLOAT_EQ(2.1, a(1, 1));
   EXPECT_FLOAT_EQ(2.2, a(1, 2));
-  test_out_of_range(m, index_list(index_min_max(0, 3)));
-  test_out_of_range(m, index_list(index_min_max(2, 15)));
+
+  a = rvalue(m.array() + 2, index_list(index_min_max(2, 3)));
+  EXPECT_EQ(2, a.rows());
+  EXPECT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(3.0, a(0, 0));
+  EXPECT_FLOAT_EQ(3.1, a(0, 1));
+  EXPECT_FLOAT_EQ(3.2, a(0, 2));
+  EXPECT_FLOAT_EQ(4.0, a(1, 0));
+  EXPECT_FLOAT_EQ(4.1, a(1, 1));
+  EXPECT_FLOAT_EQ(4.2, a(1, 2));
+
+  a = rvalue(m, index_list(index_min_max(3, 2)));
+  EXPECT_EQ(2, a.rows());
+  EXPECT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(2, a(0, 0));
+  EXPECT_FLOAT_EQ(2.1, a(0, 1));
+  EXPECT_FLOAT_EQ(2.2, a(0, 2));
+  EXPECT_FLOAT_EQ(1, a(1, 0));
+  EXPECT_FLOAT_EQ(1.1, a(1, 1));
+  EXPECT_FLOAT_EQ(1.2, a(1, 2));
+  test_out_of_range(m.array(), index_list(index_min_max(0, 3)));
+  test_out_of_range(m.array(), index_list(index_min_max(2, 15)));
+
+  a = rvalue(m.block(0, 0, 4, 3).array() + 2, index_list(index_min_max(3, 2)));
+  EXPECT_EQ(2, a.rows());
+  EXPECT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(4, a(0, 0));
+  EXPECT_FLOAT_EQ(4.1, a(0, 1));
+  EXPECT_FLOAT_EQ(4.2, a(0, 2));
+  EXPECT_FLOAT_EQ(3, a(1, 0));
+  EXPECT_FLOAT_EQ(3.1, a(1, 1));
+  EXPECT_FLOAT_EQ(3.2, a(1, 2));
+  test_out_of_range(m.array(), index_list(index_min_max(0, 3)));
+  test_out_of_range(m.array(), index_list(index_min_max(2, 15)));
+
+  a = rvalue(m, index_list(index_omni(), index_min_max(2, 3)));
+  EXPECT_EQ(2, a.cols());
+  EXPECT_EQ(4, a.rows());
+  EXPECT_FLOAT_EQ(0.1, a(0, 0));
+  EXPECT_FLOAT_EQ(1.1, a(1, 0));
+  EXPECT_FLOAT_EQ(2.1, a(2, 0));
+  EXPECT_FLOAT_EQ(3.1, a(3, 0));
+  EXPECT_FLOAT_EQ(0.2, a(0, 1));
+  EXPECT_FLOAT_EQ(1.2, a(1, 1));
+  EXPECT_FLOAT_EQ(2.2, a(2, 1));
+  EXPECT_FLOAT_EQ(3.2, a(3, 1));
+
+  a = rvalue(m, index_list(index_omni(), index_min_max(3, 2)));
+  EXPECT_EQ(2, a.cols());
+  EXPECT_EQ(4, a.rows());
+  EXPECT_FLOAT_EQ(0.2, a(0, 0));
+  EXPECT_FLOAT_EQ(1.2, a(1, 0));
+  EXPECT_FLOAT_EQ(2.2, a(2, 0));
+  EXPECT_FLOAT_EQ(3.2, a(3, 0));
+  EXPECT_FLOAT_EQ(0.1, a(0, 1));
+  EXPECT_FLOAT_EQ(1.1, a(1, 1));
+  EXPECT_FLOAT_EQ(2.1, a(2, 1));
+  EXPECT_FLOAT_EQ(3.1, a(3, 1));
+  test_out_of_range(m.array(), index_list(index_min_max(0, 3)));
+  test_out_of_range(m.array(), index_list(index_min_max(2, 15)));
 
   a = rvalue(m, index_list(index_omni()));
+  EXPECT_EQ(4, a.rows());
+  EXPECT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(0.0, a(0, 0));
+  EXPECT_FLOAT_EQ(0.1, a(0, 1));
+  EXPECT_FLOAT_EQ(0.2, a(0, 2));
+  EXPECT_FLOAT_EQ(3.0, a(3, 0));
+  EXPECT_FLOAT_EQ(3.1, a(3, 1));
+  EXPECT_FLOAT_EQ(3.2, a(3, 2));
+
+  a = rvalue(m.array(), index_list(index_omni()));
   EXPECT_EQ(4, a.rows());
   EXPECT_EQ(3, a.cols());
   EXPECT_FLOAT_EQ(0.0, a(0, 0));
@@ -534,6 +860,19 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(0.1, a(6, 1));
   EXPECT_FLOAT_EQ(0.2, a(6, 2));
 
+  a = rvalue(m.array(), index_list(index_multi(ns)));
+  EXPECT_FLOAT_EQ(7, a.rows());
+  EXPECT_FLOAT_EQ(3, a.cols());
+  EXPECT_FLOAT_EQ(2.0, a(0, 0));
+  EXPECT_FLOAT_EQ(2.1, a(0, 1));
+  EXPECT_FLOAT_EQ(2.2, a(0, 2));
+  EXPECT_FLOAT_EQ(3.0, a(5, 0));
+  EXPECT_FLOAT_EQ(3.1, a(5, 1));
+  EXPECT_FLOAT_EQ(3.2, a(5, 2));
+  EXPECT_FLOAT_EQ(0.0, a(6, 0));
+  EXPECT_FLOAT_EQ(0.1, a(6, 1));
+  EXPECT_FLOAT_EQ(0.2, a(6, 2));
+
   ns.push_back(0);
   test_out_of_range(m, index_list(index_multi(ns)));
 
@@ -545,10 +884,20 @@ TEST(ModelIndexing, rvalueMatrixSingleSingle) {
   Eigen::MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
-  for (int m = 0; m < 3; ++m)
-    for (int n = 0; n < 4; ++n)
+  for (int m = 0; m < 3; ++m) {
+    for (int n = 0; n < 4; ++n) {
       EXPECT_FLOAT_EQ(m + n / 10.0, rvalue(x, index_list(index_uni(m + 1),
                                                          index_uni(n + 1))));
+    }
+  }
+
+  for (int m = 0; m < 3; ++m) {
+    for (int n = 0; n < 4; ++n) {
+      EXPECT_FLOAT_EQ((m + n / 10.0) + 2,
+                      rvalue(x.array() + 2,
+                             index_list(index_uni(m + 1), index_uni(n + 1))));
+    }
+  }
   test_out_of_range(x, index_list(index_uni(0), index_uni(1)));
   test_out_of_range(x, index_list(index_uni(0), index_uni(10)));
   test_out_of_range(x, index_list(index_uni(1), index_uni(0)));
@@ -561,15 +910,17 @@ TEST(ModelIndexing, rvalueMatrixSingleMulti) {
 
   Eigen::RowVectorXd v = rvalue(x, index_list(index_uni(2), index_omni()));
   EXPECT_EQ(4, v.size());
-  for (int i = 0; i < 4; ++i)
+  for (int i = 0; i < 4; ++i) {
     EXPECT_FLOAT_EQ(v(i), x(1, i));
+  }
   test_out_of_range(x, index_list(index_uni(0), index_omni()));
   test_out_of_range(x, index_list(index_uni(10), index_omni()));
 
-  v = rvalue(x, index_list(index_uni(3), index_min(2)));
-  EXPECT_EQ(3, v.size());
-  for (int i = 0; i < 3; ++i)
-    EXPECT_FLOAT_EQ(v(i), x(2, i + 1));
+  v = rvalue(x.block(0, 0, 3, 4), index_list(index_uni(2), index_omni()));
+  EXPECT_EQ(4, v.size());
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_FLOAT_EQ(v(i), x(1, i));
+  }
   test_out_of_range(x, index_list(index_uni(0), index_min(2)));
   test_out_of_range(x, index_list(index_uni(1), index_min(0)));
 }
@@ -589,6 +940,17 @@ TEST(ModelIndexing, rvalueMatrixMultiSingle) {
   EXPECT_EQ(2, v.size());
   for (int j = 0; j < 2; ++j)
     EXPECT_EQ(1 + j + 0.2, v(j));
+
+  v = rvalue(x.array() + 2, index_list(index_min(2), index_uni(3)));
+  EXPECT_EQ(2, v.size());
+  for (int j = 0; j < 2; ++j) {
+    EXPECT_EQ(1 + j + 2.2, v(j));
+  }
+  v = rvalue(x.array() + 2, index_list(index_uni(3), index_min(2)));
+  EXPECT_EQ(3, v.size());
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_FLOAT_EQ(v(i), x(2, i + 1) + 2);
+  }
   test_out_of_range(x, index_list(index_min(0), index_uni(3)));
   test_out_of_range(x, index_list(index_min(2), index_uni(0)));
   test_out_of_range(x, index_list(index_min(2), index_uni(30)));
@@ -605,6 +967,15 @@ TEST(ModelIndexing, rvalueMatrixMultiMulti) {
     for (int j = 0; j < x.cols(); ++j)
       EXPECT_FLOAT_EQ(x(i, j), y(i, j));
 
+  y = rvalue(x.array() + 2, index_list(index_omni(), index_omni()));
+  EXPECT_EQ(x.rows(), y.rows());
+  EXPECT_EQ(x.cols(), y.cols());
+  for (int i = 0; i < x.rows(); ++i) {
+    for (int j = 0; j < x.cols(); ++j) {
+      EXPECT_FLOAT_EQ(x(i, j) + 2, y(i, j));
+    }
+  }
+
   y = rvalue(x, index_list(index_min(2), index_min(3)));
   EXPECT_EQ(2, y.rows());
   EXPECT_EQ(2, y.cols());
@@ -613,4 +984,14 @@ TEST(ModelIndexing, rvalueMatrixMultiMulti) {
       EXPECT_FLOAT_EQ(i + 1 + (j + 2) / 10.0, y(i, j));
   test_out_of_range(x, index_list(index_min(0), index_min(3)));
   test_out_of_range(x, index_list(index_min(2), index_min(0)));
+
+  y = rvalue(x.block(0, 0, 3, 4).array() + 2,
+             index_list(index_min(2), index_min(3)));
+  EXPECT_EQ(2, y.rows());
+  EXPECT_EQ(2, y.cols());
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 2; ++j) {
+      EXPECT_FLOAT_EQ(2 + i + 1 + (j + 2) / 10.0, y(i, j));
+    }
+  }
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is the `rvalue()` func version of #2964 for doing efficient slices of eigen matrices.

#### Intended Effect

Should hopefully make indexing like 1:N etc more useful. This will mainly give a performance bump once we are passing around expressions.

#### How to Verify

Tests have been added to `rvalue_test.cpp`

```
./runTests.py -j4 ./src/test/unit/model/indexing/
```

#### Side Effects

#### Documentation

Docs updated for all overloads for indexing 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
