### PR TITLE
Fix include orders for indexing

### DIFF
--- a/src/stan/model/indexing.hpp
+++ b/src/stan/model/indexing.hpp
@@ -1,16 +1,18 @@
 #ifndef STAN_MODEL_INDEXING_HPP
 #define STAN_MODEL_INDEXING_HPP
 
+#include <stan/model/indexing/assign.hpp>
 #ifdef STAN_OPENCL
 #include <stan/model/indexing/assign_cl.hpp>
-#include <stan/model/indexing/rvalue_cl.hpp>
 #endif
+#include <stan/model/indexing/assign_varmat.hpp>
 
 #include <stan/model/indexing/deep_copy.hpp>
 #include <stan/model/indexing/index.hpp>
-#include <stan/model/indexing/assign.hpp>
-#include <stan/model/indexing/assign_varmat.hpp>
 #include <stan/model/indexing/rvalue.hpp>
+#ifdef STAN_OPENCL
+#include <stan/model/indexing/rvalue_cl.hpp>
+#endif
 #include <stan/model/indexing/rvalue_varmat.hpp>
 
 #endif

--- a/src/stan/model/indexing.hpp
+++ b/src/stan/model/indexing.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MODEL_INDEXING_HPP
 #define STAN_MODEL_INDEXING_HPP
 
+#include <stan/model/indexing/access_helpers.hpp>
 #include <stan/model/indexing/assign.hpp>
 #ifdef STAN_OPENCL
 #include <stan/model/indexing/assign_cl.hpp>

--- a/src/stan/model/indexing/access_helpers.hpp
+++ b/src/stan/model/indexing/access_helpers.hpp
@@ -66,7 +66,6 @@ void assign_impl(Mat1&& x, Mat2&& y) {
   });
 }
 
-
 }  // namespace internal
 }  // namespace model
 }  // namespace stan

--- a/src/stan/model/indexing/access_helpers.hpp
+++ b/src/stan/model/indexing/access_helpers.hpp
@@ -29,6 +29,44 @@ inline auto colwise_reverse(const T& x) {
   return x.colwise().reverse();
 }
 
+/**
+ * Base case of assignment
+ * @tparam T1 Any type that's not a var matrix.
+ * @tparam T2 Any type that's not a var matrix.
+ * @param x The value to assign to
+ * @param y The value to assign from.
+ */
+template <typename T1, typename T2,
+          require_any_not_t<is_var_matrix<T1>, is_eigen<T2>>* = nullptr>
+void assign_impl(T1&& x, T2&& y) {
+  x = std::forward<T2>(y);
+}
+
+/**
+ * Assigning an `Eigen::Matrix<double>` to a `var<Matrix>`
+ * In this case we need to
+ * 1. Store the previous values from `x`
+ * 2. Assign the values from `y` to the values of `x`
+ * 3. Setup a reverse pass callback that sets the `x` values to it's previous
+ *  values and then zero's out the adjoints.
+ *
+ * @tparam Mat1 A `var_value` with inner type derived from `EigenBase`
+ * @tparam Mat2 A type derived from `EigenBase` with an arithmetic scalar.
+ * @param x The var matrix to assign to
+ * @param y The eigen matrix to assign from.
+ */
+template <typename Mat1, typename Mat2, require_var_matrix_t<Mat1>,
+          require_eigen_st<std::is_arithmetic, Mat2>>
+void assign_impl(Mat1&& x, Mat2&& y) {
+  auto prev_vals = stan::math::to_arena(x.val());
+  x.vi_->val_ = std::forward<Mat2>(y);
+  stan::math::reverse_pass_callback([x, prev_vals]() mutable {
+    x.vi_->val_ = prev_vals;
+    x.vi_->adj_.setZero();
+  });
+}
+
+
 }  // namespace internal
 }  // namespace model
 }  // namespace stan

--- a/src/stan/model/indexing/access_helpers.hpp
+++ b/src/stan/model/indexing/access_helpers.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MODEL_INDEXING_ACCESS_HELPERS_HPP
 #define STAN_MODEL_INDEXING_ACCESS_HELPERS_HPP
 
