### PR TITLE
Adds free function tests for serializer

### DIFF
--- a/src/stan/io/serializer.hpp
+++ b/src/stan/io/serializer.hpp
@@ -232,257 +232,258 @@ class serializer {
     }
   }
 
+  /**
+   * Write a serialized lower bounded variable and unconstrain it
+   *
+   * @tparam S A scalar, Eigen type, or `std::vector`
+   * @tparam L Type of lower bound
+   * @param lb Lower bound
+   * @param x An object of the types listed above.
+   */
+  template <typename S, typename L>
+  inline void write_free_lb(const L& lb, const S& x) {
+    this->write(stan::math::lb_free(x, lb));
+  }
 
-    /**
-     * Write a serialized lower bounded variable and unconstrain it
-     *
-     * @tparam S A scalar, Eigen type, or `std::vector`
-     * @tparam L Type of lower bound
-     * @param lb Lower bound
-     * @param x An object of the types listed above.
-     */
-    template <typename S, typename L>
-    inline void write_free_lb(const L& lb, const S& x) {
-      this->write(stan::math::lb_free(x, lb));
+  /**
+   * Write a serialized lower bounded variable and unconstrain it
+   *
+   * @tparam S A scalar, Eigen type, or `std::vector`
+   * @tparam U Type of upper bound
+   * @param ub Upper bound
+   * @param x An object of the types listed above.
+   */
+  template <typename S, typename U>
+  inline void write_free_ub(const U& ub, const S& x) {
+    this->write(stan::math::ub_free(x, ub));
+  }
+
+  /**
+   * Write a serialized bounded variable and unconstrain it
+   *
+   * @tparam S A scalar, Eigen type, or `std::vector`
+   * @tparam L Type of lower bound
+   * @tparam U Type of upper bound
+   * @param lb Lower bound
+   * @param ub Upper bound
+   * @param x An object of the types listed above.
+   */
+  template <typename S, typename L, typename U>
+  inline void write_free_lub(const L& lb, const U& ub, const S& x) {
+    this->write(stan::math::lub_free(x, lb, ub));
+  }
+
+  /**
+   * Write a serialized offset-multiplied variable and unconstrain it
+   *
+   * @tparam S A scalar, Eigen type, or `std::vector`
+   * @tparam O Type of offset
+   * @tparam M Type of multiplier
+   * @param offset Offset
+   * @param multiplier Multiplier
+   * @param x An object of the types listed above.
+   */
+  template <typename S, typename O, typename M>
+  inline void write_free_offset_multiplier(const O& offset, const M& multiplier,
+                                           const S& x) {
+    this->write(stan::math::offset_multiplier_free(x, offset, multiplier));
+  }
+
+  /**
+   * Write a serialized unit vector and unconstrain it
+   *
+   * @tparam Vec An Eigen type with either fixed rows or columns at compile
+   * time.
+   * @param x The vector to read from.
+   */
+  template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
+  inline void write_free_unit_vector(const Vec& x) {
+    this->write(stan::math::unit_vector_free(x));
+  }
+
+  /**
+   * Write serialized unit vectors and unconstrain them
+   *
+   * @tparam StdVec A `std:vector`
+   * @param x An std vector.
+   */
+  template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+  inline void write_free_unit_vector(const StdVec& x) {
+    for (auto&& ret_i : x) {
+      this->write_free_unit_vector(ret_i);
     }
+  }
 
-    /**
-     * Write a serialized lower bounded variable and unconstrain it
-     *
-     * @tparam S A scalar, Eigen type, or `std::vector`
-     * @tparam U Type of upper bound
-     * @param ub Upper bound
-     * @param x An object of the types listed above.
-     */
-    template <typename S, typename U>
-    inline void write_free_ub(const U& ub, const S& x) {
-      this->write(stan::math::ub_free(x, ub));
+  /**
+   * Write a serialized simplex and unconstrain it
+   *
+   * @tparam Vec An Eigen type with either fixed rows or columns at compile
+   * time.
+   * @param x The vector to read from.
+   */
+  template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
+  inline void write_free_simplex(const Vec& x) {
+    this->write(stan::math::simplex_free(x));
+  }
+
+  /**
+   * Write serialized simplices and unconstrain them
+   *
+   * @tparam StdVec A `std:vector`
+   * @param x An std vector.
+   */
+  template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+  inline void write_free_simplex(const StdVec& x) {
+    for (auto&& ret_i : x) {
+      this->write_free_simplex(ret_i);
     }
+  }
 
-    /**
-     * Write a serialized bounded variable and unconstrain it
-     *
-     * @tparam S A scalar, Eigen type, or `std::vector`
-     * @tparam L Type of lower bound
-     * @tparam U Type of upper bound
-     * @param lb Lower bound
-     * @param ub Upper bound
-     * @param x An object of the types listed above.
-     */
-    template <typename S, typename L, typename U>
-    inline void write_free_lub(const L& lb, const U& ub, const S& x) {
-      this->write(stan::math::lub_free(x, lb, ub));
+  /**
+   * Write a serialized ordered and unconstrain it
+   *
+   * @tparam Vec An Eigen type with either fixed rows or columns at compile
+   * time.
+   * @param x The vector to read from.
+   */
+  template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
+  inline void write_free_ordered(const Vec& x) {
+    this->write(stan::math::ordered_free(x));
+  }
+
+  /**
+   * Write serialized ordered vectors and unconstrain them
+   *
+   * @tparam StdVec A `std:vector`
+   * @param x An std vector.
+   */
+  template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+  inline void write_free_ordered(const StdVec& x) {
+    for (auto&& ret_i : x) {
+      this->write_free_ordered(ret_i);
     }
+  }
 
-    /**
-     * Write a serialized offset-multiplied variable and unconstrain it
-     *
-     * @tparam S A scalar, Eigen type, or `std::vector`
-     * @tparam O Type of offset
-     * @tparam M Type of multiplier
-     * @param offset Offset
-     * @param multiplier Multiplier
-     * @param x An object of the types listed above.
-     */
-    template <typename S, typename O, typename M>
-    inline void write_free_offset_multiplier(const O& offset, const M& multiplier,
-                                            const S& x) {
-      this->write(stan::math::offset_multiplier_free(x, offset, multiplier));
+  /**
+   * Write a serialized positive ordered vector and unconstrain it
+   *
+   * @tparam Vec An Eigen type with either fixed rows or columns at compile
+   * time.
+   * @param x The vector to read from.
+   */
+  template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
+  inline void write_free_positive_ordered(const Vec& x) {
+    this->write(stan::math::positive_ordered_free(x));
+  }
+
+  /**
+   * Write serialized positive ordered vectors and unconstrain them
+   *
+   * @tparam StdVec A `std:vector`
+   * @param x An std vector.
+   */
+  template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+  inline void write_free_positive_ordered(const StdVec& x) {
+    for (auto&& ret_i : x) {
+      this->write_free_positive_ordered(ret_i);
     }
+  }
 
-    /**
-     * Write a serialized unit vector and unconstrain it
-     *
-     * @tparam Vec An Eigen type with either fixed rows or columns at compile time.
-     * @param x The vector to read from.
-     */
-    template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
-    inline void write_free_unit_vector(const Vec& x) {
-      this->write(stan::math::unit_vector_free(x));
+  /**
+   * Write a serialized covariance matrix cholesky factor and unconstrain it
+   *
+   * @tparam Mat An Eigen type with dynamic rows and columns at compile time.
+   * @param x An Eigen matrix to write to the serialized vector.
+   */
+  template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
+  inline void write_free_cholesky_factor_cov(const Mat& x) {
+    this->write(stan::math::cholesky_factor_free(x));
+  }
+
+  /**
+   * Write serialized covariance matrix cholesky factors and unconstrain them
+   *
+   * @tparam StdVec A `std:vector`
+   * @param x An std vector.
+   */
+  template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+  inline void write_free_cholesky_factor_cov(const StdVec& x) {
+    for (auto&& ret_i : x) {
+      this->write_free_cholesky_factor_cov(ret_i);
     }
+  }
 
-    /**
-     * Write serialized unit vectors and unconstrain them
-     *
-     * @tparam StdVec A `std:vector`
-     * @param x An std vector.
-     */
-    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
-    inline void write_free_unit_vector(const StdVec& x) {
-      for (auto&& ret_i : x) {
-        this->write_free_unit_vector(ret_i);
-      }
+  /**
+   * Write a serialized covariance matrix cholesky factor and unconstrain it
+   *
+   * @tparam Mat Type of input
+   * @param x An Eigen matrix to write to the serialized vector.
+   */
+  template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
+  inline void write_free_cholesky_factor_corr(const Mat& x) {
+    this->write(stan::math::cholesky_corr_free(x));
+  }
+
+  /**
+   * Write serialized correlation matrix cholesky factors and unconstrain them
+   *
+   * @tparam StdVec A `std:vector`
+   * @param x An std vector.
+   */
+  template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+  inline void write_free_cholesky_factor_corr(const StdVec& x) {
+    for (auto&& ret_i : x) {
+      this->write_free_cholesky_factor_corr(ret_i);
     }
+  }
 
-    /**
-     * Write a serialized simplex and unconstrain it
-     *
-     * @tparam Vec An Eigen type with either fixed rows or columns at compile time.
-     * @param x The vector to read from.
-     */
-    template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
-    inline void write_free_simplex(const Vec& x) {
-      this->write(stan::math::simplex_free(x));
+  /**
+   * Write a serialized covariance matrix cholesky factor and unconstrain it
+   *
+   * @tparam Mat An Eigen type with dynamic rows and columns at compile time
+   * @param x An Eigen matrix to write to the serialized vector.
+   */
+  template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
+  inline void write_free_cov_matrix(const Mat& x) {
+    this->write(stan::math::cov_matrix_free(x));
+  }
+
+  /**
+   * Write serialized covariance matrices and unconstrain them
+   *
+   * @tparam StdVec A `std:vector`
+   * @param x a standard vector.
+   */
+  template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+  inline void write_free_cov_matrix(const StdVec& x) {
+    for (auto&& ret_i : x) {
+      this->write_free_cov_matrix(ret_i);
     }
+  }
 
-    /**
-     * Write serialized simplices and unconstrain them
-     *
-     * @tparam StdVec A `std:vector`
-     * @param x An std vector.
-     */
-    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
-    inline void write_free_simplex(const StdVec& x) {
-      for (auto&& ret_i : x) {
-        this->write_free_simplex(ret_i);
-      }
+  /**
+   * Write a serialized covariance matrix cholesky factor and unconstrain it
+   *
+   * @tparam Mat An Eigen type with dynamic rows and columns at compile time.
+   * @param x An Eigen matrix to write to the serialized vector.
+   */
+  template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
+  inline void write_free_corr_matrix(const Mat& x) {
+    this->write(stan::math::corr_matrix_free(x));
+  }
+
+  /**
+   * Write serialized correlation matrices and unconstrain them
+   *
+   * @tparam StdVec A `std:vector`
+   * @param x An std vector.
+   */
+  template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+  inline void write_free_corr_matrix(const StdVec& x) {
+    for (auto&& ret_i : x) {
+      this->write_free_corr_matrix(ret_i);
     }
-
-    /**
-     * Write a serialized ordered and unconstrain it
-     *
-     * @tparam Vec An Eigen type with either fixed rows or columns at compile time.
-     * @param x The vector to read from.
-     */
-    template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
-    inline void write_free_ordered(const Vec& x) {
-      this->write(stan::math::ordered_free(x));
-    }
-
-    /**
-     * Write serialized ordered vectors and unconstrain them
-     *
-     * @tparam StdVec A `std:vector`
-     * @param x An std vector.
-     */
-    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
-    inline void write_free_ordered(const StdVec& x) {
-      for (auto&& ret_i : x) {
-        this->write_free_ordered(ret_i);
-      }
-    }
-
-    /**
-     * Write a serialized positive ordered vector and unconstrain it
-     *
-     * @tparam Vec An Eigen type with either fixed rows or columns at compile time.
-     * @param x The vector to read from.
-     */
-    template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
-    inline void write_free_positive_ordered(const Vec& x) {
-      this->write(stan::math::positive_ordered_free(x));
-    }
-
-    /**
-     * Write serialized positive ordered vectors and unconstrain them
-     *
-     * @tparam StdVec A `std:vector`
-     * @param x An std vector.
-     */
-    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
-    inline void write_free_positive_ordered(const StdVec& x) {
-      for (auto&& ret_i : x) {
-        this->write_free_positive_ordered(ret_i);
-      }
-    }
-
-    /**
-     * Write a serialized covariance matrix cholesky factor and unconstrain it
-     *
-     * @tparam Mat An Eigen type with dynamic rows and columns at compile time.
-     * @param x An Eigen matrix to write to the serialized vector.
-     */
-    template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
-    inline void write_free_cholesky_factor_cov(const Mat& x) {
-      this->write(stan::math::cholesky_factor_free(x));
-    }
-
-    /**
-     * Write serialized covariance matrix cholesky factors and unconstrain them
-     *
-     * @tparam StdVec A `std:vector`
-     * @param x An std vector.
-     */
-    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
-    inline void write_free_cholesky_factor_cov(const StdVec& x) {
-      for (auto&& ret_i : x) {
-        this->write_free_cholesky_factor_cov(ret_i);
-      }
-    }
-
-    /**
-     * Write a serialized covariance matrix cholesky factor and unconstrain it
-     *
-     * @tparam Mat Type of input
-     * @param x An Eigen matrix to write to the serialized vector.
-     */
-    template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
-    inline void write_free_cholesky_factor_corr(const Mat& x) {
-      this->write(stan::math::cholesky_corr_free(x));
-    }
-
-    /**
-     * Write serialized correlation matrix cholesky factors and unconstrain them
-     *
-     * @tparam StdVec A `std:vector`
-     * @param x An std vector.
-     */
-    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
-    inline void write_free_cholesky_factor_corr(const StdVec& x) {
-      for (auto&& ret_i : x) {
-        this->write_free_cholesky_factor_corr(ret_i);
-      }
-    }
-
-    /**
-     * Write a serialized covariance matrix cholesky factor and unconstrain it
-     *
-     * @tparam Mat An Eigen type with dynamic rows and columns at compile time
-     * @param x An Eigen matrix to write to the serialized vector.
-     */
-    template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
-    inline void write_free_cov_matrix(const Mat& x) {
-      this->write(stan::math::cov_matrix_free(x));
-    }
-
-    /**
-     * Write serialized covariance matrices and unconstrain them
-     *
-     * @tparam StdVec A `std:vector`
-     * @param x a standard vector.
-     */
-    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
-    inline void write_free_cov_matrix(const StdVec& x) {
-      for (auto&& ret_i : x) {
-        this->write_free_cov_matrix(ret_i);
-      }
-    }
-
-    /**
-     * Write a serialized covariance matrix cholesky factor and unconstrain it
-     *
-     * @tparam Mat An Eigen type with dynamic rows and columns at compile time.
-     * @param x An Eigen matrix to write to the serialized vector.
-     */
-    template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
-    inline void write_free_corr_matrix(const Mat& x) {
-      this->write(stan::math::corr_matrix_free(x));
-    }
-
-    /**
-     * Write serialized correlation matrices and unconstrain them
-     *
-     * @tparam StdVec A `std:vector`
-     * @param x An std vector.
-     */
-    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
-    inline void write_free_corr_matrix(const StdVec& x) {
-      for (auto&& ret_i : x) {
-        this->write_free_corr_matrix(ret_i);
-      }
-    }
-
-
+  }
 };
 
 }  // namespace io

--- a/src/stan/io/serializer.hpp
+++ b/src/stan/io/serializer.hpp
@@ -178,8 +178,6 @@ class serializer {
    * Write a Eigen matrix of size `(rows, cols)` with complex inner type to
    * storage
    * @tparam Mat The type to write
-   * @param rows The size of the rows of the matrix.
-   * @param cols The size of the cols of the matrix.
    */
   template <typename Mat, require_eigen_matrix_dynamic_t<Mat>* = nullptr,
             require_vt_complex<Mat>* = nullptr>
@@ -238,85 +236,80 @@ class serializer {
     /**
      * Write a serialized lower bounded variable and unconstrain it
      *
-     * @tparam Ret Type of output
+     * @tparam S A scalar, Eigen type, or `std::vector`
      * @tparam L Type of lower bound
-     * @tparam Sizes Types of dimensions of output
      * @param lb Lower bound
-     * @param sizes dimensions
+     * @param x An object of the types listed above.
      */
-    template <typename Ret, typename L>
-    inline void write_free_lb(const L& lb, const Ret& ret) {
-      this->write(stan::math::lb_free(ret, lb));
+    template <typename S, typename L>
+    inline void write_free_lb(const L& lb, const S& x) {
+      this->write(stan::math::lb_free(x, lb));
     }
 
     /**
      * Write a serialized lower bounded variable and unconstrain it
      *
-     * @tparam Ret Type of output
+     * @tparam S A scalar, Eigen type, or `std::vector`
      * @tparam U Type of upper bound
-     * @tparam Sizes Types of dimensions of output
      * @param ub Upper bound
-     * @param sizes dimensions
+     * @param x An object of the types listed above.
      */
-    template <typename Ret, typename U>
-    inline void write_free_ub(const U& ub, const Ret& ret) {
-      this->write(stan::math::ub_free(ret, ub));
+    template <typename S, typename U>
+    inline void write_free_ub(const U& ub, const S& x) {
+      this->write(stan::math::ub_free(x, ub));
     }
 
     /**
      * Write a serialized bounded variable and unconstrain it
      *
-     * @tparam Ret Type of output
+     * @tparam S A scalar, Eigen type, or `std::vector`
      * @tparam L Type of lower bound
      * @tparam U Type of upper bound
-     * @tparam Sizes Types of dimensions of output
      * @param lb Lower bound
      * @param ub Upper bound
-     * @param sizes dimensions
+     * @param x An object of the types listed above.
      */
-    template <typename Ret, typename L, typename U>
-    inline void write_free_lub(const L& lb, const U& ub, const Ret& ret) {
-      this->write(stan::math::lub_free(ret, lb, ub));
+    template <typename S, typename L, typename U>
+    inline void write_free_lub(const L& lb, const U& ub, const S& x) {
+      this->write(stan::math::lub_free(x, lb, ub));
     }
 
     /**
      * Write a serialized offset-multiplied variable and unconstrain it
      *
-     * @tparam Ret Type of output
+     * @tparam S A scalar, Eigen type, or `std::vector`
      * @tparam O Type of offset
      * @tparam M Type of multiplier
-     * @tparam Sizes Types of dimensions of output
      * @param offset Offset
      * @param multiplier Multiplier
-     * @param sizes dimensions
+     * @param x An object of the types listed above.
      */
-    template <typename Ret, typename O, typename M>
+    template <typename S, typename O, typename M>
     inline void write_free_offset_multiplier(const O& offset, const M& multiplier,
-                                            const Ret& ret) {
-      this->write(stan::math::offset_multiplier_free(ret, offset, multiplier));
+                                            const S& x) {
+      this->write(stan::math::offset_multiplier_free(x, offset, multiplier));
     }
 
     /**
      * Write a serialized unit vector and unconstrain it
      *
-     * @tparam Ret Type of output
+     * @tparam Vec An Eigen type with either fixed rows or columns at compile time.
+     * @param x The vector to read from.
      */
-    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
-    inline void write_free_unit_vector(const Ret& ret) {
-      this->write(stan::math::unit_vector_free(ret));
+    template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
+    inline void write_free_unit_vector(const Vec& x) {
+      this->write(stan::math::unit_vector_free(x));
     }
 
     /**
      * Write serialized unit vectors and unconstrain them
      *
-     * @tparam Ret Type of output
-     * @tparam Sizes Types of dimensions of output
-     * @param vecsize Vector size
-     * @param sizes dimensions
+     * @tparam StdVec A `std:vector`
+     * @param x An std vector.
      */
-    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
-    inline void write_free_unit_vector(const Ret& ret) {
-      for (auto&& ret_i : ret) {
+    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+    inline void write_free_unit_vector(const StdVec& x) {
+      for (auto&& ret_i : x) {
         this->write_free_unit_vector(ret_i);
       }
     }
@@ -324,24 +317,23 @@ class serializer {
     /**
      * Write a serialized simplex and unconstrain it
      *
-     * @tparam Ret Type of output
+     * @tparam Vec An Eigen type with either fixed rows or columns at compile time.
+     * @param x The vector to read from.
      */
-    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
-    inline void write_free_simplex(const Ret& ret) {
-      this->write(stan::math::simplex_free(ret));
+    template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
+    inline void write_free_simplex(const Vec& x) {
+      this->write(stan::math::simplex_free(x));
     }
 
     /**
      * Write serialized simplices and unconstrain them
      *
-     * @tparam Ret Type of output
-     * @tparam Sizes Types of dimensions of output
-     * @param vecsize Vector size
-     * @param sizes dimensions
+     * @tparam StdVec A `std:vector`
+     * @param x An std vector.
      */
-    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
-    inline void write_free_simplex(const Ret& ret) {
-      for (auto&& ret_i : ret) {
+    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+    inline void write_free_simplex(const StdVec& x) {
+      for (auto&& ret_i : x) {
         this->write_free_simplex(ret_i);
       }
     }
@@ -349,24 +341,23 @@ class serializer {
     /**
      * Write a serialized ordered and unconstrain it
      *
-     * @tparam Ret Type of output
+     * @tparam Vec An Eigen type with either fixed rows or columns at compile time.
+     * @param x The vector to read from.
      */
-    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
-    inline void write_free_ordered(const Ret& ret) {
-      this->write(stan::math::ordered_free(ret));
+    template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
+    inline void write_free_ordered(const Vec& x) {
+      this->write(stan::math::ordered_free(x));
     }
 
     /**
      * Write serialized ordered vectors and unconstrain them
      *
-     * @tparam Ret Type of output
-     * @tparam Sizes Types of dimensions of output
-     * @param vecsize Vector size
-     * @param sizes dimensions
+     * @tparam StdVec A `std:vector`
+     * @param x An std vector.
      */
-    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
-    inline void write_free_ordered(const Ret& ret) {
-      for (auto&& ret_i : ret) {
+    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+    inline void write_free_ordered(const StdVec& x) {
+      for (auto&& ret_i : x) {
         this->write_free_ordered(ret_i);
       }
     }
@@ -374,24 +365,23 @@ class serializer {
     /**
      * Write a serialized positive ordered vector and unconstrain it
      *
-     * @tparam Ret Type of output
+     * @tparam Vec An Eigen type with either fixed rows or columns at compile time.
+     * @param x The vector to read from.
      */
-    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
-    inline void write_free_positive_ordered(const Ret& ret) {
-      this->write(stan::math::positive_ordered_free(ret));
+    template <typename Vec, require_not_std_vector_t<Vec>* = nullptr>
+    inline void write_free_positive_ordered(const Vec& x) {
+      this->write(stan::math::positive_ordered_free(x));
     }
 
     /**
      * Write serialized positive ordered vectors and unconstrain them
      *
-     * @tparam Ret Type of output
-     * @tparam Sizes Types of dimensions of output
-     * @param vecsize Vector size
-     * @param sizes dimensions
+     * @tparam StdVec A `std:vector`
+     * @param x An std vector.
      */
-    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
-    inline void write_free_positive_ordered(const Ret& ret) {
-      for (auto&& ret_i : ret) {
+    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+    inline void write_free_positive_ordered(const StdVec& x) {
+      for (auto&& ret_i : x) {
         this->write_free_positive_ordered(ret_i);
       }
     }
@@ -399,26 +389,23 @@ class serializer {
     /**
      * Write a serialized covariance matrix cholesky factor and unconstrain it
      *
-     * @tparam Ret Type of output
-     * @param M Rows of matrix
-     * @param N Cols of matrix
+     * @tparam Mat An Eigen type with dynamic rows and columns at compile time.
+     * @param x An Eigen matrix to write to the serialized vector.
      */
-    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
-    inline void write_free_cholesky_factor_cov(const Ret& ret) {
-      this->write(stan::math::cholesky_factor_free(ret));
+    template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
+    inline void write_free_cholesky_factor_cov(const Mat& x) {
+      this->write(stan::math::cholesky_factor_free(x));
     }
 
     /**
      * Write serialized covariance matrix cholesky factors and unconstrain them
      *
-     * @tparam Ret Type of output
-     * @tparam Sizes Types of dimensions of output
-     * @param vecsize Vector size
-     * @param sizes dimensions
+     * @tparam StdVec A `std:vector`
+     * @param x An std vector.
      */
-    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
-    inline void write_free_cholesky_factor_cov(const Ret& ret) {
-      for (auto&& ret_i : ret) {
+    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+    inline void write_free_cholesky_factor_cov(const StdVec& x) {
+      for (auto&& ret_i : x) {
         this->write_free_cholesky_factor_cov(ret_i);
       }
     }
@@ -426,25 +413,23 @@ class serializer {
     /**
      * Write a serialized covariance matrix cholesky factor and unconstrain it
      *
-     * @tparam Ret Type of output
-     * @param M Rows/Cols of matrix
+     * @tparam Mat Type of input
+     * @param x An Eigen matrix to write to the serialized vector.
      */
-    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
-    inline void write_free_cholesky_factor_corr(const Ret& ret) {
-      this->write(stan::math::cholesky_corr_free(ret));
+    template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
+    inline void write_free_cholesky_factor_corr(const Mat& x) {
+      this->write(stan::math::cholesky_corr_free(x));
     }
 
     /**
      * Write serialized correlation matrix cholesky factors and unconstrain them
      *
-     * @tparam Ret Type of output
-     * @tparam Sizes Types of dimensions of output
-     * @param vecsize Vector size
-     * @param sizes dimensions
+     * @tparam StdVec A `std:vector`
+     * @param x An std vector.
      */
-    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
-    inline void write_free_cholesky_factor_corr(const Ret& ret) {
-      for (auto&& ret_i : ret) {
+    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+    inline void write_free_cholesky_factor_corr(const StdVec& x) {
+      for (auto&& ret_i : x) {
         this->write_free_cholesky_factor_corr(ret_i);
       }
     }
@@ -452,25 +437,23 @@ class serializer {
     /**
      * Write a serialized covariance matrix cholesky factor and unconstrain it
      *
-     * @tparam Ret Type of output
-     * @param M Rows/Cols of matrix
+     * @tparam Mat An Eigen type with dynamic rows and columns at compile time
+     * @param x An Eigen matrix to write to the serialized vector.
      */
-    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
-    inline void write_free_cov_matrix(const Ret& ret) {
-      this->write(stan::math::cov_matrix_free(ret));
+    template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
+    inline void write_free_cov_matrix(const Mat& x) {
+      this->write(stan::math::cov_matrix_free(x));
     }
 
     /**
      * Write serialized covariance matrices and unconstrain them
      *
-     * @tparam Ret Type of output
-     * @tparam Sizes Types of dimensions of output
-     * @param vecsize Vector size
-     * @param sizes dimensions
+     * @tparam StdVec A `std:vector`
+     * @param x a standard vector.
      */
-    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
-    inline void write_free_cov_matrix(const Ret& ret) {
-      for (auto&& ret_i : ret) {
+    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+    inline void write_free_cov_matrix(const StdVec& x) {
+      for (auto&& ret_i : x) {
         this->write_free_cov_matrix(ret_i);
       }
     }
@@ -478,25 +461,23 @@ class serializer {
     /**
      * Write a serialized covariance matrix cholesky factor and unconstrain it
      *
-     * @tparam Ret Type of output
-     * @param M Rows/Cols of matrix
+     * @tparam Mat An Eigen type with dynamic rows and columns at compile time.
+     * @param x An Eigen matrix to write to the serialized vector.
      */
-    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
-    inline void write_free_corr_matrix(const Ret& ret) {
-      this->write(stan::math::corr_matrix_free(ret));
+    template <typename Mat, require_not_std_vector_t<Mat>* = nullptr>
+    inline void write_free_corr_matrix(const Mat& x) {
+      this->write(stan::math::corr_matrix_free(x));
     }
 
     /**
      * Write serialized correlation matrices and unconstrain them
      *
-     * @tparam Ret Type of output
-     * @tparam Sizes Types of dimensions of output
-     * @param vecsize Vector size
-     * @param sizes dimensions
+     * @tparam StdVec A `std:vector`
+     * @param x An std vector.
      */
-    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
-    inline void write_free_corr_matrix(const Ret& ret) {
-      for (auto&& ret_i : ret) {
+    template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
+    inline void write_free_corr_matrix(const StdVec& x) {
+      for (auto&& ret_i : x) {
         this->write_free_corr_matrix(ret_i);
       }
     }

--- a/src/stan/io/serializer.hpp
+++ b/src/stan/io/serializer.hpp
@@ -227,7 +227,7 @@ class serializer {
    */
   template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
   inline void write(StdVec&& x) {
-    for (auto&& x_i : x) {
+    for (const auto& x_i : x) {
       this->write(x_i);
     }
   }
@@ -309,7 +309,7 @@ class serializer {
    */
   template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
   inline void write_free_unit_vector(const StdVec& x) {
-    for (auto&& ret_i : x) {
+    for (const auto& ret_i : x) {
       this->write_free_unit_vector(ret_i);
     }
   }
@@ -334,7 +334,7 @@ class serializer {
    */
   template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
   inline void write_free_simplex(const StdVec& x) {
-    for (auto&& ret_i : x) {
+    for (const auto& ret_i : x) {
       this->write_free_simplex(ret_i);
     }
   }
@@ -359,7 +359,7 @@ class serializer {
    */
   template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
   inline void write_free_ordered(const StdVec& x) {
-    for (auto&& ret_i : x) {
+    for (const auto& ret_i : x) {
       this->write_free_ordered(ret_i);
     }
   }
@@ -384,7 +384,7 @@ class serializer {
    */
   template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
   inline void write_free_positive_ordered(const StdVec& x) {
-    for (auto&& ret_i : x) {
+    for (const auto& ret_i : x) {
       this->write_free_positive_ordered(ret_i);
     }
   }
@@ -408,7 +408,7 @@ class serializer {
    */
   template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
   inline void write_free_cholesky_factor_cov(const StdVec& x) {
-    for (auto&& ret_i : x) {
+    for (const auto& ret_i : x) {
       this->write_free_cholesky_factor_cov(ret_i);
     }
   }
@@ -432,7 +432,7 @@ class serializer {
    */
   template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
   inline void write_free_cholesky_factor_corr(const StdVec& x) {
-    for (auto&& ret_i : x) {
+    for (const auto& ret_i : x) {
       this->write_free_cholesky_factor_corr(ret_i);
     }
   }
@@ -456,7 +456,7 @@ class serializer {
    */
   template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
   inline void write_free_cov_matrix(const StdVec& x) {
-    for (auto&& ret_i : x) {
+    for (const auto& ret_i : x) {
       this->write_free_cov_matrix(ret_i);
     }
   }
@@ -480,7 +480,7 @@ class serializer {
    */
   template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
   inline void write_free_corr_matrix(const StdVec& x) {
-    for (auto&& ret_i : x) {
+    for (const auto& ret_i : x) {
       this->write_free_corr_matrix(ret_i);
     }
   }

--- a/src/stan/io/serializer.hpp
+++ b/src/stan/io/serializer.hpp
@@ -24,7 +24,7 @@ class serializer {
   /**
    * Check there is room for at least m more reals to store
    *
-   * @param m Number of reals to read
+   * @param m Number of reals to Write
    * @throws std::runtime_error if there isn't room for m reals
    */
   void check_r_capacity(size_t m) const {
@@ -229,10 +229,279 @@ class serializer {
    */
   template <typename StdVec, require_std_vector_t<StdVec>* = nullptr>
   inline void write(StdVec&& x) {
-    for (size_t i = 0; i < x.size(); ++i) {
-      this->write(x[i]);
+    for (auto&& x_i : x) {
+      this->write(x_i);
     }
   }
+
+
+    /**
+     * Write a serialized lower bounded variable and unconstrain it
+     *
+     * @tparam Ret Type of output
+     * @tparam L Type of lower bound
+     * @tparam Sizes Types of dimensions of output
+     * @param lb Lower bound
+     * @param sizes dimensions
+     */
+    template <typename Ret, typename L>
+    inline void write_free_lb(const L& lb, const Ret& ret) {
+      this->write(stan::math::lb_free(ret, lb));
+    }
+
+    /**
+     * Write a serialized lower bounded variable and unconstrain it
+     *
+     * @tparam Ret Type of output
+     * @tparam U Type of upper bound
+     * @tparam Sizes Types of dimensions of output
+     * @param ub Upper bound
+     * @param sizes dimensions
+     */
+    template <typename Ret, typename U>
+    inline void write_free_ub(const U& ub, const Ret& ret) {
+      this->write(stan::math::ub_free(ret, ub));
+    }
+
+    /**
+     * Write a serialized bounded variable and unconstrain it
+     *
+     * @tparam Ret Type of output
+     * @tparam L Type of lower bound
+     * @tparam U Type of upper bound
+     * @tparam Sizes Types of dimensions of output
+     * @param lb Lower bound
+     * @param ub Upper bound
+     * @param sizes dimensions
+     */
+    template <typename Ret, typename L, typename U>
+    inline void write_free_lub(const L& lb, const U& ub, const Ret& ret) {
+      this->write(stan::math::lub_free(ret, lb, ub));
+    }
+
+    /**
+     * Write a serialized offset-multiplied variable and unconstrain it
+     *
+     * @tparam Ret Type of output
+     * @tparam O Type of offset
+     * @tparam M Type of multiplier
+     * @tparam Sizes Types of dimensions of output
+     * @param offset Offset
+     * @param multiplier Multiplier
+     * @param sizes dimensions
+     */
+    template <typename Ret, typename O, typename M>
+    inline void write_free_offset_multiplier(const O& offset, const M& multiplier,
+                                            const Ret& ret) {
+      this->write(stan::math::offset_multiplier_free(ret, offset, multiplier));
+    }
+
+    /**
+     * Write a serialized unit vector and unconstrain it
+     *
+     * @tparam Ret Type of output
+     */
+    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
+    inline void write_free_unit_vector(const Ret& ret) {
+      this->write(stan::math::unit_vector_free(ret));
+    }
+
+    /**
+     * Write serialized unit vectors and unconstrain them
+     *
+     * @tparam Ret Type of output
+     * @tparam Sizes Types of dimensions of output
+     * @param vecsize Vector size
+     * @param sizes dimensions
+     */
+    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
+    inline void write_free_unit_vector(const Ret& ret) {
+      for (auto&& ret_i : ret) {
+        this->write_free_unit_vector(ret_i);
+      }
+    }
+
+    /**
+     * Write a serialized simplex and unconstrain it
+     *
+     * @tparam Ret Type of output
+     */
+    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
+    inline void write_free_simplex(const Ret& ret) {
+      this->write(stan::math::simplex_free(ret));
+    }
+
+    /**
+     * Write serialized simplices and unconstrain them
+     *
+     * @tparam Ret Type of output
+     * @tparam Sizes Types of dimensions of output
+     * @param vecsize Vector size
+     * @param sizes dimensions
+     */
+    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
+    inline void write_free_simplex(const Ret& ret) {
+      for (auto&& ret_i : ret) {
+        this->write_free_simplex(ret_i);
+      }
+    }
+
+    /**
+     * Write a serialized ordered and unconstrain it
+     *
+     * @tparam Ret Type of output
+     */
+    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
+    inline void write_free_ordered(const Ret& ret) {
+      this->write(stan::math::ordered_free(ret));
+    }
+
+    /**
+     * Write serialized ordered vectors and unconstrain them
+     *
+     * @tparam Ret Type of output
+     * @tparam Sizes Types of dimensions of output
+     * @param vecsize Vector size
+     * @param sizes dimensions
+     */
+    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
+    inline void write_free_ordered(const Ret& ret) {
+      for (auto&& ret_i : ret) {
+        this->write_free_ordered(ret_i);
+      }
+    }
+
+    /**
+     * Write a serialized positive ordered vector and unconstrain it
+     *
+     * @tparam Ret Type of output
+     */
+    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
+    inline void write_free_positive_ordered(const Ret& ret) {
+      this->write(stan::math::positive_ordered_free(ret));
+    }
+
+    /**
+     * Write serialized positive ordered vectors and unconstrain them
+     *
+     * @tparam Ret Type of output
+     * @tparam Sizes Types of dimensions of output
+     * @param vecsize Vector size
+     * @param sizes dimensions
+     */
+    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
+    inline void write_free_positive_ordered(const Ret& ret) {
+      for (auto&& ret_i : ret) {
+        this->write_free_positive_ordered(ret_i);
+      }
+    }
+
+    /**
+     * Write a serialized covariance matrix cholesky factor and unconstrain it
+     *
+     * @tparam Ret Type of output
+     * @param M Rows of matrix
+     * @param N Cols of matrix
+     */
+    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
+    inline void write_free_cholesky_factor_cov(const Ret& ret) {
+      this->write(stan::math::cholesky_factor_free(ret));
+    }
+
+    /**
+     * Write serialized covariance matrix cholesky factors and unconstrain them
+     *
+     * @tparam Ret Type of output
+     * @tparam Sizes Types of dimensions of output
+     * @param vecsize Vector size
+     * @param sizes dimensions
+     */
+    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
+    inline void write_free_cholesky_factor_cov(const Ret& ret) {
+      for (auto&& ret_i : ret) {
+        this->write_free_cholesky_factor_cov(ret_i);
+      }
+    }
+
+    /**
+     * Write a serialized covariance matrix cholesky factor and unconstrain it
+     *
+     * @tparam Ret Type of output
+     * @param M Rows/Cols of matrix
+     */
+    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
+    inline void write_free_cholesky_factor_corr(const Ret& ret) {
+      this->write(stan::math::cholesky_corr_free(ret));
+    }
+
+    /**
+     * Write serialized correlation matrix cholesky factors and unconstrain them
+     *
+     * @tparam Ret Type of output
+     * @tparam Sizes Types of dimensions of output
+     * @param vecsize Vector size
+     * @param sizes dimensions
+     */
+    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
+    inline void write_free_cholesky_factor_corr(const Ret& ret) {
+      for (auto&& ret_i : ret) {
+        this->write_free_cholesky_factor_corr(ret_i);
+      }
+    }
+
+    /**
+     * Write a serialized covariance matrix cholesky factor and unconstrain it
+     *
+     * @tparam Ret Type of output
+     * @param M Rows/Cols of matrix
+     */
+    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
+    inline void write_free_cov_matrix(const Ret& ret) {
+      this->write(stan::math::cov_matrix_free(ret));
+    }
+
+    /**
+     * Write serialized covariance matrices and unconstrain them
+     *
+     * @tparam Ret Type of output
+     * @tparam Sizes Types of dimensions of output
+     * @param vecsize Vector size
+     * @param sizes dimensions
+     */
+    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
+    inline void write_free_cov_matrix(const Ret& ret) {
+      for (auto&& ret_i : ret) {
+        this->write_free_cov_matrix(ret_i);
+      }
+    }
+
+    /**
+     * Write a serialized covariance matrix cholesky factor and unconstrain it
+     *
+     * @tparam Ret Type of output
+     * @param M Rows/Cols of matrix
+     */
+    template <typename Ret, require_not_std_vector_t<Ret>* = nullptr>
+    inline void write_free_corr_matrix(const Ret& ret) {
+      this->write(stan::math::corr_matrix_free(ret));
+    }
+
+    /**
+     * Write serialized correlation matrices and unconstrain them
+     *
+     * @tparam Ret Type of output
+     * @tparam Sizes Types of dimensions of output
+     * @param vecsize Vector size
+     * @param sizes dimensions
+     */
+    template <typename Ret, require_std_vector_t<Ret>* = nullptr>
+    inline void write_free_corr_matrix(const Ret& ret) {
+      for (auto&& ret_i : ret) {
+        this->write_free_corr_matrix(ret_i);
+      }
+    }
+
+
 };
 
 }  // namespace io

--- a/src/test/unit/io/serializer_test.cpp
+++ b/src/test/unit/io/serializer_test.cpp
@@ -291,7 +291,6 @@ TEST(serializer, eos_exception) {
   }
 }
 
-
 template <typename Ret, typename... Sizes>
 void write_free_lb_test(Sizes... sizes) {
   double lb = 0.5;
@@ -364,7 +363,6 @@ TEST(serializer_vectorized, write_free_ub) {
   write_free_ub_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2, 4);
 }
 
-
 template <typename Ret, typename... Sizes>
 void write_free_lub_test(Sizes... sizes) {
   double ub = 0.5;
@@ -376,7 +374,8 @@ void write_free_lub_test(Sizes... sizes) {
   // Read an constrained variable
   stan::io::deserializer<double> deserializer(theta1, theta_i);
   double lp = 0.0;
-  Ret vec_ref = deserializer.read_constrain_lub<Ret, false>(lb, ub, lp, sizes...);
+  Ret vec_ref
+      = deserializer.read_constrain_lub<Ret, false>(lb, ub, lp, sizes...);
 
   // Serialize a constrained variable
   Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta_size);
@@ -401,7 +400,6 @@ TEST(serializer_vectorized, write_free_lub) {
   write_free_lub_test<std::vector<Eigen::VectorXd>>(2, 4);
   write_free_lub_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2, 4);
 }
-
 
 template <typename Ret, typename... Sizes>
 void write_free_offset_multiplier_test(Sizes... sizes) {
@@ -438,7 +436,8 @@ TEST(serializer_vectorized, write_free_offset_multiplier) {
   write_free_offset_multiplier_test<double>();
   write_free_offset_multiplier_test<Eigen::VectorXd>(4);
   write_free_offset_multiplier_test<std::vector<Eigen::VectorXd>>(2, 4);
-  write_free_offset_multiplier_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2, 4);
+  write_free_offset_multiplier_test<std::vector<std::vector<Eigen::VectorXd>>>(
+      3, 2, 4);
 }
 template <typename Ret, typename... Sizes>
 void write_free_unit_vector_test(Sizes... sizes) {
@@ -475,7 +474,7 @@ TEST(serializer_vectorized, write_free_unit_vector) {
   write_free_unit_vector_test<Eigen::VectorXd>(4);
   write_free_unit_vector_test<std::vector<Eigen::VectorXd>>(2, 4);
   write_free_unit_vector_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2,
-                                                                        4);
+                                                                         4);
 }
 
 template <typename Ret, typename... Sizes>
@@ -511,7 +510,6 @@ TEST(serializer_vectorized, write_free_simplex) {
   write_free_simplex_test<std::vector<Eigen::VectorXd>>(2, 4);
   write_free_simplex_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2, 4);
 }
-
 
 // ordered
 
@@ -617,20 +615,19 @@ void write_free_cholesky_factor_cov_test(Sizes... sizes) {
 TEST(serializer_vectorized, write_free_cholesky_factor_cov) {
   write_free_cholesky_factor_cov_test<Eigen::MatrixXd>(4, 3);
   write_free_cholesky_factor_cov_test<std::vector<Eigen::MatrixXd>>(2, 4, 3);
-  write_free_cholesky_factor_cov_test<std::vector<std::vector<Eigen::MatrixXd>>>(
-      3, 2, 4, 3);
+  write_free_cholesky_factor_cov_test<
+      std::vector<std::vector<Eigen::MatrixXd>>>(3, 2, 4, 3);
 
   write_free_cholesky_factor_cov_test<Eigen::MatrixXd>(2, 2);
   write_free_cholesky_factor_cov_test<std::vector<Eigen::MatrixXd>>(2, 2, 2);
-  write_free_cholesky_factor_cov_test<std::vector<std::vector<Eigen::MatrixXd>>>(
-      3, 2, 2, 2);
+  write_free_cholesky_factor_cov_test<
+      std::vector<std::vector<Eigen::MatrixXd>>>(3, 2, 2, 2);
 }
 
 // cholesky_factor_corr
 
 template <typename Ret, typename... Sizes>
 void write_free_cholesky_factor_corr_test(Sizes... sizes) {
-
   // Read an constrained variable
   Eigen::VectorXd theta1 = Eigen::VectorXd::Random(100);
   std::vector<int> theta_i;
@@ -696,7 +693,8 @@ void write_free_cov_matrix_test(Sizes... sizes) {
 TEST(serializer_vectorized, write_free_cov_matrix) {
   write_free_cov_matrix_test<Eigen::MatrixXd>(2);
   write_free_cov_matrix_test<std::vector<Eigen::MatrixXd>>(2, 2);
-  write_free_cov_matrix_test<std::vector<std::vector<Eigen::MatrixXd>>>(3, 2, 2);
+  write_free_cov_matrix_test<std::vector<std::vector<Eigen::MatrixXd>>>(3, 2,
+                                                                        2);
 }
 
 // corr_matrix
@@ -733,5 +731,5 @@ TEST(serializer_vectorized, write_free_corr_matrix) {
   write_free_corr_matrix_test<Eigen::MatrixXd>(2);
   write_free_corr_matrix_test<std::vector<Eigen::MatrixXd>>(2, 2);
   write_free_corr_matrix_test<std::vector<std::vector<Eigen::MatrixXd>>>(3, 2,
-                                                                        2);
+                                                                         2);
 }

--- a/src/test/unit/io/serializer_test.cpp
+++ b/src/test/unit/io/serializer_test.cpp
@@ -1,3 +1,4 @@
+#include <stan/io/deserializer.hpp>
 #include <stan/io/serializer.hpp>
 // expect_near_rel comes from lib/stan_math
 #include <test/unit/math/expect_near_rel.hpp>
@@ -288,4 +289,449 @@ TEST(serializer, eos_exception) {
                      std::vector<Eigen::MatrixXd>(2, Eigen::MatrixXd(3, 2))),
                  std::runtime_error);
   }
+}
+
+
+template <typename Ret, typename... Sizes>
+void write_free_lb_test(Sizes... sizes) {
+  double lb = 0.5;
+  constexpr size_t theta_size = 100;
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(theta_size);
+  std::vector<int> theta_i;
+
+  // Read an constrained variable
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref = deserializer.read_constrain_lb<Ret, false>(lb, lp, sizes...);
+
+  // Serialize a constrained variable
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta_size);
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_lb(lb, vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_lb) {
+  write_free_lb_test<double>();
+  write_free_lb_test<Eigen::VectorXd>(4);
+  write_free_lb_test<std::vector<Eigen::VectorXd>>(2, 4);
+  write_free_lb_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2, 4);
+}
+
+template <typename Ret, typename... Sizes>
+void write_free_ub_test(Sizes... sizes) {
+  double ub = 0.5;
+  constexpr size_t theta_size = 100;
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(theta_size);
+  std::vector<int> theta_i;
+
+  // Read an constrained variable
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref = deserializer.read_constrain_ub<Ret, false>(ub, lp, sizes...);
+
+  // Serialize a constrained variable
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta_size);
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_ub(ub, vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_ub) {
+  write_free_ub_test<double>();
+  write_free_ub_test<Eigen::VectorXd>(4);
+  write_free_ub_test<std::vector<Eigen::VectorXd>>(2, 4);
+  write_free_ub_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2, 4);
+}
+
+
+template <typename Ret, typename... Sizes>
+void write_free_lub_test(Sizes... sizes) {
+  double ub = 0.5;
+  double lb = 0.1;
+  constexpr size_t theta_size = 100;
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(theta_size);
+  std::vector<int> theta_i;
+
+  // Read an constrained variable
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref = deserializer.read_constrain_lub<Ret, false>(lb, ub, lp, sizes...);
+
+  // Serialize a constrained variable
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta_size);
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_lub(lb, ub, vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_lub) {
+  write_free_lub_test<double>();
+  write_free_lub_test<Eigen::VectorXd>(4);
+  write_free_lub_test<std::vector<Eigen::VectorXd>>(2, 4);
+  write_free_lub_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2, 4);
+}
+
+
+template <typename Ret, typename... Sizes>
+void write_free_offset_multiplier_test(Sizes... sizes) {
+  double offset = 0.5;
+  double multiplier = 0.35;
+  constexpr size_t theta_size = 100;
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(theta_size);
+  std::vector<int> theta_i;
+
+  // Read an constrained variable
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref = deserializer.read_constrain_offset_multiplier<Ret, false>(
+      offset, multiplier, lp, sizes...);
+
+  // Serialize a constrained variable
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta_size);
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_offset_multiplier(offset, multiplier, vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_offset_multiplier) {
+  write_free_offset_multiplier_test<double>();
+  write_free_offset_multiplier_test<Eigen::VectorXd>(4);
+  write_free_offset_multiplier_test<std::vector<Eigen::VectorXd>>(2, 4);
+  write_free_offset_multiplier_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2, 4);
+}
+template <typename Ret, typename... Sizes>
+void write_free_unit_vector_test(Sizes... sizes) {
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(100);
+  std::vector<int> theta_i;
+
+  // Read an constrained variable
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref
+      = deserializer.read_constrain_unit_vector<Ret, false>(lp, sizes...);
+
+  // Serialize a constrained variable
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta1.size());
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_unit_vector(vec_ref);
+
+  // For unit vector, it's not actually doing a change of variables so we check
+  // theta2 equals theta2 (freeing doesn't actually get the unconstrained
+  // variable back).
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta1.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta2.segment(0, used1),
+                              theta2.segment(0, used2));
+}
+
+TEST(serializer_vectorized, write_free_unit_vector) {
+  write_free_unit_vector_test<Eigen::VectorXd>(4);
+  write_free_unit_vector_test<std::vector<Eigen::VectorXd>>(2, 4);
+  write_free_unit_vector_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2,
+                                                                        4);
+}
+
+template <typename Ret, typename... Sizes>
+void write_free_simplex_test(Sizes... sizes) {
+  constexpr size_t theta_size = 100;
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(theta_size);
+  std::vector<int> theta_i;
+
+  // Read an constrained variable
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref = deserializer.read_constrain_simplex<Ret, false>(lp, sizes...);
+
+  // Serialize a constrained variable
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta_size);
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_simplex(vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_simplex) {
+  write_free_simplex_test<Eigen::VectorXd>(4);
+  write_free_simplex_test<std::vector<Eigen::VectorXd>>(2, 4);
+  write_free_simplex_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2, 4);
+}
+
+
+// ordered
+
+template <typename Ret, typename... Sizes>
+void write_free_ordered_test(Sizes... sizes) {
+  // Read an constrained variable
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(100);
+  std::vector<int> theta_i;
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref = deserializer.read_constrain_ordered<Ret, false>(lp, sizes...);
+
+  // Serialize a constrained variable
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta1.size());
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_ordered(vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_ordered) {
+  write_free_ordered_test<Eigen::VectorXd>(4);
+  write_free_ordered_test<std::vector<Eigen::VectorXd>>(2, 4);
+  write_free_ordered_test<std::vector<std::vector<Eigen::VectorXd>>>(3, 2, 4);
+}
+
+// positive_ordered
+
+template <typename Ret, typename... Sizes>
+void write_free_positive_ordered_test(Sizes... sizes) {
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(100);
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta1.size());
+  std::vector<int> theta_i;
+
+  // Read an constrained variable
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref
+      = deserializer.read_constrain_positive_ordered<Ret, false>(lp, sizes...);
+
+  // Serialize a constrained variable
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_positive_ordered(vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_positive_ordered) {
+  write_free_positive_ordered_test<Eigen::VectorXd>(4);
+  write_free_positive_ordered_test<std::vector<Eigen::VectorXd>>(2, 4);
+  write_free_positive_ordered_test<std::vector<std::vector<Eigen::VectorXd>>>(
+      3, 2, 4);
+}
+
+// cholesky_factor_cov
+
+template <typename Ret, typename... Sizes>
+void write_free_cholesky_factor_cov_test(Sizes... sizes) {
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(100);
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta1.size());
+  std::vector<int> theta_i;
+
+  // Read an constrained variable
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref = deserializer.read_constrain_cholesky_factor_cov<Ret, false>(
+      lp, sizes...);
+
+  // Serialize a constrained variable
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_cholesky_factor_cov(vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_cholesky_factor_cov) {
+  write_free_cholesky_factor_cov_test<Eigen::MatrixXd>(4, 3);
+  write_free_cholesky_factor_cov_test<std::vector<Eigen::MatrixXd>>(2, 4, 3);
+  write_free_cholesky_factor_cov_test<std::vector<std::vector<Eigen::MatrixXd>>>(
+      3, 2, 4, 3);
+
+  write_free_cholesky_factor_cov_test<Eigen::MatrixXd>(2, 2);
+  write_free_cholesky_factor_cov_test<std::vector<Eigen::MatrixXd>>(2, 2, 2);
+  write_free_cholesky_factor_cov_test<std::vector<std::vector<Eigen::MatrixXd>>>(
+      3, 2, 2, 2);
+}
+
+// cholesky_factor_corr
+
+template <typename Ret, typename... Sizes>
+void write_free_cholesky_factor_corr_test(Sizes... sizes) {
+
+  // Read an constrained variable
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(100);
+  std::vector<int> theta_i;
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref = deserializer.read_constrain_cholesky_factor_corr<Ret, false>(
+      lp, sizes...);
+
+  // Serialize a constrained variable
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta1.size());
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_cholesky_factor_corr(vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_cholesky_factor_corr) {
+  write_free_cholesky_factor_corr_test<Eigen::MatrixXd>(2);
+  write_free_cholesky_factor_corr_test<std::vector<Eigen::MatrixXd>>(2, 2);
+  write_free_cholesky_factor_corr_test<
+      std::vector<std::vector<Eigen::MatrixXd>>>(3, 2, 2);
+}
+
+// cov_matrix
+
+template <typename Ret, typename... Sizes>
+void write_free_cov_matrix_test(Sizes... sizes) {
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(100);
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta1.size());
+  std::vector<int> theta_i;
+
+  // Read an constrained variable
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref
+      = deserializer.read_constrain_cov_matrix<Ret, false>(lp, sizes...);
+
+  // Serialize a constrained variable
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_cov_matrix(vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_cov_matrix) {
+  write_free_cov_matrix_test<Eigen::MatrixXd>(2);
+  write_free_cov_matrix_test<std::vector<Eigen::MatrixXd>>(2, 2);
+  write_free_cov_matrix_test<std::vector<std::vector<Eigen::MatrixXd>>>(3, 2, 2);
+}
+
+// corr_matrix
+
+template <typename Ret, typename... Sizes>
+void write_free_corr_matrix_test(Sizes... sizes) {
+  Eigen::VectorXd theta1 = Eigen::VectorXd::Random(100);
+  Eigen::VectorXd theta2 = Eigen::VectorXd::Random(theta1.size());
+  std::vector<int> theta_i;
+
+  // Read an constrained variable
+  stan::io::deserializer<double> deserializer(theta1, theta_i);
+  double lp = 0.0;
+  Ret vec_ref
+      = deserializer.read_constrain_corr_matrix<Ret, false>(lp, sizes...);
+
+  // Serialize a constrained variable
+  stan::io::serializer<double> serializer(theta2);
+  serializer.write_free_corr_matrix(vec_ref);
+
+  size_t used1 = theta1.size() - deserializer.available();
+  size_t used2 = theta2.size() - serializer.available();
+
+  // Number of variables read should equal number of variables written
+  EXPECT_EQ(used1, used2);
+
+  // Make sure the variables written back are the same
+  stan::test::expect_near_rel("deserializer read free",
+                              theta1.segment(0, used1),
+                              theta2.segment(0, used1));
+}
+
+TEST(serializer_vectorized, write_free_corr_matrix) {
+  write_free_corr_matrix_test<Eigen::MatrixXd>(2);
+  write_free_corr_matrix_test<std::vector<Eigen::MatrixXd>>(2, 2);
+  write_free_corr_matrix_test<std::vector<std::vector<Eigen::MatrixXd>>>(3, 2,
+                                                                        2);
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

For the refactoring of `transform_inits()` in the compiler we actually need the free functions to be in the serializer. See the discussion [here](https://github.com/stan-dev/stanc3/pull/872#issuecomment-815128608) for more info.

#### Intended Effect

Allow the serializer to perform the free'ing of constrained variables

#### How to Verify

Tests were added to do the same checks as the `deserializer`'s free tests

```bash
./runTests.py ./src/test/unit/io/serializer_test.cpp
```

#### Side Effects

#### Documentation

Documentation for each of the free functions in `serializer`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
