### PR TITLE
Fix: Eigen double to matrix var assignment

### DIFF
--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -53,7 +53,7 @@ template <
     typename T, typename U,
     require_t<std::is_assignable<std::decay_t<T>&, std::decay_t<U>>>* = nullptr>
 inline void assign(T&& x, U&& y, const char* name) {
-  x = std::forward<U>(y);
+  internal::assign_impl(x, std::forward<U>(y));
 }
 
 /**
@@ -390,7 +390,8 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max idx) {
     stan::math::check_size_match("matrix[reverse_min_max] assign",
                                  "left hand side rows", row_size, name,
                                  y.rows());
-    internal::assign_impl(x.middleRows(idx.max_ - 1, row_size), internal::colwise_reverse(y));
+    internal::assign_impl(x.middleRows(idx.max_ - 1, row_size),
+                          internal::colwise_reverse(y));
     return;
   }
 }
@@ -433,7 +434,8 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
       stan::math::check_size_match("matrix[min_max, min_max] assign",
                                    "left hand side columns", col_size, name,
                                    y.cols());
-      internal::assign_impl(x.block(row_idx.min_ - 1, col_idx.min_ - 1, row_size, col_size), y);
+      internal::assign_impl(
+          x.block(row_idx.min_ - 1, col_idx.min_ - 1, row_size, col_size), y);
       return;
     } else {
       auto row_size = row_idx.max_ - (row_idx.min_ - 1);
@@ -444,7 +446,9 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
       stan::math::check_size_match("matrix[min_max, reverse_min_max] assign",
                                    "left hand side columns", col_size, name,
                                    y.cols());
-      internal::assign_impl(x.block(row_idx.min_ - 1, col_idx.max_ - 1, row_size, col_size), internal::rowwise_reverse(y));
+      internal::assign_impl(
+          x.block(row_idx.min_ - 1, col_idx.max_ - 1, row_size, col_size),
+          internal::rowwise_reverse(y));
       return;
     }
   } else {
@@ -457,7 +461,9 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
       stan::math::check_size_match("matrix[reverse_min_max, min_max] assign",
                                    "left hand side columns", col_size, name,
                                    y.cols());
-      internal::assign_impl(x.block(row_idx.max_ - 1, col_idx.min_ - 1, row_size, col_size), internal::colwise_reverse(y));
+      internal::assign_impl(
+          x.block(row_idx.max_ - 1, col_idx.min_ - 1, row_size, col_size),
+          internal::colwise_reverse(y));
       return;
     } else {
       auto row_size = row_idx.min_ - (row_idx.max_ - 1);
@@ -468,7 +474,9 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
       stan::math::check_size_match(
           "matrix[reverse_min_max, reverse_min_max] assign",
           "left hand side columns", col_size, name, y.cols());
-      internal::assign_impl(x.block(row_idx.max_ - 1, col_idx.max_ - 1, row_size, col_size), y.reverse());
+      internal::assign_impl(
+          x.block(row_idx.max_ - 1, col_idx.max_ - 1, row_size, col_size),
+          y.reverse());
       return;
     }
   }

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -2,6 +2,7 @@
 #define STAN_MODEL_INDEXING_ASSIGN_HPP
 
 #include <stan/math/prim.hpp>
+#include <stan/model/indexing/assign_varmat.hpp>
 #include <stan/model/indexing/access_helpers.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>
@@ -133,13 +134,13 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name,
     const auto slice_size = idx.max_ - slice_start;
     stan::math::check_size_match("vector[min_max] assign", "left hand side",
                                  slice_size, name, y.size());
-    x.segment(slice_start, slice_size) = y;
+    internal::assign_impl(x.segment(slice_start, slice_size), y);
   } else {
     const auto slice_start = idx.max_ - 1;
     const auto slice_size = idx.min_ - slice_start;
     stan::math::check_size_match("vector[reverse_min_max] assign",
                                  "left hand side", slice_size, name, y.size());
-    x.segment(slice_start, slice_size) = y.reverse();
+    internal::assign_impl(x.segment(slice_start, slice_size), y.reverse());
   }
 }
 
@@ -165,7 +166,7 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name, index_min idx) {
   stan::math::check_range("vector[min] assign", name, x.size(), idx.min_);
   stan::math::check_size_match("vector[min] assign", "left hand side",
                                x.size() - idx.min_ + 1, name, y.size());
-  x.tail(x.size() - idx.min_ + 1) = y;
+  internal::assign_impl(x.tail(x.size() - idx.min_ + 1), y);
 }
 
 /**
@@ -190,7 +191,7 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name, index_max idx) {
   stan::math::check_range("vector[max] assign", name, x.size(), idx.max_);
   stan::math::check_size_match("vector[max] assign", "left hand side", idx.max_,
                                name, y.size());
-  x.head(idx.max_) = y;
+  internal::assign_impl(x.head(idx.max_), y);
 }
 
 /**
@@ -212,7 +213,7 @@ template <typename Vec1, typename Vec2,
 inline void assign(Vec1&& x, Vec2&& y, const char* name, index_omni /* idx */) {
   stan::math::check_size_match("vector[omni] assign", "left hand side",
                                x.size(), name, y.size());
-  x = std::forward<Vec2>(y);
+  internal::assign_impl(x, std::forward<Vec2>(y));
 }
 
 /**
@@ -238,7 +239,7 @@ inline void assign(Mat&& x, const RowVec& y, const char* name, index_uni idx) {
   stan::math::check_size_match("matrix[uni] assign", "left hand side columns",
                                x.cols(), name, y.size());
   stan::math::check_range("matrix[uni] assign row", name, x.rows(), idx.n_);
-  x.row(idx.n_ - 1) = y;
+  internal::assign_impl(x.row(idx.n_ - 1), y);
 }
 
 /**
@@ -293,7 +294,7 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_omni /* idx */) {
                                x.rows(), name, y.rows());
   stan::math::check_size_match("matrix[omni] assign", "left hand side columns",
                                x.cols(), name, y.cols());
-  x = std::forward<Mat2>(y);
+  internal::assign_impl(x, std::forward<Mat2>(y));
 }
 
 /**
@@ -321,7 +322,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name, index_min idx) {
                                row_size, name, y.rows());
   stan::math::check_size_match("matrix[min] assign", "left hand side columns",
                                x.cols(), name, y.cols());
-  x.bottomRows(row_size) = y;
+  internal::assign_impl(x.bottomRows(row_size), y);
 }
 
 /**
@@ -348,7 +349,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name, index_max idx) {
                                idx.max_, name, y.rows());
   stan::math::check_size_match("matrix[max] assign", "left hand side columns",
                                x.cols(), name, y.cols());
-  x.topRows(idx.max_) = y;
+  internal::assign_impl(x.topRows(idx.max_), y);
 }
 
 /**
@@ -382,14 +383,14 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max idx) {
     stan::math::check_size_match("matrix[min_max] assign",
                                  "left hand side rows", row_size, name,
                                  y.rows());
-    x.middleRows(idx.min_ - 1, row_size) = y;
+    internal::assign_impl(x.middleRows(idx.min_ - 1, row_size), y);
     return;
   } else {
     const auto row_size = idx.min_ - idx.max_ + 1;
     stan::math::check_size_match("matrix[reverse_min_max] assign",
                                  "left hand side rows", row_size, name,
                                  y.rows());
-    x.middleRows(idx.max_ - 1, row_size) = internal::colwise_reverse(y);
+    internal::assign_impl(x.middleRows(idx.max_ - 1, row_size), internal::colwise_reverse(y));
     return;
   }
 }
@@ -432,7 +433,7 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
       stan::math::check_size_match("matrix[min_max, min_max] assign",
                                    "left hand side columns", col_size, name,
                                    y.cols());
-      x.block(row_idx.min_ - 1, col_idx.min_ - 1, row_size, col_size) = y;
+      internal::assign_impl(x.block(row_idx.min_ - 1, col_idx.min_ - 1, row_size, col_size), y);
       return;
     } else {
       auto row_size = row_idx.max_ - (row_idx.min_ - 1);
@@ -443,8 +444,7 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
       stan::math::check_size_match("matrix[min_max, reverse_min_max] assign",
                                    "left hand side columns", col_size, name,
                                    y.cols());
-      x.block(row_idx.min_ - 1, col_idx.max_ - 1, row_size, col_size)
-          = internal::rowwise_reverse(y);
+      internal::assign_impl(x.block(row_idx.min_ - 1, col_idx.max_ - 1, row_size, col_size), internal::rowwise_reverse(y));
       return;
     }
   } else {
@@ -457,8 +457,7 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
       stan::math::check_size_match("matrix[reverse_min_max, min_max] assign",
                                    "left hand side columns", col_size, name,
                                    y.cols());
-      x.block(row_idx.max_ - 1, col_idx.min_ - 1, row_size, col_size)
-          = internal::colwise_reverse(y);
+      internal::assign_impl(x.block(row_idx.max_ - 1, col_idx.min_ - 1, row_size, col_size), internal::colwise_reverse(y));
       return;
     } else {
       auto row_size = row_idx.min_ - (row_idx.max_ - 1);
@@ -469,8 +468,7 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
       stan::math::check_size_match(
           "matrix[reverse_min_max, reverse_min_max] assign",
           "left hand side columns", col_size, name, y.cols());
-      x.block(row_idx.max_ - 1, col_idx.max_ - 1, row_size, col_size)
-          = y.reverse();
+      internal::assign_impl(x.block(row_idx.max_ - 1, col_idx.max_ - 1, row_size, col_size), y.reverse());
       return;
     }
   }
@@ -775,7 +773,7 @@ template <typename T, typename U, require_all_std_vector_t<T, U>* = nullptr,
               std::is_assignable<std::decay_t<T>&, std::decay_t<U>>>* = nullptr>
 inline void assign(T&& x, U&& y, const char* name) {
   x.resize(y.size());
-  if (std::is_rvalue_reference<U>::value) {
+  if (std::is_rvalue_reference<U&&>::value) {
     for (size_t i = 0; i < y.size(); ++i) {
       assign(x[i], std::move(y[i]), name);
     }

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -2,7 +2,6 @@
 #define STAN_MODEL_INDEXING_ASSIGN_HPP
 
 #include <stan/math/prim.hpp>
-#include <stan/model/indexing/assign_varmat.hpp>
 #include <stan/model/indexing/access_helpers.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>
@@ -13,6 +12,27 @@
 namespace stan {
 
 namespace model {
+
+namespace internal {
+  /**
+   * Does an NAND to require the lhs is not a var_matrix and the rhs is not an
+   *  eigen matrix.
+   */
+  template <typename T1, typename T2>
+  using require_nand_var_matrix_or_eigen = require_not_t<stan::math::conjunction<is_var_matrix<T1>, is_eigen<T2>>>;
+  /**
+   * Base case of assignment
+   * @tparam T1 Any type that's not a var matrix.
+   * @tparam T2 Any type that's not a var matrix.
+   * @param x The value to assign to
+   * @param y The value to assign from.
+   */
+  template <typename T1, typename T2, require_nand_var_matrix_or_eigen<T1, T2>* = nullptr>
+  void assign_impl(T1&& x, T2&& y) {
+    x = std::forward<T2>(y);
+  }
+
+}
 
 /**
  * Indexing Notes:

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -14,19 +14,20 @@ namespace stan {
 namespace model {
 
 namespace internal {
-  /**
-   * Base case of assignment
-   * @tparam T1 Any type that's not a var matrix.
-   * @tparam T2 Any type that's not a var matrix.
-   * @param x The value to assign to
-   * @param y The value to assign from.
-   */
-  template <typename T1, typename T2, require_any_not_t<is_var_matrix<T1>, is_eigen<T2>>* = nullptr>
-  void assign_impl(T1&& x, T2&& y) {
-    x = std::forward<T2>(y);
-  }
-
+/**
+ * Base case of assignment
+ * @tparam T1 Any type that's not a var matrix.
+ * @tparam T2 Any type that's not a var matrix.
+ * @param x The value to assign to
+ * @param y The value to assign from.
+ */
+template <typename T1, typename T2,
+          require_any_not_t<is_var_matrix<T1>, is_eigen<T2>>* = nullptr>
+void assign_impl(T1&& x, T2&& y) {
+  x = std::forward<T2>(y);
 }
+
+}  // namespace internal
 
 /**
  * Indexing Notes:

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -15,19 +15,13 @@ namespace model {
 
 namespace internal {
   /**
-   * Does an NAND to require the lhs is not a var_matrix and the rhs is not an
-   *  eigen matrix.
-   */
-  template <typename T1, typename T2>
-  using require_nand_var_matrix_or_eigen = require_not_t<stan::math::conjunction<is_var_matrix<T1>, is_eigen<T2>>>;
-  /**
    * Base case of assignment
    * @tparam T1 Any type that's not a var matrix.
    * @tparam T2 Any type that's not a var matrix.
    * @param x The value to assign to
    * @param y The value to assign from.
    */
-  template <typename T1, typename T2, require_nand_var_matrix_or_eigen<T1, T2>* = nullptr>
+  template <typename T1, typename T2, require_any_not_t<is_var_matrix<T1>, is_eigen<T2>>* = nullptr>
   void assign_impl(T1&& x, T2&& y) {
     x = std::forward<T2>(y);
   }

--- a/src/stan/model/indexing/assign_varmat.hpp
+++ b/src/stan/model/indexing/assign_varmat.hpp
@@ -42,28 +42,20 @@ using require_all_var_matrix_or_all_var_eigen = require_any_t<
     stan::math::conjunction<is_var_matrix<Mat1>, is_var_matrix<Mat2>>>;
 
 /**
+ * Does an xor
+ */
+template <typename T1, typename T2>
+using require_nand_var_matrix_or_eigen = require_not_t<stan::math::conjunction<is_var_matrix<T1>, is_eigen<T2>>>;
+/**
  * Base case of assignment
  * @tparam T1 Any type that's not a var matrix.
  * @tparam T2 Any type that's not a var matrix.
  * @param x The value to assign to
  * @param y The value to assign from.
  */
-template <typename T1, typename T2, require_not_var_matrix_t<T1>* = nullptr>
+template <typename T1, typename T2, require_nand_var_matrix_or_eigen<T1, T2>* = nullptr>
 void assign_impl(T1&& x, T2&& y) {
   x = std::forward<T2>(y);
-}
-
-/**
- * For assigning one var matrix to another
- * @tparam Mat1 A `var_value` with inner type derived from `EigenBase`
- * @tparam Mat1 A `var_value` with inner type derived from `EigenBase`
- * @param x The var matrix to assign to
- * @param x The var matrix to assign from
- */
-template <typename Mat1, typename Mat2,
-          require_all_var_matrix_t<Mat1, Mat2>* = nullptr>
-void assign_impl(Mat1&& x, Mat2&& y) {
-  x = std::forward<Mat2>(y);
 }
 
 /**

--- a/src/stan/model/indexing/assign_varmat.hpp
+++ b/src/stan/model/indexing/assign_varmat.hpp
@@ -34,15 +34,6 @@ using require_var_row_vector_or_arithmetic_eigen = require_any_t<
                             is_eigen_row_vector<T>>>;
 
 /**
- * Require both types to be either `var<Matrix>` or `Eigen::Matrix`
- */
-template <typename Mat1, typename Mat2>
-using require_all_var_matrix_or_all_var_eigen = require_any_t<
-    stan::math::conjunction<is_eigen<Mat1>, is_eigen<Mat2>>,
-    stan::math::conjunction<is_var_matrix<Mat1>, is_var_matrix<Mat2>>>;
-
-
-/**
  * Assigning an `Eigen::Matrix<double>` to a `var<Matrix>`
  * In this case we need to
  * 1. Store the previous values from `x`

--- a/src/stan/model/indexing/assign_varmat.hpp
+++ b/src/stan/model/indexing/assign_varmat.hpp
@@ -2,8 +2,8 @@
 #define STAN_MODEL_INDEXING_ASSIGN_VARMAT_HPP
 
 #include <stan/math/rev.hpp>
+#include <stan/model/indexing/access_helpers.hpp>
 #include <stan/model/indexing/index.hpp>
-#include <stan/model/indexing/assign.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>
 #include <stan/model/indexing/rvalue_index_size.hpp>
 #include <type_traits>
@@ -14,6 +14,19 @@ namespace stan {
 
 namespace model {
 
+namespace internal {
+  template <typename T>
+  using require_var_matrix_or_arithmetic_eigen = require_any_t<is_var_matrix<T>,
+   stan::math::disjunction<std::is_arithmetic<scalar_type_t<T>>, is_eigen_matrix_dynamic<T>>>;
+
+   template <typename T>
+   using require_var_vector_or_arithmetic_eigen = require_any_t<is_var_vector<T>,
+    stan::math::disjunction<std::is_arithmetic<scalar_type_t<T>>, is_eigen_vector<T>>>;
+
+    template <typename T>
+    using require_var_row_vector_or_arithmetic_eigen = require_any_t<is_var_row_vector<T>,
+     stan::math::disjunction<std::is_arithmetic<scalar_type_t<T>>, is_eigen_row_vector<T>>>;
+}
 /**
  * Indexing Notes:
  * The different index types:
@@ -55,18 +68,42 @@ namespace model {
  * @throw std::out_of_range If the index is out of bounds.
  */
 template <typename VarVec, typename U, require_var_vector_t<VarVec>* = nullptr,
