### PR TITLE
Do not write to stream when given a nullptr in the writer

### DIFF
--- a/src/stan/callbacks/stream_writer.hpp
+++ b/src/stan/callbacks/stream_writer.hpp
@@ -41,7 +41,6 @@ class stream_writer : public writer {
    * @param[in] names Names in a std::vector
    */
   void operator()(const std::vector<std::string>& names) {
-    if (output_ == nullptr) return;
     write_vector(names);
   }
 
@@ -53,10 +52,7 @@ class stream_writer : public writer {
    *
    * @param[in] state Values in a std::vector
    */
-  void operator()(const std::vector<double>& state) {
-    if (output_ == nullptr) return;
-    write_vector(state);
-  }
+  void operator()(const std::vector<double>& state) { write_vector(state); }
 
   /**
    * Writes the comment_prefix to the stream followed by a newline.
@@ -93,7 +89,6 @@ class stream_writer : public writer {
    */
   template <class T>
   void write_vector(const std::vector<T>& v) {
-    if (output_ == nullptr) return;
     if (v.empty())
       return;
 

--- a/src/stan/callbacks/stream_writer.hpp
+++ b/src/stan/callbacks/stream_writer.hpp
@@ -41,6 +41,7 @@ class stream_writer : public writer {
    * @param[in] names Names in a std::vector
    */
   void operator()(const std::vector<std::string>& names) {
+    if (output_ == nullptr) return;
     write_vector(names);
   }
 
@@ -52,7 +53,10 @@ class stream_writer : public writer {
    *
    * @param[in] state Values in a std::vector
    */
-  void operator()(const std::vector<double>& state) { write_vector(state); }
+  void operator()(const std::vector<double>& state) {
+    if (output_ == nullptr) return;
+    write_vector(state);
+  }
 
   /**
    * Writes the comment_prefix to the stream followed by a newline.
@@ -89,6 +93,7 @@ class stream_writer : public writer {
    */
   template <class T>
   void write_vector(const std::vector<T>& v) {
+    if (output_ == nullptr) return;
     if (v.empty())
       return;
 

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -48,76 +48,80 @@ class unique_stream_writer final : public writer {
    *
    * @param[in] names Names in a std::vector
    */
-   void operator()(const std::vector<std::string>& names) {
-     if (output_ == nullptr) return;
-     write_vector(names);
-   }
-   /**
-    * Get the underlying stream
-    */
-   inline auto& get_stream() noexcept { return *output_; }
+  void operator()(const std::vector<std::string>& names) {
+    if (output_ == nullptr)
+      return;
+    write_vector(names);
+  }
+  /**
+   * Get the underlying stream
+   */
+  inline auto& get_stream() noexcept { return *output_; }
 
-   /**
-    * Writes a set of values in csv format followed by a newline.
-    *
-    * Note: the precision of the output is determined by the settings
-    *  of the stream on construction.
-    *
-    * @param[in] state Values in a std::vector
-    */
-   void operator()(const std::vector<double>& state) { write_vector(state); }
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] state Values in a std::vector
+   */
+  void operator()(const std::vector<double>& state) { write_vector(state); }
 
-   /**
-    * Writes the comment_prefix to the stream followed by a newline.
-    */
-   void operator()() {
-     if (output_ == nullptr) return;
-       *output_ << comment_prefix_ << std::endl;
-   }
+  /**
+   * Writes the comment_prefix to the stream followed by a newline.
+   */
+  void operator()() {
+    if (output_ == nullptr)
+      return;
+    *output_ << comment_prefix_ << std::endl;
+  }
 
-   /**
-    * Writes the comment_prefix then the message followed by a newline.
-    *
-    * @param[in] message A string
-    */
-   void operator()(const std::string& message) {
-     if (output_ == nullptr) return;
-       *output_ << comment_prefix_ << message << std::endl;
-   }
+  /**
+   * Writes the comment_prefix then the message followed by a newline.
+   *
+   * @param[in] message A string
+   */
+  void operator()(const std::string& message) {
+    if (output_ == nullptr)
+      return;
+    *output_ << comment_prefix_ << message << std::endl;
+  }
 
-  private:
-   /**
-    * Output stream
-    */
-   std::unique_ptr<Stream> output_;
+ private:
+  /**
+   * Output stream
+   */
+  std::unique_ptr<Stream> output_;
 
-   /**
-    * Comment prefix to use when printing comments: strings and blank lines
-    */
-   std::string comment_prefix_;
+  /**
+   * Comment prefix to use when printing comments: strings and blank lines
+   */
+  std::string comment_prefix_;
 
-   /**
-    * Writes a set of values in csv format followed by a newline.
-    *
-    * Note: the precision of the output is determined by the settings
-    *  of the stream on construction.
-    *
-    * @param[in] v Values in a std::vector
-    */
-   template <class T>
-   void write_vector(const std::vector<T>& v) {
-       if (output_ == nullptr) return;
-       if (v.empty()) {
-         return;
-       }
-       auto last = v.end();
-       --last;
-       for (auto it = v.begin(); it != last; ++it) {
-              *output_ << *it << ",";
-       }
-       *output_ << v.back() << std::endl;
-     }
- };
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in a std::vector
+   */
+  template <class T>
+  void write_vector(const std::vector<T>& v) {
+    if (output_ == nullptr)
+      return;
+    if (v.empty()) {
+      return;
+    }
+    auto last = v.end();
+    --last;
+    for (auto it = v.begin(); it != last; ++it) {
+      *output_ << *it << ",";
+    }
+    *output_ << v.back() << std::endl;
+  }
+};
 
 }  // namespace callbacks
 }  // namespace stan

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -48,81 +48,76 @@ class unique_stream_writer final : public writer {
    *
    * @param[in] names Names in a std::vector
    */
-  void operator()(const std::vector<std::string>& names) {
-    write_vector(names);
-  }
-  /**
-   * Get the underlying stream
-   */
-  auto& get_stream() { return *output_; }
+   void operator()(const std::vector<std::string>& names) {
+     if (output_ == nullptr) return;
+     write_vector(names);
+   }
+   /**
+    * Get the underlying stream
+    */
+   inline auto& get_stream() noexcept { return *output_; }
 
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] state Values in a std::vector
-   */
-  void operator()(const std::vector<double>& state) { write_vector(state); }
+   /**
+    * Writes a set of values in csv format followed by a newline.
+    *
+    * Note: the precision of the output is determined by the settings
+    *  of the stream on construction.
+    *
+    * @param[in] state Values in a std::vector
+    */
+   void operator()(const std::vector<double>& state) { write_vector(state); }
 
-  /**
-   * Writes the comment_prefix to the stream followed by a newline.
-   */
-  void operator()() {
-    std::stringstream streamer;
-    streamer.precision(output_.get()->precision());
-    streamer << comment_prefix_ << std::endl;
-    *output_ << streamer.str();
-  }
+   /**
+    * Writes the comment_prefix to the stream followed by a newline.
+    */
+   void operator()() {
+     if (output_ == nullptr) return;
+       *output_ << comment_prefix_ << std::endl;
+   }
 
-  /**
-   * Writes the comment_prefix then the message followed by a newline.
-   *
-   * @param[in] message A string
-   */
-  void operator()(const std::string& message) {
-    std::stringstream streamer;
-    streamer.precision(output_.get()->precision());
-    streamer << comment_prefix_ << message << std::endl;
-    *output_ << streamer.str();
-  }
+   /**
+    * Writes the comment_prefix then the message followed by a newline.
+    *
+    * @param[in] message A string
+    */
+   void operator()(const std::string& message) {
+     if (output_ == nullptr) return;
+       *output_ << comment_prefix_ << message << std::endl;
+   }
 
- private:
-  /**
-   * Output stream
-   */
-  std::unique_ptr<Stream> output_;
+  private:
+   /**
+    * Output stream
+    */
+   std::unique_ptr<Stream> output_;
 
-  /**
-   * Comment prefix to use when printing comments: strings and blank lines
-   */
-  std::string comment_prefix_;
+   /**
+    * Comment prefix to use when printing comments: strings and blank lines
+    */
+   std::string comment_prefix_;
 
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in a std::vector
-   */
-  template <class T>
-  void write_vector(const std::vector<T>& v) {
-    if (v.empty())
-      return;
-    using const_iter = typename std::vector<T>::const_iterator;
-    const_iter last = v.end();
-    --last;
-    std::stringstream streamer;
-    streamer.precision(output_.get()->precision());
-    for (const_iter it = v.begin(); it != last; ++it) {
-      streamer << *it << ",";
-    }
-    streamer << v.back() << std::endl;
-    *output_ << streamer.str();
-  }
-};
+   /**
+    * Writes a set of values in csv format followed by a newline.
+    *
+    * Note: the precision of the output is determined by the settings
+    *  of the stream on construction.
+    *
+    * @param[in] v Values in a std::vector
+    */
+   template <class T>
+   void write_vector(const std::vector<T>& v) {
+       if (output_ == nullptr) return;
+       if (v.empty()) {
+         return;
+       }
+       auto last = v.end();
+       --last;
+       for (auto it = v.begin(); it != last; ++it) {
+              *output_ << *it << ",";
+       }
+       *output_ << v.back() << std::endl;
+     }
+ };
 
 }  // namespace callbacks
 }  // namespace stan


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is a simpler fix for https://github.com/stan-dev/cmdstan/issues/1055 where we just do a check if the `output_` unique pointer is a `nullptr` and if so we don't write anything. For the diagnostics fix we just need to change line 502 in command.hpp so that if the diagnostic file to be written to is the default `""` then we just insert a nullptr i.e.

```cpp
    if (diagnostic_file != "") {
      auto diagnostic_filename
          = diagnostic_name + name_iterator(i) + diagnostic_ending;
      diagnostic_writers.emplace_back(
          std::make_unique<std::fstream>(diagnostic_filename,
                                         std::fstream::out),
          "# ");
    } else {
      diagnostic_writers.emplace_back(nullptr, "# ");
    }
```

Doing this and comparing 2.28 and 2.27 things look fine to me (in fact a bit faster but just a little so could be fuzz)

```
 # 2.27
 Elapsed Time: 7.075 seconds (Warm-up)
               11.757 seconds (Sampling)
               18.832 seconds (Total)
```

```
 2.28 with the linechange above and this branch
 Elapsed Time: 6.574 seconds (Warm-up)
               10.657 seconds (Sampling)
               17.231 seconds (Total)
```
#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
