### PR TITLE
remove const from reader inner maps

### DIFF
--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -39,16 +39,16 @@ class reader {
   size_t pos_{0};
   size_t int_pos_{0};
 
-  inline T& scalar_ptr() { return data_r_.coeffRef(pos_); }
+  inline T &scalar_ptr() { return data_r_.coeffRef(pos_); }
 
-  inline T& scalar_ptr_increment(size_t m) {
+  inline T &scalar_ptr_increment(size_t m) {
     pos_ += m;
     return data_r_.coeffRef(pos_ - m);
   }
 
-  inline int& int_ptr() { return data_i_.coeffRef(int_pos_); }
+  inline int &int_ptr() { return data_i_.coeffRef(int_pos_); }
 
-  inline int& int_ptr_increment(size_t m) {
+  inline int &int_ptr_increment(size_t m) {
     int_pos_ += m;
     return data_i_.coeffRef(int_pos_ - m);
   }

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -34,21 +34,21 @@ namespace io {
 template <typename T>
 class reader {
  private:
-  Eigen::Map<const Eigen::Matrix<T, -1, 1>> data_r_;
-  Eigen::Map<const Eigen::Matrix<int, -1, 1>> data_i_;
+  Eigen::Map<Eigen::Matrix<T, -1, 1>> data_r_;
+  Eigen::Map<Eigen::Matrix<int, -1, 1>> data_i_;
   size_t pos_{0};
   size_t int_pos_{0};
 
-  inline const T &scalar_ptr() { return data_r_.coeffRef(pos_); }
+  inline T& scalar_ptr() { return data_r_.coeffRef(pos_); }
 
-  inline const T &scalar_ptr_increment(size_t m) {
+  inline T& scalar_ptr_increment(size_t m) {
     pos_ += m;
     return data_r_.coeffRef(pos_ - m);
   }
 
-  inline const int &int_ptr() { return data_i_.coeffRef(int_pos_); }
+  inline int& int_ptr() { return data_i_.coeffRef(int_pos_); }
 
-  inline const int &int_ptr_increment(size_t m) {
+  inline int& int_ptr_increment(size_t m) {
     int_pos_ += m;
     return data_i_.coeffRef(int_pos_ - m);
   }
@@ -58,9 +58,9 @@ class reader {
   using vector_t = Eigen::Matrix<T, Eigen::Dynamic, 1>;
   using row_vector_t = Eigen::Matrix<T, 1, Eigen::Dynamic>;
 
-  using map_matrix_t = Eigen::Map<const matrix_t>;
-  using map_vector_t = Eigen::Map<const vector_t>;
-  using map_row_vector_t = Eigen::Map<const row_vector_t>;
+  using map_matrix_t = Eigen::Map<matrix_t>;
+  using map_vector_t = Eigen::Map<vector_t>;
+  using map_row_vector_t = Eigen::Map<row_vector_t>;
 
   using var_matrix_t = stan::math::var_value<
       Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is just a little fix, reader always makes copies of it's output in a stan model, but having these be const maps stops them from being assigned directly assigned to non-const maps in the model if we ever want to do that in the future.

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