-          require_var_t<U>* = nullptr,
-          require_floating_point_t<value_type_t<U>>* = nullptr>
+          require_stan_scalar_t<U>* = nullptr>
 inline void assign(VarVec&& x, const U& y, const char* name, index_uni idx) {
   stan::math::check_range("var_vector[uni] assign", name, x.size(), idx.n_);
   const auto coeff_idx = idx.n_ - 1;
   double prev_val = x.val().coeffRef(coeff_idx);
-  x.vi_->val_.coeffRef(coeff_idx) = y.val();
+  x.vi_->val_.coeffRef(coeff_idx) = stan::math::value_of(y);
   stan::math::reverse_pass_callback([x, y, coeff_idx, prev_val]() mutable {
     x.vi_->val_.coeffRef(coeff_idx) = prev_val;
-    y.adj() += x.adj().coeffRef(coeff_idx);
+    using stan::math::forward_as;
+    using stan::math::var;
+    if (!is_constant<U>::value) {
+      forward_as<var>(y).adj() += x.adj().coeffRef(coeff_idx);
+    }
     x.adj().coeffRef(coeff_idx) = 0.0;
   });
+}
+
+namespace internal {
+  template <typename Mat1, typename Mat2>
+  using require_all_var_matrix_or_all_var_eigen = require_any_t<
+  stan::math::conjunction<is_eigen<Mat1>, is_eigen<Mat2>>,
+  stan::math::conjunction<is_var_matrix<Mat1>, is_var_matrix<Mat2>>>;
+  template <typename Mat1, typename Mat2, require_all_var_matrix_or_all_var_eigen<Mat1, Mat2>* = nullptr>
+  void assign_impl(Mat1&& x, Mat2&& y) {
+    x = std::forward<Mat2>(y);
+  }
+  template <typename Mat1, typename Mat2, require_var_matrix_t<Mat1>* = nullptr,
+   require_eigen_st<std::is_arithmetic, Mat2>* = nullptr>
+  void assign_impl(Mat1&& x, Mat2&& y) {
+    auto prev_vals = stan::math::to_arena(x.val());
+    x.vi_->val_ = std::forward<Mat2>(y);
+    stan::math::reverse_pass_callback([x, prev_vals]() mutable {
+      x.vi_->val_ = prev_vals;
+      x.vi_->adj_.setZero();
+    });
+  }
 }
 
 /**
@@ -87,7 +124,8 @@ inline void assign(VarVec&& x, const U& y, const char* name, index_uni idx) {
  * the indexed size.
  */
 template <typename Vec1, typename Vec2,
-          require_all_var_vector_t<Vec1, Vec2>* = nullptr>
+          require_var_vector_t<Vec1>* = nullptr,
+          internal::require_var_vector_or_arithmetic_eigen<Vec2>* = nullptr>
 inline void assign(Vec1&& x, const Vec2& y, const char* name,
                    const index_multi& idx) {
   stan::math::check_size_match("vector[multi] assign", "left hand side",
@@ -96,40 +134,58 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name,
   const auto assign_size = idx.ns_.size();
   arena_t<std::vector<int>> x_idx(assign_size);
   arena_t<Eigen::Matrix<double, -1, 1>> prev_vals(assign_size);
-  Eigen::Matrix<double, -1, 1> y_vals(assign_size);
+  Eigen::Matrix<double, -1, 1> y_idx_vals(assign_size);
   std::unordered_set<int> x_set;
   x_set.reserve(assign_size);
+  const auto& y_val = stan::math::value_of(y);
   // We have to use two loops to avoid aliasing issues.
   for (int i = assign_size - 1; i >= 0; --i) {
     if (likely(x_set.insert(idx.ns_[i]).second)) {
       stan::math::check_range("vector[multi] assign", name, x_size, idx.ns_[i]);
       x_idx[i] = idx.ns_[i] - 1;
       prev_vals.coeffRef(i) = x.vi_->val_.coeffRef(x_idx[i]);
-      y_vals.coeffRef(i) = y.vi_->val_.coeff(i);
+      y_idx_vals.coeffRef(i) = y_val.coeff(i);
     } else {
       x_idx[i] = -1;
     }
   }
   for (int i = assign_size - 1; i >= 0; --i) {
     if (likely(x_idx[i] != -1)) {
-      x.vi_->val_.coeffRef(x_idx[i]) = y_vals.coeff(i);
+      x.vi_->val_.coeffRef(x_idx[i]) = y_idx_vals.coeff(i);
     }
   }
 
-  stan::math::reverse_pass_callback([x, y, x_idx, prev_vals]() mutable {
-    for (Eigen::Index i = 0; i < x_idx.size(); ++i) {
-      if (likely(x_idx[i] != -1)) {
-        x.vi_->val_.coeffRef(x_idx[i]) = prev_vals.coeffRef(i);
-        prev_vals.coeffRef(i) = x.adj().coeffRef(x_idx[i]);
-        x.adj().coeffRef(x_idx[i]) = 0.0;
+  if (!is_constant<Vec2>::value) {
+    stan::math::reverse_pass_callback([x, y, x_idx, prev_vals]() mutable {
+      for (Eigen::Index i = 0; i < x_idx.size(); ++i) {
+        if (likely(x_idx[i] != -1)) {
+          x.vi_->val_.coeffRef(x_idx[i]) = prev_vals.coeffRef(i);
+          prev_vals.coeffRef(i) = x.adj().coeffRef(x_idx[i]);
+          x.adj().coeffRef(x_idx[i]) = 0.0;
+        }
       }
-    }
-    for (Eigen::Index i = 0; i < x_idx.size(); ++i) {
-      if (likely(x_idx[i] != -1)) {
-        y.adj().coeffRef(i) += prev_vals.coeffRef(i);
+      using stan::math::forward_as;
+      using stan::math::promote_scalar_t;
+      using stan::math::var;
+      if (!is_constant<Vec2>::value) {
+        for (Eigen::Index i = 0; i < x_idx.size(); ++i) {
+          if (likely(x_idx[i] != -1)) {
+            forward_as<promote_scalar_t<var, Vec2>>(y).adj().coeffRef(i) += prev_vals.coeffRef(i);
+          }
+        }
       }
-    }
-  });
+    });
+  } else {
+    stan::math::reverse_pass_callback([x, x_idx, prev_vals]() mutable {
+      for (Eigen::Index i = 0; i < x_idx.size(); ++i) {
+        if (likely(x_idx[i] != -1)) {
+          x.vi_->val_.coeffRef(x_idx[i]) = prev_vals.coeffRef(i);
+          prev_vals.coeffRef(i) = x.adj().coeffRef(x_idx[i]);
+          x.adj().coeffRef(x_idx[i]) = 0.0;
+        }
+      }
+    });
+  }
 }
 
 /**
@@ -147,8 +203,7 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name,
  * @throw std::out_of_range If either of the indices are out of bounds.
  */
 template <typename Mat, typename U, require_var_dense_dynamic_t<Mat>* = nullptr,
-          require_var_t<U>* = nullptr,
-          require_floating_point_t<value_type_t<U>>* = nullptr>
+          require_stan_scalar_t<U>* = nullptr>
 inline void assign(Mat&& x, const U& y, const char* name, index_uni row_idx,
                    index_uni col_idx) {
   stan::math::check_range("matrix[uni,uni] assign", name, x.rows(), row_idx.n_);
@@ -156,11 +211,15 @@ inline void assign(Mat&& x, const U& y, const char* name, index_uni row_idx,
   const int row_idx_val = row_idx.n_ - 1;
   const int col_idx_val = col_idx.n_ - 1;
   double prev_val = x.val().coeffRef(row_idx_val, col_idx_val);
-  x.vi_->val_.coeffRef(row_idx_val, col_idx_val) = y.val();
+  x.vi_->val_.coeffRef(row_idx_val, col_idx_val) = stan::math::value_of(y);
   stan::math::reverse_pass_callback(
       [x, y, row_idx_val, col_idx_val, prev_val]() mutable {
         x.vi_->val_.coeffRef(row_idx_val, col_idx_val) = prev_val;
-        y.adj() += x.adj().coeffRef(row_idx_val, col_idx_val);
+        using stan::math::forward_as;
+        using stan::math::var;
+        if (!is_constant<U>::value) {
+          forward_as<var>(y).adj() += x.adj().coeffRef(row_idx_val, col_idx_val);
+        }
         x.adj().coeffRef(row_idx_val, col_idx_val) = 0.0;
       });
 }
@@ -185,8 +244,7 @@ inline void assign(Mat&& x, const U& y, const char* name, index_uni row_idx,
  */
 template <typename Mat1, typename Vec,
           require_var_dense_dynamic_t<Mat1>* = nullptr,
-          require_eigen_dense_dynamic_t<value_type_t<Mat1>>* = nullptr,
-          require_var_row_vector_t<Vec>* = nullptr>
+          internal::require_var_row_vector_or_arithmetic_eigen<Vec>* = nullptr>
 inline void assign(Mat1&& x, const Vec& y, const char* name, index_uni row_idx,
                    const index_multi& col_idx) {
   stan::math::check_range("matrix[uni, multi] assign", name, x.rows(),
@@ -197,9 +255,10 @@ inline void assign(Mat1&& x, const Vec& y, const char* name, index_uni row_idx,
   const int row_idx_val = row_idx.n_ - 1;
   arena_t<std::vector<int>> x_idx(assign_cols);
   arena_t<Eigen::Matrix<double, -1, 1>> prev_val(assign_cols);
-  Eigen::Matrix<double, -1, 1> y_vals(assign_cols);
+  Eigen::Matrix<double, -1, 1> y_val_idx(assign_cols);
   std::unordered_set<int> x_set;
   x_set.reserve(assign_cols);
+  const auto& y_val = stan::math::value_of(y);
   // Need to remove duplicates for cases like {2, 3, 2, 2}
   for (int i = assign_cols - 1; i >= 0; --i) {
     if (likely(x_set.insert(col_idx.ns_[i]).second)) {
@@ -207,31 +266,47 @@ inline void assign(Mat1&& x, const Vec& y, const char* name, index_uni row_idx,
                               col_idx.ns_[i]);
       x_idx[i] = col_idx.ns_[i] - 1;
       prev_val.coeffRef(i) = x.val().coeffRef(row_idx_val, x_idx[i]);
-      y_vals.coeffRef(i) = y.val().coeff(i);
+      y_val_idx.coeffRef(i) = y_val.coeff(i);
     } else {
       x_idx[i] = -1;
     }
   }
   for (int i = assign_cols - 1; i >= 0; --i) {
     if (likely(x_idx[i] != -1)) {
-      x.vi_->val_.coeffRef(row_idx_val, x_idx[i]) = y_vals.coeff(i);
+      x.vi_->val_.coeffRef(row_idx_val, x_idx[i]) = y_val_idx.coeff(i);
     }
   }
-  stan::math::reverse_pass_callback(
-      [x, y, row_idx_val, x_idx, prev_val]() mutable {
-        for (size_t i = 0; i < x_idx.size(); ++i) {
-          if (likely(x_idx[i] != -1)) {
-            x.vi_->val_.coeffRef(row_idx_val, x_idx[i]) = prev_val.coeff(i);
-            prev_val.coeffRef(i) = x.adj().coeffRef(row_idx_val, x_idx[i]);
-            x.adj().coeffRef(row_idx_val, x_idx[i]) = 0.0;
+  if (!is_constant<Vec>::value) {
+    stan::math::reverse_pass_callback(
+        [x, y, row_idx_val, x_idx, prev_val]() mutable {
+          for (size_t i = 0; i < x_idx.size(); ++i) {
+            if (likely(x_idx[i] != -1)) {
+              x.vi_->val_.coeffRef(row_idx_val, x_idx[i]) = prev_val.coeff(i);
+              prev_val.coeffRef(i) = x.adj().coeffRef(row_idx_val, x_idx[i]);
+              x.adj().coeffRef(row_idx_val, x_idx[i]) = 0.0;
+            }
           }
-        }
-        for (size_t i = 0; i < x_idx.size(); ++i) {
-          if (likely(x_idx[i] != -1)) {
-            y.adj().coeffRef(i) += prev_val.coeffRef(i);
+          using stan::math::forward_as;
+          using stan::math::var;
+          using stan::math::promote_scalar_t;
+          for (size_t i = 0; i < x_idx.size(); ++i) {
+            if (likely(x_idx[i] != -1)) {
+              forward_as<promote_scalar_t<var, Vec>>(y).adj().coeffRef(i) += prev_val.coeffRef(i);
+            }
           }
-        }
-      });
+        });
+  } else {
+    stan::math::reverse_pass_callback(
+        [x, row_idx_val, x_idx, prev_val]() mutable {
+          for (size_t i = 0; i < x_idx.size(); ++i) {
+            if (likely(x_idx[i] != -1)) {
+              x.vi_->val_.coeffRef(row_idx_val, x_idx[i]) = prev_val.coeff(i);
+              prev_val.coeffRef(i) = x.adj().coeffRef(row_idx_val, x_idx[i]);
+              x.adj().coeffRef(row_idx_val, x_idx[i]) = 0.0;
+            }
+          }
+        });
+  }
 }
 
 /**
@@ -251,7 +326,8 @@ inline void assign(Mat1&& x, const Vec& y, const char* name, index_uni row_idx,
  * matrix and value matrix do not match.
  */
 template <typename Mat1, typename Mat2,
-          require_all_var_dense_dynamic_t<Mat1, Mat2>* = nullptr>
+          require_var_dense_dynamic_t<Mat1>* = nullptr,
+          internal::require_var_matrix_or_arithmetic_eigen<Mat2>* = nullptr>
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const index_multi& idx) {
   const auto assign_rows = idx.ns_.size();
@@ -261,9 +337,10 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
                                x.cols(), name, y.cols());
   arena_t<std::vector<int>> x_idx(assign_rows);
   arena_t<Eigen::Matrix<double, -1, -1>> prev_vals(assign_rows, x.cols());
-  Eigen::Matrix<double, -1, -1> y_vals(assign_rows, x.cols());
+  Eigen::Matrix<double, -1, -1> y_val_idx(assign_rows, x.cols());
   std::unordered_set<int> x_set;
   x_set.reserve(assign_rows);
+  const auto& y_val = stan::math::value_of(y);
   // Need to remove duplicates for cases like {2, 3, 2, 2}
   for (int i = assign_rows - 1; i >= 0; --i) {
     if (likely(x_set.insert(idx.ns_[i]).second)) {
@@ -271,31 +348,46 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
                               idx.ns_[i]);
       x_idx[i] = idx.ns_[i] - 1;
       prev_vals.row(i) = x.vi_->val_.row(x_idx[i]);
-      y_vals.row(i) = y.vi_->val_.row(i);
+      y_val_idx.row(i) = y_val.row(i);
     } else {
       x_idx[i] = -1;
     }
   }
   for (int i = assign_rows - 1; i >= 0; --i) {
     if (likely(x_idx[i] != -1)) {
-      x.vi_->val_.row(x_idx[i]) = y_vals.row(i);
+      x.vi_->val_.row(x_idx[i]) = y_val_idx.row(i);
     }
   }
 
-  stan::math::reverse_pass_callback([x, y, prev_vals, x_idx]() mutable {
-    for (size_t i = 0; i < x_idx.size(); ++i) {
-      if (likely(x_idx[i] != -1)) {
-        x.vi_->val_.row(x_idx[i]) = prev_vals.row(i);
-        prev_vals.row(i) = x.adj().row(x_idx[i]);
-        x.adj().row(x_idx[i]).fill(0);
+  if (!is_constant<Mat2>::value) {
+    stan::math::reverse_pass_callback([x, y, prev_vals, x_idx]() mutable {
+      for (size_t i = 0; i < x_idx.size(); ++i) {
+        if (likely(x_idx[i] != -1)) {
+          x.vi_->val_.row(x_idx[i]) = prev_vals.row(i);
+          prev_vals.row(i) = x.adj().row(x_idx[i]);
+          x.adj().row(x_idx[i]).fill(0);
+        }
       }
-    }
-    for (size_t i = 0; i < x_idx.size(); ++i) {
-      if (likely(x_idx[i] != -1)) {
-        y.adj().row(i) += prev_vals.row(i);
+      using stan::math::forward_as;
+      using stan::math::var;
+      using stan::math::promote_scalar_t;
+        for (size_t i = 0; i < x_idx.size(); ++i) {
+          if (likely(x_idx[i] != -1)) {
+            forward_as<promote_scalar_t<var, Mat2>>(y).adj().row(i) += prev_vals.row(i);
+          }
+        }
+    });
+  } else {
+    stan::math::reverse_pass_callback([x, prev_vals, x_idx]() mutable {
+      for (size_t i = 0; i < x_idx.size(); ++i) {
+        if (likely(x_idx[i] != -1)) {
+          x.vi_->val_.row(x_idx[i]) = prev_vals.row(i);
+          prev_vals.row(i) = x.adj().row(x_idx[i]);
+          x.adj().row(x_idx[i]).fill(0);
+        }
       }
-    }
-  });
+    });
+  }
 }
 
 /**
@@ -316,7 +408,8 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
  * matrix and value matrix do not match.
  */
 template <typename Mat1, typename Mat2,
-          require_all_var_matrix_t<Mat1, Mat2>* = nullptr>
+          require_var_matrix_t<Mat1>* = nullptr,
+          internal::require_var_matrix_or_arithmetic_eigen<Mat2>* = nullptr>
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const index_multi& row_idx, const index_multi& col_idx) {
   const auto assign_rows = row_idx.ns_.size();
@@ -345,6 +438,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
       x_row_idx[i] = -1;
     }
   }
+  const auto& y_val = stan::math::value_of(y);
   for (int j = assign_cols - 1; j >= 0; --j) {
     if (likely(x_set.insert(col_idx.ns_[j]).second)) {
       stan::math::check_range("matrix[multi, multi] assign col", name, x.cols(),
@@ -353,7 +447,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
       for (int i = assign_rows - 1; i >= 0; --i) {
         if (likely(x_row_idx[i] != -1)) {
           prev_vals.coeffRef(i, j) = x.vi_->val_(x_row_idx[i], x_col_idx[j]);
-          y_vals(i, j) = y.vi_->val_(i, j);
+          y_vals(i, j) = y_val(i, j);
         }
       }
     } else {
@@ -369,29 +463,49 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
       }
     }
   }
-  stan::math::reverse_pass_callback([x, y, prev_vals, x_col_idx,
-                                     x_row_idx]() mutable {
-    for (int j = 0; j < x_col_idx.size(); ++j) {
-      if (likely(x_col_idx[j] != -1)) {
-        for (int i = 0; i < x_row_idx.size(); ++i) {
-          if (likely(x_row_idx[i] != -1)) {
-            x.vi_->val_(x_row_idx[i], x_col_idx[j]) = prev_vals.coeffRef(i, j);
-            prev_vals.coeffRef(i, j) = x.adj()(x_row_idx[i], x_col_idx[j]);
-            x.adj()(x_row_idx[i], x_col_idx[j]) = 0;
+  if (!is_constant<Mat2>::value) {
+    stan::math::reverse_pass_callback([x, y, prev_vals, x_col_idx,
+                                       x_row_idx]() mutable {
+      for (int j = 0; j < x_col_idx.size(); ++j) {
+        if (likely(x_col_idx[j] != -1)) {
+          for (int i = 0; i < x_row_idx.size(); ++i) {
+            if (likely(x_row_idx[i] != -1)) {
+              x.vi_->val_(x_row_idx[i], x_col_idx[j]) = prev_vals.coeffRef(i, j);
+              prev_vals.coeffRef(i, j) = x.adj()(x_row_idx[i], x_col_idx[j]);
+              x.adj()(x_row_idx[i], x_col_idx[j]) = 0;
+            }
           }
         }
       }
-    }
-    for (int j = 0; j < x_col_idx.size(); ++j) {
-      if (likely(x_col_idx[j] != -1)) {
-        for (int i = 0; i < x_row_idx.size(); ++i) {
-          if (likely(x_row_idx[i] != -1)) {
-            y.adj()(i, j) += prev_vals.coeffRef(i, j);
+      using stan::math::forward_as;
+      using stan::math::var;
+      using stan::math::promote_scalar_t;
+      for (int j = 0; j < x_col_idx.size(); ++j) {
+        if (likely(x_col_idx[j] != -1)) {
+          for (int i = 0; i < x_row_idx.size(); ++i) {
+            if (likely(x_row_idx[i] != -1)) {
+              forward_as<promote_scalar_t<var, Mat2>>(y).adj()(i, j) += prev_vals.coeffRef(i, j);
+            }
           }
         }
       }
-    }
-  });
+    });
+  } else {
+    stan::math::reverse_pass_callback([x, prev_vals, x_col_idx,
+                                       x_row_idx]() mutable {
+      for (int j = 0; j < x_col_idx.size(); ++j) {
+        if (likely(x_col_idx[j] != -1)) {
+          for (int i = 0; i < x_row_idx.size(); ++i) {
+            if (likely(x_row_idx[i] != -1)) {
+              x.vi_->val_(x_row_idx[i], x_col_idx[j]) = prev_vals.coeffRef(i, j);
+              prev_vals.coeffRef(i, j) = x.adj()(x_row_idx[i], x_col_idx[j]);
+              x.adj()(x_row_idx[i], x_col_idx[j]) = 0;
+            }
+          }
+        }
+      }
+    });
+  }
 }
 
 /**
@@ -412,14 +526,15 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
  * matrix and value matrix do not match.
  */
 template <typename Mat1, typename Mat2, typename Idx,
-          require_all_var_dense_dynamic_t<Mat1, Mat2>* = nullptr>
+          require_var_dense_dynamic_t<Mat1>* = nullptr,
+         internal::require_var_matrix_or_arithmetic_eigen<Mat2>* = nullptr>
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const Idx& row_idx, const index_multi& col_idx) {
   const auto assign_cols = col_idx.ns_.size();
   stan::math::check_size_match("matrix[..., multi] assign", "left hand side",
                                assign_cols, name, y.cols());
   std::unordered_set<int> x_set;
-  auto y_eval = y.eval();
+  const auto& y_eval = y.eval();
   x_set.reserve(assign_cols);
   // Need to remove duplicates for cases like {2, 3, 2, 2}
   for (int j = assign_cols - 1; j >= 0; --j) {

--- a/src/stan/model/indexing/assign_varmat.hpp
+++ b/src/stan/model/indexing/assign_varmat.hpp
@@ -172,7 +172,9 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name,
       }
       for (Eigen::Index i = 0; i < x_idx.size(); ++i) {
         if (likely(x_idx[i] != -1)) {
-          math::forward_as<math::promote_scalar_t<math::var, Vec2>>(y).adj().coeffRef(i)
+          math::forward_as<math::promote_scalar_t<math::var, Vec2>>(y)
+              .adj()
+              .coeffRef(i)
               += prev_vals.coeff(i);
         }
       }
@@ -214,14 +216,14 @@ inline void assign(Mat&& x, const U& y, const char* name, index_uni row_idx,
   const int col_idx_val = col_idx.n_ - 1;
   double prev_val = x.val().coeffRef(row_idx_val, col_idx_val);
   x.vi_->val_.coeffRef(row_idx_val, col_idx_val) = stan::math::value_of(y);
-  stan::math::reverse_pass_callback([x, y, row_idx_val, col_idx_val,
-                                     prev_val]() mutable {
-    x.vi_->val_.coeffRef(row_idx_val, col_idx_val) = prev_val;
-    if (!is_constant<U>::value) {
-      math::adjoint_of(y) += x.adj().coeff(row_idx_val, col_idx_val);
-    }
-    x.adj().coeffRef(row_idx_val, col_idx_val) = 0.0;
-  });
+  stan::math::reverse_pass_callback(
+      [x, y, row_idx_val, col_idx_val, prev_val]() mutable {
+        x.vi_->val_.coeffRef(row_idx_val, col_idx_val) = prev_val;
+        if (!is_constant<U>::value) {
+          math::adjoint_of(y) += x.adj().coeff(row_idx_val, col_idx_val);
+        }
+        x.adj().coeffRef(row_idx_val, col_idx_val) = 0.0;
+      });
 }
 
 /**
@@ -288,7 +290,9 @@ inline void assign(Mat1&& x, const Vec& y, const char* name, index_uni row_idx,
           }
           for (size_t i = 0; i < x_idx.size(); ++i) {
             if (likely(x_idx[i] != -1)) {
-              math::forward_as<math::promote_scalar_t<math::var, Vec>>(y).adj().coeffRef(i)
+              math::forward_as<math::promote_scalar_t<math::var, Vec>>(y)
+                  .adj()
+                  .coeffRef(i)
                   += prev_val.coeff(i);
             }
           }
@@ -368,7 +372,9 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
       }
       for (size_t i = 0; i < x_idx.size(); ++i) {
         if (likely(x_idx[i] != -1)) {
-          math::forward_as<math::promote_scalar_t<math::var, Mat2>>(y).adj().row(i)
+          math::forward_as<math::promote_scalar_t<math::var, Mat2>>(y)
+              .adj()
+              .row(i)
               += prev_vals.row(i);
         }
       }
@@ -441,7 +447,8 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
       x_col_idx[j] = col_idx.ns_[j] - 1;
       for (int i = assign_rows - 1; i >= 0; --i) {
         if (likely(x_row_idx[i] != -1)) {
-          prev_vals.coeffRef(i, j) = x.vi_->val_.coeff(x_row_idx[i], x_col_idx[j]);
+          prev_vals.coeffRef(i, j)
+              = x.vi_->val_.coeff(x_row_idx[i], x_col_idx[j]);
           y_vals.coeffRef(i, j) = y_val.coeff(i, j);
         }
       }
@@ -459,47 +466,51 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
     }
   }
   if (!is_constant<Mat2>::value) {
-    stan::math::reverse_pass_callback([x, y, prev_vals, x_col_idx,
-                                       x_row_idx]() mutable {
-      for (int j = 0; j < x_col_idx.size(); ++j) {
-        if (likely(x_col_idx[j] != -1)) {
-          for (int i = 0; i < x_row_idx.size(); ++i) {
-            if (likely(x_row_idx[i] != -1)) {
-              x.vi_->val_.coeffRef(x_row_idx[i], x_col_idx[j])
-                  = prev_vals.coeff(i, j);
-              prev_vals.coeffRef(i, j) = x.adj().coeff(x_row_idx[i], x_col_idx[j]);
-              x.adj().coeffRef(x_row_idx[i], x_col_idx[j]) = 0;
+    stan::math::reverse_pass_callback(
+        [x, y, prev_vals, x_col_idx, x_row_idx]() mutable {
+          for (int j = 0; j < x_col_idx.size(); ++j) {
+            if (likely(x_col_idx[j] != -1)) {
+              for (int i = 0; i < x_row_idx.size(); ++i) {
+                if (likely(x_row_idx[i] != -1)) {
+                  x.vi_->val_.coeffRef(x_row_idx[i], x_col_idx[j])
+                      = prev_vals.coeff(i, j);
+                  prev_vals.coeffRef(i, j)
+                      = x.adj().coeff(x_row_idx[i], x_col_idx[j]);
+                  x.adj().coeffRef(x_row_idx[i], x_col_idx[j]) = 0;
+                }
+              }
             }
           }
-        }
-      }
-      for (int j = 0; j < x_col_idx.size(); ++j) {
-        if (likely(x_col_idx[j] != -1)) {
-          for (int i = 0; i < x_row_idx.size(); ++i) {
-            if (likely(x_row_idx[i] != -1)) {
-              math::forward_as<math::promote_scalar_t<math::var, Mat2>>(y).adj().coeffRef(i, j)
-                  += prev_vals.coeff(i, j);
+          for (int j = 0; j < x_col_idx.size(); ++j) {
+            if (likely(x_col_idx[j] != -1)) {
+              for (int i = 0; i < x_row_idx.size(); ++i) {
+                if (likely(x_row_idx[i] != -1)) {
+                  math::forward_as<math::promote_scalar_t<math::var, Mat2>>(y)
+                      .adj()
+                      .coeffRef(i, j)
+                      += prev_vals.coeff(i, j);
+                }
+              }
             }
           }
-        }
-      }
-    });
+        });
   } else {
-    stan::math::reverse_pass_callback([x, prev_vals, x_col_idx,
-                                       x_row_idx]() mutable {
-      for (int j = 0; j < x_col_idx.size(); ++j) {
-        if (likely(x_col_idx[j] != -1)) {
-          for (int i = 0; i < x_row_idx.size(); ++i) {
-            if (likely(x_row_idx[i] != -1)) {
-              x.vi_->val_.coeffRef(x_row_idx[i], x_col_idx[j])
-                  = prev_vals.coeff(i, j);
-              prev_vals.coeffRef(i, j) = x.adj().coeff(x_row_idx[i], x_col_idx[j]);
-              x.adj().coeffRef(x_row_idx[i], x_col_idx[j]) = 0;
+    stan::math::reverse_pass_callback(
+        [x, prev_vals, x_col_idx, x_row_idx]() mutable {
+          for (int j = 0; j < x_col_idx.size(); ++j) {
+            if (likely(x_col_idx[j] != -1)) {
+              for (int i = 0; i < x_row_idx.size(); ++i) {
+                if (likely(x_row_idx[i] != -1)) {
+                  x.vi_->val_.coeffRef(x_row_idx[i], x_col_idx[j])
+                      = prev_vals.coeff(i, j);
+                  prev_vals.coeffRef(i, j)
+                      = x.adj().coeff(x_row_idx[i], x_col_idx[j]);
+                  x.adj().coeffRef(x_row_idx[i], x_col_idx[j]) = 0;
+                }
+              }
             }
           }
-        }
-      }
-    });
+        });
   }
 }
 

--- a/src/test/unit/model/indexing/assign_varmat_test.cpp
+++ b/src/test/unit/model/indexing/assign_varmat_test.cpp
@@ -70,10 +70,10 @@ void test_nil_vec() {
   using stan::math::var;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_vector<Vec, var>(5);
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_vector<Vec, var>(5);
   Eigen::VectorXd x_val = x.val();
-  auto y = generate_linear_var_vector<Vec, RhsScalar>(5, 1.0);
+  auto y = conditionally_generate_linear_var_vector<Vec, RhsScalar>(5, 1.0);
   assign(x, y, "");
   EXPECT_MATRIX_EQ(x.val(), stan::math::value_of(y));
   stan::math::sum(x).grad();
@@ -97,8 +97,8 @@ void test_uni_vec() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_vector<Vec>(5);
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_vector<Vec>(5);
   Vec x_val = x.val();
   RhsScalar y(18);
   assign(x, y, "", index_uni(2));
@@ -127,10 +127,10 @@ void test_multi_vec() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_vector<Vec>(5);
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_vector<Vec>(5);
   Vec x_val = x.val();
-  auto y = generate_linear_var_vector<Vec, RhsScalar>(3, 10);
+  auto y = conditionally_generate_linear_var_vector<Vec, RhsScalar>(3, 10);
   vector<int> ns;
   ns.push_back(2);
   ns.push_back(4);
@@ -151,9 +151,9 @@ void test_multi_vec() {
   ns.push_back(2);
   test_throw_invalid_arg(x, y, index_multi(ns));
   ns.pop_back();
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(4),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(4),
                          index_multi(ns));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(2),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(2),
                          index_multi(ns));
 }
 
@@ -172,8 +172,8 @@ void test_multi_alias_vec() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_vector<Eigen::VectorXd>(5, 1);
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_vector<Eigen::VectorXd>(5, 1);
   Eigen::VectorXd x_val = x.val();
   vector<int> ns{1, 1, 2, 3};
   assign(x, x.segment(1, 4), "", index_multi(ns));
@@ -193,10 +193,10 @@ void test_omni_vec() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_vector<Vec>(5);
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_vector<Vec>(5);
   Vec x_val = stan::math::value_of(x);
-  auto y = generate_linear_var_vector<Vec, RhsScalar>(5, 10);
+  auto y = conditionally_generate_linear_var_vector<Vec, RhsScalar>(5, 10);
   Vec y_val = stan::math::value_of(y);
   auto x_copy = var_value<Vec>(x.vi_);
   assign(x, y, "", index_omni());
@@ -219,9 +219,9 @@ void test_omni_vec() {
     check_adjs(check_i, x, "lhs", 0.0);
   }
   check_adjs(check_i, y, "rhs", 1.0);
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec, RhsScalar>(4),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec, RhsScalar>(4),
                          index_omni());
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec, RhsScalar>(6),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec, RhsScalar>(6),
                          index_omni());
 }
 
@@ -240,9 +240,9 @@ void test_min_vec() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_vector<Vec>(5);
-  auto y = generate_linear_var_vector<Vec, RhsScalar>(3, 10);
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_vector<Vec>(5);
+  auto y = conditionally_generate_linear_var_vector<Vec, RhsScalar>(3, 10);
   Vec x_val(x.val());
   auto y_val = stan::math::value_of(y).eval();
   assign(x, y, "", index_min(3));
@@ -256,8 +256,8 @@ void test_min_vec() {
   check_adjs([](int /* i */) { return true; }, y, "rhs");
   test_throw_out_of_range(x, y, index_min(0));
   test_throw_out_of_range(x, y, index_min(6));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(4), index_min(3));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(2), index_min(3));
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(4), index_min(3));
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(2), index_min(3));
 }
 TEST_F(VarAssign, min_vec) {
   test_min_vec<Eigen::VectorXd, stan::math::var>();
@@ -274,10 +274,10 @@ void test_max_vec() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_vector<Vec>(5);
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_vector<Vec>(5);
   Vec x_val = x.val();
-  auto y = generate_linear_var_vector<Vec, RhsScalar>(2, 10);
+  auto y = conditionally_generate_linear_var_vector<Vec, RhsScalar>(2, 10);
   auto y_val = stan::math::value_of(y);
   assign(x, y, "", index_max(2));
   EXPECT_FLOAT_EQ(y_val[0], x.val()[0]);
@@ -289,8 +289,8 @@ void test_max_vec() {
   check_adjs([](int /* i */) { return true; }, y, "rhs");
   test_throw_out_of_range(x, y, index_max(0));
   test_throw_out_of_range(x, y, index_max(6));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(3), index_max(2));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(1), index_max(2));
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(3), index_max(2));
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(1), index_max(2));
 }
 
 TEST_F(VarAssign, max_vec) {
@@ -308,10 +308,10 @@ void test_positive_minmax_varvector() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_vector<Vec>(5);
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_vector<Vec>(5);
   Vec x_val = x.val();
-  auto y = generate_linear_var_vector<Vec, RhsScalar>(4, 10);
+  auto y = conditionally_generate_linear_var_vector<Vec, RhsScalar>(4, 10);
 
   assign(x, y, "", index_min_max(1, 4));
   EXPECT_FLOAT_EQ(x.val()(0), 10);
@@ -326,9 +326,9 @@ void test_positive_minmax_varvector() {
   check_adjs([](int /* i */) { return true; }, y, "rhs");
   test_throw_out_of_range(x, y, index_min_max(0, 3));
   test_throw_out_of_range(x, y, index_min_max(1, 6));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(5),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(5),
                          index_min_max(1, 4));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(3),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(3),
                          index_min_max(1, 4));
 }
 
