### PR TITLE
Skip metric regularization if adapt window=0

### DIFF
--- a/src/stan/mcmc/covar_adaptation.hpp
+++ b/src/stan/mcmc/covar_adaptation.hpp
@@ -23,10 +23,12 @@ class covar_adaptation : public windowed_adaptation {
 
       estimator_.sample_covariance(covar);
 
-      double n = static_cast<double>(estimator_.num_samples());
-      covar = (n / (n + 5.0)) * covar
-              + 1e-3 * (5.0 / (n + 5.0))
-                    * Eigen::MatrixXd::Identity(covar.rows(), covar.cols());
+      if (estimator_.num_samples() > 1) {
+        double n = static_cast<double>(estimator_.num_samples());
+        covar = (n / (n + 5.0)) * covar
+                + 1e-3 * (5.0 / (n + 5.0))
+                      * Eigen::MatrixXd::Identity(covar.rows(), covar.cols());
+      }
 
       estimator_.restart();
 

--- a/src/stan/mcmc/var_adaptation.hpp
+++ b/src/stan/mcmc/var_adaptation.hpp
@@ -23,9 +23,11 @@ class var_adaptation : public windowed_adaptation {
 
       estimator_.sample_variance(var);
 
-      double n = static_cast<double>(estimator_.num_samples());
-      var = (n / (n + 5.0)) * var
-            + 1e-3 * (5.0 / (n + 5.0)) * Eigen::VectorXd::Ones(var.size());
+      if (estimator_.num_samples() > 1) {
+        double n = static_cast<double>(estimator_.num_samples());
+        var = (n / (n + 5.0)) * var
+              + 1e-3 * (5.0 / (n + 5.0)) * Eigen::VectorXd::Ones(var.size());
+      }
 
       estimator_.restart();
 

--- a/src/test/unit/mcmc/covar_adaptation_test.cpp
+++ b/src/test/unit/mcmc/covar_adaptation_test.cpp
@@ -27,3 +27,32 @@ TEST(McmcCovarAdaptation, learn_covariance) {
   }
   EXPECT_EQ(0, logger.call_count());
 }
+
+TEST(McmcCovarAdaptation, learn_covariance_one_sample) {
+  stan::test::unit::instrumented_logger logger;
+
+  const int n = 10;
+  Eigen::VectorXd q = Eigen::VectorXd::Zero(n);
+  Eigen::MatrixXd covar(Eigen::MatrixXd::Identity(n, n));
+
+  const int n_learn = 1;
+
+  Eigen::MatrixXd target_covar(Eigen::MatrixXd::Identity(n, n));
+
+  stan::mcmc::covar_adaptation adapter(n);
+  adapter.set_window_params(50, 0, 0, n_learn, logger);
+
+  bool update = false;
+
+  for (int i = 0; i < n_learn; ++i)
+    update = adapter.learn_covariance(covar, q);
+
+  EXPECT_TRUE(update);
+
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < n; ++j) {
+      EXPECT_EQ(target_covar(i, j), covar(i, j));
+    }
+  }
+  EXPECT_EQ(0, logger.call_count());
+}


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py src/test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary

This came up in https://github.com/stan-dev/stan/pull/3027#issuecomment-814223714

CmdStan accepts `window=0` as a valid argument even though it means the adaptation cannot possibly estimate the inverse metric. The intended effect appears to be adapt only stepsize and leave the metric at its initial value, either the default identity or a user specified value. That works _but only if_ you also set `init_buffer=0`. If `init_buffer>0` the sampler tries to update the metric anyway and messes it up.

The metric update code is
https://github.com/stan-dev/stan/blob/35a15c8c206a09415318fbdfc0b324993929fd08/src/stan/mcmc/var_adaptation.hpp#L24-L28
The Welford estimator's `sample_variance()` is a no-op if there are not enough samples so that part's fine.
The problem is the subsequent regularization which in case of zero samples just discards the (unchanged) metric.
The fix is to simply skip the regularization when `sample_variance()` didn't do anything.

#### Intended Effect

Setting `window=0` always keeps the initial metric.

#### How to Verify

Run the `examples/bernoulli` model with `adapt init_buffer=10 window=0` and look for the mass matrix in output.csv.
On develop it says
```
# Diagonal elements of inverse mass matrix:
# 0.001
```
On this branch
```
# Diagonal elements of inverse mass matrix:
# 1
```

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Niko Huurre



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
