### PR TITLE
Restrict Jenkins Windows Integration tests to AWS EC2 agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,7 +256,7 @@ pipeline {
                     post { always { deleteDir() } }
                 }
                 stage('Integration Windows') {
-                    agent { label 'windows' }
+                    agent { label 'windowsec2' }
                     when {
                         expression {
                             ( env.BRANCH_NAME == "develop" ||


### PR DESCRIPTION
#### Summary

Restrict Jenkins Windows Integration tests to AWS EC2 agents

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar, Uni. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
