### PR TITLE
StanHeaders: compatibility for both Stan 2.26 and 2.21

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,6 +29,8 @@ include make/cpplint                      # cpplint
 include make/tests                        # tests
 include make/clang-tidy
 
+CPPFLAGS += -DUSE_STANC3
+
 INC_FIRST = -I $(if $(STAN),$(STAN)/src,src) -I ./src/
 LDLIBS_STANC ?= -Ltest -lstanc
 

--- a/src/stan/io/array_var_context.hpp
+++ b/src/stan/io/array_var_context.hpp
@@ -337,6 +337,7 @@ class array_var_context : public var_context {
     return empty_vec_ui_;
   }
 
+#ifdef USE_STANC3
   /**
    * Check variable dimensions against variable declaration.
    * Only used for data read in from file.
@@ -353,6 +354,7 @@ class array_var_context : public var_context {
                      const std::vector<size_t>& dims_declared) const {
     stan::io::validate_dims(*this, stage, name, base_type, dims_declared);
   }
+#endif
 
   /**
    * Return a list of the names of the floating point variables in

--- a/src/stan/io/chained_var_context.hpp
+++ b/src/stan/io/chained_var_context.hpp
@@ -60,6 +60,7 @@ class chained_var_context : public var_context {
     names.insert(names.end(), names2.begin(), names2.end());
   }
 
+#ifdef USE_STANC3
   /**
    * Check variable dimensions against variable declaration.
    * Only used for data read in from file.
@@ -76,6 +77,7 @@ class chained_var_context : public var_context {
                      const std::vector<size_t>& dims_declared) const {
     stan::io::validate_dims(*this, stage, name, base_type, dims_declared);
   }
+#endif
 };
 }  // namespace io
 }  // namespace stan

--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -761,6 +761,7 @@ class dump : public stan::io::var_context {
       names.push_back((*it).first);
   }
 
+#ifdef USE_STANC3
   /**
    * Check variable dimensions against variable declaration.
    *
@@ -776,6 +777,7 @@ class dump : public stan::io::var_context {
                      const std::vector<size_t>& dims_declared) const {
     stan::io::validate_dims(*this, stage, name, base_type, dims_declared);
   }
+#endif
 
   /**
    * Remove variable from the object.

--- a/src/stan/io/empty_var_context.hpp
+++ b/src/stan/io/empty_var_context.hpp
@@ -79,6 +79,7 @@ class empty_var_context : public var_context {
     return std::vector<size_t>();
   }
 
+#ifdef USE_STANC3
   /**
    * Check variable dimensions against variable declaration.
    * This context has no variables.
@@ -95,6 +96,7 @@ class empty_var_context : public var_context {
                      const std::vector<size_t>& dims_declared) const {
     stan::io::validate_dims(*this, stage, name, base_type, dims_declared);
   }
+#endif
 
   /**
    * Fill a list of the names of the floating point variables in

--- a/src/stan/io/random_var_context.hpp
+++ b/src/stan/io/random_var_context.hpp
@@ -179,6 +179,7 @@ class random_var_context : public var_context {
    */
   void names_i(std::vector<std::string>& names) const { names.clear(); }
 