-#include <stan/math/prim.hpp>
 #include <stan/math/rev/meta.hpp>
 
 namespace stan {

--- a/src/stan/model/indexing/access_helpers.hpp
+++ b/src/stan/model/indexing/access_helpers.hpp
@@ -2,6 +2,7 @@
 #define STAN_MODEL_INDEXING_ACCESS_HELPERS_HPP
 
 #include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/fun/to_arena.hpp>
 
 namespace stan {
 
@@ -55,8 +56,8 @@ void assign_impl(T1&& x, T2&& y) {
  * @param x The var matrix to assign to
  * @param y The eigen matrix to assign from.
  */
-template <typename Mat1, typename Mat2, require_var_matrix_t<Mat1>,
-          require_eigen_st<std::is_arithmetic, Mat2>>
+template <typename Mat1, typename Mat2, require_var_matrix_t<Mat1>* = nullptr,
+          require_eigen_st<std::is_arithmetic, Mat2>* = nullptr>
 void assign_impl(Mat1&& x, Mat2&& y) {
   auto prev_vals = stan::math::to_arena(x.val());
   x.vi_->val_ = std::forward<Mat2>(y);

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -15,27 +15,6 @@ namespace stan {
 
 namespace model {
 
-namespace internal {
-/**
- * Base case of assignment
- * @tparam T1 Any type that's not a var matrix.
- * @tparam T2 Any type that's not a var matrix.
- * @param x The value to assign to
- * @param y The value to assign from.
- */
-template <typename T1, typename T2,
-          require_any_not_t<is_var_matrix<T1>, is_eigen<T2>>* = nullptr>
-void assign_impl(T1&& x, T2&& y) {
-  x = std::forward<T2>(y);
-}
-
-// Fwd decl here and define later.
-template <typename Mat1, typename Mat2, require_var_matrix_t<Mat1>* = nullptr,
-          require_eigen_st<std::is_arithmetic, Mat2>* = nullptr>
-void assign_impl(Mat1&& x, Mat2&& y);
-
-}  // namespace internal
-
 /**
  * Indexing Notes:
  * The different index types:

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -1,7 +1,9 @@
 #ifndef STAN_MODEL_INDEXING_ASSIGN_HPP
 #define STAN_MODEL_INDEXING_ASSIGN_HPP
 
-#include <stan/math/prim.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/model/indexing/access_helpers.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>
@@ -26,6 +28,11 @@ template <typename T1, typename T2,
 void assign_impl(T1&& x, T2&& y) {
   x = std::forward<T2>(y);
 }
+
+// Fwd decl here and define later.
+template <typename Mat1, typename Mat2, require_var_matrix_t<Mat1>* = nullptr,
+          require_eigen_st<std::is_arithmetic, Mat2>* = nullptr>
+void assign_impl(Mat1&& x, Mat2&& y);
 
 }  // namespace internal
 

--- a/src/stan/model/indexing/assign_varmat.hpp
+++ b/src/stan/model/indexing/assign_varmat.hpp
@@ -33,29 +33,6 @@ using require_var_row_vector_or_arithmetic_eigen = require_any_t<
     stan::math::disjunction<std::is_arithmetic<scalar_type_t<T>>,
                             is_eigen_row_vector<T>>>;
 
-/**
- * Assigning an `Eigen::Matrix<double>` to a `var<Matrix>`
- * In this case we need to
- * 1. Store the previous values from `x`
- * 2. Assign the values from `y` to the values of `x`
- * 3. Setup a reverse pass callback that sets the `x` values to it's previous
- *  values and then zero's out the adjoints.
- *
- * @tparam Mat1 A `var_value` with inner type derived from `EigenBase`
- * @tparam Mat2 A type derived from `EigenBase` with an arithmetic scalar.
- * @param x The var matrix to assign to
- * @param y The eigen matrix to assign from.
- */
-template <typename Mat1, typename Mat2, require_var_matrix_t<Mat1>,
-          require_eigen_st<std::is_arithmetic, Mat2>>
-void assign_impl(Mat1&& x, Mat2&& y) {
-  auto prev_vals = stan::math::to_arena(x.val());
-  x.vi_->val_ = std::forward<Mat2>(y);
-  stan::math::reverse_pass_callback([x, prev_vals]() mutable {
-    x.vi_->val_ = prev_vals;
-    x.vi_->adj_.setZero();
-  });
-}
 }  // namespace internal
 /**
  * Indexing Notes:

--- a/src/stan/model/indexing/assign_varmat.hpp
+++ b/src/stan/model/indexing/assign_varmat.hpp
@@ -1,11 +1,11 @@
 #ifndef STAN_MODEL_INDEXING_ASSIGN_VARMAT_HPP
 #define STAN_MODEL_INDEXING_ASSIGN_VARMAT_HPP
 
-#include <stan/math/rev.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/fun/adjoint_of.hpp>
 #include <stan/model/indexing/access_helpers.hpp>
 #include <stan/model/indexing/index.hpp>
-#include <stan/model/indexing/rvalue_at.hpp>
-#include <stan/model/indexing/rvalue_index_size.hpp>
 #include <type_traits>
 #include <vector>
 #include <unordered_set>

--- a/src/stan/model/indexing/assign_varmat.hpp
+++ b/src/stan/model/indexing/assign_varmat.hpp
@@ -46,8 +46,8 @@ using require_var_row_vector_or_arithmetic_eigen = require_any_t<
  * @param x The var matrix to assign to
  * @param y The eigen matrix to assign from.
  */
-template <typename Mat1, typename Mat2, require_var_matrix_t<Mat1>* = nullptr,
-          require_eigen_st<std::is_arithmetic, Mat2>* = nullptr>
+template <typename Mat1, typename Mat2, require_var_matrix_t<Mat1>,
+          require_eigen_st<std::is_arithmetic, Mat2>>
 void assign_impl(Mat1&& x, Mat2&& y) {
   auto prev_vals = stan::math::to_arena(x.val());
   x.vi_->val_ = std::forward<Mat2>(y);

--- a/src/stan/model/indexing/index.hpp
+++ b/src/stan/model/indexing/index.hpp
@@ -1,8 +1,9 @@
 #ifndef STAN_MODEL_INDEXING_INDEX_HPP
 #define STAN_MODEL_INDEXING_INDEX_HPP
 
-#include <vector>
 #include <stan/math/prim/meta.hpp>
+#include <vector>
+
 namespace stan {
 
 namespace model {

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -1,8 +1,9 @@
 #ifndef STAN_MODEL_INDEXING_RVALUE_HPP
 #define STAN_MODEL_INDEXING_RVALUE_HPP
 
-#include <stan/math/prim.hpp>
-#include <stan/math/rev.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/rvalue_at.hpp>
 #include <stan/model/indexing/rvalue_index_size.hpp>

--- a/src/stan/model/indexing/rvalue_varmat.hpp
+++ b/src/stan/model/indexing/rvalue_varmat.hpp
@@ -1,8 +1,8 @@
 #ifndef STAN_MODEL_INDEXING_RVALUE_VARMAT_HPP
 #define STAN_MODEL_INDEXING_RVALUE_VARMAT_HPP
 
-#include <stan/math/prim.hpp>
-#include <stan/math/rev.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/meta.hpp>
 #include <stan/model/indexing/index.hpp>
 #include <stan/model/indexing/rvalue.hpp>
 #include <type_traits>

--- a/src/test/unit/model/indexing/assign_test.cpp
+++ b/src/test/unit/model/indexing/assign_test.cpp
@@ -1,10 +1,9 @@
+#include <src/stan/model/indexing.hpp>
+#include <stan/math/rev.hpp>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <stdexcept>
 #include <vector>
-#include <stan/model/indexing/assign.hpp>
-#include <stan/model/indexing/rvalue.hpp>
-#include <stan/math/rev.hpp>
-#include <gtest/gtest.h>
 
 using Eigen::Dynamic;
 using Eigen::Matrix;

--- a/src/test/unit/model/indexing/assign_varmat_test.cpp
+++ b/src/test/unit/model/indexing/assign_varmat_test.cpp
@@ -1,13 +1,11 @@
-#include <iostream>
-#include <stdexcept>
-#include <vector>
-#include <stan/model/indexing/assign_varmat.hpp>
-#include <stan/model/indexing/assign.hpp>
-#include <stan/model/indexing/rvalue.hpp>
+#include <src/stan/model/indexing.hpp>
 #include <stan/math/rev.hpp>
 #include <test/unit/util.hpp>
 #include <test/unit/model/indexing/util.hpp>
 #include <gtest/gtest.h>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
 
 using Eigen::Dynamic;
 using Eigen::Matrix;

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -1,9 +1,9 @@
+#include <src/stan/model/indexing.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <stdexcept>
 #include <vector>
-#include <stan/model/indexing/rvalue.hpp>
-#include <stan/math.hpp>
-#include <gtest/gtest.h>
 
 using stan::model::rvalue;
 

--- a/src/test/unit/model/indexing/rvalue_varmat_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_varmat_test.cpp
@@ -1,12 +1,11 @@
-#include <iostream>
-#include <stdexcept>
-#include <vector>
-#include <stan/model/indexing/rvalue.hpp>
-#include <stan/model/indexing/rvalue_varmat.hpp>
+#include <src/stan/model/indexing.hpp>
 #include <test/unit/util.hpp>
 #include <test/unit/model/indexing/util.hpp>
 #include <stan/math.hpp>
 #include <gtest/gtest.h>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
 
 using stan::model::index_max;
 using stan::model::index_min;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

There were some include order issues with https://github.com/stan-dev/stanc3/pull/898 that this PR fixes. This tries to cleanup some of the init orders so that we only bring in what we need for the rvalue and assign functions. Mostly that involves not including `/prim/fun.hpp` and `/rev/fun.hpp`. The only extra functions we need from those are really `to_ref()` and `adjoint_of()`

#### Intended Effect

Cleanup include orders so new var matrix compiles.

#### How to Verify

No new tests, I pulled down a few of the failing stan models locally and checked they compiled. 

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
