### PR TITLE
StanHeaders patches for RStan 2.21

### DIFF
--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -1638,16 +1638,30 @@ class reader {
   inline auto vector_offset_multiplier_constrain(const TL offset,
                                                  const TS multiplier,
                                                  size_t m) {
+#ifdef USE_STANC3
     return stan::math::offset_multiplier_constrain(vector(m), offset,
                                                    multiplier);
+#else
+    vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_offset_multiplier_constrain(offset, multiplier);
+    return v;
+#endif
   }
 
   template <typename TL, typename TS>
   inline auto vector_offset_multiplier_constrain(const TL offset,
                                                  const TS multiplier, size_t m,
                                                  T &lp) {
+#ifdef USE_STANC3
     return stan::math::offset_multiplier_constrain(vector(m), offset,
                                                    multiplier, lp);
+#else
+    vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_offset_multiplier_constrain(offset, multiplier, lp);
+    return v;
+#endif
   }
 
   template <typename TL, typename TS>
@@ -1661,16 +1675,30 @@ class reader {
   inline auto row_vector_offset_multiplier_constrain(const TL offset,
                                                      const TS multiplier,
                                                      size_t m) {
+#ifdef USE_STANC3
     return stan::math::offset_multiplier_constrain(row_vector(m), offset,
                                                    multiplier);
+#else
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_offset_multiplier_constrain(offset, multiplier);
+    return v;
+#endif
   }
 
   template <typename TL, typename TS>
   inline auto row_vector_offset_multiplier_constrain(const TL offset,
                                                      const TS multiplier,
                                                      size_t m, T &lp) {
+#ifdef USE_STANC3
     return stan::math::offset_multiplier_constrain(row_vector(m), offset,
                                                    multiplier, lp);
+#else
+    row_vector_t v(m);
+    for (size_t i = 0; i < m; ++i)
+      v(i) = scalar_offset_multiplier_constrain(offset, multiplier, lp);
+    return v;
+#endif
   }
 
   template <typename TL, typename TS>
@@ -1684,16 +1712,32 @@ class reader {
   inline auto matrix_offset_multiplier_constrain(const TL offset,
                                                  const TS multiplier, size_t m,
                                                  size_t n) {
+#ifdef USE_STANC3
     return stan::math::offset_multiplier_constrain(matrix(m, n), offset,
                                                    multiplier);
+#else
+    matrix_t v(m, n);
+    for (size_t j = 0; j < n; ++j)
+      for (size_t i = 0; i < m; ++i)
+        v(i, j) = scalar_offset_multiplier_constrain(offset, multiplier);
+    return v;
+#endif
   }
 
   template <typename TL, typename TS>
   inline auto matrix_offset_multiplier_constrain(const TL offset,
                                                  const TS multiplier, size_t m,
                                                  size_t n, T &lp) {
+#ifdef USE_STANC3
     return stan::math::offset_multiplier_constrain(matrix(m, n), offset,
                                                    multiplier, lp);
+#else
+    matrix_t v(m, n);
+    for (size_t j = 0; j < n; ++j)
+      for (size_t i = 0; i < m; ++i)
+        v(i, j) = scalar_offset_multiplier_constrain(offset, multiplier, lp);
+    return v;
+#endif
   }
 };
 

--- a/src/stan/io/reader.hpp
+++ b/src/stan/io/reader.hpp
@@ -1189,7 +1189,6 @@ class reader {
     return stan::math::cholesky_corr_constrain(vector((K * (K - 1)) / 2), K);
   }
 
-
   /**
    * Return the next Cholesky factor for a correlation matrix with
    * the specified dimensionality, reading from an unconstrained

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -195,7 +195,8 @@ inline auto rvalue(Vec&& v,
  */
 template <typename Vec, require_vector_t<Vec>* = nullptr,
           require_not_std_vector_t<Vec>* = nullptr>
-inline auto rvalue(Vec&& x, const cons_index_list<index_min, nil_index_list>& idxs,
+inline auto rvalue(Vec&& x,
+                   const cons_index_list<index_min, nil_index_list>& idxs,
                    const char* name = "ANON", int depth = 0) {
   stan::math::check_range("vector[min] indexing", name, x.size(),
                           idxs.head_.min_);

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -195,17 +195,15 @@ inline auto rvalue(Vec&& v,
  */
 template <typename Vec, require_vector_t<Vec>* = nullptr,
           require_not_std_vector_t<Vec>* = nullptr>
-inline
-#ifdef USE_STANC3
-  auto
-#else
-  plain_type_t<Vec>
-#endif  
-  rvalue(Vec&& x, const cons_index_list<index_min, nil_index_list>& idxs,
-         const char* name = "ANON", int depth = 0) {
+inline auto rvalue(Vec&& x, const cons_index_list<index_min, nil_index_list>& idxs,
+                   const char* name = "ANON", int depth = 0) {
   stan::math::check_range("vector[min] indexing", name, x.size(),
                           idxs.head_.min_);
+#ifdef USE_STANC3
   return x.tail(x.size() - idxs.head_.min_ + 1);
+#else
+  return x.tail(x.size() - idxs.head_.min_ + 1).eval();
+#endif
 }
 
 /**
@@ -250,7 +248,11 @@ inline auto rvalue(Mat&& x,
                    const cons_index_list<index_uni, nil_index_list>& idxs,
                    const char* name = "ANON", int depth = 0) {
   math::check_range("matrix[uni] indexing", name, x.rows(), idxs.head_.n_);
+#ifdef USE_STANC3
   return x.row(idxs.head_.n_ - 1);
+#else
+  return x.row(idxs.head_.n_ - 1).eval();
+#endif
 }
 
 /**
@@ -560,13 +562,7 @@ inline plain_type_t<EigMat> rvalue(
  * @param[in] depth Depth of indexing dimension.
  */
 template <typename Mat, typename Idx, require_dense_dynamic_t<Mat>* = nullptr>
-inline
-#ifdef USE_STANC3
-  auto
-#else
-  Eigen::Matrix<value_type_t<Mat>, -1, 1>
-#endif  
-  rvalue(
+inline auto rvalue(
     Mat&& x,
     const cons_index_list<Idx, cons_index_list<index_uni, nil_index_list>>&
         idxs,

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -226,7 +226,11 @@ inline auto rvalue(Vec&& x,
                    const char* name = "ANON", int depth = 0) {
   stan::math::check_range("vector[max] indexing", name, x.size(),
                           idxs.head_.max_);
+#ifdef USE_STANC3
   return x.head(idxs.head_.max_);
+#else
+  return x.head(idxs.head_.max_).eval();
+#endif
 }
 
 /**

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -195,9 +195,14 @@ inline auto rvalue(Vec&& v,
  */
 template <typename Vec, require_vector_t<Vec>* = nullptr,
           require_not_std_vector_t<Vec>* = nullptr>
-inline auto rvalue(Vec&& x,
-                   const cons_index_list<index_min, nil_index_list>& idxs,
-                   const char* name = "ANON", int depth = 0) {
+inline
+#ifdef USE_STANC3
+  auto
+#else
+  plain_type_t<Vec>
+#endif  
+  rvalue(Vec&& x, const cons_index_list<index_min, nil_index_list>& idxs,
+         const char* name = "ANON", int depth = 0) {
   stan::math::check_range("vector[min] indexing", name, x.size(),
                           idxs.head_.min_);
   return x.tail(x.size() - idxs.head_.min_ + 1);
@@ -555,7 +560,13 @@ inline plain_type_t<EigMat> rvalue(
  * @param[in] depth Depth of indexing dimension.
  */
 template <typename Mat, typename Idx, require_dense_dynamic_t<Mat>* = nullptr>
-inline auto rvalue(
+inline
+#ifdef USE_STANC3
+  auto
+#else
+  Eigen::Matrix<value_type_t<Mat>, -1, 1>
+#endif  
+  rvalue(
     Mat&& x,
     const cons_index_list<Idx, cons_index_list<index_uni, nil_index_list>>&
         idxs,


### PR DESCRIPTION
Hi @hsbadr this PR is a companion to the Math PR, and adds changes needed for the rstan revdeps to build with the rstan 2.21 & StanHeaders 2.26 combo.

The `rvalue` changes are needed because they were returning `Eigen::Block` types, which caused build errors for `idem` and `ubms`.

The `reader` changes were needed to allow for the vectorised `offset_constrain`, to fix build errors with `ppcseq`