+#ifdef USE_STANC3
   /**
    * Check variable dimensions against variable declaration.
    * Only used for data read in from file.
@@ -195,6 +196,7 @@ class random_var_context : public var_context {
                      const std::vector<size_t>& dims_declared) const {
     stan::io::validate_dims(*this, stage, name, base_type, dims_declared);
   }
+#endif
 
   /**
    * Return the random initialization on the unconstrained scale.

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -1300,6 +1300,7 @@ class reader {
     return v;
   }
 
+#ifdef USE_STANC3
   template <typename TL>
   inline auto vector_lb_constrain(const TL lb, size_t m) {
     return stan::math::lb_constrain(vector(m), lb);
@@ -1327,6 +1328,47 @@ class reader {
   inline auto row_vector_lb_constrain(const TL lb, size_t m, T &lp) {
     return stan::math::lb_constrain(row_vector(m), lb, lp);
   }
+#else
+  template <typename TL>
+  inline vector_t vector_lb_constrain(const TL lb, size_t m) {
+    vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lb_constrain(lb);
+    return v;
+  }
+
+  template <typename TL>
+  inline vector_t vector_lb_constrain(const TL lb, size_t m, T &lp) {
+    vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lb_constrain(lb, lp);
+    return v;
+  }
+
+  template <typename TL>
+  inline row_vector_t row_vector_lb(const TL lb, size_t m) {
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lb(lb);
+    return v;
+  }
+
+  template <typename TL>
+  inline row_vector_t row_vector_lb_constrain(const TL lb, size_t m) {
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lb_constrain(lb);
+    return v;
+  }
+
+  template <typename TL>
+  inline row_vector_t row_vector_lb_constrain(const TL lb, size_t m, T &lp) {
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lb_constrain(lb, lp);
+    return v;
+  }
+#endif
 
   template <typename TL>
   inline map_matrix_t matrix_lb(const TL lb, const size_t m, size_t n) {
@@ -1351,6 +1393,7 @@ class reader {
         .eval();
   }
 
+#ifdef USE_STANC3
   template <typename TU>
   inline map_vector_t vector_ub(const TU ub, size_t m) {
     map_vector_t v(vector(m));
@@ -1386,6 +1429,55 @@ class reader {
   inline auto row_vector_ub_constrain(const TU ub, size_t m, T &lp) {
     return stan::math::ub_constrain(row_vector(m), ub, lp);
   }
+#else
+  template <typename TU>
+  inline vector_t vector_ub(const TU ub, size_t m) {
+    vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_ub(ub);
+    return v;
+  }
+
+  template <typename TU>
+  inline vector_t vector_ub_constrain(const TU ub, size_t m) {
+    vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_ub_constrain(ub);
+    return v;
+  }
+
+  template <typename TU>
+  inline vector_t vector_ub_constrain(const TU ub, size_t m, T &lp) {
+    vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_ub_constrain(ub, lp);
+    return v;
+  }
+
+  template <typename TU>
+  inline row_vector_t row_vector_ub(const TU ub, size_t m) {
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_ub(ub);
+    return v;
+  }
+
+  template <typename TU>
+  inline row_vector_t row_vector_ub_constrain(const TU ub, size_t m) {
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_ub_constrain(ub);
+    return v;
+  }
+
+  template <typename TU>
+  inline row_vector_t row_vector_ub_constrain(const TU ub, size_t m, T &lp) {
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_ub_constrain(ub, lp);
+    return v;
+  }
+#endif
 
   template <typename TU>
   inline map_matrix_t matrix_ub(const TU ub, size_t m, size_t n) {
@@ -1419,6 +1511,7 @@ class reader {
     return v;
   }
 
+#ifdef USE_STANC3
   template <typename TL, typename TU>
   inline auto vector_lub_constrain(const TL lb, const TU ub, size_t m) {
     return stan::math::lub_constrain(vector(m), lb, ub);
@@ -1447,6 +1540,57 @@ class reader {
                                                size_t m, T &lp) {
     return stan::math::lub_constrain(row_vector(m), lb, ub, lp);
   }
+#else
+  template <typename TL, typename TU>
+  inline vector_t vector_lub(const TL lb, const TU ub, size_t m) {
+    vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lub(lb, ub);
+    return v;
+  }
+
+  template <typename TL, typename TU>
+  inline vector_t vector_lub_constrain(const TL lb, const TU ub, size_t m) {
+    vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lub_constrain(lb, ub);
+    return v;
+  }
+
+  template <typename TL, typename TU>
+  inline vector_t vector_lub_constrain(const TL lb, const TU ub, size_t m,
+                                       T &lp) {
+    vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lub_constrain(lb, ub, lp);
+    return v;
+  }
+
+  template <typename TL, typename TU>
+  inline row_vector_t row_vector_lub(const TL lb, const TU ub, size_t m) {
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lub(lb, ub);
+    return v;
+  }
+  template <typename TL, typename TU>
+  inline row_vector_t row_vector_lub_constrain(const TL lb, const TU ub,
+                                               size_t m) {
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lub_constrain(lb, ub);
+    return v;
+  }
+
+  template <typename TL, typename TU>
+  inline row_vector_t row_vector_lub_constrain(const TL lb, const TU ub,
+                                               size_t m, T &lp) {
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_lub_constrain(lb, ub, lp);
+    return v;
+  }
+#endif
 
   template <typename TL, typename TU>
   inline map_matrix_t matrix_lub(const TL lb, const TU ub, size_t m, size_t n) {

--- a/src/stan/io/validate_dims.hpp
+++ b/src/stan/io/validate_dims.hpp
@@ -1,3 +1,5 @@
+#ifdef USE_STANC3
+
 #ifndef STAN_IO_VALIDATE_DIMS_HPP
 #define STAN_IO_VALIDATE_DIMS_HPP
 
@@ -69,4 +71,6 @@ inline void validate_dims(const stan::io::var_context& context,
 
 }  // namespace io
 }  // namespace stan
+#endif
+
 #endif

--- a/src/stan/io/writer.hpp
+++ b/src/stan/io/writer.hpp
@@ -445,6 +445,12 @@ class writer {
       data_r_.push_back(y_free[i]);
   }
 
+#ifndef USE_STANC3
+  void cholesky_corr_unconstrain(matrix_t &y) {
+    return cholesky_factor_corr_unconstrain(y);
+  }
+#endif
+
   /**
    * Writes the unconstrained covariance matrix corresponding
    * to the specified constrained correlation matrix.

--- a/src/stan/lang/generator/generate_cpp.hpp
+++ b/src/stan/lang/generator/generate_cpp.hpp
@@ -71,7 +71,9 @@ void generate_cpp(const program& prog, const std::string& model_name,
   generate_dims_method(prog, o);
   generate_write_array_method(prog, model_name, o);
   generate_model_name_method(model_name, o);
+#ifdef USE_STANC3
   generate_model_compile_info_method(o);
+#endif
   generate_constrained_param_names_method(prog, o);
   generate_unconstrained_param_names_method(prog, o);
   generate_class_decl_end(o);

--- a/src/stan/lang/generator/generate_model_compile_info_method.hpp
+++ b/src/stan/lang/generator/generate_model_compile_info_method.hpp
@@ -1,3 +1,5 @@
+#ifdef USE_STANC3
+
 #ifndef STAN_LANG_GENERATOR_GENERATE_MODEL_COMPILE_INFO_METHOD_HPP
 #define STAN_LANG_GENERATOR_GENERATE_MODEL_COMPILE_INFO_METHOD_HPP
 
@@ -23,4 +25,6 @@ void generate_model_compile_info_method(std::ostream& o) {
 
 }  // namespace lang
 }  // namespace stan
+#endif
+
 #endif

--- a/src/stan/model/model_base.hpp
+++ b/src/stan/model/model_base.hpp
@@ -53,6 +53,7 @@ class model_base : public prob_grad {
    */
   virtual std::string model_name() const = 0;
 
