### PR TITLE
Remove constexpr from indexing classes/functions as mingw's gcc 4.9 cannot support it

### DIFF
--- a/src/stan/model/indexing/index.hpp
+++ b/src/stan/model/indexing/index.hpp
@@ -22,7 +22,7 @@ struct index_uni {
    *
    * @param n single index.
    */
-  explicit constexpr index_uni(int n) noexcept : n_(n) {}
+  explicit index_uni(int n) noexcept : n_(n) {}
 };
 
 // MULTIPLE INDEXING (does not reduce dimensionality)
@@ -40,7 +40,7 @@ struct index_multi {
    * @param ns multiple indexes.
    */
   template <typename T, require_std_vector_vt<std::is_integral, T>* = nullptr>
-  explicit constexpr index_multi(T&& ns) noexcept : ns_(std::forward<T>(ns)) {}
+  explicit index_multi(T&& ns) noexcept : ns_(std::forward<T>(ns)) {}
 };
 
 /**
@@ -61,7 +61,7 @@ struct index_min {
    *
    * @param min minimum index (inclusive).
    */
-  explicit constexpr index_min(int min) noexcept : min_(min) {}
+  explicit index_min(int min) noexcept : min_(min) {}
 };
 
 /**
@@ -77,7 +77,7 @@ struct index_max {
    *
    * @param max maximum index (inclusive).
    */
-  explicit constexpr index_max(int max) noexcept : max_(max) {}
+  explicit index_max(int max) noexcept : max_(max) {}
 };
 
 /**
@@ -90,7 +90,7 @@ struct index_min_max {
   /**
    * Return whether the index is positive or negative
    */
-  bool is_ascending() const { return min_ <= max_; }
+  inline bool is_ascending() const noexcept { return min_ <= max_; }
   /**
    * Construct an indexing from the specified minimum index
    * (inclusive) and maximum index (inclusive).
@@ -98,7 +98,7 @@ struct index_min_max {
    * @param min minimum index (inclusive).
    * @param max maximum index (inclusive).
    */
-  constexpr index_min_max(int min, int max) noexcept : min_(min), max_(max) {}
+  index_min_max(int min, int max) noexcept : min_(min), max_(max) {}
 };
 
 }  // namespace model

--- a/src/stan/model/indexing/index_list.hpp
+++ b/src/stan/model/indexing/index_list.hpp
@@ -32,7 +32,7 @@ struct cons_index_list {
    * @param tail Index list for tail.
    */
   template <typename Head, typename Tail>
-  explicit constexpr cons_index_list(Head&& head, Tail&& tail)
+  explicit cons_index_list(Head&& head, Tail&& tail)
       : head_(std::forward<Head>(head)), tail_(std::forward<Tail>(tail)) {}
 };
 
