### PR TITLE
Fix tags / git-describe, and update release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,13 @@ Note: these are the release notes for the stan-dev/stan repository.
 Further changes may arise at the interface level (stan-dev/{rstan,
 pystan, cmdstan}) and math library level (stan-dev/math).
 
+v.2.25.0 (26 October 2020)
+======================================================================
+
+- added a const accessor to _z in base_hmc.hpp
+- bugfixed validate_dims in array_var_context
+- cleaned up includes of Eigen
+
 v.2.24.0 (28 July 2020)
 ======================================================================
 


### PR DESCRIPTION
#### Summary

This adds the missing `v2.25.0` tag, fixes `git describe`, and updates the release notes. This is done by merging the the `release/v2.25.0` branch and resolving the conflicts (just updating the release notes and merging the tags). For the future releases, everything should be updated with a tag added in the `develop` branch before creating a new `release/vX.Y.Z` branch.

**Since I can't push tags in a pull request, a dev needs to merge the tags from `release/v2.25.0` and `git push --follow-tags`.**

**Before:**
`git describe`
> v2.24.0-347-gd8d52cd28

**After:**
`git describe`
> v2.25.0-252-ge283d0b86

This may also be used in the versioning of the `develop` branch, following https://github.com/stan-dev/stan/pull/2990 and [this discussion](https://discourse.mc-stan.org/t/versioning-after-release/19803).

#### Intended Effect

`git describe` will now give a human readable name based on the correct ref/tag from the last release.

#### How to Verify

`git describe`

#### Side Effects

N/A

#### Documentation

N/A

#### Copyright and Licensing

Hamada S. Badr <hamada.s.badr@gmail.com>