### PR TITLE
allow reader to read out var<matrix> types

### DIFF
--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -55,16 +55,19 @@ class reader {
 
  public:
   using matrix_t = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
-  using vector_t =  Eigen::Matrix<T, Eigen::Dynamic, 1>;
+  using vector_t = Eigen::Matrix<T, Eigen::Dynamic, 1>;
   using row_vector_t = Eigen::Matrix<T, 1, Eigen::Dynamic>;
 
   using map_matrix_t = Eigen::Map<matrix_t>;
   using map_vector_t = Eigen::Map<vector_t>;
   using map_row_vector_t = Eigen::Map<row_vector_t>;
 
-  using var_matrix_t = stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>;
-  using var_vector_t =  stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, 1>>;
-  using var_row_vector_t = stan::math::var_value<Eigen::Matrix<double, 1, Eigen::Dynamic>>;
+  using var_matrix_t = stan::math::var_value<
+      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>;
+  using var_vector_t
+      = stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, 1>>;
+  using var_row_vector_t
+      = stan::math::var_value<Eigen::Matrix<double, 1, Eigen::Dynamic>>;
 
   /**
    * Construct a variable reader using the specified vectors
@@ -198,7 +201,7 @@ class reader {
    * @param m Number of rows in the vector to read.
    * @return Column vector made up of the next scalars.
    */
-  template <typename T_ = T, require_st_var<T_>* = nullptr>
+  template <typename T_ = T, require_st_var<T_> * = nullptr>
   inline var_vector_t var_vector(size_t m) {
     if (m == 0)
       return var_vector_t(Eigen::VectorXd(0));
@@ -212,7 +215,7 @@ class reader {
    * @param m Number of rows in the vector to read.
    * @return Column vector made up of the next scalars.
    */
-  template <typename T_ = T, require_st_arithmetic<T_>* = nullptr>
+  template <typename T_ = T, require_st_arithmetic<T_> * = nullptr>
   inline vector_t var_vector(size_t m) {
     return this->vector(m);
   }
@@ -263,11 +266,12 @@ class reader {
    * @param m Number of rows in the vector to read.
    * @return Column vector made up of the next scalars.
    */
-  template <typename T_ = T, require_st_var<T_>* = nullptr>
+  template <typename T_ = T, require_st_var<T_> * = nullptr>
   inline var_row_vector_t var_row_vector(size_t m) {
     if (m == 0)
       return var_row_vector_t(Eigen::RowVectorXd(0));
-    return stan::math::to_var_value(map_row_vector_t(&scalar_ptr_increment(m), m));
+    return stan::math::to_var_value(
+        map_row_vector_t(&scalar_ptr_increment(m), m));
   }
 
   /**
@@ -277,7 +281,7 @@ class reader {
    * @param m Number of rows in the vector to read.
    * @return Column vector made up of the next scalars.
    */
-  template <typename T_ = T, require_st_arithmetic<T_>* = nullptr>
+  template <typename T_ = T, require_st_arithmetic<T_> * = nullptr>
   inline row_vector_t var_row_vector(size_t m) {
     return this->row_vector(m);
   }
@@ -350,11 +354,12 @@ class reader {
    * @param n Number of columns.
    * @return Eigen::Matrix made up of the next scalars.
    */
-  template <typename T_ = T, require_st_var<T_>* = nullptr>
+  template <typename T_ = T, require_st_var<T_> * = nullptr>
   inline var_matrix_t var_matrix(size_t m, size_t n) {
     if (m == 0 || n == 0)
       return var_matrix_t(Eigen::MatrixXd(0, 0));
-    return stan::math::to_var_value(map_matrix_t(&scalar_ptr_increment(m * n), m, n));
+    return stan::math::to_var_value(
+        map_matrix_t(&scalar_ptr_increment(m * n), m, n));
   }
 
   /**
@@ -374,7 +379,7 @@ class reader {
    * @param n Number of columns.
    * @return Eigen::Matrix made up of the next scalars.
    */
-  template <typename T_ = T, require_st_arithmetic<T_>* = nullptr>
+  template <typename T_ = T, require_st_arithmetic<T_> * = nullptr>
   inline matrix_t var_matrix(size_t m, size_t n) {
     return this->matrix(m, n);
   }

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_IO_READER_HPP
 #define STAN_IO_READER_HPP
 
-#include <stan/math/prim.hpp>
+#include <stan/math/rev.hpp>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -54,13 +54,17 @@ class reader {
   }
 
  public:
-  typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_t;
-  typedef Eigen::Matrix<T, Eigen::Dynamic, 1> vector_t;
-  typedef Eigen::Matrix<T, 1, Eigen::Dynamic> row_vector_t;
+  using matrix_t = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+  using vector_t =  Eigen::Matrix<T, Eigen::Dynamic, 1>;
+  using row_vector_t = Eigen::Matrix<T, 1, Eigen::Dynamic>;
 
-  typedef Eigen::Map<matrix_t> map_matrix_t;
-  typedef Eigen::Map<vector_t> map_vector_t;
-  typedef Eigen::Map<row_vector_t> map_row_vector_t;
+  using map_matrix_t = Eigen::Map<matrix_t>;
+  using map_vector_t = Eigen::Map<vector_t>;
+  using map_row_vector_t = Eigen::Map<row_vector_t>;
+
+  using var_matrix_t = stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>;
+  using var_vector_t =  stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, 1>>;
+  using var_row_vector_t = stan::math::var_value<Eigen::Matrix<double, 1, Eigen::Dynamic>>;
 
   /**
    * Construct a variable reader using the specified vectors
@@ -186,6 +190,33 @@ class reader {
       return vector_t();
     return map_vector_t(&scalar_ptr_increment(m), m);
   }
+
+  /**
+   * Return a `var_value` with inner type column vector with specified
+   * dimensionality made up of the next scalars.
+   *
+   * @param m Number of rows in the vector to read.
+   * @return Column vector made up of the next scalars.
+   */
+  template <typename T_ = T, require_st_var<T_>* = nullptr>
+  inline var_vector_t var_vector(size_t m) {
+    if (m == 0)
+      return var_vector_t(Eigen::VectorXd(0));
+    return stan::math::to_var_value(map_vector_t(&scalar_ptr_increment(m), m));
+  }
+
+  /**
+   * Return a column vector of specified dimensionality made up of
+   * the next scalars.
+   *
+   * @param m Number of rows in the vector to read.
+   * @return Column vector made up of the next scalars.
+   */
+  template <typename T_ = T, require_st_arithmetic<T_>* = nullptr>
+  inline vector_t var_vector(size_t m) {
+    return this->vector(m);
+  }
+
   /**
    * Return a column vector of specified dimensionality made up of
    * the next scalars.  The constraint is a no-op.
@@ -223,6 +254,32 @@ class reader {
     if (m == 0)
       return row_vector_t();
     return map_row_vector_t(&scalar_ptr_increment(m), m);
+  }
+
+  /**
+   * Return a `var_value` with inner type as a row vector with specified
+   * dimensionality made up of the next scalars.
+   *
+   * @param m Number of rows in the vector to read.
+   * @return Column vector made up of the next scalars.
+   */
+  template <typename T_ = T, require_st_var<T_>* = nullptr>
+  inline var_row_vector_t var_row_vector(size_t m) {
+    if (m == 0)
+      return var_row_vector_t(Eigen::RowVectorXd(0));
+    return stan::math::to_var_value(map_row_vector_t(&scalar_ptr_increment(m), m));
+  }
+
+  /**
+   * Return a row vector of specified dimensionality made up of
+   * the next scalars.
+   *
+   * @param m Number of rows in the vector to read.
+   * @return Column vector made up of the next scalars.
+   */
+  template <typename T_ = T, require_st_arithmetic<T_>* = nullptr>
+  inline row_vector_t var_row_vector(size_t m) {
+    return this->row_vector(m);
   }
 
   /**
@@ -274,6 +331,52 @@ class reader {
     if (m == 0 || n == 0)
       return matrix_t(m, n);
     return map_matrix_t(&scalar_ptr_increment(m * n), m, n);
+  }
+
+  /**
+   * Return a `var_value` with inner type matrix with the specified
+   * dimensionality made up of  the next scalars arranged in column-major order.
+   *
+   * Row-major reading means that if a matrix of <code>m=2</code>
+   * rows and <code>n=3</code> columns is read and the next
+   * scalar values are <code>1,2,3,4,5,6</code>, the result is
+   *
+   * <pre>
+   * a = 1 4
+   *     2 5
+   *     3 6</pre>
+   *
+   * @param m Number of rows.
+   * @param n Number of columns.
+   * @return Eigen::Matrix made up of the next scalars.
+   */
+  template <typename T_ = T, require_st_var<T_>* = nullptr>
+  inline var_matrix_t var_matrix(size_t m, size_t n) {
+    if (m == 0 || n == 0)
+      return var_matrix_t(Eigen::MatrixXd(0, 0));
+    return stan::math::to_var_value(map_matrix_t(&scalar_ptr_increment(m * n), m, n));
+  }
+
+  /**
+   * Return a matrix of the specified dimensionality made up of
+   * the next scalars arranged in column-major order.
+   *
+   * Row-major reading means that if a matrix of <code>m=2</code>
+   * rows and <code>n=3</code> columns is read and the next
+   * scalar values are <code>1,2,3,4,5,6</code>, the result is
+   *
+   * <pre>
+   * a = 1 4
+   *     2 5
+   *     3 6</pre>
+   *
+   * @param m Number of rows.
+   * @param n Number of columns.
+   * @return Eigen::Matrix made up of the next scalars.
+   */
+  template <typename T_ = T, require_st_arithmetic<T_>* = nullptr>
+  inline matrix_t var_matrix(size_t m, size_t n) {
+    return this->matrix(m, n);
   }
 
   /**

--- a/src/test/unit/io/reader_test.cpp
+++ b/src/test/unit/io/reader_test.cpp
@@ -1429,3 +1429,88 @@ TEST(IoReader, UnitVectorThrows) {
   EXPECT_THROW(reader.unit_vector_constrain(x), std::invalid_argument);
   EXPECT_THROW(reader.unit_vector_constrain(x, lp), std::invalid_argument);
 }
+
+
+TEST(IoReader, var_vector) {
+  using stan::math::var;
+  using stan::math::var_value;
+  std::vector<var> theta{0, 1, 2, 3, 4};
+  std::vector<int> theta_i;
+  stan::io::reader<stan::math::var> reader(theta, theta_i);
+  auto vec_x = reader.var_vector(5);
+  EXPECT_TRUE((stan::is_var_vector<decltype(vec_x)>::value));
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(vec_x.val()(i), i);
+  }
+  auto vec_x_empty = reader.var_vector(0);
+  stan::math::recover_memory();
+}
+
+TEST(IoReader, var_vector_double) {
+  using stan::math::var;
+  using stan::math::var_value;
+  std::vector<double> theta{0, 1, 2, 3, 4};
+  std::vector<int> theta_i;
+  stan::io::reader<double> reader(theta, theta_i);
+  auto vec_x = reader.var_vector(5);
+  EXPECT_TRUE((stan::is_eigen_vector<decltype(vec_x)>::value && std::is_arithmetic<stan::value_type_t<decltype(vec_x)>>::value));
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(vec_x.val()(i), i);
+  }
+}
+
+TEST(IoReader, var_row_vector) {
+  using stan::math::var;
+  using stan::math::var_value;
+  std::vector<var> theta{0, 1, 2, 3, 4};
+  std::vector<int> theta_i;
+  stan::io::reader<stan::math::var> reader(theta, theta_i);
+  auto vec_x = reader.var_row_vector(5);
+  EXPECT_TRUE((stan::is_var_row_vector<decltype(vec_x)>::value));
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(vec_x.val()(i), i);
+  }
+  auto vec_x_empty = reader.var_row_vector(0);
+}
+
+TEST(IoReader, var_row_vector_double) {
+  using stan::math::var;
+  using stan::math::var_value;
+  std::vector<double> theta{0, 1, 2, 3, 4};
+  std::vector<int> theta_i;
+  stan::io::reader<double> reader(theta, theta_i);
+  auto vec_x = reader.var_row_vector(5);
+  EXPECT_TRUE((stan::is_eigen_row_vector<decltype(vec_x)>::value && std::is_arithmetic<stan::value_type_t<decltype(vec_x)>>::value));
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(vec_x.val()(i), i);
+  }
+  auto vec_x_empty = reader.var_row_vector(0);
+}
+
+TEST(IoReader, var_matrix) {
+  using stan::math::var;
+  using stan::math::var_value;
+  std::vector<var> theta{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<int> theta_i;
+  stan::io::reader<stan::math::var> reader(theta, theta_i);
+  auto mat_x = reader.var_matrix(3, 3);
+  EXPECT_TRUE((stan::is_var_matrix<decltype(mat_x)>::value));
+  for (int i = 0; i < 9; ++i) {
+    EXPECT_EQ(mat_x.val()(i), i);
+  }
+  auto mat_x_empty = reader.var_matrix(0, 0);
+}
+
+TEST(IoReader, var_matrix_double) {
+  using stan::math::var;
+  using stan::math::var_value;
+  std::vector<double> theta{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<int> theta_i;
+  stan::io::reader<double> reader(theta, theta_i);
+  auto mat_x = reader.var_matrix(3, 3);
+  EXPECT_TRUE((stan::is_eigen_dense_dynamic<decltype(mat_x)>::value && std::is_arithmetic<stan::value_type_t<decltype(mat_x)>>::value));
+  for (int i = 0; i < 9; ++i) {
+    EXPECT_EQ(mat_x.val()(i), i);
+  }
+  auto mat_x_empty = reader.var_matrix(0, 0);
+}

--- a/src/test/unit/io/reader_test.cpp
+++ b/src/test/unit/io/reader_test.cpp
@@ -1430,7 +1430,6 @@ TEST(IoReader, UnitVectorThrows) {
   EXPECT_THROW(reader.unit_vector_constrain(x, lp), std::invalid_argument);
 }
 
-
 TEST(IoReader, var_vector) {
   using stan::math::var;
   using stan::math::var_value;
@@ -1453,7 +1452,9 @@ TEST(IoReader, var_vector_double) {
   std::vector<int> theta_i;
   stan::io::reader<double> reader(theta, theta_i);
   auto vec_x = reader.var_vector(5);
-  EXPECT_TRUE((stan::is_eigen_vector<decltype(vec_x)>::value && std::is_arithmetic<stan::value_type_t<decltype(vec_x)>>::value));
+  EXPECT_TRUE(
+      (stan::is_eigen_vector<decltype(vec_x)>::value
+       && std::is_arithmetic<stan::value_type_t<decltype(vec_x)>>::value));
   for (int i = 0; i < 5; ++i) {
     EXPECT_EQ(vec_x.val()(i), i);
   }
@@ -1480,7 +1481,9 @@ TEST(IoReader, var_row_vector_double) {
   std::vector<int> theta_i;
   stan::io::reader<double> reader(theta, theta_i);
   auto vec_x = reader.var_row_vector(5);
-  EXPECT_TRUE((stan::is_eigen_row_vector<decltype(vec_x)>::value && std::is_arithmetic<stan::value_type_t<decltype(vec_x)>>::value));
+  EXPECT_TRUE(
+      (stan::is_eigen_row_vector<decltype(vec_x)>::value
+       && std::is_arithmetic<stan::value_type_t<decltype(vec_x)>>::value));
   for (int i = 0; i < 5; ++i) {
     EXPECT_EQ(vec_x.val()(i), i);
   }
@@ -1508,7 +1511,9 @@ TEST(IoReader, var_matrix_double) {
   std::vector<int> theta_i;
   stan::io::reader<double> reader(theta, theta_i);
   auto mat_x = reader.var_matrix(3, 3);
-  EXPECT_TRUE((stan::is_eigen_dense_dynamic<decltype(mat_x)>::value && std::is_arithmetic<stan::value_type_t<decltype(mat_x)>>::value));
+  EXPECT_TRUE(
+      (stan::is_eigen_dense_dynamic<decltype(mat_x)>::value
+       && std::is_arithmetic<stan::value_type_t<decltype(mat_x)>>::value));
   for (int i = 0; i < 9; ++i) {
     EXPECT_EQ(mat_x.val()(i), i);
   }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This adds functions in reader that allow it to output a `var<matrix>`

#### Intended Effect

This will be used by the stan compiler when reading out `var<matrix>` types in log_prob, write_array, etc

#### How to Verify

Tests were added to check that io works for the normal path, zero sized path, and when the reader has a `double` type (which for `var<matrix>` function we need to return back a `matrix<double>`

```
./runTests.py ./src/test/unit/io/reader_test
```

#### Side Effects

This currently only supports standard io and not lower bound, upper bound, correlation matrices, etc. type vars. We need a few things in stan math before we can support all those

#### Documentation

Docs added for each new function

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
