### PR TITLE
add std:: in tests to avoid ambiguity

### DIFF
--- a/src/test/unit/variational/advi_univar_no_constraint_test.cpp
+++ b/src/test/unit/variational/advi_univar_no_constraint_test.cpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-
 typedef boost::ecuyer1988 rng_t;
 typedef univariate_no_constraint_model_namespace::univariate_no_constraint_model
     Model;
@@ -66,7 +65,8 @@ TEST(advi_test, univar_no_constraint_fullrank) {
 
   elbo_true += log(S_j);
   elbo_true += log(1.0 / (sqrt(sigma_j_sq * 2.0 * stan::math::pi())));
-  elbo_true += -0.5 * (std::pow(mu_j - 1.88, 2) / sigma_j_sq + 1.0 / sigma_j_sq);
+  elbo_true
+      += -0.5 * (std::pow(mu_j - 1.88, 2) / sigma_j_sq + 1.0 / sigma_j_sq);
   elbo_true += 0.5 * (1 + log(2.0 * stan::math::pi()));
 
   double const EPSILON = 0.1;
@@ -191,7 +191,8 @@ TEST(advi_test, univar_no_constraint_meanfield) {
 
   elbo_true += log(S_j);
   elbo_true += log(1.0 / (sqrt(sigma_j_sq * 2.0 * stan::math::pi())));
-  elbo_true += -0.5 * (std::pow(mu_j - 1.88, 2) / sigma_j_sq + 1.0 / sigma_j_sq);
+  elbo_true
+      += -0.5 * (std::pow(mu_j - 1.88, 2) / sigma_j_sq + 1.0 / sigma_j_sq);
   elbo_true += 0.5 * (1 + log(2.0 * stan::math::pi()));
 
   double const EPSILON = 0.1;

--- a/src/test/unit/variational/advi_univar_no_constraint_test.cpp
+++ b/src/test/unit/variational/advi_univar_no_constraint_test.cpp
@@ -1,11 +1,13 @@
 #include <test/test-models/good/variational/univariate_no_constraint.hpp>
 #include <stan/variational/advi.hpp>
 #include <stan/callbacks/stream_logger.hpp>
-#include <gtest/gtest.h>
 #include <test/unit/util.hpp>
-#include <vector>
-#include <string>
 #include <boost/random/additive_combine.hpp>  // L'Ecuyer RNG
+#include <gtest/gtest.h>
+#include <cmath>
+#include <string>
+#include <vector>
+
 
 typedef boost::ecuyer1988 rng_t;
 typedef univariate_no_constraint_model_namespace::univariate_no_constraint_model
@@ -57,14 +59,14 @@ TEST(advi_test, univar_no_constraint_fullrank) {
 
   double S_j = 1.0 / (2.0 * stan::math::pi()) * sqrt(sigma_j_sq / (1.0))
                * exp(-0.5
-                     * (pow(1.5, 2) + pow(1.4, 2) + pow(1.6, 2)
-                        - pow(mu_j, 2) / sigma_j_sq));
+                     * (std::pow(1.5, 2) + std::pow(1.4, 2) + std::pow(1.6, 2)
+                        - std::pow(mu_j, 2) / sigma_j_sq));
 
   double elbo_true = 0.0;
 
   elbo_true += log(S_j);
   elbo_true += log(1.0 / (sqrt(sigma_j_sq * 2.0 * stan::math::pi())));
-  elbo_true += -0.5 * (pow(mu_j - 1.88, 2) / sigma_j_sq + 1.0 / sigma_j_sq);
+  elbo_true += -0.5 * (std::pow(mu_j - 1.88, 2) / sigma_j_sq + 1.0 / sigma_j_sq);
   elbo_true += 0.5 * (1 + log(2.0 * stan::math::pi()));
 
   double const EPSILON = 0.1;
@@ -182,14 +184,14 @@ TEST(advi_test, univar_no_constraint_meanfield) {
 
   double S_j = 1.0 / (2.0 * stan::math::pi()) * sqrt(sigma_j_sq / (1.0))
                * exp(-0.5
-                     * (pow(1.5, 2) + pow(1.4, 2) + pow(1.6, 2)
-                        - pow(mu_j, 2) / sigma_j_sq));
+                     * (std::pow(1.5, 2) + std::pow(1.4, 2) + std::pow(1.6, 2)
+                        - std::pow(mu_j, 2) / sigma_j_sq));
 
   double elbo_true = 0.0;
 
   elbo_true += log(S_j);
   elbo_true += log(1.0 / (sqrt(sigma_j_sq * 2.0 * stan::math::pi())));
-  elbo_true += -0.5 * (pow(mu_j - 1.88, 2) / sigma_j_sq + 1.0 / sigma_j_sq);
+  elbo_true += -0.5 * (std::pow(mu_j - 1.88, 2) / sigma_j_sq + 1.0 / sigma_j_sq);
   elbo_true += 0.5 * (1 + log(2.0 * stan::math::pi()));
 
   double const EPSILON = 0.1;

--- a/src/test/unit/variational/advi_univar_with_constraint_test.cpp
+++ b/src/test/unit/variational/advi_univar_with_constraint_test.cpp
@@ -8,8 +8,6 @@
 #include <string>
 #include <vector>
 
-
-
 typedef boost::ecuyer1988 rng_t;
 typedef univariate_with_constraint_model_namespace::
     univariate_with_constraint_model Model;

--- a/src/test/unit/variational/advi_univar_with_constraint_test.cpp
+++ b/src/test/unit/variational/advi_univar_with_constraint_test.cpp
@@ -1,11 +1,14 @@
 #include <test/test-models/good/variational/univariate_with_constraint.hpp>
 #include <stan/variational/advi.hpp>
 #include <stan/callbacks/stream_logger.hpp>
-#include <gtest/gtest.h>
 #include <test/unit/util.hpp>
-#include <vector>
-#include <string>
 #include <boost/random/additive_combine.hpp>  // L'Ecuyer RNG
+#include <gtest/gtest.h>
+#include <cmath>
+#include <string>
+#include <vector>
+
+
 
 typedef boost::ecuyer1988 rng_t;
 typedef univariate_with_constraint_model_namespace::
@@ -58,8 +61,8 @@ TEST(advi_test, univar_with_constraint_fullrank) {
 
   double S_j = 1.0 / (2.0 * stan::math::pi()) * sqrt(sigma_j_sq / (1.0))
                * exp(-0.5
-                     * (pow(1.5, 2) + pow(1.4, 2) + pow(1.6, 2)
-                        - pow(mu_j, 2) / sigma_j_sq));
+                     * (std::pow(1.5, 2) + std::pow(1.4, 2) + std::pow(1.6, 2)
+                        - std::pow(mu_j, 2) / sigma_j_sq));
 
   double elbo_true = 0.0;
 
@@ -69,7 +72,7 @@ TEST(advi_test, univar_with_constraint_fullrank) {
       += -0.5 * one_over_sigma_j_sq * (exp(2.0 * log(1.88)) * exp(2.0 * 1.0));
   elbo_true += -0.5 * one_over_sigma_j_sq
                * (-2.0 * mu_j * exp(log(1.88)) * exp(0.5 * 1.0));
-  elbo_true += -0.5 * one_over_sigma_j_sq * (pow(mu_j, 2.0));
+  elbo_true += -0.5 * one_over_sigma_j_sq * (std::pow(mu_j, 2.0));
   elbo_true += log(1.88);
   elbo_true += 0.5 * (1 + log(2.0 * stan::math::pi()));
 
@@ -189,8 +192,8 @@ TEST(advi_test, univar_with_constraint_meanfield) {
 
   double S_j = 1.0 / (2.0 * stan::math::pi()) * sqrt(sigma_j_sq / (1.0))
                * exp(-0.5
-                     * (pow(1.5, 2) + pow(1.4, 2) + pow(1.6, 2)
-                        - pow(mu_j, 2) / sigma_j_sq));
+                     * (std::pow(1.5, 2) + std::pow(1.4, 2) + std::pow(1.6, 2)
+                        - std::pow(mu_j, 2) / sigma_j_sq));
 
   double elbo_true = 0.0;
 
@@ -200,7 +203,7 @@ TEST(advi_test, univar_with_constraint_meanfield) {
       += -0.5 * one_over_sigma_j_sq * (exp(2.0 * log(1.88)) * exp(2.0 * 1.0));
   elbo_true += -0.5 * one_over_sigma_j_sq
                * (-2.0 * mu_j * exp(log(1.88)) * exp(0.5 * 1.0));
-  elbo_true += -0.5 * one_over_sigma_j_sq * (pow(mu_j, 2.0));
+  elbo_true += -0.5 * one_over_sigma_j_sq * (std::pow(mu_j, 2.0));
   elbo_true += log(1.88);
   elbo_true += 0.5 * (1 + log(2.0 * stan::math::pi()));
 


### PR DESCRIPTION
Adds namespace qualifiers in a couple of spots. After https://github.com/stan-dev/math/pull/2612, Stan Math will have overloads for all primitive scalar argument types and we need to avoid ambiguity in a couple of places.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
