### PR TITLE
Mark rethrow_located as [[noreturn]]

### DIFF
--- a/src/stan/model/rethrow_located.hpp
+++ b/src/stan/model/rethrow_located.hpp
@@ -81,7 +81,8 @@ struct located_exception : public E {
  * @param[in] e original exception
  * @param[in] location string representing the source file location
  */
-inline void rethrow_located(const std::exception& e, std::string location) {
+[[noreturn]] inline void rethrow_located(const std::exception& e,
+                                         std::string location) {
   using std::bad_alloc;      // -> exception
   using std::bad_cast;       // -> exception
   using std::bad_exception;  // -> exception
@@ -143,9 +144,9 @@ inline void rethrow_located(const std::exception& e, std::string location) {
  *   exception originated
  * @param[in] reader trace of how program was included from files
  */
-inline void rethrow_located(const std::exception& e, int line,
-                            const io::program_reader& reader
-                            = stan::io::program_reader()) {
+[[noreturn]] inline void rethrow_located(const std::exception& e, int line,
+                                         const io::program_reader& reader
+                                         = stan::io::program_reader()) {
   std::stringstream o;
   if (line < 1) {
     o << "  Found before start of program.";


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Marks `rethrow_located` as never returning using the [noreturn attribute](https://en.cppreference.com/w/cpp/language/attributes/noreturn). This should allow us to simplify the existing code generation in stanc3, as currently we generate this code:
```c++
    try {
        ....
    } catch (const std::exception& e) {
      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
      // Next line prevents compiler griping about no return
      throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
    }

```

This should make that extra `throw` unnecessary. 

#### Intended Effect
Let the compiler know that rethrow_located will never return

#### How to Verify

I've tested this in a local cmdstan instance, though I was not able to get the error described in the comment to appear, with or without this change.

#### Side Effects

None

#### Documentation

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
