### PR TITLE
Revert "Feature/bounds no inf"

### DIFF
--- a/src/test/unit/io/writer_test.cpp
+++ b/src/test/unit/io/writer_test.cpp
@@ -16,34 +16,35 @@ TEST(ioWriter, infBounds) {
 
   // lb finite; ub = +inf
   double y = 12;
-  EXPECT_THROW(writer.scalar_lub_unconstrain(
-                   0, std::numeric_limits<double>::infinity(), y),
-               std::domain_error);
+  writer.scalar_lub_unconstrain(0, std::numeric_limits<double>::infinity(), y);
+  writer.scalar_lb_unconstrain(0, y);
+  EXPECT_FLOAT_EQ(writer.data_r()[0], writer.data_r()[1]);
 
   // lb = -inf; ub finite
   double z = -7.7;
-  EXPECT_THROW(writer.scalar_lub_unconstrain(
-                   -std::numeric_limits<double>::infinity(), -1.9, z),
-               std::domain_error);
+  writer.scalar_lub_unconstrain(-std::numeric_limits<double>::infinity(), -1.9,
+                                z);
+  writer.scalar_ub_unconstrain(-1.9, z);
+  EXPECT_FLOAT_EQ(writer.data_r()[2], writer.data_r()[3]);
 
   // lb = -inf;  ub = +inf
   double w = 197.345;
-  EXPECT_THROW(
-      writer.scalar_lub_unconstrain(-std::numeric_limits<double>::infinity(),
-                                    std::numeric_limits<double>::infinity(), w),
-      std::domain_error);
+  writer.scalar_lub_unconstrain(-std::numeric_limits<double>::infinity(),
+                                std::numeric_limits<double>::infinity(), w);
+  writer.scalar_unconstrain(w);
+  EXPECT_FLOAT_EQ(writer.data_r()[4], writer.data_r()[5]);
 
   // ub = inf
   double u = 9283475;
-  EXPECT_THROW(
-      writer.scalar_ub_unconstrain(std::numeric_limits<double>::infinity(), u),
-      std::domain_error);
+  writer.scalar_ub_unconstrain(std::numeric_limits<double>::infinity(), u);
+  writer.scalar_unconstrain(u);
+  EXPECT_FLOAT_EQ(writer.data_r()[6], writer.data_r()[7]);
 
   // lb = -inf
   double v = -7464.737474;
-  EXPECT_THROW(
-      writer.scalar_lb_unconstrain(-std::numeric_limits<double>::infinity(), v),
-      std::domain_error);
+  writer.scalar_lb_unconstrain(-std::numeric_limits<double>::infinity(), v);
+  writer.scalar_unconstrain(v);
+  EXPECT_FLOAT_EQ(writer.data_r()[8], writer.data_r()[9]);
 }
 
 TEST(io_writer, integer) {


### PR DESCRIPTION
This reverts the infinite bounds checks PR as we rewrote them in Stan to support the bounds checking behavior for pos/neg infinity. This branch needs to do the dual merge thing to have this and the math branch [#2373](https://github.com/stan-dev/math/pull/2373) at the same time