@@ -347,10 +347,10 @@ void test_negative_minmax_varvector() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_vector<Vec>(5);
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_vector<Vec>(5);
   Vec x_val = x.val();
-  auto y = generate_linear_var_vector<Vec, RhsScalar>(4, 10);
+  auto y = conditionally_generate_linear_var_vector<Vec, RhsScalar>(4, 10);
 
   assign(x, y, "", index_min_max(4, 1));
   EXPECT_FLOAT_EQ(x.val()(0), 13);
@@ -365,9 +365,9 @@ void test_negative_minmax_varvector() {
   check_adjs([](int /* i */) { return true; }, y, "rhs");
   test_throw_out_of_range(x, y, index_min_max(3, 0));
   test_throw_out_of_range(x, y, index_min_max(6, 1));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(5),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(5),
                          index_min_max(4, 1));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(3),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(3),
                          index_min_max(4, 1));
 }
 
@@ -454,12 +454,12 @@ auto uni_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(5, 10);
+  auto y = conditionally_generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(5, 10);
   assign(x, y, "", index_uni(1));
   EXPECT_MATRIX_EQ(y.val().row(0), x.val().row(0));
   sum(x).grad();
@@ -482,8 +482,8 @@ auto uni_uni_mat_test() {
   using stan::math::var;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  auto x = generate_linear_var_matrix(5, 5);
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
   RhsScalar y = 10.12;
   assign(x, y, "", index_uni(2), index_uni(3));
@@ -511,12 +511,12 @@ auto multi_uni_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(3, 10);
+  auto y = conditionally_generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(3, 10);
 
   std::vector<int> ns;
   ns.push_back(3);
@@ -551,12 +551,12 @@ template <typename RhsScalar>
 auto omni_uni_mat_test() {
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::VectorXd, RhsScalar>(5, 10);
+  auto y = conditionally_generate_linear_var_vector<Eigen::VectorXd, RhsScalar>(5, 10);
   assign(x, y, "", index_omni(), index_uni(1));
   auto y_val = stan::math::value_of(y);
   EXPECT_MATRIX_EQ(y_val, x.val().col(0));
@@ -568,9 +568,9 @@ auto omni_uni_mat_test() {
   check_adjs(check_all, y, "rhs");
   test_throw_out_of_range(x, y, index_omni(), index_uni(0));
   test_throw_out_of_range(x, y, index_omni(), index_uni(6));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Eigen::VectorXd>(6),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Eigen::VectorXd>(6),
                          index_omni(), index_uni(1));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Eigen::VectorXd>(4),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Eigen::VectorXd>(4),
                          index_omni(), index_uni(1));
 }
 
