### PR TITLE
Update version numbers to 2.28

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -24,4 +24,4 @@ Describe what you expect the output to be. Knowing the correct behavior is also 
 Provide any additional information here.
 
 #### Current Version:
-v2.28.0
+v2.28.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,11 @@ Note: these are the release notes for the stan-dev/stan repository.
 Further changes may arise at the interface level (stan-dev/{rstan,
 pystan, cmdstan}) and math library level (stan-dev/math).
 
+v2.28.1 (21 October 2021)
+======================================================================
+
+ - Updated to Stan Math 4.2.1
+
 v2.28.0 (5 October 2021)
 ======================================================================
 

--- a/src/doxygen/doxygen.cfg
+++ b/src/doxygen/doxygen.cfg
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Stan"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.28.0
+PROJECT_NUMBER         = 2.28.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/stan/version.hpp
+++ b/src/stan/version.hpp
@@ -13,7 +13,7 @@
 
 #define STAN_MAJOR 2
 #define STAN_MINOR 28
-#define STAN_PATCH 0
+#define STAN_PATCH 1
 
 namespace stan {
 

--- a/src/test/unit/version_test.cpp
+++ b/src/test/unit/version_test.cpp
@@ -4,11 +4,11 @@
 TEST(Stan, macro) {
   EXPECT_EQ(2, STAN_MAJOR);
   EXPECT_EQ(28, STAN_MINOR);
-  EXPECT_EQ(0, STAN_PATCH);
+  EXPECT_EQ(1, STAN_PATCH);
 }
 
 TEST(Stan, version) {
   EXPECT_EQ("2", stan::MAJOR_VERSION);
   EXPECT_EQ("28", stan::MINOR_VERSION);
-  EXPECT_EQ("0", stan::PATCH_VERSION);
+  EXPECT_EQ("1", stan::PATCH_VERSION);
 }


### PR DESCRIPTION
#### Summary

Updates the version numbers to 2.28. Had to make a branch to make sure the Stan Math submodule is not changed.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar, Nicusor Serban


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
