### PR TITLE
Low-rank ADVI

### DIFF
--- a/src/stan/services/experimental/advi/defaults.hpp
+++ b/src/stan/services/experimental/advi/defaults.hpp
@@ -10,6 +10,17 @@ namespace experimental {
 namespace advi {
 
 /**
+ * Rank of the approximation when using low-rank ADVI.
+ */
+struct rank {
+  static std::string description() {
+    return "Rank of the covariance approximation when using low-rank ADVI.";
+  }
+
+  static int default_value() { return 0; }
+};
+
+/**
  * Number of samples for Monte Carlo estimate of gradients.
  */
 struct gradient_samples {

--- a/src/stan/services/experimental/advi/lowrank.hpp
+++ b/src/stan/services/experimental/advi/lowrank.hpp
@@ -1,0 +1,90 @@
+#ifndef STAN_SERVICES_EXPERIMENTAL_ADVI_LOWRANK_HPP
+#define STAN_SERVICES_EXPERIMENTAL_ADVI_LOWRANK_HPP
+
+#include <stan/callbacks/interrupt.hpp>
+#include <stan/callbacks/logger.hpp>
+#include <stan/callbacks/writer.hpp>
+#include <stan/services/util/experimental_message.hpp>
+#include <stan/services/util/initialize.hpp>
+#include <stan/services/util/create_rng.hpp>
+#include <stan/io/var_context.hpp>
+#include <stan/variational/advi.hpp>
+#include <boost/random/additive_combine.hpp>
+#include <string>
+#include <vector>
+
+namespace stan {
+namespace services {
+namespace experimental {
+namespace advi {
+
+/**
+ * Runs low rank ADVI.
+ *
+ * @tparam Model A model implementation
+ * @param[in] model Input model to test (with data already instantiated)
+ * @param[in] init var context for initialization
+ * @param[in] random_seed random seed for the random number generator
+ * @param[in] chain chain id to advance the random number generator
+ * @param[in] init_radius radius to initialize
+ * @param[in] grad_samples number of samples for Monte Carlo estimate
+ *   of gradients
+ * @param[in] elbo_samples number of samples for Monte Carlo estimate
+ *   of ELBO
+ * @param[in] max_iterations maximum number of iterations
+ * @param[in] tol_rel_obj convergence tolerance on the relative norm
+ *   of the objective
+ * @param[in] eta stepsize scaling parameter for variational inference
+ * @param[in] adapt_engaged adaptation engaged?
+ * @param[in] adapt_iterations number of iterations for eta adaptation
+ * @param[in] eval_elbo evaluate ELBO every Nth iteration
+ * @param[in] output_samples number of posterior samples to draw and
+ *   save
+ * @param[in,out] interrupt callback to be called every iteration
+ * @param[in,out] logger Logger for messages
+ * @param[in,out] init_writer Writer callback for unconstrained inits
+ * @param[in,out] parameter_writer output for parameter values
+ * @param[in,out] diagnostic_writer output for diagnostic values
+ * @return error_codes::OK if successful
+ */
+template <class Model>
+int lowrank(Model& model, const stan::io::var_context& init,
+            unsigned int random_seed, unsigned int chain, double init_radius,
+            int grad_samples, int elbo_samples, int max_iterations,
+            double tol_rel_obj, int rank, double eta, bool adapt_engaged,
+            int adapt_iterations, int eval_elbo, int output_samples,
+            callbacks::interrupt& interrupt, callbacks::logger& logger,
+            callbacks::writer& init_writer,
+            callbacks::writer& parameter_writer,
+            callbacks::writer& diagnostic_writer) {
+  util::experimental_message(logger);
+
+  boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
+
+  std::vector<int> disc_vector;
+  std::vector<double> cont_vector = util::initialize(
+      model, init, rng, init_radius, true, logger, init_writer);
+
+  std::vector<std::string> names;
+  names.push_back("lp__");
+  names.push_back("log_p__");
+  names.push_back("log_g__");
+  model.constrained_param_names(names, true, true);
+  parameter_writer(names);
+
+  Eigen::VectorXd cont_params
+      = Eigen::Map<Eigen::VectorXd>(&cont_vector[0], cont_vector.size(), 1);
+
+  stan::variational::advi_lowrank<Model, boost::ecuyer1988>
+      cmd_advi(model, cont_params, rng, rank, grad_samples, elbo_samples,
+               eval_elbo, output_samples);
+  cmd_advi.run(eta, adapt_engaged, adapt_iterations, tol_rel_obj,
+               max_iterations, logger, parameter_writer, diagnostic_writer);
+
+  return 0;
+}
+}  // namespace advi
+}  // namespace experimental
+}  // namespace services
+}  // namespace stan
+#endif

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -76,7 +76,7 @@ class advi_base {
     math::check_positive(function, "Number of posterior samples for output",
                          n_posterior_samples_);
   }
-  
+
   /**
    * Calculates the Evidence Lower BOund (ELBO) by sampling from
    * the variational distribution and then evaluating the log joint,
@@ -590,7 +590,8 @@ class advi : public advi_base<Model, Q, BaseRNG> {
 };
 
 template<class Model, class BaseRNG>
-class advi_lowrank : public advi_base<Model, stan::variational::normal_lowrank, BaseRNG> {
+class advi_lowrank : public advi_base
+  <Model, stan::variational::normal_lowrank, BaseRNG> {
  public:
   /**
     * Constructor
@@ -625,8 +626,7 @@ class advi_lowrank : public advi_base<Model, stan::variational::normal_lowrank, 
 
  private:
   stan::variational::normal_lowrank init_variational(
-    Eigen::VectorXd& cont_params
-  ) const {
+    Eigen::VectorXd& cont_params) const {
     return stan::variational::normal_lowrank(cont_params, rank_);
   }
 

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -10,6 +10,7 @@
 #include <stan/variational/print_progress.hpp>
 #include <stan/variational/families/normal_fullrank.hpp>
 #include <stan/variational/families/normal_meanfield.hpp>
+#include <stan/variational/families/normal_lowrank.hpp>
 #include <boost/circular_buffer.hpp>
 #include <boost/lexical_cast.hpp>
 #include <algorithm>
@@ -37,7 +38,7 @@ namespace variational {
  * @tparam BaseRNG class of random number generator
  */
 template <class Model, class Q, class BaseRNG>
-class advi {
+class advi_base {
  public:
   /**
    * Constructor
@@ -54,9 +55,9 @@ class advi {
    * @throw std::runtime_error if eval_elbo is not positive
    * @throw std::runtime_error if n_posterior_samples is not positive
    */
-  advi(Model& m, Eigen::VectorXd& cont_params, BaseRNG& rng,
-       int n_monte_carlo_grad, int n_monte_carlo_elbo, int eval_elbo,
-       int n_posterior_samples)
+  advi_base(Model& m, Eigen::VectorXd& cont_params, BaseRNG& rng,
+            int n_monte_carlo_grad, int n_monte_carlo_elbo, int eval_elbo,
+            int n_posterior_samples)
       : model_(m),
         cont_params_(cont_params),
         rng_(rng),
@@ -75,7 +76,7 @@ class advi {
     math::check_positive(function, "Number of posterior samples for output",
                          n_posterior_samples_);
   }
-
+  
   /**
    * Calculates the Evidence Lower BOund (ELBO) by sampling from
    * the variational distribution and then evaluating the log joint,
@@ -192,10 +193,10 @@ class advi {
     }
 
     // Variational family to store gradients
-    Q elbo_grad = Q(model_.num_params_r());
+    Q elbo_grad = init_variational(model_.num_params_r());
 
     // Adaptive step-size sequence
-    Q history_grad_squared = Q(model_.num_params_r());
+    Q history_grad_squared = init_variational(model_.num_params_r());
     double tau = 1.0;
     double pre_factor = 0.9;
     double post_factor = 0.1;
@@ -287,7 +288,7 @@ class advi {
         history_grad_squared.set_to_zero();
       }
       ++eta_sequence_index;
-      variational = Q(cont_params_);
+      variational = init_variational(cont_params_);
     }
     return eta_best;
   }
@@ -317,10 +318,10 @@ class advi {
     stan::math::check_positive(function, "Maximum iterations", max_iterations);
 
     // Gradient parameters
-    Q elbo_grad = Q(model_.num_params_r());
+    Q elbo_grad = init_variational(model_.num_params_r());
 
     // Stepsize sequence parameters
-    Q history_grad_squared = Q(model_.num_params_r());
+    Q history_grad_squared = init_variational(model_.num_params_r());
     double tau = 1.0;
     double pre_factor = 0.9;
     double post_factor = 0.1;
@@ -462,7 +463,7 @@ class advi {
     diagnostic_writer("iter,time_in_seconds,ELBO");
 
     // Initialize variational approximation
-    Q variational = Q(cont_params_);
+    Q variational = init_variational(cont_params_);
 
     if (adapt_engaged) {
       eta = adapt_eta(variational, adapt_iterations, logger);
@@ -562,6 +563,76 @@ class advi {
   int n_monte_carlo_elbo_;
   int eval_elbo_;
   int n_posterior_samples_;
+
+ private:
+  virtual Q init_variational(Eigen::VectorXd& cont_params) const = 0;
+  virtual Q init_variational(size_t dimension) const = 0;
+};
+
+template<class Model, class Q, class BaseRNG>
+class advi : public advi_base<Model, Q, BaseRNG> {
+ public:
+  advi(Model& m, Eigen::VectorXd& cont_params, BaseRNG& rng,
+            int n_monte_carlo_grad, int n_monte_carlo_elbo, int eval_elbo,
+            int n_posterior_samples)
+    : advi_base<Model, Q, BaseRNG>(m, cont_params, rng, n_monte_carlo_grad,
+                                   n_monte_carlo_elbo, eval_elbo,
+                                   n_posterior_samples) {}
+
+ private:
+  Q init_variational(Eigen::VectorXd& cont_params) const {
+    return Q(cont_params);
+  }
+
+  Q init_variational(size_t dimension) const {
+    return Q(dimension);
+  }
+};
+
+template<class Model, class BaseRNG>
+class advi_lowrank : public advi_base<Model, stan::variational::normal_lowrank, BaseRNG> {
+ public:
+  /**
+    * Constructor
+    *
+    * @param[in] m stan model
+    * @param[in] cont_params initialization of continuous parameters
+    * @param[in,out] rng random number generator
+    * @param[in] rank rank of approximation
+    * @param[in] n_monte_carlo_grad number of samples for gradient computation
+    * @param[in] n_monte_carlo_elbo number of samples for ELBO computation
+    * @param[in] eval_elbo evaluate ELBO at every "eval_elbo" iters
+    * @param[in] n_posterior_samples number of samples to draw from posterior
+    * @throw std::runtime_error if n_monte_carlo_grad is not positive
+    * @throw std::runtime_error if n_monte_carlo_elbo is not positive
+    * @throw std::runtime_error if eval_elbo is not positive
+    * @throw std::runtime_error if n_posterior_samples is not positive
+    */
+  advi_lowrank(Model& m, Eigen::VectorXd& cont_params, BaseRNG& rng,
+               size_t rank, int n_monte_carlo_grad, int n_monte_carlo_elbo,
+               int eval_elbo, int n_posterior_samples)
+      : advi_base<Model, stan::variational::normal_lowrank, BaseRNG>(m,
+          cont_params,
+          rng, n_monte_carlo_grad, n_monte_carlo_elbo,
+          eval_elbo, n_posterior_samples),
+        rank_(rank) {
+    static const char* function = "stan::variational::advi_lowrank";
+    math::check_positive(function, "Approximation rank", rank_);
+  }
+
+ protected:
+  size_t rank_;
+
+ private:
+  stan::variational::normal_lowrank init_variational(
+    Eigen::VectorXd& cont_params
+  ) const {
+    return stan::variational::normal_lowrank(cont_params, rank_);
+  }
+
+  stan::variational::normal_lowrank init_variational(size_t dimension) const {
+    return stan::variational::normal_lowrank(dimension, rank_);
+  }
 };
 }  // namespace variational
 }  // namespace stan

--- a/src/stan/variational/base_family.hpp
+++ b/src/stan/variational/base_family.hpp
@@ -8,7 +8,6 @@
 
 namespace stan {
 namespace variational {
-
 class base_family {
  public:
   // Constructors
@@ -22,63 +21,14 @@ class base_family {
   // Distribution-based operations
   virtual const Eigen::VectorXd& mean() const = 0;
   virtual double entropy() const = 0;
-  virtual Eigen::VectorXd transform(const Eigen::VectorXd& eta) const = 0;
-  /**
-   * Assign a draw from this mean field approximation to the
-   * specified vector using the specified random number generator.
-   *
-   * @tparam BaseRNG Class of random number generator.
-   * @param[in] rng Base random number generator.
-   * @param[out] eta Vector to which the draw is assigned; dimension has to be
-   * the same as the dimension of variational q.
-   * @throws std::range_error If the index is out of range.
-   */
+  Eigen::VectorXd transform(const Eigen::VectorXd& eta) const;
   template <class BaseRNG>
-  void sample(BaseRNG& rng, Eigen::VectorXd& eta) const {
-    // Draw from standard normal and transform to real-coordinate space
-    for (int d = 0; d < dimension(); ++d)
-      eta(d) = stan::math::normal_rng(0, 1, rng);
-    eta = transform(eta);
-  }
-  /**
-   * Draw a posterior sample from the normal distribution,
-   * and return its log normal density. The constants are dropped.
-   *
-   * @param[in] rng Base random number generator.
-   * @param[out] eta Vector to which the draw is assigned; dimension has to be
-   * the same as the dimension of variational q. eta will be transformed into
-   * variational posteriors.
-   * @param[out] log_g The log  density in the variational approximation;
-   * The constant term is dropped.
-   * @throws std::range_error If the index is out of range.
-   */
+  Eigen::VectorXd sample(BaseRNG& rng, Eigen::VectorXd& eta) const;
   template <class BaseRNG>
-  void sample_log_g(BaseRNG& rng, Eigen::VectorXd& eta, double& log_g) const {
-    // Draw from the approximation
-    for (int d = 0; d < dimension(); ++d) {
-      eta(d) = stan::math::normal_rng(0, 1, rng);
-    }
-    // Compute the log density before transformation
-    log_g = calc_log_g(eta);
-    // Transform to real-coordinate space
-    eta = transform(eta);
-  }
-  /**
-   * Compute the unnormalized log unit normal density wrt eta. All constants are
-   * dropped.
-   *
-   * @param[in] eta Vector; dimension has to be the same as the dimension
-   * of variational q.
-   * @return The unnormalized log density in the variational approximation;
-   * @throws std::range_error If the index is out of range.
-   */
-  double calc_log_g(const Eigen::VectorXd& eta) const {
-    double log_g = 0;
-    for (int d = 0; d < dimension(); ++d) {
-      log_g += -stan::math::square(eta(d)) * 0.5;
-    }
-    return log_g;
-  }
+  Eigen::VectorXd sample_log_g(BaseRNG& rng,
+                               Eigen::VectorXd& eta,
+                               double& log_g) const;
+  double calc_log_g(Eigen::VectorXd& eta) const;
   template <class M, class BaseRNG>
   void calc_grad(base_family& elbo_grad, M& m, Eigen::VectorXd& cont_params,
                  int n_monte_carlo_grad, BaseRNG& rng,

--- a/src/stan/variational/families/normal_lowrank.hpp
+++ b/src/stan/variational/families/normal_lowrank.hpp
@@ -271,10 +271,10 @@ class normal_lowrank : public base_family {
     Eigen::MatrixXd d_inv2
         = log_d_.array().exp().square().matrix().asDiagonal().inverse();
     Eigen::MatrixXd Bt = B_.transpose();
-    Eigen::MatrixXd id = Eigen::MatrixXd::Identity(rank(), rank());
+    Eigen::MatrixXd I = Eigen::MatrixXd::Identity(rank(), rank());
     Eigen::MatrixXd woodbury
-        = d_inv2 - d_inv2 * B_ * (id + Bt * d_inv2 * B_).inverse() * Bt * d_inv2;
-    
+        = d_inv2 - d_inv2 * B_ * (I + Bt * d_inv2 * B_).inverse() * Bt * d_inv2;
+
     Eigen::VectorXd tmp_mu_grad = Eigen::VectorXd::Zero(dimension());
 
     // Naive Monte Carlo integration
@@ -381,7 +381,7 @@ inline normal_lowrank operator+(double scalar, normal_lowrank rhs) {
 inline normal_lowrank operator*(double scalar, normal_lowrank rhs) {
   return rhs *= scalar;
 }
-} // namespace variational
-} // namespace stan
+}  // namespace variational
+}  // namespace stan
 
 #endif

--- a/src/stan/variational/families/normal_lowrank.hpp
+++ b/src/stan/variational/families/normal_lowrank.hpp
@@ -1,0 +1,387 @@
+#ifndef STAN_VARIATIONAL_NORMAL_LOWRANK_HPP
+#define STAN_VARIATIONAL_NORMAL_LOWRANK_HPP
+
+#include <stan/callbacks/logger.hpp>
+#include <stan/math/prim.hpp>
+#include <stan/model/gradient.hpp>
+#include <stan/variational/base_family.hpp>
+#include <algorithm>
+#include <ostream>
+#include <vector>
+
+namespace stan {
+namespace variational {
+class normal_lowrank : public base_family {
+ private:
+  Eigen::VectorXd mu_;
+  Eigen::MatrixXd B_;
+  Eigen::VectorXd log_d_;
+
+  const int dimension_;
+  const int rank_;
+
+  void validate_mean(const char* function,
+                     const Eigen::VectorXd& mu) {
+    stan::math::check_not_nan(function, "Mean vector", mu);
+    stan::math::check_size_match(function,
+                               "Dimension of input vector", mu.size(),
+                               "Dimension of current vector", dimension());
+  }
+
+  void validate_factor(const char* function,
+                       const Eigen::MatrixXd& B) {
+    stan::math::check_not_nan(function, "Low rank factor", B);
+    stan::math::check_size_match(function,
+                                 "Dimension of mean vector", dimension(),
+                                 "Dimension of low-rank factor", B.rows());
+    stan::math::check_size_match(function,
+                                 "Rank of factor", B.cols(),
+                                 "Rank of approximation", rank());
+  }
+
+  void validate_noise(const char *function,
+                      const Eigen::VectorXd& log_d) {
+    stan::math::check_not_nan(function, "log std vector", log_d);
+    stan::math::check_size_match(function,
+                                 "Dimension of mean vector", dimension(),
+                                 "Dimension of log std vector", log_d.size());
+  }
+
+ public:
+  explicit normal_lowrank(const Eigen::VectorXd& mu, size_t rank)
+  : mu_(mu),
+    B_(Eigen::MatrixXd::Zero(mu.size(), rank)),
+    log_d_(Eigen::VectorXd::Zero(mu.size())),
+    dimension_(mu.size()),
+    rank_(rank) {
+  }
+
+  explicit normal_lowrank(size_t dimension, size_t rank)
+  : mu_(Eigen::VectorXd::Zero(dimension)),
+    B_(Eigen::MatrixXd::Zero(dimension, rank)),
+    log_d_(Eigen::VectorXd::Zero(dimension)),
+    dimension_(dimension),
+    rank_(rank) {
+  }
+
+  explicit normal_lowrank(const Eigen::VectorXd& mu,
+                          const Eigen::MatrixXd& B,
+                          const Eigen::VectorXd& log_d)
+  : mu_(mu), B_(B), log_d_(log_d), dimension_(mu.size()), rank_(B.cols()) {
+    static const char* function = "stan::variational::normal_lowrank";
+    validate_mean(function, mu);
+    validate_factor(function, B);
+    validate_noise(function, log_d);
+  }
+
+  int dimension() const { return dimension_; }
+  int rank() const { return rank_; }
+
+  const Eigen::VectorXd& mean() const { return mu(); }
+  const Eigen::VectorXd& mu() const { return mu_; }
+  const Eigen::MatrixXd& B() const { return B_; }
+  const Eigen::VectorXd& log_d() const { return log_d_; }
+
+  void set_mu(const Eigen::VectorXd& mu) {
+    static const char* function = "stan::variational::set_mu";
+    validate_mean(function, mu);
+    mu_ = mu;
+  }
+
+  void set_B(const Eigen::MatrixXd& B) {
+    static const char* function = "stan::variational::set_B";
+    validate_factor(function, B);
+    B_ = B;
+  }
+
+  void set_log_d(const Eigen::VectorXd& log_d) {
+    static const char* function = "stan::variational::set_log_d";
+    validate_noise(function, log_d);
+    log_d_ = log_d;
+  }
+
+  void set_to_zero() {
+    mu_ = Eigen::VectorXd::Zero(dimension());
+    B_ = Eigen::MatrixXd::Zero(dimension(), rank());
+    log_d_ = Eigen::VectorXd::Zero(dimension());
+  }
+
+  normal_lowrank square() const {
+    return normal_lowrank(Eigen::VectorXd(mu_.array().square()),
+                          Eigen::MatrixXd(B_.array().square()),
+                          Eigen::VectorXd(log_d_.array().square()));
+  }
+
+  normal_lowrank sqrt() const {
+    return normal_lowrank(Eigen::VectorXd(mu_.array().sqrt()),
+                          Eigen::MatrixXd(B_.array().sqrt()),
+                          Eigen::VectorXd(log_d_.array().sqrt()));
+  }
+
+  normal_lowrank& operator=(const normal_lowrank& rhs) {
+    static const char* function
+        = "stan::variational::normal_lowrank::operator=";
+    stan::math::check_size_match(function, "Dimension of lhs", dimension(),
+                                 "Dimension of rhs", rhs.dimension());
+    stan::math::check_size_match(function, "Rank of lhs", rank(),
+                                 "Rank of rhs", rhs.rank());
+    mu_ = rhs.mu();
+    B_ = rhs.B();
+    log_d_ = rhs.log_d();
+    return *this;
+  }
+
+  normal_lowrank& operator+=(const normal_lowrank& rhs) {
+    static const char* function
+        = "stan::variational::normal_lowrank::operator+=";
+    stan::math::check_size_match(function, "Dimension of lhs", dimension(),
+                                 "Dimension of rhs", rhs.dimension());
+    stan::math::check_size_match(function, "Rank of lhs", rank(),
+                                 "Rank of rhs", rhs.rank());
+    mu_ += rhs.mu();
+    B_ += rhs.B();
+    log_d_ += rhs.log_d();
+    return *this;
+  }
+
+  inline normal_lowrank& operator/=(const normal_lowrank& rhs) {
+    static const char* function
+        = "stan::variational::normal_lowrank::operator/=";
+
+    stan::math::check_size_match(function, "Dimension of lhs", dimension(),
+                                 "Dimension of rhs", rhs.dimension());
+    stan::math::check_size_match(function, "Rank of lhs", rank(),
+                                 "Rank of rhs", rhs.rank());
+    mu_.array() /= rhs.mu().array();
+    B_.array() /= rhs.B().array();
+    log_d_.array() /= rhs.log_d().array();
+    return *this;
+  }
+
+  normal_lowrank& operator+=(double scalar) {
+    mu_.array() += scalar;
+    B_.array() += scalar;
+    log_d_.array() += scalar;
+    return *this;
+  }
+
+  normal_lowrank& operator*=(double scalar) {
+    mu_ *= scalar;
+    B_ *= scalar;
+    log_d_ *= scalar;
+    return *this;
+  }
+
+  double entropy() const {
+    static int r = rank();
+    static double mult = 0.5 * (1.0 + stan::math::LOG_TWO_PI);
+    double result = mult * dimension();
+    // Determinant by the matrix determinant lemma
+    //   det(D^2 + B.B^T) = det(I + B^T.D^-2.B) * det(D^2)
+    // where D^2 is diagonal and so can be computed accordingly
+    result
+        += 0.5 * log(
+             (Eigen::MatrixXd::Identity(r, r) +
+              B_.transpose() *
+              log_d_.array().exp().square().matrix().asDiagonal().inverse() *
+              B_).determinant());
+    for (int d = 0; d < dimension(); ++d) {
+      result += log_d_(d);
+    }
+    return result;
+  }
+
+  Eigen::VectorXd transform(const Eigen::VectorXd& eta) const {
+    static const char* function =
+      "stan::variational::normal_lowrank::transform";
+    stan::math::check_size_match(function,
+                         "Dimension of input vector", eta.size(),
+                         "Sum of dimension and rank", dimension() + rank());
+    stan::math::check_not_nan(function, "Input vector", eta);
+    Eigen::VectorXd z = eta.head(rank());
+    Eigen::VectorXd eps = eta.tail(dimension());
+    return (log_d_.array().exp() * eps.array()).matrix() + (B_ * z) + mu_;
+  }
+
+  template <class BaseRNG>
+  void sample(BaseRNG& rng, Eigen::VectorXd& eta) const {
+    // Draw from standard normal and transform to real-coordinate space
+    Eigen::VectorXd zeta = Eigen::VectorXd::Zero(dimension() + rank());
+    for (int d = 0; d < dimension() + rank(); ++d)
+      zeta(d) = stan::math::normal_rng(0, 1, rng);
+    eta = transform(zeta);
+  }
+
+  /**
+   * Draw a posterior sample from the normal distribution,
+   * and return its log normal density. The constants are dropped.
+   *
+   * @param[in] rng Base random number generator.
+   * @param[out] eta Vector to which the draw is assigned; dimension has to be
+   * the same as the dimension of variational q. eta will be transformed into
+   * variational posteriors.
+   * @param[out] log_g The log  density in the variational approximation;
+   * The constant term is dropped.
+   * @throws std::range_error If the index is out of range.
+   */
+  template <class BaseRNG>
+  void sample_log_g(BaseRNG& rng, Eigen::VectorXd& eta, double& log_g) const {
+    // Draw from the approximation
+    Eigen::VectorXd zeta = Eigen::VectorXd::Zero(dimension() + rank());
+    for (int d = 0; d < dimension() + rank(); ++d) {
+      zeta(d) = stan::math::normal_rng(0, 1, rng);
+    }
+    // Compute the log density before transformation
+    log_g = calc_log_g(zeta);
+    // Transform to real-coordinate space
+    eta = transform(zeta);
+  }
+
+  template <class M, class BaseRNG>
+  void calc_grad(normal_lowrank& elbo_grad,
+                 M& m,
+                 Eigen::VectorXd& cont_params,
+                 int n_monte_carlo_grad,
+                 BaseRNG& rng,
+                 callbacks::logger& logger) const {
+    static const char* function =
+      "stan::variational::normal_lowrank::calc_grad";
+
+    stan::math::check_size_match(function, "Dimension of elbo_grad",
+                                 elbo_grad.dimension(),
+                                 "Dimension of variational q", dimension());
+    stan::math::check_size_match(function, "Dimension of variational q",
+                                 dimension(), "Dimension of variables in model",
+                                 cont_params.size());
+
+    stan::math::check_size_match(function, "Rank of elbo_grad",
+                                 elbo_grad.rank(),
+                                 "Rank of variational q", rank());
+
+    Eigen::VectorXd mu_grad = Eigen::VectorXd::Zero(dimension());
+    Eigen::MatrixXd B_grad = Eigen::MatrixXd::Zero(dimension(), rank());
+    Eigen::VectorXd d_grad = Eigen::VectorXd::Zero(dimension());
+    Eigen::VectorXd log_d_grad = Eigen::VectorXd::Zero(dimension());
+
+    double tmp_lp = 0.0;
+    Eigen::VectorXd eta = Eigen::VectorXd::Zero(dimension() + rank());
+    Eigen::VectorXd zeta = Eigen::VectorXd::Zero(dimension());
+
+    // (B.B^T + D^2)^-1 by Woodbury formula
+    Eigen::MatrixXd d_inv2
+        = log_d_.array().exp().square().matrix().asDiagonal().inverse();
+    Eigen::MatrixXd Bt = B_.transpose();
+    Eigen::MatrixXd id = Eigen::MatrixXd::Identity(rank(), rank());
+    Eigen::MatrixXd woodbury
+        = d_inv2 - d_inv2 * B_ * (id + Bt * d_inv2 * B_).inverse() * Bt * d_inv2;
+    
+    Eigen::VectorXd tmp_mu_grad = Eigen::VectorXd::Zero(dimension());
+
+    // Naive Monte Carlo integration
+    static const int n_retries = 10;
+    for (int i = 0, n_monte_carlo_drop = 0; i < n_monte_carlo_grad; ) {
+      // Draw from standard normal and transform to real-coordinate space
+      for (int d = 0; d < dimension() + rank(); ++d) {
+        eta(d) = stan::math::normal_rng(0, 1, rng);
+      }
+      Eigen::VectorXd z = eta.head(rank());
+      Eigen::VectorXd eps = eta.tail(dimension());
+      zeta = transform(eta);
+
+      // (B.B^T + D^2)^-1 . (B.z + d*eps)
+      Eigen::VectorXd woodbury_zeta = woodbury * (zeta - mu_);
+
+      try {
+        std::stringstream ss;
+        stan::model::gradient(m, zeta, tmp_lp, tmp_mu_grad, &ss);
+        if (ss.str().length() > 0)
+          logger.info(ss);
+        stan::math::check_finite(function, "Gradient of mu", mu_grad);
+
+        mu_grad += tmp_mu_grad;
+        for (int ii = 0; ii < dimension(); ++ii) {
+          for (int jj = 0; jj <= ii && jj < rank(); ++jj) {
+            B_grad(ii, jj) += (tmp_mu_grad(ii) + woodbury_zeta(ii)) * z(jj);
+          }
+          d_grad(ii) += (tmp_mu_grad(ii) + woodbury_zeta(ii)) * eps(ii);
+          log_d_grad(ii) += d_grad(ii) * exp(log_d_(ii));
+        }
+        ++i;
+      } catch (const std::exception& e) {
+        ++n_monte_carlo_drop;
+        if (n_monte_carlo_drop >= n_retries * n_monte_carlo_grad) {
+          const char* name = "The number of dropped evaluations";
+          const char* msg1 = "has reached its maximum amount (";
+          int y = n_retries * n_monte_carlo_grad;
+          const char* msg2 = "). Your model may be either severely "
+            "ill-conditioned or misspecified.";
+          stan::math::domain_error(function, name, y, msg1, msg2);
+        }
+      }
+    }
+    mu_grad /= static_cast<double>(n_monte_carlo_grad);
+    B_grad /= static_cast<double>(n_monte_carlo_grad);
+    log_d_grad /= static_cast<double>(n_monte_carlo_grad);
+
+    elbo_grad.set_mu(mu_grad);
+    elbo_grad.set_B(B_grad);
+    elbo_grad.set_log_d(log_d_grad);
+  }
+
+  double calc_log_g(const Eigen::VectorXd& eta) const {
+    double log_g = 0;
+    for (int d = 0; d < rank() + dimension(); ++d) {
+      log_g += -stan::math::square(eta(d)) * 0.5;
+    }
+    return log_g;
+  }
+};
+
+inline normal_lowrank operator+(normal_lowrank lhs,
+                                 const normal_lowrank& rhs) {
+  return lhs += rhs;
+}
+
+/**
+ * Return a new approximation resulting from elementwise division of
+ * of the first specified approximation by the second.
+ *
+ * @param[in] lhs First approximation.
+ * @param[in] rhs Second approximation.
+ * @return Elementwise division of the specified approximations.
+ * @throw std::domain_error If the dimensionalities do not match.
+ */
+inline normal_lowrank operator/(normal_lowrank lhs,
+                                 const normal_lowrank& rhs) {
+  return lhs /= rhs;
+}
+
+/**
+ * Return a new approximation resulting from elementwise addition
+ * of the specified scalar to the mean and Cholesky factor of
+ * covariance entries for the specified approximation.
+ *
+ * @param[in] scalar Scalar value
+ * @param[in] rhs Approximation.
+ * @return Addition of scalar to specified approximation.
+ */
+inline normal_lowrank operator+(double scalar, normal_lowrank rhs) {
+  return rhs += scalar;
+}
+
+/**
+ * Return a new approximation resulting from elementwise
+ * multiplication of the specified scalar to the mean and Cholesky
+ * factor of covariance entries for the specified approximation.
+ *
+ * @param[in] scalar Scalar value
+ * @param[in] rhs Approximation.
+ * @return Multiplication of scalar by the specified approximation.
+ */
+inline normal_lowrank operator*(double scalar, normal_lowrank rhs) {
+  return rhs *= scalar;
+}
+} // namespace variational
+} // namespace stan
+
+#endif

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -315,6 +315,65 @@ class normal_meanfield : public base_family {
   }
 
   /**
+   * Assign a draw from this mean field approximation to the
+   * specified vector using the specified random number generator.
+   *
+   * @tparam BaseRNG Class of random number generator.
+   * @param[in] rng Base random number generator.
+   * @param[out] eta Vector to which the draw is assigned; dimension has to be
+   * the same as the dimension of variational q.
+   * @throws std::range_error If the index is out of range.
+   */
+  template <class BaseRNG>
+  void sample(BaseRNG& rng, Eigen::VectorXd& eta) const {
+    // Draw from standard normal and transform to real-coordinate space
+    for (int d = 0; d < dimension(); ++d)
+      eta(d) = stan::math::normal_rng(0, 1, rng);
+    eta = transform(eta);
+  }
+
+  /**
+   * Draw a posterior sample from the normal distribution,
+   * and return its log normal density. The constants are dropped.
+   *
+   * @param[in] rng Base random number generator.
+   * @param[out] eta Vector to which the draw is assigned; dimension has to be
+   * the same as the dimension of variational q. eta will be transformed into
+   * variational posteriors.
+   * @param[out] log_g The log  density in the variational approximation;
+   * The constant term is dropped.
+   * @throws std::range_error If the index is out of range.
+   */
+  template <class BaseRNG>
+  void sample_log_g(BaseRNG& rng, Eigen::VectorXd& eta, double& log_g) const {
+    // Draw from the approximation
+    for (int d = 0; d < dimension(); ++d) {
+      eta(d) = stan::math::normal_rng(0, 1, rng);
+    }
+    // Compute the log density before transformation
+    log_g = calc_log_g(eta);
+    // Transform to real-coordinate space
+    eta = transform(eta);
+  }
+
+  /**
+   * Compute the unnormalized log unit normal density wrt eta. All constants are
+   * dropped.
+   *
+   * @param[in] eta Vector; dimension has to be the same as the dimension
+   * of variational q.
+   * @return The unnormalized log density in the variational approximation;
+   * @throws std::range_error If the index is out of range.
+   */
+  double calc_log_g(const Eigen::VectorXd& eta) const {
+    double log_g = 0;
+    for (int d = 0; d < dimension(); ++d) {
+      log_g += -stan::math::square(eta(d)) * 0.5;
+    }
+    return log_g;
+  }
+
+  /**
    * Calculates the "blackbox" gradient with respect to both the
    * location vector (mu) and the log-std vector (omega) in
    * parallel.  It uses the same gradient computed from a set of

--- a/src/test/unit/variational/advi_messages_test.cpp
+++ b/src/test/unit/variational/advi_messages_test.cpp
@@ -38,17 +38,23 @@ class advi_test : public ::testing::Test {
     parameter_stream_.str("");
     diagnostic_stream_.str("");
 
+    // low-rank approximation rank
+    size_t rank = 1;
+
     advi_meanfield_ = new stan::variational::advi<
         stan_model, stan::variational::normal_meanfield, rng_t>(
         *model_, cont_params_, base_rng_, 1, 100, 1, 1);
     advi_fullrank_ = new stan::variational::advi<
         stan_model, stan::variational::normal_fullrank, rng_t>(
         *model_, cont_params_, base_rng_, 1, 100, 1, 1);
+    advi_lowrank_ = new stan::variational::advi_lowrank<stan_model, rng_t>(
+        *model_, cont_params_, base_rng_, rank, 1, 100, 1, 1);
   }
 
   void TearDown() {
     delete advi_meanfield_;
     delete advi_fullrank_;
+    delete advi_lowrank_;
     delete model_;
   }
 
@@ -59,6 +65,7 @@ class advi_test : public ::testing::Test {
                           rng_t> *advi_meanfield_;
   stan::variational::advi<stan_model, stan::variational::normal_fullrank, rng_t>
       *advi_fullrank_;
+  stan::variational::advi_lowrank<stan_model, rng_t> *advi_lowrank_;
   std::stringstream model_stream_;
   std::stringstream log_stream_;
   std::stringstream parameter_stream_;
@@ -87,6 +94,13 @@ TEST_F(advi_test, max_iteration_warn_fullrank) {
       << "The message should have err_msg1 inside it.";
 }
 
+TEST_F(advi_test, max_iteration_warn_lowrank) {
+  EXPECT_EQ(0, advi_lowrank_->run(10, 0, 50, 0.01, 1, logger, parameter_writer,
+                                  diagnostic_writer));
+  EXPECT_TRUE(log_stream_.str().find(err_msg1) != std::string::npos)
+      << "The message should have err_msg1 inside it.";
+}
+
 TEST_F(advi_test, prev_elbo_larger_meanfield) {
   EXPECT_EQ(0, advi_meanfield_->run(10, 0, 50, 0.1, 100, logger,
                                     parameter_writer, diagnostic_writer));
@@ -97,6 +111,13 @@ TEST_F(advi_test, prev_elbo_larger_meanfield) {
 TEST_F(advi_test, prev_elbo_larger_fullrank) {
   EXPECT_EQ(0, advi_fullrank_->run(10, 0, 50, 0.2, 100, logger,
                                    parameter_writer, diagnostic_writer));
+  EXPECT_TRUE(log_stream_.str().find(err_msg2) != std::string::npos)
+      << "The message should have err_msg2 inside it.";
+}
+
+TEST_F(advi_test, prev_elbo_larger_lowrank) {
+  EXPECT_EQ(0, advi_lowrank_->run(10, 0, 50, 0.2, 100, logger,
+                                  parameter_writer, diagnostic_writer));
   EXPECT_TRUE(log_stream_.str().find(err_msg2) != std::string::npos)
       << "The message should have err_msg2 inside it.";
 }

--- a/src/test/unit/variational/advi_multivar_no_constraint_test.cpp
+++ b/src/test/unit/variational/advi_multivar_no_constraint_test.cpp
@@ -237,3 +237,133 @@ TEST(advi_test, multivar_no_constraint_meanfield) {
                                           n_monte_carlo_grad, base_rng, logger),
                    std::invalid_argument, error);
 }
+
+TEST(advi_test, multivar_no_constraint_lowrank) {
+  // Create mock data_var_context
+  static const std::string DATA = "";
+  std::stringstream data_stream(DATA);
+  stan::io::dump dummy_context(data_stream);
+
+  // Instantiate model
+  Model my_model(dummy_context);
+
+  // RNG
+  rng_t base_rng(0);
+
+  // Other params
+  int n_monte_carlo_grad = 10;
+  std::stringstream log_stream;
+  stan::callbacks::stream_logger logger(log_stream, log_stream, log_stream,
+                                        log_stream, log_stream);
+
+  // Dummy input
+  Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(2);
+  cont_params(0) = 0.75;
+  cont_params(1) = 0.75;
+
+  // ADVI
+  size_t rank = 1;
+  stan::variational::advi_lowrank<Model, rng_t>
+      test_advi(my_model, cont_params, base_rng, rank, n_monte_carlo_grad,
+                1e4,  // absurdly high!
+                100, 1);
+
+  // Create some arbitrary variational q() family to calculate the ELBO over
+  Eigen::VectorXd mu = Eigen::VectorXd::Constant(my_model.num_params_r(), 2.5);
+  Eigen::VectorXd fac = Eigen::MatrixXd::Constant(my_model.num_params_r(),
+                                                  rank, 0.0); // no covariance
+                                                              // in posterior
+  Eigen::VectorXd log_d
+      = Eigen::VectorXd::Constant(my_model.num_params_r(),
+                                  0.0);  // initializing log_d = 0
+                                         // means sigma = 1
+  stan::variational::normal_lowrank mufaclog_d
+      = stan::variational::normal_lowrank(mu, fac, log_d);
+
+  double elbo = 0.0;
+  elbo = test_advi.calc_ELBO(mufaclog_d, logger);
+
+  // Can calculate ELBO analytically
+  double zeta = -0.5 * (3 * 2 * log(2.0 * stan::math::pi()) + 18.5 + 25 + 13);
+  Eigen::VectorXd mu_J = Eigen::VectorXd::Zero(2);
+  mu_J(0) = 10.5;
+  mu_J(1) = 7.5;
+
+  double elbo_true = 0.0;
+  elbo_true += zeta;
+  elbo_true += mu_J.dot(mu);
+  elbo_true += -0.5 * (3 * mu.dot(mu) + 3 * 2);
+  elbo_true += 1 + log(2.0 * stan::math::pi());
+
+  double const EPSILON = 0.1;
+  EXPECT_NEAR(elbo_true, elbo, EPSILON);
+
+  Eigen::VectorXd mu_grad = Eigen::VectorXd::Zero(3);
+  Eigen::MatrixXd B_grad = Eigen::MatrixXd::Zero(3, 2);
+  Eigen::VectorXd log_d_grad = Eigen::VectorXd::Zero(my_model.num_params_r());
+
+  std::string error
+      = "stan::variational::normal_lowrank: "
+        "Dimension of mean vector (3) and "
+        "Dimension of log std vector (2) must match in size";
+  EXPECT_THROW_MSG(stan::variational::normal_lowrank(mu_grad, B_grad, log_d_grad),
+                   std::invalid_argument, error);
+
+  mu_grad = Eigen::VectorXd::Zero(0);
+
+  error
+      = "stan::variational::normal_lowrank: "
+        "Dimension of mean vector (0) and "
+        "Dimension of low-rank factor (3) must match in size";
+  EXPECT_THROW_MSG(stan::variational::normal_lowrank(mu_grad, B_grad, log_d_grad),
+                   std::invalid_argument, error);
+
+  mu_grad = Eigen::VectorXd::Zero(my_model.num_params_r());
+  B_grad = Eigen::MatrixXd::Zero(my_model.num_params_r(), 1);
+  log_d_grad = Eigen::VectorXd::Zero(3);
+
+  error
+      = "stan::variational::normal_lowrank: "
+        "Dimension of mean vector (2) and "
+        "Dimension of log std vector (3) must match in size";
+  EXPECT_THROW_MSG(stan::variational::normal_lowrank(mu_grad, B_grad, log_d_grad),
+                   std::invalid_argument, error);
+
+  mu_grad = Eigen::VectorXd::Zero(my_model.num_params_r());
+  log_d_grad = Eigen::VectorXd::Zero(0);
+
+  error
+      = "stan::variational::normal_lowrank: "
+        "Dimension of mean vector (2) and "
+        "Dimension of log std vector (0) must match in size";
+  EXPECT_THROW_MSG(stan::variational::normal_lowrank(mu_grad, B_grad, log_d_grad),
+                   std::invalid_argument, error);
+
+  mu_grad = Eigen::VectorXd::Zero(3);
+  B_grad = Eigen::VectorXd::Zero(3, rank);
+  log_d_grad = Eigen::VectorXd::Zero(3);
+  stan::variational::normal_lowrank elbo_grad
+      = stan::variational::normal_lowrank(mu_grad, B_grad, log_d_grad);
+
+  error
+      = "stan::variational::normal_lowrank::calc_grad: "
+        "Dimension of elbo_grad (3) and "
+        "Dimension of variational q (2) must match in size";
+  EXPECT_THROW_MSG(mufaclog_d.calc_grad(elbo_grad, my_model, cont_params,
+                                        n_monte_carlo_grad, base_rng, logger),
+                   std::invalid_argument, error);
+
+  mu_grad = Eigen::VectorXd::Zero(2);
+  B_grad = Eigen::MatrixXd::Zero(2, rank + 1);
+  log_d_grad = Eigen::VectorXd::Zero(2);
+  stan::variational::normal_lowrank elbo_grad2
+      = stan::variational::normal_lowrank(mu_grad, B_grad, log_d_grad);
+
+  error
+      = "stan::variational::normal_lowrank::calc_grad: "
+        "Rank of elbo_grad (2) and "
+        "Rank of variational q (1) must match in size";
+  EXPECT_THROW_MSG(mufaclog_d.calc_grad(elbo_grad2, my_model, cont_params,
+                                        n_monte_carlo_grad, base_rng, logger),
+                   std::invalid_argument, error);
+}

--- a/src/test/unit/variational/advi_multivar_with_constraint_test.cpp
+++ b/src/test/unit/variational/advi_multivar_with_constraint_test.cpp
@@ -178,3 +178,138 @@ TEST(advi_test, multivar_with_constraint_meanfield) {
                                           n_monte_carlo_grad, base_rng, logger),
                    std::invalid_argument, error);
 }
+
+TEST(advi_test, multivar_with_constraint_lowrank) {
+  // Create mock data_var_context
+  static const std::string DATA = "";
+  std::stringstream data_stream(DATA);
+  stan::io::dump dummy_context(data_stream);
+
+  // Instantiate model
+  Model my_model(dummy_context);
+
+  // RNG
+  rng_t base_rng(0);
+
+  // Other params
+  int n_monte_carlo_grad = 10;
+  int n_monte_carlo_elbo = 1e6;
+  std::stringstream log_stream;
+  stan::callbacks::stream_logger logger(log_stream, log_stream, log_stream,
+                                        log_stream, log_stream);
+
+  // Dummy input
+  Eigen::VectorXd cont_params = Eigen::VectorXd::Zero(2);
+  cont_params(0) = 0.75;
+  cont_params(1) = 0.75;
+
+  // ADVI
+  size_t rank = 1;
+  stan::variational::advi_lowrank<Model, rng_t>
+      test_advi(my_model, cont_params, base_rng, rank, n_monte_carlo_grad,
+                n_monte_carlo_elbo, 100, 1);
+
+  // Create some arbitrary variational q() family to calculate the ELBO over
+  Eigen::VectorXd mu
+      = Eigen::VectorXd::Constant(my_model.num_params_r(), log(2.5));
+  Eigen::MatrixXd fac
+      = Eigen::MatrixXd::Constant(my_model.num_params_r(), rank, 0.0); // no cov
+  Eigen::VectorXd log_d
+      = Eigen::VectorXd::Constant(my_model.num_params_r(),
+                                  0.0);  // initializing sigma_tilde = 0
+                                         // means sigma = 1
+  stan::variational::normal_lowrank mufaclog_d
+      = stan::variational::normal_lowrank(mu, fac, log_d);
+
+  double elbo = 0.0;
+  elbo = test_advi.calc_ELBO(mufaclog_d, logger);
+
+  // Can calculate ELBO analytically
+  double zeta = -0.5 * (3 * 2 * log(2.0 * stan::math::pi()) + 18.5 + 25 + 13);
+  Eigen::VectorXd mu_J = Eigen::VectorXd::Zero(2);
+  mu_J(0) = 10.5;
+  mu_J(1) = 7.5;
+
+  double elbo_true = 0.0;
+  elbo_true += zeta;
+  elbo_true += 74.192457181505773;  //;mu_J.dot( (mu + 0.5).exp() );
+  elbo_true += -0.5 * 3 * (92.363201236633131);
+  elbo_true += 2 * log(2.5);
+  elbo_true += 1 + log(2.0 * stan::math::pi());
+
+  double const EPSILON = 1.0;
+  EXPECT_NEAR(elbo_true, elbo, EPSILON);
+
+  Eigen::VectorXd mu_grad = Eigen::VectorXd::Zero(3);
+  Eigen::MatrixXd B_grad = Eigen::MatrixXd::Zero(3, rank);
+  Eigen::VectorXd log_d_grad = Eigen::VectorXd::Zero(my_model.num_params_r());
+
+  std::string error
+      = "stan::variational::normal_lowrank: "
+        "Dimension of mean vector (3) and "
+        "Dimension of log std vector (2) must match in size";
+  EXPECT_THROW_MSG(stan::variational::normal_lowrank(mu_grad, B_grad,
+                                                     log_d_grad),
+                   std::invalid_argument, error);
+
+  mu_grad = Eigen::VectorXd::Zero(0);
+
+  error
+      = "stan::variational::normal_lowrank: "
+        "Dimension of mean vector (0) and "
+        "Dimension of low-rank factor (3) must match in size";
+  EXPECT_THROW_MSG(stan::variational::normal_lowrank(mu_grad, B_grad,
+                                                     log_d_grad),
+                   std::invalid_argument, error);
+
+  mu_grad = Eigen::VectorXd::Zero(my_model.num_params_r());
+  B_grad = Eigen::MatrixXd::Zero(my_model.num_params_r(), rank);
+  log_d_grad = Eigen::VectorXd::Zero(3);
+
+  error
+      = "stan::variational::normal_lowrank: "
+        "Dimension of mean vector (2) and "
+        "Dimension of log std vector (3) must match in size";
+  EXPECT_THROW_MSG(stan::variational::normal_lowrank(mu_grad, B_grad,
+                                                     log_d_grad),
+                   std::invalid_argument, error);
+
+  mu_grad = Eigen::VectorXd::Zero(my_model.num_params_r());
+  log_d_grad = Eigen::VectorXd::Zero(0);
+
+  error
+      = "stan::variational::normal_lowrank: "
+        "Dimension of mean vector (2) and "
+        "Dimension of log std vector (0) must match in size";
+  EXPECT_THROW_MSG(stan::variational::normal_lowrank(mu_grad, B_grad,
+                                                     log_d_grad),
+                   std::invalid_argument, error);
+
+  mu_grad = Eigen::VectorXd::Zero(3);
+  B_grad = Eigen::MatrixXd::Zero(3, rank);
+  log_d_grad = Eigen::VectorXd::Zero(3);
+  stan::variational::normal_lowrank elbo_grad
+      = stan::variational::normal_lowrank(mu_grad, B_grad, log_d_grad);
+
+  error
+      = "stan::variational::normal_lowrank::calc_grad: "
+        "Dimension of elbo_grad (3) and "
+        "Dimension of variational q (2) must match in size";
+  EXPECT_THROW_MSG(mufaclog_d.calc_grad(elbo_grad, my_model, cont_params,
+                                        n_monte_carlo_grad, base_rng, logger),
+                   std::invalid_argument, error);
+
+  mu_grad = Eigen::VectorXd::Zero(my_model.num_params_r());
+  B_grad = Eigen::MatrixXd::Zero(my_model.num_params_r(), rank + 1);
+  log_d_grad = Eigen::VectorXd::Zero(my_model.num_params_r());
+  stan::variational::normal_lowrank elbo_grad2
+      = stan::variational::normal_lowrank(mu_grad, B_grad, log_d_grad);
+
+  error
+      = "stan::variational::normal_lowrank::calc_grad: "
+        "Rank of elbo_grad (2) and "
+        "Rank of variational q (1) must match in size";
+  EXPECT_THROW_MSG(mufaclog_d.calc_grad(elbo_grad2, my_model, cont_params,
+                                        n_monte_carlo_grad, base_rng, logger),
+                   std::invalid_argument, error);
+}

--- a/src/test/unit/variational/eta_adapt_big_test.cpp
+++ b/src/test/unit/variational/eta_adapt_big_test.cpp
@@ -34,11 +34,15 @@ class eta_adapt_big_test : public ::testing::Test {
     advi_fullrank_ = new stan::variational::advi<
         stan_model, stan::variational::normal_fullrank, rng_t>(
         *model_, cont_params_, base_rng_, 1, 100, 100, 1);
+
+    advi_lowrank_ = new stan::variational::advi_lowrank<stan_model, rng_t>(
+        *model_, cont_params_, base_rng_, 1, 1, 100, 100, 1);
   }
 
   void TearDown() {
     delete advi_meanfield_;
     delete advi_fullrank_;
+    delete advi_lowrank_;
     delete model_;
   }
 
@@ -46,6 +50,7 @@ class eta_adapt_big_test : public ::testing::Test {
                           rng_t> *advi_meanfield_;
   stan::variational::advi<stan_model, stan::variational::normal_fullrank, rng_t>
       *advi_fullrank_;
+  stan::variational::advi_lowrank<stan_model, rng_t> *advi_lowrank_;
   std::stringstream model_stream_;
   std::stringstream log_stream_;
   stan::callbacks::stream_logger logger;
@@ -60,7 +65,10 @@ TEST_F(eta_adapt_big_test, eta_should_be_big) {
       = stan::variational::normal_meanfield(cont_params_);
   stan::variational::normal_fullrank fullrank_init
       = stan::variational::normal_fullrank(cont_params_);
+  stan::variational::normal_lowrank lowrank_init
+      = stan::variational::normal_lowrank(cont_params_, 1);
 
   EXPECT_EQ(100.0, advi_meanfield_->adapt_eta(meanfield_init, 50, logger));
   EXPECT_EQ(100.0, advi_fullrank_->adapt_eta(fullrank_init, 50, logger));
+  EXPECT_EQ(100.0, advi_lowrank_->adapt_eta(lowrank_init, 50, logger));
 }

--- a/src/test/unit/variational/eta_adapt_fail_test.cpp
+++ b/src/test/unit/variational/eta_adapt_fail_test.cpp
@@ -34,18 +34,27 @@ class eta_should_fail_test : public ::testing::Test {
     advi_fullrank_ = new stan::variational::advi<
         stan_model, stan::variational::normal_fullrank, rng_t>(
         *model_, cont_params_, base_rng_, 1, 1, 100, 1);
+
+    rank_ = 1;
+    advi_lowrank_ = new stan::variational::advi_lowrank<stan_model, rng_t>(
+        *model_, cont_params_, base_rng_, rank_, 1, 1, 100, 1);
   }
 
   void TearDown() {
     delete advi_meanfield_;
     delete advi_fullrank_;
+    delete advi_lowrank_;
     delete model_;
   }
+
+  // low-rank approx rank
+  size_t rank_;
 
   stan::variational::advi<stan_model, stan::variational::normal_meanfield,
                           rng_t> *advi_meanfield_;
   stan::variational::advi<stan_model, stan::variational::normal_fullrank, rng_t>
       *advi_fullrank_;
+  stan::variational::advi_lowrank<stan_model, rng_t> *advi_lowrank_;
   std::stringstream model_stream_;
   std::stringstream log_stream_;
   stan::callbacks::stream_logger logger;
@@ -60,6 +69,8 @@ TEST_F(eta_should_fail_test, eta_adapt_should_fail) {
       = stan::variational::normal_meanfield(cont_params_);
   stan::variational::normal_fullrank fullrank_init
       = stan::variational::normal_fullrank(cont_params_);
+  stan::variational::normal_lowrank lowrank_init
+      = stan::variational::normal_lowrank(cont_params_, rank_);
 
   std::string error
       = "stan::variational::advi::adapt_eta: "
@@ -70,5 +81,7 @@ TEST_F(eta_should_fail_test, eta_adapt_should_fail) {
   EXPECT_THROW_MSG(advi_meanfield_->adapt_eta(meanfield_init, 1, logger),
                    std::domain_error, error);
   EXPECT_THROW_MSG(advi_fullrank_->adapt_eta(fullrank_init, 1, logger),
+                   std::domain_error, error);
+  EXPECT_THROW_MSG(advi_lowrank_->adapt_eta(lowrank_init, 1, logger),
                    std::domain_error, error);
 }

--- a/src/test/unit/variational/families/normal_lowrank_test.cpp
+++ b/src/test/unit/variational/families/normal_lowrank_test.cpp
@@ -13,11 +13,11 @@ TEST(normal_lowrank_test, zero_init) {
 
   const Eigen::VectorXd& mu_out = my_normal_lowrank.mu();
   const Eigen::MatrixXd& B_out  = my_normal_lowrank.B();
-  const Eigen::MatrixXd& d_out  = my_normal_lowrank.d();
+  const Eigen::MatrixXd& log_d_out  = my_normal_lowrank.log_d();
 
   for (int i = 0; i < my_dimension; ++i) {
     EXPECT_FLOAT_EQ(0.0, mu_out(i));
-    EXPECT_FLOAT_EQ(0.0, d_out(i));
+    EXPECT_FLOAT_EQ(0.0, log_d_out(i));
     for (int j = 0; j < my_rank; ++j) {
       EXPECT_FLOAT_EQ(0.0, B_out(i,j));
     }
@@ -36,6 +36,7 @@ TEST(normal_lowrank_test, dimension_and_rank) {
 
   Eigen::VectorXd d(4);
   d << 0.63, 0.94, 1.32, 1.18;
+  Eigen::VectorXd log_d = d.array().log().matrix();
 
   stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
 
@@ -54,8 +55,9 @@ TEST(normal_lowrank_test, mean_vector) {
 
   Eigen::Vector3d d;
   d << 0.63, 0.94, 1.32;
+  Eigen::VectorXd log_d = d.array().log().matrix();
 
-  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, log_d);
 
   const Eigen::Vector3d& mu_out = my_normal_lowrank.mu();
 
@@ -65,13 +67,15 @@ TEST(normal_lowrank_test, mean_vector) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   Eigen::Vector3d mu_nan = Eigen::VectorXd::Constant(3, nan);
 
-  EXPECT_THROW(stan::variational::normal_lowrank my_normal_lowrank_nan(mu_nan, B, d);,
-                   std::domain_error);
+  EXPECT_THROW(stan::variational::normal_lowrank my_normal_lowrank_nan(
+                 mu_nan, B, log_d);,
+               std::domain_error);
   EXPECT_THROW(my_normal_lowrank.set_mu(mu_nan);,
-                   std::domain_error);
+               std::domain_error);
   Eigen::MatrixXd B_nan = Eigen::MatrixXd::Constant(3,3,nan);
-  EXPECT_THROW(stan::variational::normal_lowrank my_normal_lowrank_nan(mu, B_nan, d);,
-                   std::domain_error);
+  EXPECT_THROW(stan::variational::normal_lowrank my_normal_lowrank_nan(mu,
+                 B_nan, log_d);,
+               std::domain_error);
 
   my_normal_lowrank.set_to_zero();
   const Eigen::Vector3d& mu_out_zero = my_normal_lowrank.mu();
@@ -92,8 +96,9 @@ TEST(normal_lowrank_test, lowrank_factor) {
 
   Eigen::Vector3d d;
   d << 0.63, 0.94, 1.32;
+  Eigen::VectorXd log_d = d.array().log().matrix();
 
-  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, log_d);
 
   const Eigen::MatrixXd& B_out = my_normal_lowrank.B();
 
@@ -128,8 +133,9 @@ TEST(normal_lowrank_test, entropy) {
 
   Eigen::Vector3d d;
   d << 0.63, 0.94, 1.32;
+  Eigen::VectorXd log_d = d.array().log().matrix();
 
-  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, log_d);
 
   double entropy_true = 8.86050306582748;
 
@@ -149,6 +155,7 @@ TEST(normal_lowrank_test, transform) {
 
   Eigen::Vector3d d;
   d << 0.63, 0.94, 0.1332;
+  Eigen::VectorXd log_d = d.array().log().matrix();
 
   Eigen::VectorXd x(5);
   x << 7.1, -9.2, 0.59, 0.24, -1.92;
@@ -156,7 +163,7 @@ TEST(normal_lowrank_test, transform) {
   Eigen::Vector3d x_transformed;
   x_transformed << 15.3017, -363.8444, -363.092544;
 
-  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, log_d);
 
   Eigen::Vector3d x_result;
   x_result = my_normal_lowrank.transform(x);
@@ -184,8 +191,9 @@ TEST(normal_lowrank_test, calc_log_g) {
 
   Eigen::Vector3d d;
   d << 0.63, 0.94, 0.1332;
+  Eigen::VectorXd log_d = d.array().log().matrix();
 
-  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, log_d);
 
   double log_g_true = -69.57104999999999;
 

--- a/src/test/unit/variational/families/normal_lowrank_test.cpp
+++ b/src/test/unit/variational/families/normal_lowrank_test.cpp
@@ -1,0 +1,195 @@
+#include <stan/variational/families/normal_lowrank.hpp>
+#include <vector>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+TEST(normal_lowrank_test, zero_init) {
+  int my_dimension =  10;
+  int my_rank = 3;
+
+  stan::variational::normal_lowrank my_normal_lowrank(my_dimension, my_rank);
+  EXPECT_FLOAT_EQ(my_dimension, my_normal_lowrank.dimension());
+  EXPECT_FLOAT_EQ(my_rank, my_normal_lowrank.rank());
+
+  const Eigen::VectorXd& mu_out = my_normal_lowrank.mu();
+  const Eigen::MatrixXd& B_out  = my_normal_lowrank.B();
+  const Eigen::MatrixXd& d_out  = my_normal_lowrank.d();
+
+  for (int i = 0; i < my_dimension; ++i) {
+    EXPECT_FLOAT_EQ(0.0, mu_out(i));
+    EXPECT_FLOAT_EQ(0.0, d_out(i));
+    for (int j = 0; j < my_rank; ++j) {
+      EXPECT_FLOAT_EQ(0.0, B_out(i,j));
+    }
+  }
+}
+
+TEST(normal_lowrank_test, dimension_and_rank) {
+  Eigen::VectorXd mu(4);
+  mu << 5.7, -3.2, 0.1332, -1.87;
+
+  Eigen::MatrixXd B(4, 3);
+  B << 1.3, 0, 0,
+       2.3, 41, 0,
+       3.3, 42, 92,
+       4.3, 43, 93;
+
+  Eigen::VectorXd d(4);
+  d << 0.63, 0.94, 1.32, 1.18;
+
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+
+  EXPECT_FLOAT_EQ(mu.size(), my_normal_lowrank.dimension());
+  EXPECT_FLOAT_EQ(B.cols(), my_normal_lowrank.rank());
+}
+
+TEST(normal_lowrank_test, mean_vector) {
+  Eigen::Vector3d mu;
+  mu << 5.7, -3.2, 0.1332;
+
+  Eigen::MatrixXd B(3, 2);
+  B << 1.3, 0,
+       2.3, 41,
+       3.3, 42;
+
+  Eigen::Vector3d d;
+  d << 0.63, 0.94, 1.32;
+
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+
+  const Eigen::Vector3d& mu_out = my_normal_lowrank.mu();
+
+  for (int i = 0; i < my_normal_lowrank.dimension(); ++i)
+    EXPECT_FLOAT_EQ(mu(i), mu_out(i));
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  Eigen::Vector3d mu_nan = Eigen::VectorXd::Constant(3, nan);
+
+  EXPECT_THROW(stan::variational::normal_lowrank my_normal_lowrank_nan(mu_nan, B, d);,
+                   std::domain_error);
+  EXPECT_THROW(my_normal_lowrank.set_mu(mu_nan);,
+                   std::domain_error);
+  Eigen::MatrixXd B_nan = Eigen::MatrixXd::Constant(3,3,nan);
+  EXPECT_THROW(stan::variational::normal_lowrank my_normal_lowrank_nan(mu, B_nan, d);,
+                   std::domain_error);
+
+  my_normal_lowrank.set_to_zero();
+  const Eigen::Vector3d& mu_out_zero = my_normal_lowrank.mu();
+
+  for (int i = 0; i < my_normal_lowrank.dimension(); ++i) {
+    EXPECT_FLOAT_EQ(0.0, mu_out_zero(i));
+  }
+}
+
+TEST(normal_lowrank_test, lowrank_factor) {
+  Eigen::Vector3d mu;
+  mu << 5.7, -3.2, 0.1332;
+
+  Eigen::MatrixXd B(3, 2);
+  B << 1.3, 0,
+       2.3, 41,
+       3.3, 42;
+
+  Eigen::Vector3d d;
+  d << 0.63, 0.94, 1.32;
+
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+
+  const Eigen::MatrixXd& B_out = my_normal_lowrank.B();
+
+  for (int j = 0, nRows = B.rows(), nCols = B.cols(); j < nCols; ++j) {
+    for (int i = 0; i < nRows; ++i) {
+      EXPECT_FLOAT_EQ(B(i, j), B_out(i, j));
+    }
+  }
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  Eigen::MatrixXd B_nan = Eigen::MatrixXd::Constant(3,2,nan);
+  EXPECT_THROW(my_normal_lowrank.set_B(B_nan);,
+                   std::domain_error);
+  my_normal_lowrank.set_to_zero();
+  const Eigen::MatrixXd& B_out_zero = my_normal_lowrank.B();
+
+  for (int i = 0; i < my_normal_lowrank.dimension(); ++i) {
+    for (int j = 0; j < my_normal_lowrank.rank(); ++j) {
+      EXPECT_FLOAT_EQ(0.0, B_out_zero(i,j));
+    }
+  }
+}
+
+TEST(normal_lowrank_test, entropy) {
+  Eigen::Vector3d mu;
+  mu << 5.7, -3.2, 0.1332;
+
+  Eigen::MatrixXd B(3,2);
+  B << 1.3, 0,
+       2.3, 41,
+       3.3, 42;
+
+  Eigen::Vector3d d;
+  d << 0.63, 0.94, 1.32;
+
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+
+  double entropy_true = 8.86050306582748;
+
+  const double entropy_out = my_normal_lowrank.entropy();
+
+  EXPECT_FLOAT_EQ(entropy_out, entropy_true);
+}
+
+TEST(normal_lowrank_test, transform) {
+  Eigen::Vector3d mu;
+  mu << 5.7, -3.2, 0.1332;
+
+  Eigen::MatrixXd B(3,2);
+  B << 1.3, 0,
+       2.3, 41,
+       3.3, 42;
+
+  Eigen::Vector3d d;
+  d << 0.63, 0.94, 0.1332;
+
+  Eigen::VectorXd x(5);
+  x << 7.1, -9.2, 0.59, 0.24, -1.92;
+
+  Eigen::Vector3d x_transformed;
+  x_transformed << 15.3017, -363.8444, -363.092544;
+
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+
+  Eigen::Vector3d x_result;
+  x_result = my_normal_lowrank.transform(x);
+
+  for (int i = 0; i < my_normal_lowrank.dimension(); ++i)
+    EXPECT_FLOAT_EQ(x_result(i), x_transformed(i));
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  Eigen::VectorXd x_nan = Eigen::VectorXd::Constant(5, nan);
+  EXPECT_THROW(my_normal_lowrank.transform(x_nan);,
+                   std::domain_error);
+}
+
+TEST(normal_lowrank_test, calc_log_g) {
+  Eigen::VectorXd x(5);
+  x << 7.1, -9.2, 0.59, 0.24, -1.92;
+
+  Eigen::Vector3d mu;
+  mu << 5.7, -3.2, 0.1332;
+
+  Eigen::MatrixXd B(3,2);
+  B << 1.3, 0,
+       2.3, 41,
+       3.3, 42;
+
+  Eigen::Vector3d d;
+  d << 0.63, 0.94, 0.1332;
+
+  stan::variational::normal_lowrank my_normal_lowrank(mu, B, d);
+
+  double log_g_true = -69.57104999999999;
+
+  const double log_g_out = my_normal_lowrank.calc_log_g(x);
+
+  EXPECT_FLOAT_EQ(log_g_out, log_g_true);
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below
- [ ] Flesh out more unit tests
- [ ] Inline documentation
- [ ] Argument validation (cmdstan)
- [ ] C++ conventions check

#### Summary

Implement low-rank ADVI. See also #2750 and #2751.

#### Intended Effect

Make available a new variational family called `lowrank` which supports an intermediate between mean-field and full-rank ADVI, intended for more robust posterior variance estimates in large models.

#### How to Verify

Use the CmdStan interface implemented at wjn0/cmdstan@277b37001a5c3ba458478c84dea223713f43de8d

`./model variational algorithm=lowrank rank=4 <...>`

where `1 <= rank < # model params`. The example models repo ARM/Ch.25/earnings2 is an interesting example.

#### Side Effects

#### Documentation

In progress.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Walter Nelson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
