### PR TITLE
Add clean-all to integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -302,6 +302,7 @@ pipeline {
                             cd performance-tests-cmdstan/cmdstan
                             echo 'O=0' >> make/local
                             echo 'CXX=${env.CXX}' >> make/local
+                            make clean-all
                             make -j${env.PARALLEL} build
                             cd ..
                             ./runPerformanceTests.py -j${env.PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good
@@ -337,6 +338,7 @@ pipeline {
                             cd performance-tests-cmdstan/cmdstan
                             echo 'O=0' >> make/local
                             echo 'CXX=${env.CXX}' >> make/local
+                            make clean-all
                             make -j${env.PARALLEL} build
                             cd ..
                             ./runPerformanceTests.py -j${env.PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good


### PR DESCRIPTION
#### Summary

Integration tests sometimes fail because of precompiled header issues. I think there is something leftover from previous runs that causes issues. Adding a clean-all step should help.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
