### PR TITLE
Feature/2968 csv reader header row check

### DIFF
--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -8,7 +8,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#include <ctype.h>
+#include <ctype>
 
 namespace stan {
 namespace io {
@@ -179,7 +179,7 @@ class stan_csv_reader {
                           std::ostream* out, bool prettify_name = true) {
     std::string line;
 
-    if (!isalpha(in.peek()))
+    if (!std::isalpha(in.peek()))
       return false;
 
     std::getline(in, line);

--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -3,12 +3,12 @@
 
 #include <boost/algorithm/string.hpp>
 #include <stan/math/prim.hpp>
+#include <cctype>
 #include <istream>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <ctype>
 
 namespace stan {
 namespace io {

--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <ctype.h>
 
 namespace stan {
 namespace io {
@@ -178,7 +179,7 @@ class stan_csv_reader {
                           std::ostream* out, bool prettify_name = true) {
     std::string line;
 
-    if (in.peek() != 'l')
+    if (!isalpha(in.peek()))
       return false;
 
     std::getline(in, line);

--- a/src/test/unit/io/stan_csv_reader_test.cpp
+++ b/src/test/unit/io/stan_csv_reader_test.cpp
@@ -11,14 +11,11 @@ class StanIoStanCsvReader : public testing::Test {
     metadata1_stream.open("src/test/unit/io/test_csv_files/metadata1.csv");
     metadata3_stream.open("src/test/unit/io/test_csv_files/metadata3.csv");
     header1_stream.open("src/test/unit/io/test_csv_files/header1.csv");
+    header2_stream.open("src/test/unit/io/test_csv_files/header2.csv");
     adaptation1_stream.open("src/test/unit/io/test_csv_files/adaptation1.csv");
     samples1_stream.open("src/test/unit/io/test_csv_files/samples1.csv");
 
     epil0_stream.open("src/test/unit/io/test_csv_files/epil.0.csv");
-    metadata2_stream.open("src/test/unit/io/test_csv_files/metadata2.csv");
-    header2_stream.open("src/test/unit/io/test_csv_files/header2.csv");
-    adaptation2_stream.open("src/test/unit/io/test_csv_files/adaptation2.csv");
-    samples2_stream.open("src/test/unit/io/test_csv_files/samples2.csv");
 
     blocker_nondiag0_stream.open(
         "src/test/unit/io/test_csv_files/blocker_nondiag.0.csv");
@@ -31,14 +28,11 @@ class StanIoStanCsvReader : public testing::Test {
     metadata1_stream.close();
     metadata3_stream.close();
     header1_stream.close();
+    header2_stream.close();
     adaptation1_stream.close();
     samples1_stream.close();
 
     epil0_stream.close();
-    metadata2_stream.close();
-    header2_stream.close();
-    adaptation2_stream.close();
-    samples2_stream.close();
 
     blocker_nondiag0_stream.close();
   }
@@ -47,9 +41,7 @@ class StanIoStanCsvReader : public testing::Test {
   std::ifstream blocker_nondiag0_stream;
   std::ifstream metadata1_stream, header1_stream, adaptation1_stream,
       samples1_stream;
-  std::ifstream metadata3_stream;
-  std::ifstream metadata2_stream, header2_stream, adaptation2_stream,
-      samples2_stream;
+  std::ifstream metadata3_stream, header2_stream;
   std::ifstream eight_schools_stream;
 };
 
@@ -133,6 +125,21 @@ TEST_F(StanIoStanCsvReader, read_header1) {
     EXPECT_EQ(ss.str(), header[30 + i]);
   }
   EXPECT_EQ("sigma_delta", header[54]);
+}
+
+TEST_F(StanIoStanCsvReader, read_header2) {
+  std::vector<std::string> header;
+  EXPECT_TRUE(
+      stan::io::stan_csv_reader::read_header(header2_stream, header, 0));
+
+  ASSERT_EQ(5, header.size());
+  EXPECT_EQ("d", header[0]);
+  EXPECT_EQ("sigmasq_delta", header[1]);
+  for (int i = 1; i <= 3; ++i) {
+    std::stringstream ss;
+    ss << "mu[" << i << "]";
+    EXPECT_EQ(ss.str(), header[1 + i]);
+  }
 }
 
 TEST_F(StanIoStanCsvReader, read_adaptation1) {

--- a/src/test/unit/io/test_csv_files/header2.csv
+++ b/src/test/unit/io/test_csv_files/header2.csv
@@ -1,0 +1,1 @@
+d,sigmasq_delta,mu.1,mu.2,mu.3


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

allow Stan CSV files to have first column be any Stan variable name, not just "lp__"

#### Intended Effect

reduce size of input Stan CSV files for CmdStan method `generate_quantities` by allowing inputs containing only the parameter variables.

#### How to Verify

unit tests

#### Side Effects

N/A

#### Documentation

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
