### PR TITLE
adds serializer headers to model header

### DIFF
--- a/src/stan/model/model_header.hpp
+++ b/src/stan/model/model_header.hpp
@@ -5,6 +5,8 @@
 
 #include <stan/io/cmd_line.hpp>
 #include <stan/io/dump.hpp>
+#include <stan/io/deserializer.hpp>
+#include <stan/io/serializer.hpp>
 #include <stan/io/reader.hpp>
 #include <stan/io/writer.hpp>
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

We forgot to add the header includes for the serializer/deserializer in the `model_header.hpp`

#### Intended Effect

Have the model know it can use these two classes

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
