### PR TITLE
Refactor Integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,62 +192,62 @@ pipeline {
                 }
             }
         }
-        // stage('Unit tests') {
-        //     when {
-        //         expression {
-        //             !skipRemainingStages
-        //         }
-        //     }
-        //     parallel {
-        //         stage('Windows Headers & Unit') {
-        //             agent { label 'windows' }
-        //             when {
-        //                 expression {
-        //                     ( env.BRANCH_NAME == "develop" ||
-        //                     env.BRANCH_NAME == "master" ||
-        //                     params.run_tests_all_os ) &&
-        //                     !skipRemainingStages
-        //                 }
-        //             }
-        //             steps {
-        //                 deleteDirWin()
-        //                     unstash 'StanSetup'
-        //                     bat "mingw32-make -f lib/stan_math/make/standalone math-libs"
-        //                     bat "mingw32-make -j${env.PARALLEL} test-headers"
-        //                     setupCXX(false, env.CXX, stanc3_bin_url())
-        //                     runTestsWin("src/test/unit")
-        //             }
-        //             post { always { deleteDirWin() } }
-        //         }
-        //         stage('Linux Unit') {
-        //             agent { label 'linux' }
-        //             steps {
-        //                 unstash 'StanSetup'
-        //                 setupCXX(true, env.GCC, stanc3_bin_url())
-        //                 sh "make -j${env.PARALLEL} test-headers"
-        //                 runTests("src/test/unit")
-        //             }
-        //             post { always { deleteDir() } }
-        //         }
-        //         stage('Mac Unit') {
-        //             agent { label 'osx' }
-        //             when {
-        //                 expression {
-        //                     ( env.BRANCH_NAME == "develop" ||
-        //                     env.BRANCH_NAME == "master" ||
-        //                     params.run_tests_all_os ) &&
-        //                     !skipRemainingStages
-        //                 }
-        //             }
-        //             steps {
-        //                 unstash 'StanSetup'
-        //                 setupCXX(false, env.CXX, stanc3_bin_url())
-        //                 runTests("src/test/unit")
-        //             }
-        //             post { always { deleteDir() } }
-        //         }
-        //     }
-        // }
+        stage('Unit tests') {
+            when {
+                expression {
+                    !skipRemainingStages
+                }
+            }
+            parallel {
+                stage('Windows Headers & Unit') {
+                    agent { label 'windows' }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
+                    steps {
+                        deleteDirWin()
+                            unstash 'StanSetup'
+                            bat "mingw32-make -f lib/stan_math/make/standalone math-libs"
+                            bat "mingw32-make -j${env.PARALLEL} test-headers"
+                            setupCXX(false, env.CXX, stanc3_bin_url())
+                            runTestsWin("src/test/unit")
+                    }
+                    post { always { deleteDirWin() } }
+                }
+                stage('Linux Unit') {
+                    agent { label 'linux' }
+                    steps {
+                        unstash 'StanSetup'
+                        setupCXX(true, env.GCC, stanc3_bin_url())
+                        sh "make -j${env.PARALLEL} test-headers"
+                        runTests("src/test/unit")
+                    }
+                    post { always { deleteDir() } }
+                }
+                stage('Mac Unit') {
+                    agent { label 'osx' }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
+                    steps {
+                        unstash 'StanSetup'
+                        setupCXX(false, env.CXX, stanc3_bin_url())
+                        runTests("src/test/unit")
+                    }
+                    post { always { deleteDir() } }
+                }
+            }
+        }
         stage('Integration') {
             parallel {
                 stage('Integration Linux') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,7 @@ String integration_tests_flags() {
     } else {
         ''
     }
+}
 
 def isBranch(String b) { env.BRANCH_NAME == b }
 Boolean isPR() { env.CHANGE_URL != null }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -357,15 +357,17 @@ pipeline {
                         """
                         dir('performance-tests-cmdstan/cmdstan/stan'){
                             unstash 'StanSetup'
-                        }        
-                        bat """
-                            cd performance-tests-cmdstan/cmdstan
-                            echo 'O=0' >> make/local
-                            echo 'CXX=${env.CXX}' >> make/local
-                            make -j${env.PARALLEL} build
-                            cd ..
-                            python ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good
-                        """
+                        }
+                        withEnv(["PATH+TBB=${WORKSPACE}\\performance-tests-cmdstan\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb"]) {  
+                            bat """
+                                cd performance-tests-cmdstan/cmdstan
+                                echo 'O=0' >> make/local
+                                echo 'CXX=${env.CXX}' >> make/local
+                                make -j${env.PARALLEL} build
+                                cd ..
+                                python ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good
+                            """
+                        }
                         bat """
                             cd performance-tests-cmdstan/cmdstan/stan
                             python ./runTests.py src/test/integration/compile_standalone_functions_test.cpp

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,7 +358,7 @@ pipeline {
                         dir('performance-tests-cmdstan/cmdstan/stan'){
                             unstash 'StanSetup'
                         }
-                        writeFile(file: "performance-tests-cmdstan/cmdstan/make/local", text: "CXX=${CXX}\nO=0\nPRECOMPILED_HEADERS=true")
+                        writeFile(file: "performance-tests-cmdstan/cmdstan/make/local", text: "CXX=${CXX}\nO=1\nPRECOMPILED_HEADERS=true")
                         withEnv(["PATH+TBB=${WORKSPACE}\\performance-tests-cmdstan\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb"]) {  
                             
                             bat """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -361,9 +361,9 @@ pipeline {
                         withEnv(["PATH+TBB=${WORKSPACE}\\performance-tests-cmdstan\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb"]) {  
                             bat """
                                 cd performance-tests-cmdstan/cmdstan
-                                echo 'O=0' >> make/local
-                                echo 'CXX=${env.CXX}' >> make/local
-                                echo 'PRECOMPILED_HEADERS=true' >> make/local
+                                'O=0' | Out-File -FilePath make/local
+                                'CXX=${env.CXX}' | Out-File -FilePath make/local
+                                'PRECOMPILED_HEADERS=tru' | Out-File -FilePath make/local
                                 mingw32-make -j${env.PARALLEL} build
                                 cd ..
                                 python ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,12 @@ String stan_pr() {
         env.BRANCH_NAME
     }
 }
+String integration_tests_flags() { 
+    if (params.compile_all_model) {
+        '--no-ignore-models '
+    } else {
+        ''
+    }
 
 def isBranch(String b) { env.BRANCH_NAME == b }
 Boolean isPR() { env.CHANGE_URL != null }
@@ -61,6 +67,7 @@ pipeline {
         string(defaultValue: 'nightly', name: 'stanc3_bin_url',
           description: 'Custom stanc3 binary url')
         booleanParam(defaultValue: false, name: 'run_tests_all_os', description: 'Run unit and integration tests on all OS.')
+        booleanParam(defaultValue: false, name: 'compile_all_models', description: 'Run integration tests on the full test model suite.')
     }
     options {
         skipDefaultCheckout()
@@ -295,7 +302,7 @@ pipeline {
                             echo 'CXX=${env.CXX}' >> make/local
                             make -j${env.PARALLEL} build
                             cd ..
-                            ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good
+                            ./runPerformanceTests.py -j${env.PARALLEL} ${integration_tests_flags()}--runs=0 cmdstan/stan/src/test/test-models/good
                         """
                         sh """
                             cd performance-tests-cmdstan/cmdstan/stan
@@ -329,7 +336,7 @@ pipeline {
                             echo 'CXX=${env.CXX}' >> make/local
                             make -j${env.PARALLEL} build
                             cd ..
-                            ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good
+                            ./runPerformanceTests.py -j${env.PARALLEL} ${integration_tests_flags()}--runs=0 cmdstan/stan/src/test/test-models/good
                         """
                         sh """
                             cd performance-tests-cmdstan/cmdstan/stan
@@ -365,7 +372,7 @@ pipeline {
                                 cd performance-tests-cmdstan/cmdstan
                                 mingw32-make -j${env.PARALLEL} build
                                 cd ..
-                                python ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good
+                                python ./runPerformanceTests.py -j${env.PARALLEL} ${integration_tests_flags()}--runs=0 cmdstan/stan/src/test/test-models/good
                             """
                         }
                         bat """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,7 +254,7 @@ pipeline {
                     agent { label 'linux' }
                     steps {
                         sh """
-                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan --branch remove_big_models_from_testing
+                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
                         """
                         script {
                             if (params.cmdstan_pr != 'downstream_tests') {
@@ -318,7 +318,7 @@ pipeline {
                     }
                     steps {
                         sh """
-                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan --branch remove_big_models_from_testing
+                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
                         """
                         dir('performance-tests-cmdstan/cmdstan/stan'){
                             unstash 'StanSetup'
@@ -342,23 +342,23 @@ pipeline {
                 }
                 stage('Integration Windows') {
                     agent { label 'windows-ec2' }
-                    // when {
-                    //     expression {
-                    //         ( env.BRANCH_NAME == "develop" ||
-                    //         env.BRANCH_NAME == "master" ||
-                    //         params.run_tests_all_os ) &&
-                    //         !skipRemainingStages
-                    //     }
-                    // }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
                     steps {
                         deleteDirWin()
                         bat """
-                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan --branch remove_big_models_from_testing
+                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
                         """
                         dir('performance-tests-cmdstan/cmdstan/stan'){
                             unstash 'StanSetup'
                         }
-                        writeFile(file: "performance-tests-cmdstan/cmdstan/make/local", text: "CXX=${CXX}\nO=2\nPRECOMPILED_HEADERS=true")
+                        writeFile(file: "performance-tests-cmdstan/cmdstan/make/local", text: "CXX=${CXX}\nPRECOMPILED_HEADERS=true")
                         withEnv(["PATH+TBB=${WORKSPACE}\\performance-tests-cmdstan\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb"]) {  
                             
                             bat """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -364,7 +364,7 @@ pipeline {
                             echo 'CXX=${env.CXX}' >> make/local
                             make -j${env.PARALLEL} build
                             cd ..
-                            ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good
+                            python ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good
                         """
                         bat """
                             cd performance-tests-cmdstan/cmdstan/stan

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,7 +358,7 @@ pipeline {
                         dir('performance-tests-cmdstan/cmdstan/stan'){
                             unstash 'StanSetup'
                         }
-                        writeFile(file: "performance-tests-cmdstan/cmdstan/make/local", text: "CXX=${CXX}\nO=1\nPRECOMPILED_HEADERS=true")
+                        writeFile(file: "performance-tests-cmdstan/cmdstan/make/local", text: "CXX=${CXX}\nO=2\nPRECOMPILED_HEADERS=true")
                         withEnv(["PATH+TBB=${WORKSPACE}\\performance-tests-cmdstan\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb"]) {  
                             
                             bat """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -363,7 +363,7 @@ pipeline {
                                 cd performance-tests-cmdstan/cmdstan
                                 echo 'O=0' >> make/local
                                 echo 'CXX=${env.CXX}' >> make/local
-                                make -j${env.PARALLEL} build
+                                mingw32-make -j${env.PARALLEL} build
                                 cd ..
                                 python ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good
                             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,12 +358,11 @@ pipeline {
                         dir('performance-tests-cmdstan/cmdstan/stan'){
                             unstash 'StanSetup'
                         }
+                        writeFile(file: "performance-tests-cmdstan/cmdstan/make/local", text: "CXX=${CXX}\nO=0\nPRECOMPILED_HEADERS=true")
                         withEnv(["PATH+TBB=${WORKSPACE}\\performance-tests-cmdstan\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb"]) {  
+                            
                             bat """
                                 cd performance-tests-cmdstan/cmdstan
-                                'O=0' | Out-File -FilePath make/local
-                                'CXX=${env.CXX}' | Out-File -FilePath make/local
-                                'PRECOMPILED_HEADERS=tru' | Out-File -FilePath make/local
                                 mingw32-make -j${env.PARALLEL} build
                                 cd ..
                                 python ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -342,14 +342,14 @@ pipeline {
                 }
                 stage('Integration Windows') {
                     agent { label 'windows-ec2' }
-                    when {
-                        expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ||
-                            params.run_tests_all_os ) &&
-                            !skipRemainingStages
-                        }
-                    }
+                    // when {
+                    //     expression {
+                    //         ( env.BRANCH_NAME == "develop" ||
+                    //         env.BRANCH_NAME == "master" ||
+                    //         params.run_tests_all_os ) &&
+                    //         !skipRemainingStages
+                    //     }
+                    // }
                     steps {
                         deleteDirWin()
                         bat """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,7 +254,7 @@ pipeline {
                     agent { label 'linux' }
                     steps {
                         sh """
-                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
+                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan --branch remove_big_models_from_testing
                         """
                         script {
                             if (params.cmdstan_pr != 'downstream_tests') {
@@ -308,17 +308,17 @@ pipeline {
                 }
                 stage('Integration Mac') {
                     agent { label 'osx' }
-                    when {
-                        expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ||
-                            params.run_tests_all_os ) &&
-                            !skipRemainingStages
-                        }
-                    }
+                    // when {
+                    //     expression {
+                    //         ( env.BRANCH_NAME == "develop" ||
+                    //         env.BRANCH_NAME == "master" ||
+                    //         params.run_tests_all_os ) &&
+                    //         !skipRemainingStages
+                    //     }
+                    // }
                     steps {
                         sh """
-                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
+                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan --branch remove_big_models_from_testing
                         """
                         dir('performance-tests-cmdstan/cmdstan/stan'){
                             unstash 'StanSetup'
@@ -340,26 +340,26 @@ pipeline {
                     }
                     post { always { deleteDir() } }
                 }
-                stage('Integration Windows') {
-                    agent { label 'windows-ec2' }
-                    when {
-                        expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ||
-                            params.run_tests_all_os ) &&
-                            !skipRemainingStages
-                        }
-                    }
-                    steps {
-                        deleteDirWin()
-                            unstash 'StanSetup'
-                            setupCXX(false, env.CXX, stanc3_bin_url())
-                            bat "mingw32-make -f lib/stan_math/make/standalone math-libs"
-                            setupCXX(false)
-                            runTestsWin("src/test/integration", separateMakeStep=false)
-                    }
-                    post { always { deleteDirWin() } }
-                }
+                // stage('Integration Windows') {
+                //     agent { label 'windows-ec2' }
+                //     when {
+                //         expression {
+                //             ( env.BRANCH_NAME == "develop" ||
+                //             env.BRANCH_NAME == "master" ||
+                //             params.run_tests_all_os ) &&
+                //             !skipRemainingStages
+                //         }
+                //     }
+                //     steps {
+                //         deleteDirWin()
+                //             unstash 'StanSetup'
+                //             setupCXX(false, env.CXX, stanc3_bin_url())
+                //             bat "mingw32-make -f lib/stan_math/make/standalone math-libs"
+                //             setupCXX(false)
+                //             runTestsWin("src/test/integration", separateMakeStep=false)
+                //     }
+                //     post { always { deleteDirWin() } }
+                // }
             }
             when {
                 expression {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -363,6 +363,7 @@ pipeline {
                                 cd performance-tests-cmdstan/cmdstan
                                 echo 'O=0' >> make/local
                                 echo 'CXX=${env.CXX}' >> make/local
+                                echo 'PRECOMPILED_HEADERS=true' >> make/local
                                 mingw32-make -j${env.PARALLEL} build
                                 cd ..
                                 python ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 cmdstan/stan/src/test/test-models/good


### PR DESCRIPTION
This PR will remove the extremely large test models from the regular Integration test models batch. 
The models being removed:
- `distributions/univariate/continuous/exp_mod_normal`
- `distributions/univariate/continuous/pareto_type_2`
- `distributions/univariate/continuous/skew_normal`
- `distributions/univariate/continuous/student_t`
- `distributions/univariate/continuous/wiener`

They are being removed from being used in every PR because they represent 70%+ of execution time for these tests and do not add a lot of test coverage, if any.
These models are simple but huge. They test that all different signatures compile. And because these distributions have many arguments
the models are huge. They thus also consume a lot of RAM which limits the parallel setting we can use (we quickly run out of swap, as 1500 line so lpdf calls can consume up to 10GB of RAM).

The almost exact same test (testing that signatures compile) is already being tested in Math distribution tests.
These will only be tested on request (via Jenkins) and in a separate weekly test for CmdStan we are preparing.

This is not ready for review yet, as I need to do some testing prior. Will tag once ready.