@@ -44,7 +44,7 @@ struct cons_index_list {
  * @param idx2 second index placed in `tail_`
  */
 template <typename T1, typename T2>
-inline constexpr auto cons_list(T1&& idx1, T2&& idx2) {
+inline auto cons_list(T1&& idx1, T2&& idx2) {
   return cons_index_list<std::decay_t<T1>, std::decay_t<T2>>(
       std::forward<T1>(idx1), std::forward<T2>(idx2));
 }
@@ -52,7 +52,7 @@ inline constexpr auto cons_list(T1&& idx1, T2&& idx2) {
 /**
  * Expansion stop for index_list returning back a `nul_index_list`
  */
-inline constexpr auto index_list() { return nil_index_list(); }
+inline auto index_list() { return nil_index_list(); }
 
 /**
  * Factory-like function to construct a `cons_index_list` of `cons_index_list`s
@@ -63,7 +63,7 @@ inline constexpr auto index_list() { return nil_index_list(); }
  *  `index_list()`
  */
 template <typename T, typename... Types>
-inline constexpr auto index_list(T&& idx1, Types&&... idx2) {
+inline auto index_list(T&& idx1, Types&&... idx2) {
   return cons_list(std::forward<T>(idx1),
                    index_list(std::forward<Types>(idx2)...));
 }

--- a/src/stan/model/indexing/rvalue_at.hpp
+++ b/src/stan/model/indexing/rvalue_at.hpp
@@ -40,9 +40,7 @@ inline int rvalue_at(int n, const index_omni& idx) { return n + 1; }
  * @param[in] idx Index (from 1)
  * @return Underlying index position (from 1).
  */
-inline int rvalue_at(int n, const index_min& idx) {
-  return idx.min_ + n;
-}
+inline int rvalue_at(int n, const index_min& idx) { return idx.min_ + n; }
 
 /**
  * Return the index in the underlying array corresponding to the

--- a/src/stan/model/indexing/rvalue_at.hpp
+++ b/src/stan/model/indexing/rvalue_at.hpp
@@ -28,7 +28,7 @@ inline int rvalue_at(int n, const index_multi& idx) { return idx.ns_[n]; }
  * @param[in] idx Index (from 1).
  * @return Underlying index position (from 1).
  */
-inline constexpr int rvalue_at(int n, const index_omni& idx) { return n + 1; }
+inline int rvalue_at(int n, const index_omni& idx) { return n + 1; }
 
 /**
  * Return the index in the underlying array corresponding to the
@@ -40,7 +40,7 @@ inline constexpr int rvalue_at(int n, const index_omni& idx) { return n + 1; }
  * @param[in] idx Index (from 1)
  * @return Underlying index position (from 1).
  */
-inline constexpr int rvalue_at(int n, const index_min& idx) {
+inline int rvalue_at(int n, const index_min& idx) {
   return idx.min_ + n;
 }
 
@@ -54,7 +54,7 @@ inline constexpr int rvalue_at(int n, const index_min& idx) {
  * @param[in] idx Index (from 1).
  * @return Underlying index position (from 1).
  */
-inline constexpr int rvalue_at(int n, const index_max& idx) { return n + 1; }
+inline int rvalue_at(int n, const index_max& idx) { return n + 1; }
 
 /**
  * Return the index in the underlying array corresponding to the
@@ -66,7 +66,7 @@ inline constexpr int rvalue_at(int n, const index_max& idx) { return n + 1; }
  * @param[in] idx Index (from 1).
  * @return Underlying index position (from 1).
  */
-inline constexpr int rvalue_at(int n, const index_min_max& idx) {
+inline int rvalue_at(int n, const index_min_max& idx) {
   if (idx.min_ < idx.max_) {
     return idx.min_ + n;
   } else {

--- a/src/stan/model/indexing/rvalue_index_size.hpp
+++ b/src/stan/model/indexing/rvalue_index_size.hpp
@@ -28,9 +28,7 @@ inline int rvalue_index_size(const index_multi& idx, int size) {
  * @param[in] size Size of container.
  * @return Size of result.
  */
-inline int rvalue_index_size(const index_omni& idx, int size) {
-  return size;
-}
+inline int rvalue_index_size(const index_omni& idx, int size) { return size; }
 
 /**
  * Return size of specified min index for specified size of

--- a/src/stan/model/indexing/rvalue_index_size.hpp
+++ b/src/stan/model/indexing/rvalue_index_size.hpp
@@ -28,7 +28,7 @@ inline int rvalue_index_size(const index_multi& idx, int size) {
  * @param[in] size Size of container.
  * @return Size of result.
  */
-inline constexpr int rvalue_index_size(const index_omni& idx, int size) {
+inline int rvalue_index_size(const index_omni& idx, int size) {
   return size;
 }
 
@@ -40,7 +40,7 @@ inline constexpr int rvalue_index_size(const index_omni& idx, int size) {
  * @param[in] size Size of container.
  * @return Size of result.
  */
-inline constexpr int rvalue_index_size(const index_min& idx, int size) {
+inline int rvalue_index_size(const index_min& idx, int size) {
   return size - idx.min_ + 1;
 }
 
@@ -51,7 +51,7 @@ inline constexpr int rvalue_index_size(const index_min& idx, int size) {
  * @param[in] size Size of container (ignored).
  * @return Size of result.
  */
-inline constexpr int rvalue_index_size(const index_max& idx, int size) {
+inline int rvalue_index_size(const index_max& idx, int size) {
   return idx.max_;
 }
 
@@ -63,7 +63,7 @@ inline constexpr int rvalue_index_size(const index_max& idx, int size) {
  * @param[in] size Size of container (ignored).
  * @return Size of result.
  */
-inline constexpr int rvalue_index_size(const index_min_max& idx, int size) {
+inline int rvalue_index_size(const index_min_max& idx, int size) {
   return (idx.max_ < idx.min_) ? 0 : (idx.max_ - idx.min_ + 1);
 }
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This removes constexpr from indexing related functions and classes as mingw's gcc 4.9.3 does not fully support them.

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
