### PR TITLE
Removed expressions tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -360,32 +360,6 @@ pipeline {
                     }
                     post { always { deleteDirWin() } }
                 }
-                stage('Math functions expressions test') {
-                    agent any
-                    steps {
-                        unstash 'StanSetup'
-                        setupCXX(true, env.CXX, stanc3_bin_url())
-                        script {
-                            dir("lib/stan_math/") {
-                                sh "echo O=0 > make/local"
-                                withEnv(['PATH+TBB=./lib/tbb']) {
-                                    try { sh "./runTests.py -j${env.PARALLEL} test/expressions" }
-                                    finally { junit 'test/**/*.xml' }
-                                }
-                                withEnv(['PATH+TBB=./lib/tbb']) {
-                                    sh "python ./test/expressions/test_expression_testing_framework.py"
-                                }
-                                sh "make clean-all"
-                                sh "echo STAN_THREADS=true >> make/local"
-                                withEnv(['PATH+TBB=./lib/tbb']) {
-                                    try { sh "./runTests.py -j${env.PARALLEL} test/expressions" }
-                                    finally { junit 'test/**/*.xml' }
-                                }
-                            }
-                        }
-                    }
-                    post { always { deleteDir() } }
-                }
             }
             when {
                 expression {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This removes the expression tests from stan-dev/stan. It should wait on https://github.com/stan-dev/math/pull/2419 which moves expressions tests back to Math.

Issue for this is: https://github.com/stan-dev/math/issues/2425

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
