### PR TITLE
Stepsize no longer reset to 1 if term_buffer = 0 (Issue #3023)

### DIFF
--- a/src/stan/mcmc/covar_adaptation.hpp
+++ b/src/stan/mcmc/covar_adaptation.hpp
@@ -14,6 +14,12 @@ class covar_adaptation : public windowed_adaptation {
   explicit covar_adaptation(int n)
       : windowed_adaptation("covariance"), estimator_(n) {}
 
+  /**
+   * Return true if covariance was updated and adaptation is not finished
+   *
+   * @param covar Covariance
+   * @param q Last draw
+   */
   bool learn_covariance(Eigen::MatrixXd& covar, const Eigen::VectorXd& q) {
     if (adaptation_window())
       estimator_.add_sample(q);
@@ -30,11 +36,11 @@ class covar_adaptation : public windowed_adaptation {
 
       estimator_.restart();
 
-      ++adapt_window_counter_;
-      return true;
+      increment_window_counter();
+      return true && !finished();
     }
 
-    ++adapt_window_counter_;
+    increment_window_counter();
     return false;
   }
 

--- a/src/stan/mcmc/var_adaptation.hpp
+++ b/src/stan/mcmc/var_adaptation.hpp
@@ -14,6 +14,12 @@ class var_adaptation : public windowed_adaptation {
   explicit var_adaptation(int n)
       : windowed_adaptation("variance"), estimator_(n) {}
 
+  /**
+   * Return true if variance was updated and adaptation is not finished
+   *
+   * @param var Diagonal covariance
+   * @param q Last draw
+   */
   bool learn_variance(Eigen::VectorXd& var, const Eigen::VectorXd& q) {
     if (adaptation_window())
       estimator_.add_sample(q);
@@ -29,11 +35,11 @@ class var_adaptation : public windowed_adaptation {
 
       estimator_.restart();
 
-      ++adapt_window_counter_;
-      return true;
+      increment_window_counter();
+      return true && !finished();
     }
 
-    ++adapt_window_counter_;
+    increment_window_counter();
     return false;
   }
 

--- a/src/stan/mcmc/windowed_adaptation.hpp
+++ b/src/stan/mcmc/windowed_adaptation.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/callbacks/logger.hpp>
 #include <stan/mcmc/base_adaptation.hpp>
-#include <ostream>
+#include <iostream>
 #include <string>
 
 namespace stan {
@@ -107,6 +107,25 @@ class windowed_adaptation : public base_adaptation {
     if (next_window_boundary >= num_warmup_ - adapt_term_buffer_) {
       adapt_next_window_ = num_warmup_ - adapt_term_buffer_ - 1;
     }
+  }
+
+  /**
+   * Check if there is any more warmup left to do
+   */
+  bool finished() {
+    if(adapt_window_counter_ + 1 >= num_warmup_) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Increment the window counter and return the new value
+   */
+  unsigned int increment_window_counter() {
+    adapt_window_counter_ += 1;
+    return adapt_window_counter_;
   }
 
  protected:

--- a/src/test/unit/mcmc/covar_adaptation_test.cpp
+++ b/src/test/unit/mcmc/covar_adaptation_test.cpp
@@ -15,15 +15,25 @@ TEST(McmcCovarAdaptation, learn_covariance) {
   target_covar *= 1e-3 * 5.0 / (n_learn + 5.0);
 
   stan::mcmc::covar_adaptation adapter(n);
-  adapter.set_window_params(50, 0, 0, n_learn, logger);
+  adapter.set_window_params(30, 0, 0, n_learn, logger);
 
-  for (int i = 0; i < n_learn; ++i)
-    adapter.learn_covariance(covar, q);
-
+  for (int i = 0; i < n_learn - 1; ++i) {
+    EXPECT_FALSE(adapter.learn_covariance(covar, q));
+  }
+  // Learn variance should return true at end of first window
+  EXPECT_TRUE(adapter.learn_covariance(covar, q));
+  
   for (int i = 0; i < n; ++i) {
     for (int j = 0; j < n; ++j) {
       EXPECT_EQ(target_covar(i, j), covar(i, j));
     }
   }
+
+  // Make sure learn_variance doesn't return true after second window (adaptation finished)
+  for (int i = 0; i < 2 * n_learn ; ++i) {
+    EXPECT_FALSE(adapter.learn_covariance(covar, q));
+  }
+  EXPECT_TRUE(adapter.finished());
+
   EXPECT_EQ(0, logger.call_count());
 }

--- a/src/test/unit/mcmc/var_adaptation_test.cpp
+++ b/src/test/unit/mcmc/var_adaptation_test.cpp
@@ -15,13 +15,22 @@ TEST(McmcVarAdaptation, learn_variance) {
   target_var *= 1e-3 * 5.0 / (n_learn + 5.0);
 
   stan::mcmc::var_adaptation adapter(n);
-  adapter.set_window_params(50, 0, 0, n_learn, logger);
+  adapter.set_window_params(30, 0, 0, n_learn, logger);
 
-  for (int i = 0; i < n_learn; ++i)
-    adapter.learn_variance(var, q);
+  for (int i = 0; i < n_learn - 1; ++i) {
+    EXPECT_FALSE(adapter.learn_variance(var, q));
+  }
+  // Learn variance should return true at end of first window
+  EXPECT_TRUE(adapter.learn_variance(var, q));
 
   for (int i = 0; i < n; ++i)
     EXPECT_EQ(target_var(i), var(i));
+
+  // Make sure learn_variance doesn't return true after second window (adaptation finished)
+  for (int i = 0; i < 2 * n_learn ; ++i) {
+    EXPECT_FALSE(adapter.learn_variance(var, q));
+  }
+  EXPECT_TRUE(adapter.finished());
 
   EXPECT_EQ(0, logger.call_count());
 }

--- a/src/test/unit/mcmc/windowed_adaptation_test.cpp
+++ b/src/test/unit/mcmc/windowed_adaptation_test.cpp
@@ -46,3 +46,17 @@ TEST(McmcWindowedAdaptation, set_window_params3) {
   ASSERT_EQ(0, logger.call_count());
   ASSERT_EQ(0, logger.call_count_info());
 }
+
+TEST(McmcWindowedAdaptation, finished) {
+  stan::test::unit::instrumented_logger logger;
+
+  stan::mcmc::windowed_adaptation adapter("test");
+
+  adapter.set_window_params(1000, 75, 50, 25, logger);
+
+  for(size_t i = 0; i < 999; i++) {
+    EXPECT_FALSE(adapter.finished());
+    adapter.increment_window_counter();
+  }
+  EXPECT_TRUE(adapter.finished());
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fix for #3023

#### Side Effects

I changed how the return codes from `covar_adaptation::learn_covariance` and `var_adaptation::learn_variance` worked.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
