### PR TITLE
Optimize Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,6 @@ String branchName() { isPR() ? env.CHANGE_BRANCH :env.BRANCH_NAME }
 
 pipeline {
     agent none
-    options {parallelsAlwaysFailFast()}
     parameters {
         string(defaultValue: '', name: 'math_pr', description: "Leave blank "
                 + "unless testing against a specific math repo pull request, "
@@ -61,6 +60,7 @@ pipeline {
     options {
         skipDefaultCheckout()
         preserveStashes(buildCount: 7)
+        parallelsAlwaysFailFast()
     }
     stages {
         stage('Kill previous builds') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,7 @@ String branchName() { isPR() ? env.CHANGE_BRANCH :env.BRANCH_NAME }
 
 pipeline {
     agent none
+    options {parallelsAlwaysFailFast()}
     parameters {
         string(defaultValue: '', name: 'math_pr', description: "Leave blank "
                 + "unless testing against a specific math repo pull request, "
@@ -240,6 +241,13 @@ pipeline {
                 }
                 stage('Integration Mac') {
                     agent { label 'osx' }
+                    when { 
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ) &&
+                            !skipRemainingStages
+                        }
+                    }
                     steps {
                         unstash 'StanSetup'
                         setupCXX()


### PR DESCRIPTION
Fixes #2971 by only running Mac integration tests on merges. The chances of Linux integration tests passing and Mac integration tests failing are so slim in my opinion, it make sense to only run this on merges. We still do want this tested.

The other change is that the pipeline will stop immediately once a stage fails (not running other stages until the end).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar, Uni. of Ljubljana


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