+#ifdef USE_STANC3
   /**
    * Returns the compile information of the model:
    * stanc version and stanc flags used to compile the model.
@@ -60,6 +61,7 @@ class model_base : public prob_grad {
    * @return model name
    */
   virtual std::vector<std::string> model_compile_info() const = 0;
+#endif
 
   /**
    * Set the specified argument to sequence of parameters, transformed

--- a/src/test/unit/io/array_var_context_test.cpp
+++ b/src/test/unit/io/array_var_context_test.cpp
@@ -3,7 +3,9 @@
 #include <stan/io/array_var_context.hpp>
 #include <gtest/gtest.h>
 #include <boost/math/special_functions/fpclassify.hpp>
+#ifdef USE_STANC3
 #include <test/test-models/good/services/bernoulli.hpp>
+#endif
 #include <Eigen/Dense>
 
 TEST(array_var_context, ctor_int) {
@@ -208,6 +210,7 @@ TEST(array_var_context, invalid_input2) {
   FAIL();
 }
 
+#ifdef USE_STANC3
 TEST(array_var_context, invalid_context_validate) {
   std::vector<int> a;
   std::vector<std::vector<size_t> > dims;
@@ -241,3 +244,4 @@ TEST(array_var_context, invalid_context_validate) {
   EXPECT_NO_THROW(
       bernoulli_model_namespace::bernoulli_model(avc3, 0, &std::cout));
 }
+#endif

--- a/src/test/unit/model/model_base_crtp_test.cpp
+++ b/src/test/unit/model/model_base_crtp_test.cpp
@@ -15,11 +15,13 @@ struct mock_model : public stan::model::model_base_crtp<mock_model> {
 
   std::string model_name() const override { return "mock_model"; }
 
+#ifdef USE_STANC3
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = stanc2");
     return stanc_info;
   }
+#endif
 
   void get_param_names(std::vector<std::string>& names) const override {}
   void get_dims(std::vector<std::vector<size_t> >& dimss) const override {}

--- a/src/test/unit/model/model_base_test.cpp
+++ b/src/test/unit/model/model_base_test.cpp
@@ -13,11 +13,13 @@ struct mock_model : public stan::model::model_base {
 
   std::string model_name() const override { return "mock_model"; }
 
+#ifdef USE_STANC3
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = stanc2");
     return stanc_info;
   }
+#endif
 
   void get_param_names(std::vector<std::string>& names) const override {}
   void get_dims(std::vector<std::vector<size_t> >& dimss) const override {}


### PR DESCRIPTION
## Summary

This makes `StanHeaders 2.26.0` (https://github.com/stan-dev/rstan/pull/887) compatible with both `Stan 2.26 & 2.21`, basically addressing backward compatibility for CRAN submission. It introduces `USE_STANC3` macro to branch changes specific to Stan 2.26 that cannot be supported by the older version of `stanc` transpiler.

## Tests

Building `rstan` & its dependencies (e.g., `rstanarm`) is successful both versions of `Stan`.

## Side Effects

N/A

## Release notes

`StanHeaders` is now compatible with all versions of `Stan`, including CRAN and the development version.

## Checklist

- [X] Copyright holder: Hamada S. Badr <badr@jhu.edu>

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
