### PR TITLE
fix range checks for the row slicing lvalue rvalue

### DIFF
--- a/src/stan/model/indexing/lvalue.hpp
+++ b/src/stan/model/indexing/lvalue.hpp
@@ -587,7 +587,7 @@ inline void assign(
                           cons_index_list<index_multi, nil_index_list>>& idxs,
     const Vec& y, const char* name = "ANON", int depth = 0) {
   const auto& y_ref = stan::math::to_ref(y);
-  stan::math::check_range("matrix[uni, multi] assign range", name, x.cols(),
+  stan::math::check_range("matrix[uni, multi] assign range", name, x.rows(),
                           idxs.head_.n_);
   stan::math::check_size_match("matrix[uni, multi] assign sizes", "lhs",
                                idxs.tail_.head_.ns_.size(), name, y_ref.size());

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -330,7 +330,7 @@ template <typename EigMat,
 inline auto rvalue(EigMat&& x,
                    const cons_index_list<index_max, nil_index_list>& idxs,
                    const char* name = "ANON", int depth = 0) {
-  math::check_range("matrix[max] indexing", name, x.cols(), idxs.head_.max_);
+  math::check_range("matrix[max] indexing", name, x.rows(), idxs.head_.max_);
   return x.topRows(idxs.head_.max_).eval();
 }
 
@@ -474,7 +474,7 @@ inline Eigen::Matrix<value_type_t<EigMat>, 1, Eigen::Dynamic> rvalue(
     const cons_index_list<index_uni,
                           cons_index_list<index_multi, nil_index_list>>& idxs,
     const char* name = "ANON", int depth = 0) {
-  math::check_range("matrix[uni, multi] index range", name, x.cols(),
+  math::check_range("matrix[uni, multi] index range", name, x.rows(),
                     idxs.head_.n_);
   const auto& x_ref = stan::math::to_ref(x);
   Eigen::Matrix<value_type_t<EigMat>, 1, Eigen::Dynamic> x_ret(


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Quick fix pr, there were three rvalue/lvalue functions that we should be checking the rows and not the columns

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
