### PR TITLE
Stan tests refactor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -258,7 +258,7 @@ pipeline {
                         sh """
                             cd performance-tests-cmdstan/cmdstan
                             echo 'O=0' >> make/local
-                            echo 'CXX=${env.GXX}' >> make/local
+                            echo 'CXX=${env.CXX}' >> make/local
                             make -j${env.PARALLEL} build
                             cd ..
                             ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,7 +216,7 @@ pipeline {
                     when {
                         expression {
                             ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" || ||
+                            env.BRANCH_NAME == "master" ||
                             params.run_tests_all_os ) &&
                             !skipRemainingStages
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -258,7 +258,7 @@ pipeline {
                         sh """
                             cd performance-tests-cmdstan/cmdstan
                             echo 'O=0' >> make/local
-                            echo 'CXX=${env.GCC}' >> make/local
+                            echo 'CXX=${env.GXX}' >> make/local
                             make -j${env.PARALLEL} build
                             cd ..
                             ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,11 +201,13 @@ pipeline {
             parallel {
                 stage('Windows Headers & Unit') {
                     agent { label 'windows' }
-                    expression {
-                        ( env.BRANCH_NAME == "develop" ||
-                        env.BRANCH_NAME == "master" ||
-                        params.run_tests_all_os ) &&
-                        !skipRemainingStages
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
                     }
                     steps {
                         deleteDirWin()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ pipeline {
           description: 'PR to test CmdStan upstream against e.g. PR-630')
         string(defaultValue: 'nightly', name: 'stanc3_bin_url',
           description: 'Custom stanc3 binary url')
+        booleanParam(defaultValue: false, name: 'run_tests_all_os', description: 'Run unit and integration tests on all OS.')
     }
     options {
         skipDefaultCheckout()
@@ -212,6 +213,14 @@ pipeline {
                 }
                 stage('Linux Unit') {
                     agent { label 'linux' }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" || ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
                     steps {
                         unstash 'StanSetup'
                         setupCXX(true, env.GCC, stanc3_bin_url())
@@ -221,6 +230,14 @@ pipeline {
                 }
                 stage('Mac Unit') {
                     agent { label 'osx' }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
                     steps {
                         unstash 'StanSetup'
                         setupCXX(false, env.CXX, stanc3_bin_url())
@@ -274,13 +291,14 @@ pipeline {
                 }
                 stage('Integration Mac') {
                     agent { label 'osx' }
-                    // when {
-                    //     expression {
-                    //         ( env.BRANCH_NAME == "develop" ||
-                    //         env.BRANCH_NAME == "master" ) &&
-                    //         !skipRemainingStages
-                    //     }
-                    // }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
                     steps {
                         sh """
                             git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
@@ -324,7 +342,8 @@ pipeline {
                     when {
                         expression {
                             ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ) &&
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
                             !skipRemainingStages
                         }
                     }


### PR DESCRIPTION
#### Summary

This PR refactors the tests: 
- Integration tests on Unix OSes now compiles using cmdstan's tests
     
    On Linux this is a lot faster (20min instead of 1h40min). On Mac its a bit faster (45min vs 1h5min). On Windows it seems to be slower so its left as is.

- Mac/Windows Unit tests are run on merges to develop/master: 

- Mac/Windows Unit tests can also be run on request
![image](https://user-images.githubusercontent.com/28476796/110934874-efcf3300-832e-11eb-828b-45fe37e0fd6b.png)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
