### PR TITLE
Use StanHeaders_2.26 branch for math submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "lib/stan_math"]
 	path = lib/stan_math
 	url = https://github.com/stan-dev/math.git
+	branch = StanHeaders_2.26
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "lib/stan_math"]
 	path = lib/stan_math
-	url = https://github.com/stan-dev/math.git
+	url = https://github.com/hsbadr/math.git
 	branch = StanHeaders_2.26
 	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "lib/stan_math"]
 	path = lib/stan_math
-	url = https://github.com/hsbadr/math.git
+	url = https://github.com/stan-dev/math.git
 	branch = StanHeaders_2.26
 	ignore = dirty


### PR DESCRIPTION
Use and update `math` submodule for `StanHeaders_2.26`.

- [X] Update the submodule when https://github.com/stan-dev/math/pull/2359 is merged.

@bgoodri 