@@ -584,12 +584,12 @@ auto minmax_uni_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::VectorXd, RhsScalar>(2, 10);
+  auto y = conditionally_generate_linear_var_vector<Eigen::VectorXd, RhsScalar>(2, 10);
 
   assign(x, y, "", index_min_max(2, 3), index_uni(4));
   EXPECT_MATRIX_EQ(stan::math::value_of(y), x.val().col(3).segment(1, 2));
@@ -604,9 +604,9 @@ auto minmax_uni_mat_test() {
   test_throw_out_of_range(x, y, index_min_max(2, 3), index_uni(5));
   test_throw_out_of_range(x, y, index_min_max(0, 1), index_uni(4));
   test_throw_out_of_range(x, y, index_min_max(2, 4), index_uni(4));
-  test_throw_invalid_arg(x, generate_linear_var_vector(1, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector(1, 10),
                          index_min_max(2, 3), index_uni(4));
-  test_throw_invalid_arg(x, generate_linear_var_vector(3, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_vector(3, 10),
                          index_min_max(2, 3), index_uni(4));
 }
 
@@ -620,11 +620,11 @@ auto multi_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix<RhsScalar>(7, 5, 10);
+  auto y = conditionally_generate_linear_var_matrix<RhsScalar>(7, 5, 10);
   std::vector<int> row_idx{3, 4, 1, 4, 1, 4, 5};
   stan::arena_t<std::vector<int>> x_idx;
   stan::arena_t<std::vector<int>> y_idx;
@@ -650,13 +650,13 @@ auto multi_mat_test() {
   auto check_i_y = [](int i) { return (i == 0 || i > 3); };
   auto check_j_y = [](int j) { return true; };
   check_adjs(check_i_y, check_j_y, y, "rhs", 1);
-  test_throw_invalid_arg(x, generate_linear_var_matrix(8, 5, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(8, 5, 10),
                          index_multi(row_idx));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(6, 5, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(6, 5, 10),
                          index_multi(row_idx));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(7, 4, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(7, 4, 10),
                          index_multi(row_idx));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(7, 6, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(7, 6, 10),
                          index_multi(row_idx));
   row_idx[3] = 20;
   test_throw_out_of_range(x, y, index_multi(row_idx));
@@ -675,9 +675,9 @@ TEST_F(VarAssign, multi_alias_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
   std::vector<int> row_idx{2, 3, 1, 3};
   assign(x, x.block(0, 0, 4, 5), "", index_multi(row_idx));
@@ -698,12 +698,12 @@ auto uni_multi_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(4, 10);
+  auto y = conditionally_generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(4, 10);
 
   vector<int> ns{4, 1, 3, 3};
   assign(x, y, "", index_uni(3), index_multi(ns));
@@ -719,10 +719,10 @@ auto uni_multi_mat_test() {
   auto check_i_y = [](int i) { return i != 2; };
   check_adjs(check_i_y, y, "rhs", 1);
   test_throw_invalid_arg(x,
-                         generate_linear_var_vector<Eigen::RowVectorXd>(5, 10),
+                         conditionally_generate_linear_var_vector<Eigen::RowVectorXd>(5, 10),
                          index_uni(3), index_multi(ns));
   test_throw_invalid_arg(x,
-                         generate_linear_var_vector<Eigen::RowVectorXd>(3, 10),
+                         conditionally_generate_linear_var_vector<Eigen::RowVectorXd>(3, 10),
                          index_uni(3), index_multi(ns));
   test_throw_out_of_range(x, y, index_uni(0), index_multi(ns));
   test_throw_out_of_range(x, y, index_uni(6), index_multi(ns));
@@ -743,10 +743,10 @@ TEST_F(VarAssign, uni_multi_alias_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
   vector<int> ns{1, 1, 2, 3};
   assign(x, x.row(2).segment(0, 4), "", index_uni(3), index_multi(ns));
@@ -768,11 +768,11 @@ auto multi_multi_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix<RhsScalar>(7, 7, 10);
+  auto y = conditionally_generate_linear_var_matrix<RhsScalar>(7, 7, 10);
   std::vector<int> row_idx{3, 4, 1, 4, 1, 4, 5};
   std::vector<int> col_idx{1, 4, 4, 3, 2, 1, 5};
 
@@ -808,13 +808,13 @@ auto multi_multi_mat_test() {
   auto check_j_y = [](int j) { return (j > 1); };
   check_adjs(check_i_y, check_j_y, y, "rhs", 1);
 
-  test_throw_invalid_arg(x, generate_linear_var_matrix(6, 7, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(6, 7, 10),
                          index_multi(row_idx), index_multi(col_idx));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(8, 7, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(8, 7, 10),
                          index_multi(row_idx), index_multi(col_idx));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(7, 6, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(7, 6, 10),
                          index_multi(row_idx), index_multi(col_idx));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(7, 8, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(7, 8, 10),
                          index_multi(row_idx), index_multi(col_idx));
   col_idx.pop_back();
   test_throw_invalid_arg(x, y, index_multi(row_idx), index_multi(col_idx));
@@ -838,9 +838,9 @@ TEST_F(VarAssign, multi_multi_alias_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
   std::vector<int> row_idx{1, 2, 2, 4};
   std::vector<int> col_idx{1, 2, 2, 3};
@@ -874,12 +874,12 @@ auto minmax_multi_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix(3, 4, 25);
+  auto y = conditionally_generate_linear_var_matrix(3, 4, 25);
 
   vector<int> ns{4, 1, 3, 3};
   assign(x, y, "", index_min_max(1, 3), index_multi(ns));
@@ -896,13 +896,13 @@ auto minmax_multi_mat_test() {
   auto check_i_y = [](int i) { return true; };
   auto check_j_y = [](int j) { return j != 2; };
   check_adjs(check_i_y, check_j_y, y, "lhs", 1);
-  test_throw_invalid_arg(x, generate_linear_var_matrix(3, 5, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(3, 5, 10),
                          index_min_max(1, 3), index_multi(ns));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(3, 3, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(3, 3, 10),
                          index_min_max(1, 3), index_multi(ns));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(4, 4, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(4, 4, 10),
                          index_min_max(1, 3), index_multi(ns));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(2, 4, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(2, 4, 10),
                          index_min_max(1, 3), index_multi(ns));
 
   test_throw_out_of_range(x, y, index_min_max(0, 3), index_multi(ns));
@@ -924,10 +924,10 @@ TEST_F(VarAssign, minmax_multi_alias_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
 
   vector<int> ns{4, 1, 3, 3};
@@ -951,12 +951,12 @@ void omni_matrix_test() {
   using stan::math::value_of;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_matrix(5, 5);
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   var_value<Eigen::MatrixXd> x_copy(x.vi_);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix<RhsScalar>(5, 5, 10);
+  auto y = conditionally_generate_linear_var_matrix<RhsScalar>(5, 5, 10);
   assign(x, y, "", index_omni());
   if (stan::is_var<RhsScalar>::value) {
     EXPECT_MATRIX_EQ(value_of(y), x.val());
@@ -975,10 +975,10 @@ void omni_matrix_test() {
     check_adjs(check_all, check_all, x, "lhs", 0.0);
     check_adjs(check_all, check_all, x_copy, "lhs", 0.0);
   }
-  test_throw_invalid_arg(x, generate_linear_var_matrix(5, 6, 10), index_omni());
-  test_throw_invalid_arg(x, generate_linear_var_matrix(5, 4, 10), index_omni());
-  test_throw_invalid_arg(x, generate_linear_var_matrix(6, 5, 10), index_omni());
-  test_throw_invalid_arg(x, generate_linear_var_matrix(4, 5, 10), index_omni());
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(5, 6, 10), index_omni());
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(5, 4, 10), index_omni());
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(6, 5, 10), index_omni());
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(4, 5, 10), index_omni());
 }
 
 TEST_F(VarAssign, omni_matrix) {
@@ -991,12 +991,12 @@ void omni_omni_matrix_test() {
   using stan::math::value_of;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
-  auto x = generate_linear_var_matrix(5, 5);
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   var_value<Eigen::MatrixXd> x_copy(x.vi_);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix<RhsScalar>(5, 5, 10);
+  auto y = conditionally_generate_linear_var_matrix<RhsScalar>(5, 5, 10);
   stan::math::var lp = sum(x_copy);
   lp.adj() = 1;
   assign(x, y, "", index_omni(), index_omni());
@@ -1013,17 +1013,18 @@ void omni_omni_matrix_test() {
     check_adjs(check_all, check_all, x, "lhs");
     check_adjs(check_all, check_all, y, "rhs");
   } else {
+    EXPECT_MATRIX_EQ(x.val(), x_val);
     // Both are one in this case
     check_adjs(check_all, check_all, x, "lhs", 1.0);
     check_adjs(check_all, check_all, x_copy, "lhs", 1.0);
   }
-  test_throw_invalid_arg(x, generate_linear_var_matrix(5, 6, 10), index_omni(),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(5, 6, 10), index_omni(),
                          index_omni());
-  test_throw_invalid_arg(x, generate_linear_var_matrix(5, 4, 10), index_omni(),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(5, 4, 10), index_omni(),
                          index_omni());
-  test_throw_invalid_arg(x, generate_linear_var_matrix(6, 5, 10), index_omni(),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(6, 5, 10), index_omni(),
                          index_omni());
-  test_throw_invalid_arg(x, generate_linear_var_matrix(4, 5, 10), index_omni(),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(4, 5, 10), index_omni(),
                          index_omni());
 }
 
@@ -1037,12 +1038,12 @@ void uni_omni_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(5, 10);
+  auto y = conditionally_generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(5, 10);
   assign(x, y, "", index_uni(1), index_omni());
   EXPECT_MATRIX_EQ(stan::math::value_of(y).row(0), x.val().row(0));
   sum(x).grad();
@@ -1053,10 +1054,10 @@ void uni_omni_matrix_test() {
   check_adjs(check_all, y, "rhs");
 
   test_throw_invalid_arg(
-      x, generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(4, 10),
+      x, conditionally_generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(4, 10),
       index_uni(1), index_omni());
   test_throw_invalid_arg(
-      x, generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(6, 10),
+      x, conditionally_generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(6, 10),
       index_uni(1), index_omni());
   test_throw_out_of_range(x, y, index_uni(0), index_omni());
   test_throw_out_of_range(x, y, index_uni(6), index_omni());
@@ -1073,11 +1074,11 @@ void min_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix<RhsScalar>(2, 4, 10);
+  auto y = conditionally_generate_linear_var_matrix<RhsScalar>(2, 4, 10);
 
   assign(x, y, "", index_min(2));
   EXPECT_MATRIX_EQ(x.val().bottomRows(2), stan::math::value_of(y));
@@ -1104,11 +1105,11 @@ void minmax_min_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix<RhsScalar>(2, 3, 10);
+  auto y = conditionally_generate_linear_var_matrix<RhsScalar>(2, 3, 10);
   assign(x, y, "", index_min_max(2, 3), index_min(2));
   EXPECT_MATRIX_EQ(stan::math::value_of(y), x.val().block(1, 1, 2, 3));
   sum(x).grad();
@@ -1122,9 +1123,9 @@ void minmax_min_matrix_test() {
   test_throw_out_of_range(x, y, index_min_max(2, 4), index_min(2));
   test_throw_out_of_range(x, y, index_min_max(2, 3), index_min(0));
   test_throw_out_of_range(x, y, index_min_max(2, 3), index_min(5));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(1, 3, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(1, 3, 10),
                          index_min_max(2, 3), index_min(2));
-  test_throw_invalid_arg(x, generate_linear_var_matrix(2, 5, 10),
+  test_throw_invalid_arg(x, conditionally_generate_linear_var_matrix(2, 5, 10),
                          index_min_max(2, 3), index_min(2));
 }
 
@@ -1139,11 +1140,11 @@ void max_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix<RhsScalar>(2, 4, 10);
+  auto y = conditionally_generate_linear_var_matrix<RhsScalar>(2, 4, 10);
 
   assign(x, y, "", index_max(2));
   EXPECT_MATRIX_EQ(x.val().topRows(2), stan::math::value_of(y));
@@ -1169,11 +1170,11 @@ void min_max_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix<RhsScalar>(2, 2, 10);
+  auto y = conditionally_generate_linear_var_matrix<RhsScalar>(2, 2, 10);
 
   assign(x, y, "", index_min(2), index_max(2));
   EXPECT_MATRIX_EQ(x.val().block(1, 0, 2, 2), stan::math::value_of(y));
@@ -1205,7 +1206,7 @@ void positive_minmax_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
   Eigen::Matrix<double, -1, -1> x_val(5, 5);
   Eigen::Matrix<double, -1, -1> x_rev_val(5, 5);
   for (int i = 0; i < x_val.size(); ++i) {
@@ -1288,7 +1289,7 @@ void positive_minmax_positive_minmax_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
   Eigen::Matrix<double, -1, -1> x_val(5, 5);
   Eigen::Matrix<double, -1, -1> x_rev_val(5, 5);
   for (int i = 0; i < x_val.size(); ++i) {
@@ -1519,12 +1520,12 @@ void uni_minmax_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(3, 10);
+  auto y = conditionally_generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(3, 10);
   assign(x, y, "", index_uni(2), index_min_max(2, 4));
   EXPECT_MATRIX_EQ(stan::math::value_of(y).segment(0, 3),
                    x.val().row(1).segment(1, 3));
@@ -1539,10 +1540,10 @@ void uni_minmax_matrix_test() {
   test_throw_out_of_range(x, y, index_uni(2), index_min_max(0, 2));
   test_throw_out_of_range(x, y, index_uni(2), index_min_max(1, 6));
   test_throw_invalid_arg(x,
-                         generate_linear_var_vector<Eigen::RowVectorXd>(2, 10),
+                         conditionally_generate_linear_var_vector<Eigen::RowVectorXd>(2, 10),
                          index_uni(2), index_min_max(2, 4));
   test_throw_invalid_arg(x,
-                         generate_linear_var_vector<Eigen::RowVectorXd>(4, 10),
+                         conditionally_generate_linear_var_vector<Eigen::RowVectorXd>(4, 10),
                          index_uni(2), index_min_max(2, 4));
 }
 
@@ -1555,13 +1556,13 @@ template <typename RhsScalar>
 void nil_matrix() {
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   var_value<Eigen::MatrixXd> x_copy(x.vi_);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix<RhsScalar>(5, 5, 10);
+  auto y = conditionally_generate_linear_var_matrix<RhsScalar>(5, 5, 10);
   assign(x, y, "");
   EXPECT_MATRIX_EQ(stan::math::value_of(y), x.val());
   sum(x).grad();

--- a/src/test/unit/model/indexing/assign_varmat_test.cpp
+++ b/src/test/unit/model/indexing/assign_varmat_test.cpp
@@ -65,67 +65,80 @@ void test_throw_invalid_arg(T1& lhs, const T2& rhs, const I&... idxs) {
                std::invalid_argument);
 }
 
-TEST_F(VarAssign, nil) {
+template <typename Vec, typename RhsScalar>
+void test_nil_vec() {
   using stan::math::var_value;
-  auto x = stan::model::test::generate_linear_var_vector(5);
-  auto y = stan::model::test::generate_linear_var_vector(5, 1.0);
+  using stan::math::var;
+  using stan::model::test::check_adjs;
+  using stan::model::test::generate_linear_var_vector;
+  auto x = generate_linear_var_vector<Vec, var>(5);
+  auto y = generate_linear_var_vector<Vec, RhsScalar>(5, 1.0);
   assign(x, y, "");
   for (Eigen::Index i = 0; i < x.size(); ++i) {
     EXPECT_FLOAT_EQ(x.val().coeffRef(i), i + 1);
   }
   stan::math::sum(x).grad();
-  for (Eigen::Index i = 0; i < x.size(); ++i) {
-    EXPECT_FLOAT_EQ(x.adj().coeffRef(i), 1);
-    EXPECT_FLOAT_EQ(y.adj().coeffRef(i), 1);
-  }
+  auto check_i = [](int i) { return true; };
+  check_adjs(check_i, x, "lhs", 1);
+  check_adjs(check_i, y, "rhs", 1);
+}
+TEST_F(VarAssign, nil) {
+  test_nil_vec<Eigen::VectorXd, stan::math::var>();
+  test_nil_vec<Eigen::VectorXd, double>();
 }
 
-template <typename Vec>
+template <typename Vec, typename RhsScalar>
 void test_uni_vec() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_vector;
   auto x = generate_linear_var_vector<Vec>(5);
   Vec x_val = x.val();
-  stan::math::var y(18);
+  RhsScalar y(18);
   assign(x, y, "", index_uni(2));
-  EXPECT_FLOAT_EQ(y.val(), x.val()[1]);
+  EXPECT_FLOAT_EQ(stan::math::value_of(y), x.val()[1]);
   stan::math::sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return i != 1; };
-  check_vector_adjs(check_i, x, "lhs");
-  EXPECT_FLOAT_EQ(y.adj(), 1);
+  check_adjs(check_i, x, "lhs");
+  check_adjs(y, "rhs", 1);
   test_throw_out_of_range(x, y, index_uni(0));
   test_throw_out_of_range(x, y, index_uni(6));
 }
 
-TEST_F(VarAssign, uni_vec) { test_uni_vec<Eigen::VectorXd>(); }
+TEST_F(VarAssign, uni_vec) {
+   test_uni_vec<Eigen::VectorXd, stan::math::var>();
+   test_uni_vec<Eigen::VectorXd, double>();
+ }
 
-TEST_F(VarAssign, uni_rowvec) { test_uni_vec<Eigen::RowVectorXd>(); }
+TEST_F(VarAssign, uni_rowvec) {
+   test_uni_vec<Eigen::RowVectorXd, stan::math::var>();
+   test_uni_vec<Eigen::RowVectorXd, double>();
+ }
 
-template <typename Vec>
+template <typename Vec, typename RhsScalar>
 void test_multi_vec() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_vector;
   auto x = generate_linear_var_vector<Vec>(5);
   Vec x_val = x.val();
-  auto y = generate_linear_var_vector<Vec>(3, 10);
+  auto y = generate_linear_var_vector<Vec, RhsScalar>(3, 10);
   vector<int> ns;
   ns.push_back(2);
   ns.push_back(4);
   ns.push_back(2);
   assign(x, y, "", index_multi(ns));
-  EXPECT_FLOAT_EQ(y.val()[1], x.val()[3]);
-  EXPECT_FLOAT_EQ(y.val()[2], x.val()[1]);
+  EXPECT_FLOAT_EQ(stan::math::value_of(y)[1], x.val()[3]);
+  EXPECT_FLOAT_EQ(stan::math::value_of(y)[2], x.val()[1]);
   stan::math::sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i_x = [](int i) { return i == 1 || i == 3; };
-  check_vector_adjs(check_i_x, x, "lhs", 0);
+  check_adjs(check_i_x, x, "lhs", 0);
   auto check_i_y = [](int i) { return i > 0; };
-  check_vector_adjs(check_i_y, y, "rhs", 1);
+  check_adjs(check_i_y, y, "rhs", 1);
   ns[2] = 20;
   test_throw_out_of_range(x, y, index_multi(ns));
   ns[2] = 0;
@@ -139,15 +152,21 @@ void test_multi_vec() {
                          index_multi(ns));
 }
 
-TEST_F(VarAssign, multi_vec) { test_multi_vec<Eigen::VectorXd>(); }
+TEST_F(VarAssign, multi_vec) {
+  test_multi_vec<Eigen::VectorXd, stan::math::var>();
+  test_multi_vec<Eigen::VectorXd, double>();
+}
 
-TEST_F(VarAssign, multi_rowvec) { test_multi_vec<Eigen::RowVectorXd>(); }
+TEST_F(VarAssign, multi_rowvec) {
+   test_multi_vec<Eigen::RowVectorXd, stan::math::var>();
+   test_multi_vec<Eigen::RowVectorXd, double>();
+}
 
 template <typename Vec>
 void test_multi_alias_vec() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_vector;
   auto x = generate_linear_var_vector<Eigen::VectorXd>(5, 1);
   Eigen::VectorXd x_val = x.val();
@@ -164,99 +183,128 @@ void test_multi_alias_vec() {
 
 TEST_F(VarAssign, multi_alias_vec) { test_multi_alias_vec<Eigen::VectorXd>(); }
 
-template <typename Vec>
+template <typename Vec, typename RhsScalar>
 void test_omni_vec() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_vector;
   auto x = generate_linear_var_vector<Vec>(5);
-  auto y = generate_linear_var_vector<Vec>(5, 10);
-  Vec y_val = y.val();
-
+  Vec x_val = stan::math::value_of(x);
+  auto y = generate_linear_var_vector<Vec, RhsScalar>(5, 10);
+  Vec y_val = stan::math::value_of(y);
+  auto x_copy = var_value<Vec>(x.vi_);
   assign(x, y, "", index_omni());
-  EXPECT_FLOAT_EQ(y.val()[0], x.val()[0]);
-  EXPECT_FLOAT_EQ(y.val()[1], x.val()[1]);
-  EXPECT_FLOAT_EQ(y.val()[2], x.val()[2]);
-  EXPECT_FLOAT_EQ(y.val()[3], x.val()[3]);
-  EXPECT_FLOAT_EQ(y.val()[4], x.val()[4]);
+  EXPECT_FLOAT_EQ(y_val[0], x.val()[0]);
+  EXPECT_FLOAT_EQ(y_val[1], x.val()[1]);
+  EXPECT_FLOAT_EQ(y_val[2], x.val()[2]);
+  EXPECT_FLOAT_EQ(y_val[3], x.val()[3]);
+  EXPECT_FLOAT_EQ(y_val[4], x.val()[4]);
   sum(x).grad();
-  EXPECT_MATRIX_EQ(x.val(), y_val);
+  if (stan::is_var<RhsScalar>::value) {
+    EXPECT_MATRIX_EQ(x.val(), y_val);
+    EXPECT_MATRIX_EQ(x_copy.val(), x_val);
+  } else {
+    EXPECT_MATRIX_EQ(x.val(), x_val);
+  }
   auto check_i = [](int i) { return true; };
-  check_vector_adjs(check_i, x, "lhs");
-  EXPECT_MATRIX_EQ(y.adj(), Vec::Ones(5));
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(4), index_omni());
-  test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(6), index_omni());
+  if (stan::is_var<RhsScalar>::value) {
+    check_adjs(check_i, x, "lhs", 1.0);
+  } else {
+    check_adjs(check_i, x, "lhs", 0.0);
+  }
+  check_adjs(check_i, y, "rhs", 1.0);
+  test_throw_invalid_arg(x, generate_linear_var_vector<Vec, RhsScalar>(4), index_omni());
+  test_throw_invalid_arg(x, generate_linear_var_vector<Vec, RhsScalar>(6), index_omni());
 }
 
-TEST_F(VarAssign, omni_vec) { test_omni_vec<Eigen::VectorXd>(); }
+TEST_F(VarAssign, omni_vec) {
+   test_omni_vec<Eigen::VectorXd, stan::math::var>();
+   test_omni_vec<Eigen::VectorXd, double>();
+ }
 
-TEST_F(VarAssign, omni_rowvec) { test_omni_vec<Eigen::RowVectorXd>(); }
+TEST_F(VarAssign, omni_rowvec) {
+   test_omni_vec<Eigen::RowVectorXd, stan::math::var>();
+   //test_omni_vec<Eigen::RowVectorXd, double>();
+ }
 
-template <typename Vec>
+template <typename Vec, typename RhsScalar>
 void test_min_vec() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_vector;
   auto x = generate_linear_var_vector<Vec>(5);
-  auto y = generate_linear_var_vector<Vec>(3, 10);
+  auto y = generate_linear_var_vector<Vec, RhsScalar>(3, 10);
   Vec x_val(x.val());
+  auto y_val = stan::math::value_of(y).eval();
   assign(x, y, "", index_min(3));
-  EXPECT_FLOAT_EQ(x.val()(2), y.val()(0));
-  EXPECT_FLOAT_EQ(x.val()(3), y.val()(1));
-  EXPECT_FLOAT_EQ(x.val()(4), y.val()(2));
+  EXPECT_FLOAT_EQ(x.val()(2), y_val(0));
+  EXPECT_FLOAT_EQ(x.val()(3), y_val(1));
+  EXPECT_FLOAT_EQ(x.val()(4), y_val(2));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return i < 2; };
-  check_vector_adjs(check_i, x, "lhs");
-  EXPECT_MATRIX_EQ(y.adj(), Vec::Ones(3));
+  check_adjs(check_i, x, "lhs");
+  check_adjs([](int /* i */) { return true;}, y, "rhs");
   test_throw_out_of_range(x, y, index_min(0));
   test_throw_out_of_range(x, y, index_min(6));
   test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(4), index_min(3));
   test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(2), index_min(3));
 }
-TEST_F(VarAssign, min_vec) { test_min_vec<Eigen::VectorXd>(); }
+TEST_F(VarAssign, min_vec) {
+   test_min_vec<Eigen::VectorXd, stan::math::var>();
+   test_min_vec<Eigen::VectorXd, double>();
+ }
 
-TEST_F(VarAssign, min_rowvec) { test_min_vec<Eigen::RowVectorXd>(); }
+TEST_F(VarAssign, min_rowvec) {
+   test_min_vec<Eigen::RowVectorXd, stan::math::var>();
+   test_min_vec<Eigen::RowVectorXd, double>();
+ }
 
-template <typename Vec>
+template <typename Vec, typename RhsScalar>
 void test_max_vec() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_vector;
   auto x = generate_linear_var_vector<Vec>(5);
   Vec x_val = x.val();
-  auto y = generate_linear_var_vector<Vec>(2, 10);
-
+  auto y = generate_linear_var_vector<Vec, RhsScalar>(2, 10);
+  auto y_val = stan::math::value_of(y);
   assign(x, y, "", index_max(2));
-  EXPECT_FLOAT_EQ(y.val()[0], x.val()[0]);
-  EXPECT_FLOAT_EQ(y.val()[1], x.val()[1]);
+  EXPECT_FLOAT_EQ(y_val[0], x.val()[0]);
+  EXPECT_FLOAT_EQ(y_val[1], x.val()[1]);
   stan::math::sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return i > 1; };
-  check_vector_adjs(check_i, x, "lhs");
-  EXPECT_MATRIX_EQ(y.adj(), Vec::Ones(2));
+  check_adjs(check_i, x, "lhs");
+  check_adjs([](int /* i */) { return true;}, y, "rhs");
   test_throw_out_of_range(x, y, index_max(0));
   test_throw_out_of_range(x, y, index_max(6));
   test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(3), index_max(2));
   test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(1), index_max(2));
 }
 
-TEST_F(VarAssign, max_vec) { test_max_vec<Eigen::VectorXd>(); }
+TEST_F(VarAssign, max_vec) {
+   test_max_vec<Eigen::VectorXd, stan::math::var>();
+   test_max_vec<Eigen::VectorXd, double>();
+ }
 
-TEST_F(VarAssign, max_rowvec) { test_max_vec<Eigen::RowVectorXd>(); }
+TEST_F(VarAssign, max_rowvec) {
+   test_max_vec<Eigen::RowVectorXd, stan::math::var>();
+   test_max_vec<Eigen::RowVectorXd, double>();
+ }
 
-template <typename Vec>
+template <typename Vec, typename RhsScalar>
 void test_positive_minmax_varvector() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_vector;
   auto x = generate_linear_var_vector<Vec>(5);
   Vec x_val = x.val();
-  auto y = generate_linear_var_vector<Vec>(4, 10);
+  auto y = generate_linear_var_vector<Vec, RhsScalar>(4, 10);
 
   assign(x, y, "", index_min_max(1, 4));
   EXPECT_FLOAT_EQ(x.val()(0), 10);
@@ -267,8 +315,8 @@ void test_positive_minmax_varvector() {
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return (i > 3); };
-  check_vector_adjs(check_i, x, "lhs");
-  EXPECT_MATRIX_EQ(y.adj(), Vec::Ones(4));
+  check_adjs(check_i, x, "lhs");
+  check_adjs([](int /* i */) { return true;}, y, "rhs");
   test_throw_out_of_range(x, y, index_min_max(0, 3));
   test_throw_out_of_range(x, y, index_min_max(1, 6));
   test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(5),
@@ -278,22 +326,24 @@ void test_positive_minmax_varvector() {
 }
 
 TEST_F(VarAssign, positive_minmax_vec) {
-  test_positive_minmax_varvector<Eigen::VectorXd>();
+  test_positive_minmax_varvector<Eigen::VectorXd, stan::math::var>();
+  test_positive_minmax_varvector<Eigen::VectorXd, double>();
 }
 
 TEST_F(VarAssign, positive_minmax_rowvec) {
-  test_positive_minmax_varvector<Eigen::RowVectorXd>();
+  test_positive_minmax_varvector<Eigen::RowVectorXd, stan::math::var>();
+  test_positive_minmax_varvector<Eigen::RowVectorXd, double>();
 }
 
-template <typename Vec>
+template <typename Vec, typename RhsScalar>
 void test_negative_minmax_varvector() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_vector;
   auto x = generate_linear_var_vector<Vec>(5);
   Vec x_val = x.val();
-  auto y = generate_linear_var_vector<Vec>(4, 10);
+  auto y = generate_linear_var_vector<Vec, RhsScalar>(4, 10);
 
   assign(x, y, "", index_min_max(4, 1));
   EXPECT_FLOAT_EQ(x.val()(0), 13);
@@ -304,8 +354,8 @@ void test_negative_minmax_varvector() {
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return (i > 3); };
-  check_vector_adjs(check_i, x, "lhs");
-  EXPECT_MATRIX_EQ(y.adj(), Vec::Ones(4));
+  check_adjs(check_i, x, "lhs");
+  check_adjs([](int /* i */) { return true;}, y, "rhs");
   test_throw_out_of_range(x, y, index_min_max(3, 0));
   test_throw_out_of_range(x, y, index_min_max(6, 1));
   test_throw_invalid_arg(x, generate_linear_var_vector<Vec>(5),
@@ -315,11 +365,13 @@ void test_negative_minmax_varvector() {
 }
 
 TEST_F(VarAssign, negative_minmax_vec) {
-  test_negative_minmax_varvector<Eigen::VectorXd>();
+  test_negative_minmax_varvector<Eigen::VectorXd, stan::math::var>();
+  test_negative_minmax_varvector<Eigen::VectorXd, double>();
 }
 
 TEST_F(VarAssign, negative_minmax_rowvec) {
-  test_negative_minmax_varvector<Eigen::RowVectorXd>();
+  test_negative_minmax_varvector<Eigen::RowVectorXd, stan::math::var>();
+  test_negative_minmax_varvector<Eigen::RowVectorXd, double>();
 }
 
 template <typename Vec>
@@ -389,46 +441,53 @@ TEST_F(VarAssign, uni_uni_std_vecrowvec) {
  */
 
 // uni
-TEST_F(VarAssign, uni_matrix) {
+
+template <typename RhsScalar>
+auto uni_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
   auto x = generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::RowVectorXd>(5, 10);
+  auto y = generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(5, 10);
   assign(x, y, "", index_uni(1));
   EXPECT_MATRIX_EQ(y.val().row(0), x.val().row(0));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return i != 0; };
-  auto check_j = [](int j) { return true; };
-  check_matrix_adjs(check_i, check_j, x, "lhs");
-  EXPECT_MATRIX_EQ(y.adj(), Eigen::RowVectorXd::Ones(5));
+  auto check_all = [](int /* j */) { return true; };
+  check_adjs(check_i, check_all, x, "lhs");
+  check_adjs(check_all, y, "rhs");
   test_throw_out_of_range(x, y, index_uni(0));
   test_throw_out_of_range(x, y, index_uni(6));
 }
+TEST_F(VarAssign, uni_matrix) {
+  uni_mat_test<stan::math::var>();
+  uni_mat_test<double>();
+}
 
-TEST_F(VarAssign, uni_uni_matrix) {
+template <typename RhsScalar>
+auto uni_uni_mat_test() {
   using stan::math::sum;
   using stan::math::var;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   auto x = generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  var y = 10.12;
+  RhsScalar y = 10.12;
   assign(x, y, "", index_uni(2), index_uni(3));
-  EXPECT_FLOAT_EQ(y.val(), x.val()(1, 2));
+  EXPECT_FLOAT_EQ(stan::math::value_of(y), x.val()(1, 2));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return i == 1; };
   auto check_j = [](int j) { return j == 2; };
-  check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-  EXPECT_FLOAT_EQ(y.adj(), 1);
+  check_adjs(check_i, check_j, x, "lhs", 0);
+  check_adjs(y, 1);
 
   test_throw_out_of_range(x, y, index_uni(0), index_uni(3));
   test_throw_out_of_range(x, y, index_uni(2), index_uni(0));
@@ -436,32 +495,39 @@ TEST_F(VarAssign, uni_uni_matrix) {
   test_throw_out_of_range(x, y, index_uni(2), index_uni(7));
 }
 
-TEST_F(VarAssign, multi_uni_matrix) {
+TEST_F(VarAssign, uni_uni_matrix) {
+  uni_uni_mat_test<stan::math::var>();
+  uni_uni_mat_test<double>();
+}
+
+template <typename RhsScalar>
+auto multi_uni_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
   auto x = generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::RowVectorXd>(3, 10);
+  auto y = generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(3, 10);
 
   std::vector<int> ns;
   ns.push_back(3);
   ns.push_back(1);
   ns.push_back(1);
   assign(x, y, "", index_multi(ns), index_uni(3));
-  EXPECT_FLOAT_EQ(y.val()(0), x.val()(2, 2));
-  EXPECT_FLOAT_EQ(y.val()(2), x.val()(0, 2));
+  auto y_val = stan::math::value_of(y);
+  EXPECT_FLOAT_EQ(y_val(0), x.val()(2, 2));
+  EXPECT_FLOAT_EQ(y_val(2), x.val()(0, 2));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i_x = [](int i) { return (i == 0 || i == 2); };
   auto check_j_x = [](int j) { return j == 2; };
-  check_matrix_adjs(check_i_x, check_j_x, x, "lhs", 0);
+  check_adjs(check_i_x, check_j_x, x, "lhs", 0);
   auto check_i_y = [](int i) { return i != 1; };
-  check_vector_adjs(check_i_y, y, "rhs", 1);
+  check_adjs(check_i_y, y, "rhs", 1);
 
   ns[ns.size() - 1] = 0;
   test_throw_out_of_range(x, y, index_multi(ns), index_uni(3));
@@ -471,23 +537,30 @@ TEST_F(VarAssign, multi_uni_matrix) {
   test_throw_invalid_arg(x, y, index_multi(ns), index_uni(3));
 }
 
-TEST_F(VarAssign, omni_uni_matrix) {
+TEST_F(VarAssign, multi_uni_matrix) {
+  multi_uni_mat_test<stan::math::var>();
+  multi_uni_mat_test<double>();
+}
+
+template <typename RhsScalar>
+auto omni_uni_mat_test() {
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
   auto x = generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::VectorXd>(5, 10);
+  auto y = generate_linear_var_vector<Eigen::VectorXd, RhsScalar>(5, 10);
   assign(x, y, "", index_omni(), index_uni(1));
-  EXPECT_MATRIX_EQ(y.val(), x.val().col(0));
+  auto y_val = stan::math::value_of(y);
+  EXPECT_MATRIX_EQ(y_val, x.val().col(0));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
-  auto check_i = [](int i) { return true; };
+  auto check_all = [](int i) { return true; };
   auto check_j = [](int j) { return j == 0; };
-  check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-  EXPECT_MATRIX_EQ(y.adj(), Eigen::VectorXd::Ones(5));
+  check_adjs(check_all, check_j, x, "lhs", 0);
+  check_adjs(check_all, y, "rhs");
   test_throw_out_of_range(x, y, index_omni(), index_uni(0));
   test_throw_out_of_range(x, y, index_omni(), index_uni(6));
   test_throw_invalid_arg(x, generate_linear_var_vector<Eigen::VectorXd>(6),
@@ -496,26 +569,31 @@ TEST_F(VarAssign, omni_uni_matrix) {
                          index_omni(), index_uni(1));
 }
 
-TEST_F(VarAssign, minmax_uni_matrix) {
+TEST_F(VarAssign, omni_uni_matrix) {
+  omni_uni_mat_test<stan::math::var>();
+  omni_uni_mat_test<double>();
+}
+
+template <typename RhsScalar>
+auto minmax_uni_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
   auto x = generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector(2, 10);
+  auto y = generate_linear_var_vector<Eigen::VectorXd, RhsScalar>(2, 10);
 
   assign(x, y, "", index_min_max(2, 3), index_uni(4));
-  EXPECT_MATRIX_EQ(y.val(), x.val().col(3).segment(1, 2));
+  EXPECT_MATRIX_EQ(stan::math::value_of(y), x.val().col(3).segment(1, 2));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return (i == 1 || i == 2); };
   auto check_j = [](int j) { return j == 3; };
-  check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-  EXPECT_FLOAT_EQ(y.adj()(0), 1);
-  EXPECT_FLOAT_EQ(y.adj()(1), 1);
+  check_adjs(check_i, check_j, x, "lhs", 0);
+  check_adjs([](int /* */) { return true;}, y, "rhs");
 
   test_throw_out_of_range(x, y, index_min_max(2, 3), index_uni(0));
   test_throw_out_of_range(x, y, index_min_max(2, 3), index_uni(5));
@@ -527,16 +605,21 @@ TEST_F(VarAssign, minmax_uni_matrix) {
                          index_min_max(2, 3), index_uni(4));
 }
 
-// multi
-TEST_F(VarAssign, multi_matrix) {
+TEST_F(VarAssign, minmax_uni_matrix) {
+  minmax_uni_mat_test<stan::math::var>();
+  minmax_uni_mat_test<double>();
+}
+
+template <typename RhsScalar>
+auto multi_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
 
   auto x = generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix(7, 5, 10);
+  auto y = generate_linear_var_matrix<RhsScalar>(7, 5, 10);
   std::vector<int> row_idx{3, 4, 1, 4, 1, 4, 5};
   stan::arena_t<std::vector<int>> x_idx;
   stan::arena_t<std::vector<int>> y_idx;
@@ -557,11 +640,11 @@ TEST_F(VarAssign, multi_matrix) {
   // We don't assign to row 1
   auto check_i_x = [](int i) { return i == 1; };
   auto check_j_x = [](int j) { return true; };
-  check_matrix_adjs(check_i_x, check_j_x, x, "lhs", 1);
+  check_adjs(check_i_x, check_j_x, x, "lhs", 1);
 
   auto check_i_y = [](int i) { return (i == 0 || i > 3); };
   auto check_j_y = [](int j) { return true; };
-  check_matrix_adjs(check_i_y, check_j_y, y, "rhs", 1);
+  check_adjs(check_i_y, check_j_y, y, "rhs", 1);
   test_throw_invalid_arg(x, generate_linear_var_matrix(8, 5, 10),
                          index_multi(row_idx));
   test_throw_invalid_arg(x, generate_linear_var_matrix(6, 5, 10),
@@ -577,10 +660,16 @@ TEST_F(VarAssign, multi_matrix) {
   test_throw_invalid_arg(x, y, index_multi(row_idx));
 }
 
+// multi
+TEST_F(VarAssign, multi_matrix) {
+  multi_mat_test<stan::math::var>();
+  multi_mat_test<double>();
+}
+
 TEST_F(VarAssign, multi_alias_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
 
   auto x = generate_linear_var_matrix(5, 5);
@@ -599,17 +688,18 @@ TEST_F(VarAssign, multi_alias_matrix) {
   EXPECT_MATRIX_EQ(x.adj(), exp_adj);
 }
 
-TEST_F(VarAssign, uni_multi_matrix) {
+template <typename RhsScalar>
+auto uni_multi_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
   auto x = generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::RowVectorXd>(4, 10);
+  auto y = generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(4, 10);
 
   vector<int> ns{4, 1, 3, 3};
   assign(x, y, "", index_uni(3), index_multi(ns));
@@ -621,9 +711,9 @@ TEST_F(VarAssign, uni_multi_matrix) {
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i_x = [](int i) { return i == 2; };
   auto check_j_x = [](int j) { return (j == 0 || j == 2 || j == 3); };
-  check_matrix_adjs(check_i_x, check_j_x, x, "lhs", 0);
+  check_adjs(check_i_x, check_j_x, x, "lhs", 0);
   auto check_i_y = [](int i) { return i != 2; };
-  check_vector_adjs(check_i_y, y, "rhs", 1);
+  check_adjs(check_i_y, y, "rhs", 1);
   test_throw_invalid_arg(x,
                          generate_linear_var_vector<Eigen::RowVectorXd>(5, 10),
                          index_uni(3), index_multi(ns));
@@ -640,11 +730,16 @@ TEST_F(VarAssign, uni_multi_matrix) {
   test_throw_invalid_arg(x, y, index_uni(3), index_multi(ns));
 }
 
+TEST_F(VarAssign, uni_multi_matrix) {
+  uni_multi_mat_test<stan::math::var>();
+  uni_multi_mat_test<double>();
+}
+
 TEST_F(VarAssign, uni_multi_alias_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
@@ -665,15 +760,16 @@ TEST_F(VarAssign, uni_multi_alias_matrix) {
   EXPECT_MATRIX_EQ(x.adj(), exp_adj);
 }
 
-TEST_F(VarAssign, multi_multi_matrix) {
+template <typename RhsScalar>
+auto multi_multi_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
 
   auto x = generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix(7, 7, 10);
+  auto y = generate_linear_var_matrix<RhsScalar>(7, 7, 10);
   std::vector<int> row_idx{3, 4, 1, 4, 1, 4, 5};
   std::vector<int> col_idx{1, 4, 4, 3, 2, 1, 5};
 
@@ -690,9 +786,10 @@ TEST_F(VarAssign, multi_multi_matrix) {
   }
   assign(x, y, "", index_multi(row_idx), index_multi(col_idx));
   // We use these to check the adjoints
+  auto y_val = stan::math::value_of(y);
   for (int i = 0; i < x_idx.size(); ++i) {
     EXPECT_FLOAT_EQ(x.val()(x_idx[i][0], x_idx[i][1]),
-                    y.val()(y_idx[i][0], y_idx[i][1]))
+                    y_val(y_idx[i][0], y_idx[i][1]))
         << "Failed for \ni: " << i << "\nx_idx[i][0]: " << x_idx[i][0]
         << " x_idx[i][1]: " << x_idx[i][1] << "\ny_idx[i][0]: " << y_idx[i][0]
         << " y_idx[i][1]: " << y_idx[i][1];
@@ -702,11 +799,11 @@ TEST_F(VarAssign, multi_multi_matrix) {
   // We don't assign to row 1
   auto check_i_x = [](int i) { return i == 1; };
   auto check_j_x = [](int j) { return true; };
-  check_matrix_adjs(check_i_x, check_j_x, x, "lhs", 1);
+  check_adjs(check_i_x, check_j_x, x, "lhs", 1);
 
   auto check_i_y = [](int i) { return (i == 0 || i > 3); };
   auto check_j_y = [](int j) { return (j > 1); };
-  check_matrix_adjs(check_i_y, check_j_y, y, "rhs", 1);
+  check_adjs(check_i_y, check_j_y, y, "rhs", 1);
 
   test_throw_invalid_arg(x, generate_linear_var_matrix(6, 7, 10),
                          index_multi(row_idx), index_multi(col_idx));
@@ -729,10 +826,15 @@ TEST_F(VarAssign, multi_multi_matrix) {
   test_throw_out_of_range(x, y, index_multi(row_idx), index_multi(col_idx));
 }
 
+TEST_F(VarAssign, multi_multi_matrix) {
+  multi_multi_mat_test<stan::math::var>();
+  multi_multi_mat_test<double>();
+}
+
 TEST_F(VarAssign, multi_multi_alias_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
 
   auto x = generate_linear_var_matrix(5, 5);
@@ -764,11 +866,12 @@ TEST_F(VarAssign, multi_multi_alias_matrix) {
   EXPECT_MATRIX_EQ(x.adj(), exp_adj);
 }
 
-TEST_F(VarAssign, minmax_multi_matrix) {
+template <typename RhsScalar>
+auto minmax_multi_mat_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
@@ -787,10 +890,10 @@ TEST_F(VarAssign, minmax_multi_matrix) {
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i_x = [](int i) { return i < 3; };
   auto check_j_x = [](int j) { return (j == 0 || j == 2 || j == 3); };
-  check_matrix_adjs(check_i_x, check_j_x, x, "lhs", 0);
+  check_adjs(check_i_x, check_j_x, x, "lhs", 0);
   auto check_i_y = [](int i) { return true; };
   auto check_j_y = [](int j) { return j != 2; };
-  check_matrix_adjs(check_i_y, check_j_y, y, "lhs", 1);
+  check_adjs(check_i_y, check_j_y, y, "lhs", 1);
   test_throw_invalid_arg(x, generate_linear_var_matrix(3, 5, 10),
                          index_min_max(1, 3), index_multi(ns));
   test_throw_invalid_arg(x, generate_linear_var_matrix(3, 3, 10),
@@ -810,11 +913,16 @@ TEST_F(VarAssign, minmax_multi_matrix) {
   test_throw_invalid_arg(x, y, index_min_max(1, 3), index_multi(ns));
 }
 
+TEST_F(VarAssign, minmax_multi_matrix) {
+  minmax_multi_mat_test<stan::math::var>();
+  minmax_multi_mat_test<double>();
+}
+
 TEST_F(VarAssign, minmax_multi_alias_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
@@ -837,42 +945,75 @@ TEST_F(VarAssign, minmax_multi_alias_matrix) {
 }
 
 // omni
-TEST_F(VarAssign, omni_matrix) {
+template <typename RhsScalar>
+void omni_matrix_test() {
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
-
+  using stan::math::value_of;
   auto x = generate_linear_var_matrix(5, 5);
+  var_value<Eigen::MatrixXd> x_copy(x.vi_);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix(5, 5, 10);
+  auto y = generate_linear_var_matrix<RhsScalar>(5, 5, 10);
   assign(x, y, "", index_omni());
-  EXPECT_MATRIX_EQ(y.val(), x.val());
+  if (stan::is_var<RhsScalar>::value) {
+    EXPECT_MATRIX_EQ(value_of(y), x.val());
+  } else {
+    EXPECT_MATRIX_EQ(value_of(y), x.val());
+    EXPECT_MATRIX_EQ(value_of(y), x_copy.val());
+  }
   sum(x).grad();
-  EXPECT_MATRIX_EQ(x.val(), y.val());
-  EXPECT_MATRIX_EQ(x.adj(), Eigen::MatrixXd::Ones(5, 5));
-  EXPECT_MATRIX_EQ(y.adj(), Eigen::MatrixXd::Ones(5, 5));
+  auto check_all = [](int /* i */) { return true;};
+  if (stan::is_var<RhsScalar>::value) {
+    EXPECT_MATRIX_EQ(x.val(), value_of(y));
+    check_adjs(check_all, check_all, x, "lhs");
+    check_adjs(check_all, check_all, y, "rhs");
+  } else {
+    // Need to double check this.
+    check_adjs(check_all, check_all, x, "lhs", 0.0);
+    check_adjs(check_all, check_all, x_copy, "lhs", 0.0);
+  }
   test_throw_invalid_arg(x, generate_linear_var_matrix(5, 6, 10), index_omni());
   test_throw_invalid_arg(x, generate_linear_var_matrix(5, 4, 10), index_omni());
   test_throw_invalid_arg(x, generate_linear_var_matrix(6, 5, 10), index_omni());
   test_throw_invalid_arg(x, generate_linear_var_matrix(4, 5, 10), index_omni());
 }
 
-TEST_F(VarAssign, omni_omni_matrix) {
+TEST_F(VarAssign, omni_matrix) {
+  omni_matrix_test<stan::math::var>();
+  omni_matrix_test<double>();
+}
+
+template <typename RhsScalar>
+void omni_omni_matrix_test() {
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
-
+  using stan::math::value_of;
   auto x = generate_linear_var_matrix(5, 5);
+  var_value<Eigen::MatrixXd> x_copy(x.vi_);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix(5, 5, 10);
+  auto y = generate_linear_var_matrix<RhsScalar>(5, 5, 10);
   assign(x, y, "", index_omni(), index_omni());
-  EXPECT_MATRIX_EQ(y.val(), x.val());
+  if (stan::is_var<RhsScalar>::value) {
+    EXPECT_MATRIX_EQ(value_of(y), x.val());
+  } else {
+    EXPECT_MATRIX_EQ(value_of(y), x.val());
+    EXPECT_MATRIX_EQ(value_of(y), x_copy.val());
+  }
   sum(x).grad();
-  EXPECT_MATRIX_EQ(x.val(), y.val());
-  EXPECT_MATRIX_EQ(x.adj(), Eigen::MatrixXd::Ones(5, 5));
-  EXPECT_MATRIX_EQ(y.adj(), Eigen::MatrixXd::Ones(5, 5));
+  auto check_all = [](int /* i */) { return true;};
+  if (stan::is_var<RhsScalar>::value) {
+    EXPECT_MATRIX_EQ(x.val(), value_of(y));
+    check_adjs(check_all, check_all, x, "lhs");
+    check_adjs(check_all, check_all, y, "rhs");
+  } else {
+    // Need to double check this.
+    check_adjs(check_all, check_all, x, "lhs", 0.0);
+    check_adjs(check_all, check_all, x_copy, "lhs", 0.0);
+  }
   test_throw_invalid_arg(x, generate_linear_var_matrix(5, 6, 10), index_omni(),
                          index_omni());
   test_throw_invalid_arg(x, generate_linear_var_matrix(5, 4, 10), index_omni(),
@@ -883,55 +1024,67 @@ TEST_F(VarAssign, omni_omni_matrix) {
                          index_omni());
 }
 
-TEST_F(VarAssign, uni_omni_matrix) {
+TEST_F(VarAssign, omni_omni_matrix) {
+  omni_omni_matrix_test<stan::math::var>();
+  omni_omni_matrix_test<double>();
+}
+
+template <typename RhsScalar>
+void uni_omni_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
   auto x = generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::RowVectorXd>(5, 10);
+  auto y = generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(5, 10);
   assign(x, y, "", index_uni(1), index_omni());
-  EXPECT_MATRIX_EQ(y.val().row(0), x.val().row(0));
+  EXPECT_MATRIX_EQ(stan::math::value_of(y).row(0), x.val().row(0));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return i != 0; };
-  auto check_j = [](int j) { return true; };
-  check_matrix_adjs(check_i, check_j, x, "lhs");
-  EXPECT_MATRIX_EQ(y.adj(), Eigen::RowVectorXd::Ones(5));
+  auto check_all = [](int j) { return true; };
+  check_adjs(check_i, check_all, x, "lhs");
+  check_adjs(check_all, y, "rhs");
 
   test_throw_invalid_arg(x,
-                         generate_linear_var_vector<Eigen::RowVectorXd>(4, 10),
+                         generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(4, 10),
                          index_uni(1), index_omni());
   test_throw_invalid_arg(x,
-                         generate_linear_var_vector<Eigen::RowVectorXd>(6, 10),
+                         generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(6, 10),
                          index_uni(1), index_omni());
   test_throw_out_of_range(x, y, index_uni(0), index_omni());
   test_throw_out_of_range(x, y, index_uni(6), index_omni());
 }
 
+TEST_F(VarAssign, uni_omni_matrix) {
+  uni_omni_matrix_test<stan::math::var>();
+  uni_omni_matrix_test<double>();
+}
+
 // min
-TEST_F(VarAssign, min_matrix) {
+template <typename RhsScalar>
+void min_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
 
   auto x = generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix(2, 4, 10);
+  auto y = generate_linear_var_matrix<RhsScalar>(2, 4, 10);
 
   assign(x, y, "", index_min(2));
-  EXPECT_MATRIX_EQ(x.val().bottomRows(2), y.val());
+  EXPECT_MATRIX_EQ(x.val().bottomRows(2), stan::math::value_of(y));
   sum(x).grad();
   // We don't assign to row 1
   auto check_i_x = [](int i) { return i > 0; };
-  auto check_j_x = [](int j) { return true; };
-  check_matrix_adjs(check_i_x, check_j_x, x, "lhs", 0);
-  EXPECT_MATRIX_EQ(y.adj(), Eigen::MatrixXd::Ones(2, 4));
+  auto check_all = [](int j) { return true; };
+  check_adjs(check_i_x, check_all, x, "lhs", 0);
+  check_adjs(check_all, y, "rhs", 1.0);
   test_throw_out_of_range(x, y, index_min(0));
   test_throw_out_of_range(x, y, index_min(4));
   test_throw_invalid_arg(x, y, index_min(1));
@@ -939,24 +1092,30 @@ TEST_F(VarAssign, min_matrix) {
   test_throw_invalid_arg(x, z, index_min(2));
 }
 
-TEST_F(VarAssign, minmax_min_matrix) {
+TEST_F(VarAssign, min_matrix) {
+  min_matrix_test<stan::math::var>();
+  min_matrix_test<double>();
+}
+
+template <typename RhsScalar>
+void minmax_min_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
 
   auto x = generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix(2, 3, 10);
+  auto y = generate_linear_var_matrix<RhsScalar>(2, 3, 10);
   assign(x, y, "", index_min_max(2, 3), index_min(2));
-  EXPECT_MATRIX_EQ(y.val(), x.val().block(1, 1, 2, 3));
+  EXPECT_MATRIX_EQ(stan::math::value_of(y), x.val().block(1, 1, 2, 3));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return (i == 1 || i == 2); };
   auto check_j = [](int j) { return j > 0; };
-  check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-  EXPECT_MATRIX_EQ(y.adj(), MatrixXd::Ones(2, 3));
-
+  check_adjs(check_i, check_j, x, "lhs", 0);
+  auto check_all = [](int /* */) { return true;};
+  check_adjs(check_all, check_all, y, "rhs");
   test_throw_out_of_range(x, y, index_min_max(0, 3), index_min(2));
   test_throw_out_of_range(x, y, index_min_max(2, 4), index_min(2));
   test_throw_out_of_range(x, y, index_min_max(2, 3), index_min(0));
@@ -967,51 +1126,63 @@ TEST_F(VarAssign, minmax_min_matrix) {
                          index_min_max(2, 3), index_min(2));
 }
 
+TEST_F(VarAssign, minmax_min_matrix) {
+  minmax_min_matrix_test<stan::math::var>();
+  minmax_min_matrix_test<double>();
+}
+
 // max
-TEST_F(VarAssign, max_matrix) {
+template <typename RhsScalar>
+void max_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
 
   auto x = generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix(2, 4, 10);
+  auto y = generate_linear_var_matrix<RhsScalar>(2, 4, 10);
 
   assign(x, y, "", index_max(2));
-  EXPECT_MATRIX_EQ(x.val().topRows(2), y.val());
+  EXPECT_MATRIX_EQ(x.val().topRows(2), stan::math::value_of(y));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i_x = [](int i) { return i < 2; };
-  auto check_j_x = [](int j) { return true; };
-  check_matrix_adjs(check_i_x, check_j_x, x, "lhs", 0);
-  EXPECT_MATRIX_EQ(y.adj(), Eigen::MatrixXd::Ones(2, 4));
+  auto check_all = [](int j) { return true; };
+  check_adjs(check_i_x, check_all, x, "lhs", 0);
+  check_adjs(check_all, y, "rhs");
   test_throw_out_of_range(x, y, index_max(0));
   test_throw_out_of_range(x, y, index_max(4));
   test_throw_invalid_arg(x, y, index_max(1));
   var_value<MatrixXd> z(MatrixXd::Ones(1, 2));
   test_throw_invalid_arg(x, z, index_max(2));
 }
+TEST_F(VarAssign, max_matrix) {
+max_matrix_test<stan::math::var>();
+max_matrix_test<double>();
+}
 
-TEST_F(VarAssign, min_max_matrix) {
+template <typename RhsScalar>
+void min_max_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
 
   auto x = generate_linear_var_matrix(3, 4);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_matrix(2, 2, 10);
+  auto y = generate_linear_var_matrix<RhsScalar>(2, 2, 10);
 
   assign(x, y, "", index_min(2), index_max(2));
-  EXPECT_MATRIX_EQ(x.val().block(1, 0, 2, 2), y.val());
+  EXPECT_MATRIX_EQ(x.val().block(1, 0, 2, 2), stan::math::value_of(y));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   // We don't assign to row 1
   auto check_i_x = [](int i) { return i > 0; };
   auto check_j_x = [](int j) { return j < 2; };
-  check_matrix_adjs(check_i_x, check_j_x, x, "lhs", 0);
-  EXPECT_MATRIX_EQ(y.adj(), Eigen::MatrixXd::Ones(2, 2));
+  check_adjs(check_i_x, check_j_x, x, "lhs", 0);
+  auto check_all = [](int /* i*/) { return true;};
+  check_adjs(check_all, check_all, y, "rhs");
   test_throw_out_of_range(x, y, index_min(0), index_max(2));
   test_throw_out_of_range(x, y, index_min(5), index_max(2));
   test_throw_out_of_range(x, y, index_min(2), index_max(0));
@@ -1021,12 +1192,17 @@ TEST_F(VarAssign, min_max_matrix) {
   test_throw_invalid_arg(x, z, index_min(2), index_max(2));
   test_throw_invalid_arg(x, z, index_min(2), index_max(3));
 }
+TEST_F(VarAssign, min_max_matrix) {
+  min_max_matrix_test<stan::math::var>();
+  min_max_matrix_test<double>();
+}
 
 // minmax
-TEST_F(VarAssign, positive_minmax_matrix) {
+template <typename RhsScalar>
+void positive_minmax_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   Eigen::Matrix<double, -1, -1> x_val(5, 5);
   Eigen::Matrix<double, -1, -1> x_rev_val(5, 5);
@@ -1037,17 +1213,17 @@ TEST_F(VarAssign, positive_minmax_matrix) {
 
   for (int i = 0; i < x_val.rows(); ++i) {
     var_value<Eigen::MatrixXd> x(x_val);
-    var_value<Eigen::MatrixXd> x_rev(x_rev_val);
+    std::conditional_t<stan::is_var<RhsScalar>::value, var_value<Eigen::MatrixXd>, Eigen::MatrixXd> x_rev(x_rev_val);
     const int ii = i + 1;
     assign(x, x_rev.block(0, 0, ii, 5), "", index_min_max(1, ii));
     auto x_val_check = x.val().block(0, 0, ii, 5);
-    auto x_rev_val_check = x_rev.val().block(0, 0, ii, 5);
+    auto x_rev_val_check = stan::math::value_of(x_rev).block(0, 0, ii, 5);
     EXPECT_MATRIX_EQ(x_val_check, x_rev_val_check);
     sum(x).grad();
     auto check_i = [i](int kk) { return kk <= i; };
-    auto check_j = [i](int jj) { return true; };
-    check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-    check_matrix_adjs(check_i, check_j, x_rev, "rhs", 1);
+    auto check_all = [i](int jj) { return true; };
+    check_adjs(check_i, check_all, x, "lhs", 0);
+    check_adjs(check_i, check_all, x_rev, "rhs", 1);
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, 5), index_min_max(0, ii));
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, 5),
                             index_min_max(1, ii + x.rows()));
@@ -1056,11 +1232,16 @@ TEST_F(VarAssign, positive_minmax_matrix) {
     stan::math::recover_memory();
   }
 }
+TEST_F(VarAssign, positive_minmax_matrix) {
+  positive_minmax_matrix_test<stan::math::var>();
+  positive_minmax_matrix_test<double>();
+}
 
-TEST_F(VarAssign, negative_minmax_matrix) {
+template <typename RhsScalar>
+void negative_minmax_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using std::vector;
   Eigen::Matrix<double, -1, -1> x_val(5, 5);
   Eigen::Matrix<double, -1, -1> x_rev_val(5, 5);
@@ -1071,17 +1252,17 @@ TEST_F(VarAssign, negative_minmax_matrix) {
 
   for (int i = 0; i < x_val.rows(); ++i) {
     var_value<Eigen::MatrixXd> x(x_val);
-    var_value<Eigen::MatrixXd> x_rev(x_rev_val);
+    std::conditional_t<stan::is_var<RhsScalar>::value, var_value<Eigen::MatrixXd>, Eigen::MatrixXd> x_rev(x_rev_val);
     const int ii = i + 1;
     assign(x, x_rev.block(0, 0, ii, 5), "", index_min_max(ii, 1));
     auto x_val_check = x.val().block(0, 0, ii, 5);
-    auto x_rev_val_check = x_rev.val().block(0, 0, ii, 5).colwise().reverse();
+    auto x_rev_val_check = stan::math::value_of(x_rev).block(0, 0, ii, 5).colwise().reverse();
     EXPECT_MATRIX_EQ(x_val_check, x_rev_val_check);
     sum(x).grad();
     auto check_i = [i](int kk) { return kk <= i; };
-    auto check_j = [i](int jj) { return true; };
-    check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-    check_matrix_adjs(check_i, check_j, x_rev, "rhs", 1);
+    auto check_all = [i](int jj) { return true; };
+    check_adjs(check_i, check_all, x, "lhs", 0);
+    check_adjs(check_i, check_all, x_rev, "rhs", 1);
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, 5), index_min_max(ii, 0));
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, 5),
                             index_min_max(ii + x.rows(), 1));
@@ -1090,11 +1271,16 @@ TEST_F(VarAssign, negative_minmax_matrix) {
     stan::math::recover_memory();
   }
 }
+TEST_F(VarAssign, negative_minmax_matrix) {
+  negative_minmax_matrix_test<stan::math::var>();
+  negative_minmax_matrix_test<double>();
+}
 
-TEST_F(VarAssign, positive_minmax_positive_minmax_matrix) {
+template <typename RhsScalar>
+void positive_minmax_positive_minmax_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   Eigen::Matrix<double, -1, -1> x_val(5, 5);
   Eigen::Matrix<double, -1, -1> x_rev_val(5, 5);
@@ -1105,7 +1291,7 @@ TEST_F(VarAssign, positive_minmax_positive_minmax_matrix) {
 
   for (int i = 0; i < x_val.rows(); ++i) {
     var_value<Eigen::MatrixXd> x(x_val);
-    var_value<Eigen::MatrixXd> x_rev(x_rev_val);
+    std::conditional_t<stan::is_var<RhsScalar>::value, var_value<Eigen::MatrixXd>, Eigen::MatrixXd> x_rev(x_rev_val);
     const int ii = i + 1;
     assign(x, x_rev.block(0, 0, ii, ii), "", index_min_max(1, ii),
            index_min_max(1, ii));
@@ -1115,8 +1301,8 @@ TEST_F(VarAssign, positive_minmax_positive_minmax_matrix) {
     sum(x).grad();
     auto check_i = [i](int kk) { return kk <= i; };
     auto check_j = [i](int jj) { return jj <= i; };
-    check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-    check_matrix_adjs(check_i, check_j, x_rev, "rhs", 1);
+    check_adjs(check_i, check_j, x, "lhs", 0);
+    check_adjs(check_i, check_j, x_rev, "rhs", 1);
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, ii), index_min_max(0, ii),
                             index_min_max(1, ii));
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, ii), index_min_max(1, ii),
@@ -1140,10 +1326,16 @@ TEST_F(VarAssign, positive_minmax_positive_minmax_matrix) {
   }
 }
 
-TEST_F(VarAssign, positive_minmax_negative_minmax_matrix) {
+TEST_F(VarAssign, positive_minmax_positive_minmax_matrix) {
+  positive_minmax_positive_minmax_matrix_test<stan::math::var>();
+  positive_minmax_positive_minmax_matrix_test<double>();
+}
+
+template <typename RhsScalar>
+void positive_minmax_negative_minmax_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using std::vector;
   Eigen::Matrix<double, -1, -1> x_val(5, 5);
   Eigen::Matrix<double, -1, -1> x_rev_val(5, 5);
@@ -1154,18 +1346,18 @@ TEST_F(VarAssign, positive_minmax_negative_minmax_matrix) {
 
   for (int i = 0; i < x_val.rows(); ++i) {
     var_value<Eigen::MatrixXd> x(x_val);
-    var_value<Eigen::MatrixXd> x_rev(x_rev_val);
+    std::conditional_t<stan::is_var<RhsScalar>::value, var_value<Eigen::MatrixXd>, Eigen::MatrixXd> x_rev(x_rev_val);
     const int ii = i + 1;
     assign(x, x_rev.block(0, 0, ii, ii), "", index_min_max(1, ii),
            index_min_max(ii, 1));
     auto x_val_check = x.val().block(0, 0, ii, ii);
-    auto x_rev_val_check = x_rev.val().block(0, 0, ii, ii).rowwise().reverse();
+    auto x_rev_val_check = stan::math::value_of(x_rev).block(0, 0, ii, ii).rowwise().reverse();
     EXPECT_MATRIX_EQ(x_val_check, x_rev_val_check);
     sum(x).grad();
     auto check_i = [i](int kk) { return kk <= i; };
     auto check_j = [i](int jj) { return jj <= i; };
-    check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-    check_matrix_adjs(check_i, check_j, x_rev, "rhs", 1);
+    check_adjs(check_i, check_j, x, "lhs", 0);
+    check_adjs(check_i, check_j, x_rev, "rhs", 1);
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, ii), index_min_max(0, ii),
                             index_min_max(ii, 1));
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, ii), index_min_max(1, ii),
@@ -1189,10 +1381,16 @@ TEST_F(VarAssign, positive_minmax_negative_minmax_matrix) {
   }
 }
 
-TEST_F(VarAssign, negative_minmax_positive_minmax_matrix) {
+TEST_F(VarAssign, positive_minmax_negative_minmax_matrix) {
+  positive_minmax_negative_minmax_matrix_test<stan::math::var>();
+  positive_minmax_negative_minmax_matrix_test<double>();
+}
+
+template <typename RhsScalar>
+void negative_minmax_positive_minmax_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using std::vector;
   Eigen::Matrix<double, -1, -1> x_val(5, 5);
   Eigen::Matrix<double, -1, -1> x_rev_val(5, 5);
@@ -1203,18 +1401,18 @@ TEST_F(VarAssign, negative_minmax_positive_minmax_matrix) {
 
   for (int i = 0; i < x_val.rows(); ++i) {
     var_value<Eigen::MatrixXd> x(x_val);
-    var_value<Eigen::MatrixXd> x_rev(x_rev_val);
+    std::conditional_t<stan::is_var<RhsScalar>::value, var_value<Eigen::MatrixXd>, Eigen::MatrixXd> x_rev(x_rev_val);
     const int ii = i + 1;
     assign(x, x_rev.block(0, 0, ii, ii), "", index_min_max(ii, 1),
            index_min_max(1, ii));
     auto x_val_check = x.val().block(0, 0, ii, ii);
-    auto x_rev_val_check = x_rev.val().block(0, 0, ii, ii).colwise().reverse();
+    auto x_rev_val_check = stan::math::value_of(x_rev).block(0, 0, ii, ii).colwise().reverse();
     EXPECT_MATRIX_EQ(x_val_check, x_rev_val_check);
     sum(x).grad();
     auto check_i = [i](int kk) { return kk <= i; };
     auto check_j = [i](int jj) { return jj <= i; };
-    check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-    check_matrix_adjs(check_i, check_j, x_rev, "rhs", 1);
+    check_adjs(check_i, check_j, x, "lhs", 0);
+    check_adjs(check_i, check_j, x_rev, "rhs", 1);
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, ii), index_min_max(ii, 0),
                             index_min_max(1, ii));
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, ii), index_min_max(ii, 1),
@@ -1238,10 +1436,16 @@ TEST_F(VarAssign, negative_minmax_positive_minmax_matrix) {
   }
 }
 
-TEST_F(VarAssign, negative_minmax_negative_minmax_matrix) {
+TEST_F(VarAssign, negative_minmax_positive_minmax_matrix) {
+negative_minmax_positive_minmax_matrix_test<stan::math::var>();
+negative_minmax_positive_minmax_matrix_test<double>();
+}
+
+template <typename RhsScalar>
+void negative_minmax_negative_minmax_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using std::vector;
   Eigen::Matrix<double, -1, -1> x_val(5, 5);
   Eigen::Matrix<double, -1, -1> x_rev_val(5, 5);
@@ -1252,18 +1456,18 @@ TEST_F(VarAssign, negative_minmax_negative_minmax_matrix) {
 
   for (int i = 0; i < x_val.rows(); ++i) {
     var_value<Eigen::MatrixXd> x(x_val);
-    var_value<Eigen::MatrixXd> x_rev(x_rev_val);
+    std::conditional_t<stan::is_var<RhsScalar>::value, var_value<Eigen::MatrixXd>, Eigen::MatrixXd> x_rev(x_rev_val);
     const int ii = i + 1;
     assign(x, x_rev.block(0, 0, ii, ii), "", index_min_max(ii, 1),
            index_min_max(ii, 1));
     auto x_val_check = x.val().block(0, 0, ii, ii);
-    auto x_rev_val_check = x_rev.val().block(0, 0, ii, ii).reverse();
+    auto x_rev_val_check = stan::math::value_of(x_rev).block(0, 0, ii, ii).reverse();
     EXPECT_MATRIX_EQ(x_val_check, x_rev_val_check);
     sum(x).grad();
     auto check_i = [i](int kk) { return kk <= i; };
     auto check_j = [i](int jj) { return jj <= i; };
-    check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-    check_matrix_adjs(check_i, check_j, x_rev, "rhs", 1);
+    check_adjs(check_i, check_j, x, "lhs", 0);
+    check_adjs(check_i, check_j, x_rev, "rhs", 1);
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, ii), index_min_max(ii, 0),
                             index_min_max(ii, 1));
     test_throw_out_of_range(x, x_rev.block(0, 0, ii, ii), index_min_max(ii, 1),
@@ -1287,25 +1491,31 @@ TEST_F(VarAssign, negative_minmax_negative_minmax_matrix) {
   }
 }
 
-TEST_F(VarAssign, uni_minmax_matrix) {
+TEST_F(VarAssign, negative_minmax_negative_minmax_matrix) {
+  negative_minmax_negative_minmax_matrix_test<stan::math::var>();
+  negative_minmax_negative_minmax_matrix_test<double>();
+}
+
+template <typename RhsScalar>
+void uni_minmax_matrix_test() {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
-  using stan::model::test::check_vector_adjs;
+  using stan::model::test::check_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
   auto x = generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
-  auto y = generate_linear_var_vector<Eigen::RowVectorXd>(3, 10);
+  auto y = generate_linear_var_vector<Eigen::RowVectorXd, RhsScalar>(3, 10);
   assign(x, y, "", index_uni(2), index_min_max(2, 4));
-  EXPECT_MATRIX_EQ(y.val().segment(0, 3), x.val().row(1).segment(1, 3));
+  EXPECT_MATRIX_EQ(stan::math::value_of(y).segment(0, 3), x.val().row(1).segment(1, 3));
   sum(x).grad();
   EXPECT_MATRIX_EQ(x.val(), x_val);
   auto check_i = [](int i) { return i == 1; };
   auto check_j = [](int j) { return (j > 0 && j < 4); };
-  check_matrix_adjs(check_i, check_j, x, "lhs", 0);
-  EXPECT_MATRIX_EQ(y.adj(), Eigen::RowVectorXd::Ones(3));
+  check_adjs(check_i, check_j, x, "lhs", 0);
+  check_adjs([](int /* */) { return true;}, y, "rhs");
   test_throw_out_of_range(x, y, index_uni(0), index_min_max(2, 4));
   test_throw_out_of_range(x, y, index_uni(6), index_min_max(2, 4));
   test_throw_out_of_range(x, y, index_uni(2), index_min_max(0, 2));
@@ -1318,10 +1528,15 @@ TEST_F(VarAssign, uni_minmax_matrix) {
                          index_uni(2), index_min_max(2, 4));
 }
 
+TEST_F(VarAssign, uni_minmax_matrix) {
+uni_minmax_matrix_test<stan::math::var>();
+uni_minmax_matrix_test<double>();
+}
+
 // nil only shows up as a single index
 TEST_F(VarAssign, nil_matrix) {
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 
@@ -1340,14 +1555,14 @@ namespace stan {
 namespace model {
 namespace test {
 
-template <typename T1, typename I1, typename I2>
+template <typename RhsScalar, typename T1, typename I1, typename I2>
 inline void assign_tester(T1&& x, const I1& idx1, const I2& idx2) {
   using stan::math::var_value;
   using stan::model::test::generate_linear_matrix;
   auto multi1 = convert_to_multi(idx1, x, false);
   auto multi2 = convert_to_multi(idx2, x, true);
   var_value<std::decay_t<T1>> x1(x);
-  var_value<std::decay_t<T1>> x2(x);
+  std::conditional_t<is_var<RhsScalar>::value, var_value<std::decay_t<T1>>, std::decay_t<T1>> x2(x);
   Eigen::MatrixXd y_val
       = generate_linear_matrix(multi1.ns_.size(), multi2.ns_.size(), 10);
   var_value<Eigen::MatrixXd> y(y_val);

--- a/src/test/unit/model/indexing/rvalue_varmat_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_varmat_test.cpp
@@ -415,9 +415,9 @@ TEST_F(RvalueRev, uni_mat) {
   using Eigen::VectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(4, 3);
+  auto x = conditionally_generate_linear_var_matrix(4, 3);
 
   var_value<Eigen::RowVectorXd> y = rvalue(x, "", index_uni(1));
   EXPECT_EQ(3, y.size());
@@ -462,9 +462,9 @@ TEST_F(RvalueRev, omni_uni_mat) {
   using Eigen::VectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::VectorXd> y = rvalue(x, "", index_omni(), index_uni(2));
   EXPECT_EQ(3, y.size());
   EXPECT_MATRIX_EQ(y.val(), x.val().col(1));
@@ -482,10 +482,10 @@ TEST_F(RvalueRev, multi_uni_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
   using stan::model::test::check_adjs;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   std::vector<int> ns{3, 1, 1};
   var_value<Eigen::VectorXd> y = rvalue(x, "", index_multi(ns), index_uni(3));
   EXPECT_FLOAT_EQ(y.val()(0), x.val()(2, 2));
@@ -511,9 +511,9 @@ TEST_F(RvalueRev, min_uni_mat) {
   using Eigen::VectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::VectorXd> y = rvalue(x, "", index_min(2), index_uni(3));
   EXPECT_EQ(2, y.size());
   EXPECT_MATRIX_EQ(y.val(), x.val().col(2).segment(1, 2));
@@ -533,9 +533,9 @@ TEST_F(RvalueRev, min_uni_mat) {
 TEST_F(RvalueRev, minmax_uni_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::VectorXd> y
       = rvalue(x, "", index_min_max(2, 3), index_uni(4));
   EXPECT_MATRIX_EQ(y.val(), x.val().col(3).segment(1, 2));
@@ -553,9 +553,9 @@ TEST_F(RvalueRev, minmax_uni_matrix) {
 TEST_F(RvalueRev, negative_minmax_uni_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::VectorXd> y
       = rvalue(x, "", index_min_max(3, 2), index_uni(4));
   EXPECT_MATRIX_EQ(y.val(), x.val().col(3).segment(1, 2).reverse());
@@ -577,9 +577,9 @@ TEST_F(RvalueRev, multi_mat) {
   using Eigen::VectorXd;
   using stan::math::var_value;
 
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(4, 3);
+  auto x = conditionally_generate_linear_var_matrix(4, 3);
   std::vector<int> row_idx{3, 4, 1, 4, 1, 4, 1};
   var_value<Eigen::MatrixXd> y = rvalue(x, "", index_multi(row_idx));
   EXPECT_FLOAT_EQ(7, y.rows());
@@ -612,10 +612,10 @@ TEST_F(RvalueRev, multi_mat) {
 TEST_F(RvalueRev, uni_multi_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   std::vector<int> ns{4, 1, 3, 3};
   var_value<Eigen::RowVectorXd> y
       = rvalue(x, "", index_uni(3), index_multi(ns));
@@ -682,10 +682,10 @@ TEST_F(RvalueRev, multi_multi_mat) {
 TEST_F(RvalueRev, minmax_multi_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   std::vector<int> ns{4, 1, 3, 3};
   var_value<Eigen::MatrixXd> y
       = rvalue(x, "", index_min_max(1, 3), index_multi(ns));
@@ -715,9 +715,9 @@ TEST_F(RvalueRev, omni_mat) {
   using Eigen::VectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(4, 3);
+  auto x = conditionally_generate_linear_var_matrix(4, 3);
   var_value<Eigen::MatrixXd> y = rvalue(x, "", index_omni());
   EXPECT_EQ(4, y.rows());
   EXPECT_EQ(3, y.cols());
@@ -733,9 +733,9 @@ TEST_F(RvalueRev, uni_omni_mat) {
   using Eigen::RowVectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::RowVectorXd> y = rvalue(x, "", index_uni(2), index_omni());
   EXPECT_EQ(4, y.size());
   EXPECT_MATRIX_EQ(y.val(), x.val().row(1));
@@ -755,9 +755,9 @@ TEST_F(RvalueRev, omni_omni_mat) {
   using Eigen::VectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::MatrixXd> y = rvalue(x, "", index_omni(), index_omni());
   EXPECT_EQ(x.rows(), y.rows());
   EXPECT_EQ(x.cols(), y.cols());
@@ -775,9 +775,9 @@ TEST_F(RvalueRev, min_mat) {
   using Eigen::VectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(4, 3);
+  auto x = conditionally_generate_linear_var_matrix(4, 3);
   var_value<Eigen::MatrixXd> y = rvalue(x, "", index_min(3));
   EXPECT_EQ(2, y.rows());
   EXPECT_EQ(3, y.cols());
@@ -797,9 +797,9 @@ TEST_F(RvalueRev, uni_min_mat) {
   using Eigen::RowVectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::RowVectorXd> y = rvalue(x, "", index_uni(3), index_min(2));
   EXPECT_EQ(3, y.size());
   EXPECT_MATRIX_EQ(y.val(), x.val().row(2).segment(1, 3));
@@ -821,8 +821,8 @@ TEST_F(RvalueRev, min_min_mat) {
   using Eigen::VectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
-  auto x = generate_linear_var_matrix(3, 4);
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   stan::math::var_value<Eigen::MatrixXd> y
       = rvalue(x, "", index_min(2), index_min(3));
   EXPECT_EQ(2, y.rows());
@@ -843,9 +843,9 @@ TEST_F(RvalueRev, min_min_mat) {
 TEST_F(RvalueRev, minmax_min_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::MatrixXd> y
       = rvalue(x, "", index_min_max(2, 3), index_min(2));
   EXPECT_MATRIX_EQ(y.val(), x.val().block(1, 1, 2, 3));
@@ -868,9 +868,9 @@ TEST_F(RvalueRev, max_mat) {
   using Eigen::VectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(4, 3);
+  auto x = conditionally_generate_linear_var_matrix(4, 3);
   var_value<Eigen::MatrixXd> y = rvalue(x, "", index_max(2));
   EXPECT_EQ(2, y.rows());
   EXPECT_EQ(3, y.cols());
@@ -888,9 +888,9 @@ TEST_F(RvalueRev, max_mat) {
 TEST_F(RvalueRev, min_max_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::MatrixXd> y = rvalue(x, "", index_min(2), index_max(2));
   EXPECT_MATRIX_EQ(y.val(), x.val().block(1, 0, 2, 2));
   sum(y).grad();
@@ -912,9 +912,9 @@ TEST_F(RvalueRev, positive_min_max_mat) {
   using Eigen::VectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(4, 3);
+  auto x = conditionally_generate_linear_var_matrix(4, 3);
   var_value<Eigen::MatrixXd> y = rvalue(x, "", index_min_max(2, 3));
   EXPECT_EQ(2, y.rows());
   EXPECT_EQ(3, y.cols());
@@ -936,9 +936,9 @@ TEST_F(RvalueRev, negative_min_max_mat) {
   using Eigen::VectorXd;
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
 
-  auto x = generate_linear_var_matrix(3, 4);
+  auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::MatrixXd> y = rvalue(x, "", index_min_max(3, 2));
   EXPECT_EQ(2, y.rows());
   EXPECT_EQ(4, y.cols());
@@ -956,7 +956,7 @@ TEST_F(RvalueRev, negative_min_max_mat) {
 TEST_F(RvalueRev, positive_minmax_positive_minmax_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
   Eigen::MatrixXd x_val(5, 5);
   for (int i = 0; i < x_val.size(); ++i) {
     x_val(i) = i;
@@ -1058,10 +1058,10 @@ TEST_F(RvalueRev, negative_minmax_negative_minmax_matrix) {
 TEST_F(RvalueRev, uni_minmax_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   var_value<Eigen::RowVectorXd> y
       = rvalue(x, "", index_uni(2), index_min_max(2, 4));
   EXPECT_MATRIX_EQ(y.val(), x.val().row(1).segment(1, 3));
@@ -1080,10 +1080,10 @@ TEST_F(RvalueRev, uni_minmax_matrix) {
 TEST_F(RvalueRev, uni_negative_minmax_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   var_value<Eigen::RowVectorXd> y
       = rvalue(x, "", index_uni(2), index_min_max(4, 2));
   EXPECT_MATRIX_EQ(y.val(), x.val().row(1).segment(1, 3).reverse());
@@ -1102,10 +1102,10 @@ TEST_F(RvalueRev, uni_negative_minmax_matrix) {
 // nil only shows up as a single index
 TEST_F(RvalueRev, nil_matrix) {
   using stan::math::var_value;
-  using stan::model::test::generate_linear_var_matrix;
-  using stan::model::test::generate_linear_var_vector;
+  using stan::model::test::conditionally_generate_linear_var_matrix;
+  using stan::model::test::conditionally_generate_linear_var_vector;
 
-  auto x = generate_linear_var_matrix(5, 5);
+  auto x = conditionally_generate_linear_var_matrix(5, 5);
   Eigen::MatrixXd x_val = x.val();
   auto y = rvalue(x, "");
   EXPECT_MATRIX_EQ(y.val(), x.val());

--- a/src/test/unit/model/indexing/rvalue_varmat_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_varmat_test.cpp
@@ -434,7 +434,7 @@ TEST_F(RvalueRev, uni_mat) {
 }
 
 TEST_F(RvalueRev, uni_uni_mat) {
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   Eigen::MatrixXd x_val(3, 4);
   x_val << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
   for (int m = 0; m < 3; ++m) {
@@ -445,7 +445,7 @@ TEST_F(RvalueRev, uni_uni_mat) {
       x_sub.grad();
       auto check_i = [m](int i) { return m == i; };
       auto check_j = [n](int j) { return n == j; };
-      check_matrix_adjs(check_i, check_j, x);
+      check_adjs(check_i, check_j, x);
       stan::math::recover_memory();
     }
   }
@@ -481,7 +481,7 @@ TEST_F(RvalueRev, omni_uni_mat) {
 TEST_F(RvalueRev, multi_uni_matrix) {
   using stan::math::sum;
   using stan::math::var_value;
-  using stan::model::test::check_matrix_adjs;
+  using stan::model::test::check_adjs;
   using stan::model::test::generate_linear_var_matrix;
   using stan::model::test::generate_linear_var_vector;
 

--- a/src/test/unit/model/indexing/util.hpp
+++ b/src/test/unit/model/indexing/util.hpp
@@ -160,7 +160,7 @@ auto generate_linear_matrix(Eigen::Index n, Eigen::Index m, double start = 0) {
  * @param start Where the linear sequence should start from.
  */
 template <typename RhsScalar = stan::math::var>
-auto generate_linear_var_matrix(Eigen::Index n, Eigen::Index m,
+auto conditionally_generate_linear_var_matrix(Eigen::Index n, Eigen::Index m,
                                 double start = 0) {
   using ret_t
       = std::conditional_t<is_var<RhsScalar>::value,
@@ -193,7 +193,7 @@ auto generate_linear_vector(Eigen::Index n, double start = 0) {
  */
 template <typename Vec = Eigen::Matrix<double, -1, 1>,
           typename RhsScalar = stan::math::var>
-auto generate_linear_var_vector(Eigen::Index n, double start = 0) {
+auto conditionally_generate_linear_var_vector(Eigen::Index n, double start = 0) {
   using ret_t = std::conditional_t<is_var<RhsScalar>::value,
                                    stan::math::var_value<Vec>, Vec>;
   return ret_t(generate_linear_vector<Vec>(n, start));

--- a/src/test/unit/model/indexing/util.hpp
+++ b/src/test/unit/model/indexing/util.hpp
@@ -19,8 +19,8 @@ namespace test {
  * @param x A vector holding underlying containers
  * @param name A helper name to print out on failure.
  */
-template <typename Check1, typename Check2, typename StdVecVar>
-void check_std_vec_adjs(Check1&& i_check, Check2&& j_check, const StdVecVar& x,
+template <typename Check1, typename Check2, typename StdVecVar, require_std_vector_t<StdVecVar>* = nullptr>
+void check_adjs(Check1&& i_check, Check2&& j_check, const StdVecVar& x,
                         const char* name) {
   for (Eigen::Index i = 0; i < x.size(); ++i) {
     for (Eigen::Index j = 0; j < x[i].size(); ++j) {
@@ -57,8 +57,8 @@ void check_std_vec_adjs(Check1&& i_check, Check2&& j_check, const StdVecVar& x,
  *  0, any cell satisfying `i_check` and `j_check` are assumed to be 0, and
  *  all cells that fail are equal to 1.
  */
-template <typename Check1, typename Check2, typename VarMat>
-void check_matrix_adjs(Check1&& i_check, Check2&& j_check, const VarMat& x,
+template <typename Check1, typename Check2, typename VarMat, require_var_matrix_t<VarMat>* = nullptr>
+void check_adjs(Check1&& i_check, Check2&& j_check, const VarMat& x,
                        const char* name = "", int check_val = 1) {
   for (Eigen::Index j = 0; j < x.cols(); ++j) {
     for (Eigen::Index i = 0; i < x.rows(); ++i) {
@@ -82,6 +82,33 @@ void check_matrix_adjs(Check1&& i_check, Check2&& j_check, const VarMat& x,
 }
 
 /**
+ * Check an Eigen matrix's adjoints
+ * @tparam Check1 Functor with one integer argument that returns bool
+ * @tparam Check1 Functor with one integer argument that returns bool
+ * @tparam VarMat A matrix of vars or var with inner matrix type.
+ * @param i_check Check whether a row of the matrix should be inspected.
+ * @param j_check Check whether a column of the matrix should be inspected.
+ * @param x A matrix type.
+ * @param name A helper name to print out on failure.
+ * @param check_val when 1, any cell satisfying `i_check` and `j_check` are
+ *  assumed to be 1 and all cells that fail either are 0. When `check_val` is
+ *  0, any cell satisfying `i_check` and `j_check` are assumed to be 0, and
+ *  all cells that fail are equal to 1.
+ */
+template <typename Check1, typename Check2, typename VarMat, require_eigen_vt<std::is_arithmetic, VarMat>* = nullptr>
+void check_adjs(Check1&& i_check, Check2&& j_check, const VarMat& x,
+                       const char* name = "", int check_val = 1) {
+}
+
+void check_adjs(stan::math::var x, const char* name = "", int check_val = 1) {
+  EXPECT_FLOAT_EQ(x.adj(), check_val)
+         << "Failed on " << name;
+}
+
+void check_adjs(double x, const char* name = "", int check_val = 1) {
+}
+
+/**
  * Check an Eigen vector's adjoints
  * @tparam Check1 Functor with one integer argument that returns bool
  * @tparam VarMat A vector of vars or var with inner matrix type.
@@ -93,8 +120,8 @@ void check_matrix_adjs(Check1&& i_check, Check2&& j_check, const VarMat& x,
  *  0, any cell satisfying `i_check` are assumed to be 0, and
  *  all cells that fail are equal to 1.
  */
-template <typename Check1, typename VarMat>
-void check_vector_adjs(Check1&& i_check, const VarMat& x, const char* name = "",
+template <typename Check1, typename VarMat, require_st_var<VarMat>* = nullptr>
+void check_adjs(Check1&& i_check, const VarMat& x, const char* name = "",
                        int check_val = 1) {
   for (Eigen::Index i = 0; i < x.size(); ++i) {
     if (i_check(i)) {
@@ -106,6 +133,15 @@ void check_vector_adjs(Check1&& i_check, const VarMat& x, const char* name = "",
     }
   }
 }
+template <typename Check1, typename VarMat, require_st_arithmetic<VarMat>* = nullptr>
+void check_adjs(Check1&& i_check, const VarMat& x, const char* name = "",
+                       int check_val = 1) {
+
+                       }
+
+
+
+
 
 /**
  * Generate a matrix holding a linear sequence.
@@ -128,9 +164,10 @@ auto generate_linear_matrix(Eigen::Index n, Eigen::Index m, double start = 0) {
  * @param m Number of columns.
  * @param start Where the linear sequence should start from.
  */
+template <typename RhsScalar = stan::math::var>
 auto generate_linear_var_matrix(Eigen::Index n, Eigen::Index m,
                                 double start = 0) {
-  using ret_t = stan::math::var_value<Eigen::Matrix<double, -1, -1>>;
+  using ret_t = std::conditional_t<is_var<RhsScalar>::value, stan::math::var_value<Eigen::Matrix<double, -1, -1>>, Eigen::Matrix<double, -1, -1>>;
   return ret_t(generate_linear_matrix(n, m, start));
 }
 
@@ -156,9 +193,9 @@ auto generate_linear_vector(Eigen::Index n, double start = 0) {
  * @param n Number of cells.
  * @param start Where the linear sequence should start from.
  */
-template <typename Vec = Eigen::Matrix<double, -1, 1>>
+template <typename Vec = Eigen::Matrix<double, -1, 1>, typename RhsScalar = stan::math::var>
 auto generate_linear_var_vector(Eigen::Index n, double start = 0) {
-  using ret_t = stan::math::var_value<Vec>;
+  using ret_t = std::conditional_t<is_var<RhsScalar>::value, stan::math::var_value<Vec>, Vec>;
   return ret_t(generate_linear_vector<Vec>(n, start));
 }
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This fixes the `assign()` errors from https://github.com/stan-dev/stanc3/pull/898 for doing `var<Matrix> = Eigen::Matrix<double>`. Combining this with https://github.com/stan-dev/math/pull/2535 removed the errors on the sample of test models I tried out in the stanc test suite that were previously failing.

Explicit paths had to be added in the callbacks for assignment using `index_uni` and `index_multi`. For all the other functions I wrote a `assign_impl()` function that is just `A = B` for all cases besides `var<Matrix> = Eigen::Matrix<double>`. For that case we do a procedure to update the var values and then in a reverse pass callback put back the old values and reset the adjoints to zero.

#### Intended Effect

Allow assignment from `Eigen::Matrix<double>` to `var<Matrix>` in the stanc generated C++.

#### How to Verify

All the old tests for `var<Matrix>` assignment were pulled out and made into functions that test assignment from both a `var<Eigen::Matrix<double>>` and `Eigen::Matrix<double>`. These can be run with 

```
./runTests.py ./src/test/unit/model/indexing/assign_varmat_test.cpp
```

#### Side Effects

None

#### Documentation

Docs added for new `assign_impl()` function.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
