### PR TITLE
Windows integration tests optimization

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,9 +20,9 @@ def runTests(String testPath, Boolean separateMakeStep=true) {
 def runTestsWin(String testPath, Boolean separateMakeStep=true) {
     withEnv(['PATH+TBB=./lib/stan_math/lib/tbb']) {
        if (separateMakeStep) {
-           bat "runTests.py -j${env.PARALLEL} ${testPath} --make-only"
+           bat "runTests.py -j8 ${testPath} --make-only"
        }
-       try { bat "runTests.py -j${env.PARALLEL} ${testPath}" }
+       try { bat "runTests.py -j8 ${testPath}" }
        finally { junit 'test/**/*.xml' }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
                     sh """#!/bin/bash
                         set -x
                         git checkout -b ${branchName()}
-                        clang-format --version
+                        dlang-format --version
                         find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
                         if [[ `git diff` != "" ]]; then
                             git config --global user.email "mc.stanislaw@gmail.com"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,83 +187,83 @@ pipeline {
                 }
             }
         }
-        stage('Unit tests') {
-            when {
-                expression {
-                    !skipRemainingStages
-                }
-            }
-            parallel {
-                stage('Windows Headers & Unit') {
-                    agent { label 'windows' }
-                    steps {
-                        deleteDirWin()
-                            unstash 'StanSetup'
-                            setupCXX()
-                            bat "mingw32-make -f lib/stan_math/make/standalone math-libs"
-                            bat "mingw32-make -j${env.PARALLEL} test-headers"
-                            setupCXX(false)
-                            runTestsWin("src/test/unit")
-                    }
-                    post { always { deleteDirWin() } }
-                }
-                stage('Linux Unit') {
-                    agent { label 'linux' }
-                    steps {
-                        unstash 'StanSetup'
-                        setupCXX(true, env.GCC)
-                        sh "g++ --version"
-                        runTests("src/test/unit")
-                    }
-                    post { always { deleteDir() } }
-                }
-                stage('Mac Unit') {
-                    agent { label 'osx' }
-                    steps {
-                        unstash 'StanSetup'
-                        setupCXX(false)
-                        runTests("src/test/unit")
-                    }
-                    post { always { deleteDir() } }
-                }
-            }
-        }
+        // stage('Unit tests') {
+        //     when {
+        //         expression {
+        //             !skipRemainingStages
+        //         }
+        //     }
+        //     parallel {
+        //         stage('Windows Headers & Unit') {
+        //             agent { label 'windows' }
+        //             steps {
+        //                 deleteDirWin()
+        //                     unstash 'StanSetup'
+        //                     setupCXX()
+        //                     bat "mingw32-make -f lib/stan_math/make/standalone math-libs"
+        //                     bat "mingw32-make -j${env.PARALLEL} test-headers"
+        //                     setupCXX(false)
+        //                     runTestsWin("src/test/unit")
+        //             }
+        //             post { always { deleteDirWin() } }
+        //         }
+        //         stage('Linux Unit') {
+        //             agent { label 'linux' }
+        //             steps {
+        //                 unstash 'StanSetup'
+        //                 setupCXX(true, env.GCC)
+        //                 sh "g++ --version"
+        //                 runTests("src/test/unit")
+        //             }
+        //             post { always { deleteDir() } }
+        //         }
+        //         stage('Mac Unit') {
+        //             agent { label 'osx' }
+        //             steps {
+        //                 unstash 'StanSetup'
+        //                 setupCXX(false)
+        //                 runTests("src/test/unit")
+        //             }
+        //             post { always { deleteDir() } }
+        //         }
+        //     }
+        // }
         stage('Integration') {
             parallel {
-                stage('Integration Linux') {
-                    agent { label 'linux' }
-                    steps {
-                        unstash 'StanSetup'
-                        setupCXX(true, env.GCC)
-                        runTests("src/test/integration", separateMakeStep=false)
-                    }
-                    post { always { deleteDir() } }
-                }
-                stage('Integration Mac') {
-                    agent { label 'osx' }
-                    when {
-                        expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ) &&
-                            !skipRemainingStages
-                        }
-                    }
-                    steps {
-                        unstash 'StanSetup'
-                        setupCXX()
-                        runTests("src/test/integration", separateMakeStep=false)
-                    }
-                    post { always { deleteDir() } }
-                }
+                // stage('Integration Linux') {
+                //     agent { label 'linux' }
+                //     steps {
+                //         unstash 'StanSetup'
+                //         setupCXX(true, env.GCC)
+                //         runTests("src/test/integration", separateMakeStep=false)
+                //     }
+                //     post { always { deleteDir() } }
+                // }
+                // stage('Integration Mac') {
+                //     agent { label 'osx' }
+                //     when {
+                //         expression {
+                //             ( env.BRANCH_NAME == "develop" ||
+                //             env.BRANCH_NAME == "master" ) &&
+                //             !skipRemainingStages
+                //         }
+                //     }
+                //     steps {
+                //         unstash 'StanSetup'
+                //         setupCXX()
+                //         runTests("src/test/integration", separateMakeStep=false)
+                //     }
+                //     post { always { deleteDir() } }
+                // }
                 stage('Integration Windows') {
-                    agent { label 'windows' }
-                    when {
-                        expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ) &&
-                            !skipRemainingStages
-                        }
-                    }
+                    agent { label 'gelman-group-win2' }
+                    // when {
+                    //     expression {
+                    //         ( env.BRANCH_NAME == "develop" ||
+                    //         env.BRANCH_NAME == "master" ) &&
+                    //         !skipRemainingStages
+                    //     }
+                    // }
                     steps {
                         deleteDirWin()
                             unstash 'StanSetup'
@@ -274,26 +274,26 @@ pipeline {
                     }
                     post { always { deleteDirWin() } }
                 }
-                stage('Math functions expressions test') {
-                    agent any
-                    steps {
-                        unstash 'StanSetup'
-                        setupCXX()
-                        script {
-                            dir("lib/stan_math/") {
-                                sh "echo O=0 > make/local"
-                                withEnv(['PATH+TBB=./lib/tbb']) {
-                                    try { sh "./runTests.py -j${env.PARALLEL} test/expressions" }
-                                    finally { junit 'test/**/*.xml' }
-                                }
-                                withEnv(['PATH+TBB=./lib/tbb']) {
-                                    sh "python ./test/expressions/test_expression_testing_framework.py"
-                                }
-                            }
-                        }
-                    }
-                    post { always { deleteDir() } }
-                }
+                // stage('Math functions expressions test') {
+                //     agent any
+                //     steps {
+                //         unstash 'StanSetup'
+                //         setupCXX()
+                //         script {
+                //             dir("lib/stan_math/") {
+                //                 sh "echo O=0 > make/local"
+                //                 withEnv(['PATH+TBB=./lib/tbb']) {
+                //                     try { sh "./runTests.py -j${env.PARALLEL} test/expressions" }
+                //                     finally { junit 'test/**/*.xml' }
+                //                 }
+                //                 withEnv(['PATH+TBB=./lib/tbb']) {
+                //                     sh "python ./test/expressions/test_expression_testing_framework.py"
+                //                 }
+                //             }
+                //         }
+                //     }
+                //     post { always { deleteDir() } }
+                // }
             }
             when {
                 expression {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
                     sh """#!/bin/bash
                         set -x
                         git checkout -b ${branchName()}
-                        dlang-format --version
+                        clang-format --version
                         find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${env.PARALLEL} clang-format -i
                         if [[ `git diff` != "" ]]; then
                             git config --global user.email "mc.stanislaw@gmail.com"
@@ -169,7 +169,7 @@ pipeline {
 
                     retry(3) { checkout scm }
                     sh 'git clean -xffd'
-
+                    sh 'exit 1'
                     // These paths will be passed to git diff
                     // If there are changes to them, CI/CD will continue else skip
                     def paths = ['make', 'src/stan', 'src/test', 'Jenkinsfile', 'makefile', 'runTests.py',

--- a/make/tests
+++ b/make/tests
@@ -149,7 +149,11 @@ test-headers: $(HEADER_TESTS)
 ##
 .PHONY: %.hpp-test
 
+ifneq ($(OS),Windows_NT)
 test/test-models/good/%.hpp-test : O = 0
+else
+test/test-models/good/%.hpp-test : O = 1
+endif
 test/test-models/good/%.hpp-test : test/test-models/good/%.hpp test/test-model-main.cpp
 	$(COMPILE.cpp) -o $(DEV_NULL) -include $^
 

--- a/make/tests
+++ b/make/tests
@@ -149,11 +149,7 @@ test-headers: $(HEADER_TESTS)
 ##
 .PHONY: %.hpp-test
 
-ifneq ($(OS),Windows_NT)
 test/test-models/good/%.hpp-test : O = 0
-else
-test/test-models/good/%.hpp-test : O = 1
-endif
 test/test-models/good/%.hpp-test : test/test-models/good/%.hpp test/test-model-main.cpp
 	$(COMPILE.cpp) -o $(DEV_NULL) -include $^
 


### PR DESCRIPTION
#### Summary

If Windows integration tests run on the gelman-group-win2 machine, they seem to run for 7h to 16h (https://jenkins.mc-stan.org/blue/organizations/jenkins/Stan/detail/develop/746/pipeline/166, https://jenkins.mc-stan.org/blue/organizations/jenkins/Stan/detail/develop/738/pipeline/166).

This PR will first attempt to check if O=0 could be used (it was switched to O=1 due to assembler file size issues for huge test models). This might not be needed after https://github.com/stan-dev/stan/pull/2970

If this will not help, we will limit Windows integration tests to AWS Windows agents.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
