### PR TITLE
local stringstreams preserve precision of main stream in unique_stream_writer

### DIFF
--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -71,6 +71,7 @@ class unique_stream_writer final : public writer {
    */
   void operator()() {
     std::stringstream streamer;
+    streamer.precision(output_.get()->precision());
     streamer << comment_prefix_ << std::endl;
     *output_ << streamer.str();
   }
@@ -82,6 +83,7 @@ class unique_stream_writer final : public writer {
    */
   void operator()(const std::string& message) {
     std::stringstream streamer;
+    streamer.precision(output_.get()->precision());
     streamer << comment_prefix_ << message << std::endl;
     *output_ << streamer.str();
   }
@@ -113,6 +115,7 @@ class unique_stream_writer final : public writer {
     const_iter last = v.end();
     --last;
     std::stringstream streamer;
+    streamer.precision(output_.get()->precision());
     for (const_iter it = v.begin(); it != last; ++it) {
       streamer << *it << ",";
     }

--- a/src/test/unit/callbacks/unique_stream_writer_test.cpp
+++ b/src/test/unit/callbacks/unique_stream_writer_test.cpp
@@ -27,6 +27,24 @@ TEST_F(StanInterfaceCallbacksStreamWriter, double_vector) {
             static_cast<std::stringstream&>(writer.get_stream()).str());
 }
 
+TEST_F(StanInterfaceCallbacksStreamWriter, double_vector_precision2) {
+  const int N = 5;
+  std::vector<double> x{1.23456789, 2.3456789, 3.45678910, 4.567890123};
+  writer.get_stream().precision(2);
+  EXPECT_NO_THROW(writer(x));
+  EXPECT_EQ("1.2,2.3,3.5,4.6\n",
+            static_cast<std::stringstream&>(writer.get_stream()).str());
+}
+
+TEST_F(StanInterfaceCallbacksStreamWriter, double_vector_precision3) {
+  const int N = 5;
+  std::vector<double> x{1.23456789, 2.3456789, 3.45678910, 4.567890123};
+  writer.get_stream().precision(3);
+  EXPECT_NO_THROW(writer(x));
+  EXPECT_EQ("1.23,2.35,3.46,4.57\n",
+            static_cast<std::stringstream&>(writer.get_stream()).str());
+}
+
 TEST_F(StanInterfaceCallbacksStreamWriter, string_vector) {
   const int N = 5;
   std::vector<std::string> x;


### PR DESCRIPTION


#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Small fix for https://github.com/stan-dev/cmdstan/pull/987, @wds15 we just need to set the precision of the local stringstreams in `unique_stream_writer` so that formatting stays correct.

#### Intended Effect

Bug fix

#### How to Verify

Tests for preserving precision can be run with 

```
./runTests.py ./src/test/unit/callbacks/unique_stream_writer_test.cpp
```

#### Side Effects

Nope!

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
