### PR TITLE
[WIP] Move ci to flatiron institute

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -543,10 +543,10 @@ pipeline {
         success {
             script {
                 utils.updateUpstream(env,'cmdstan')
-                //utils.mailBuildResults("SUCCESSFUL")
+                utils.mailBuildResults("SUCCESSFUL")
             }
         }
-        //unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
-        //failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
+        unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
+        failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,18 +81,19 @@ pipeline {
         PARALLEL = 8
     }
     stages {
-        stage('Kill previous builds') {
-            when {
-                not { branch 'develop' }
-                not { branch 'master' }
-                not { branch 'downstream_tests' }
-            }
-            steps {
-                script {
-                    utils.killOldBuilds()
-                }
-            }
-        }
+    // Scripts not permitted to use method hudson.model.ItemGroup getItem java.lang.String
+//         stage('Kill previous builds') {
+//             when {
+//                 not { branch 'develop' }
+//                 not { branch 'master' }
+//                 not { branch 'downstream_tests' }
+//             }
+//             steps {
+//                 script {
+//                     utils.killOldBuilds()
+//                 }
+//             }
+//         }
         stage("Clang-format") {
             agent {
                 docker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -415,7 +415,7 @@ pipeline {
                             unstash 'StanSetup'
                         }
                         writeFile(file: "performance-tests-cmdstan/cmdstan/make/local", text: "CXX=${CXX}\nPRECOMPILED_HEADERS=true")
-                        withEnv(["PATH+TBB=${WORKSPACE}\\performance-tests-cmdstan\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb", "MINGW_EXECUTABLE=${env.MINGW}\\bin\\mingw32-make.exe]") {
+                        withEnv(["PATH+TBB=${WORKSPACE}\\performance-tests-cmdstan\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb", "MINGW_EXECUTABLE=${env.MINGW}\\bin\\mingw32-make.exe"]) {
                             
                             bat """
                                 cd performance-tests-cmdstan/cmdstan

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,3 @@
-// TODO
-// Ensure proper cleanup
-// https://github.com/stan-dev/stan/pull/3093
-
 @Library('StanUtils')
 import org.stan.Utils
 
@@ -12,7 +8,6 @@ def setupCXX(failOnError = true, CXX = CXX, String stanc3_bin_url = "nightly") {
     errorStr = failOnError ? "-Werror " : ""
     stanc3_bin_url_str = stanc3_bin_url != "nightly" ? "\nSTANC3_TEST_BIN_URL=${stanc3_bin_url}\n" : ""
     writeFile(file: "make/local", text: "CXX=${CXX} -Wno-inconsistent-missing-override ${errorStr}${stanc3_bin_url_str}")
-    // echo "CXXFLAGS += -Wno-inconsistent-missing-override" >> make/local
 }
 
 def runTests(String testPath, Boolean separateMakeStep=true) {
@@ -254,14 +249,14 @@ pipeline {
             parallel {
                 stage('Windows Headers & Unit') {
                     agent { label 'windows' }
-//                     when {
-//                         expression {
-//                             ( env.BRANCH_NAME == "develop" ||
-//                             env.BRANCH_NAME == "master" ||
-//                             params.run_tests_all_os ) &&
-//                             !skipRemainingStages
-//                         }
-//                     }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
                     steps {
                         deleteDirWin()
                             unstash 'StanSetup'
@@ -298,14 +293,14 @@ pipeline {
                 }
                 stage('Mac Unit') {
                 agent { label 'osx' }
-//                     when {
-//                         expression {
-//                             ( env.BRANCH_NAME == "develop" ||
-//                             env.BRANCH_NAME == "master" ||
-//                             params.run_tests_all_os ) &&
-//                             !skipRemainingStages
-//                         }
-//                     }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
                     steps {
                         unstash 'StanSetup'
                         setupCXX(false, MAC_CXX, stanc3_bin_url())
@@ -389,14 +384,14 @@ pipeline {
                 }
                 stage('Integration Mac') {
                     agent { label 'osx' }
-//                     when {
-//                         expression {
-//                             ( env.BRANCH_NAME == "develop" ||
-//                             env.BRANCH_NAME == "master" ||
-//                             params.run_tests_all_os ) &&
-//                             !skipRemainingStages
-//                         }
-//                     }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
                     steps {
                         sh """
                             git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
@@ -425,14 +420,14 @@ pipeline {
                 }
                 stage('Integration Windows') {
                     agent { label 'windows' }
-//                     when {
-//                         expression {
-//                             ( env.BRANCH_NAME == "develop" ||
-//                             env.BRANCH_NAME == "master" ||
-//                             params.run_tests_all_os ) &&
-//                             !skipRemainingStages
-//                         }
-//                     }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
                     steps {
                         deleteDirWin()
                         bat """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -285,7 +285,7 @@ pipeline {
 //                     }
 //                     post { always { deleteDir() } }
 //                 }
-//             }
+            }
         }
         stage('Integration') {
             when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,7 @@
+// TODO
+// Ensure proper cleanup
+// https://github.com/stan-dev/stan/pull/3093
+
 @Library('StanUtils')
 import org.stan.Utils
 
@@ -81,23 +85,22 @@ pipeline {
         PARALLEL = 8
     }
     stages {
-    // Scripts not permitted to use method hudson.model.ItemGroup getItem java.lang.String
-//         stage('Kill previous builds') {
-//             when {
-//                 not { branch 'develop' }
-//                 not { branch 'master' }
-//                 not { branch 'downstream_tests' }
-//             }
-//             steps {
-//                 script {
-//                     utils.killOldBuilds()
-//                 }
-//             }
-//         }
+        stage('Kill previous builds') {
+            when {
+                not { branch 'develop' }
+                not { branch 'master' }
+                not { branch 'downstream_tests' }
+            }
+            steps {
+                script {
+                    utils.killOldBuilds()
+                }
+            }
+        }
         stage("Clang-format") {
             agent {
                 docker {
-                    image 'stanorg/ci:ubuntu'
+                    image 'stanorg/ci:gpu'
                     label 'linux'
                 }
             }
@@ -148,7 +151,7 @@ pipeline {
         stage('Linting & Doc checks') {
             agent {
                 docker {
-                    image 'stanorg/ci:ubuntu'
+                    image 'stanorg/ci:gpu'
                     label 'linux'
                 }
             }
@@ -191,7 +194,7 @@ pipeline {
         stage('Verify changes') {
             agent {
                 docker {
-                    image 'stanorg/ci:ubuntu'
+                    image 'stanorg/ci:gpu'
                     label 'linux'
                 }
             }
@@ -229,20 +232,20 @@ pipeline {
                     agent { label 'windows' }
                     when {
                         expression {
-//                             ( env.BRANCH_NAME == "develop" ||
-//                             env.BRANCH_NAME == "master" ||
-//                             params.run_tests_all_os ) &&
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
                             !skipRemainingStages
                         }
                     }
                     steps {
                         deleteDirWin()
                             unstash 'StanSetup'
-                            withEnv(["RTOOLS40_HOME=C:\\PROGRA~1\\R\\R-4.1.2"]) {
+                            withEnv(["RTOOLS40_HOME="]) {
                                 bat """
-                                    SET \"PATH=${RTOOLS40_HOME}\\bin;%PATH%\"
+                                    SET \"PATH=C:\\PROGRA~1\\R\\R-4.1.2\\bin;%PATH%\"
                                     SET \"PATH=${env.MINGW}\\bin;%PATH%\"
-                                    echo %PATH%
+                                    SET \"PATH=${env.RTOOLS40_HOME}\\mingw64\\bin;%PATH%\"
                                     mingw32-make -f lib/stan_math/make/standalone math-libs
                                     mingw32-make -j${PARALLEL} test-headers
                                 """
@@ -252,39 +255,39 @@ pipeline {
                     }
                     post { always { deleteDirWin() } }
                 }
-//                 stage('Linux Unit') {
-//                     agent {
-//                         docker {
-//                             image 'stanorg/ci:ubuntu'
-//                             label 'linux'
-//                             args '--pull always'
-//                         }
-//                     }
-//                     steps {
-//                         unstash 'StanSetup'
-//                         setupCXX(true, GCC, stanc3_bin_url())
-//                         sh "make -j${PARALLEL} test-headers"
-//                         runTests("src/test/unit")
-//                     }
-//                     post { always { deleteDir() } }
-//                 }
-//                 stage('Mac Unit') {
-//                 agent { label 'osx' }
-//                     when {
-//                         expression {
-//                             ( env.BRANCH_NAME == "develop" ||
-//                             env.BRANCH_NAME == "master" ||
-//                             params.run_tests_all_os ) &&
-//                             !skipRemainingStages
-//                         }
-//                     }
-//                     steps {
-//                         unstash 'StanSetup'
-//                         setupCXX(false, CXX, stanc3_bin_url())
-//                         runTests("src/test/unit")
-//                     }
-//                     post { always { deleteDir() } }
-//                 }
+                stage('Linux Unit') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu'
+                            label 'linux'
+                            args '--pull always'
+                        }
+                    }
+                    steps {
+                        unstash 'StanSetup'
+                        setupCXX(true, GCC, stanc3_bin_url())
+                        sh "make -j${PARALLEL} test-headers"
+                        runTests("src/test/unit")
+                    }
+                    post { always { deleteDir() } }
+                }
+                stage('Mac Unit') {
+                agent { label 'osx' }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
+                    steps {
+                        unstash 'StanSetup'
+                        setupCXX(false, CXX, stanc3_bin_url())
+                        runTests("src/test/unit")
+                    }
+                    post { always { deleteDir() } }
+                }
             }
         }
         stage('Integration') {
@@ -294,119 +297,119 @@ pipeline {
                 }
             }
             parallel {
-//                 stage('Integration Linux') {
-//                     agent {
-//                         docker {
-//                             image 'stanorg/ci:ubuntu'
-//                             label 'linux'
-//                         }
-//                     }
-//                     steps {
-//                         sh """
-//                             git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
-//                             git clone https://github.com/stan-dev/stanc3/ performance-tests-cmdstan/stanc3
-//                         """
-//                         script {
-//                             if (params.cmdstan_pr != 'downstream_tests') {
-//                                 if(params.cmdstan_pr.contains("PR-")){
-//                                     pr_number = params.cmdstan_pr.split("-")[1]
-//                                     sh """
-//                                         cd performance-tests-cmdstan/cmdstan
-//                                         git fetch origin pull/${pr_number}/head:pr/${pr_number}
-//                                         git checkout pr/${pr_number}
-//                                     """
-//                                 }else{
-//                                     sh """
-//                                         cd performance-tests-cmdstan/cmdstan
-//                                         git checkout develop && git pull && git checkout ${params.cmdstan_pr}
-//                                     """
-//                                 }
-//                             }
-//                             if (params.stanc3_bin_url != 'nightly') {
-//                                 sh """
-//                                     cd performance-tests-cmdstan/cmdstan
-//                                     echo 'STANC3_TEST_BIN_URL=${params.stanc3_bin_url}' >> make/local
-//                                 """
-//                             }
-//                         }
-//                         dir('performance-tests-cmdstan/cmdstan/stan'){
-//                             unstash 'StanSetup'
-//                             script {
-//                                 if (params.stanc3_bin_url != 'nightly') {
-//                                     sh """
-//                                         echo 'STANC3_TEST_BIN_URL=${params.stanc3_bin_url}' >> make/local
-//                                     """
-//                                 }
-//                             }
-//                         }
-//                         sh """
-//                             cd performance-tests-cmdstan/cmdstan
-//                             echo 'O=0' >> make/local
-//                             echo 'CXX=${CXX}' >> make/local
-//                             make clean-all
-//                             make -j${PARALLEL} build
-//                             cd ..
-//                             ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good
-//                             ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 example-models
-//                         """
-//                         sh """
-//                             cd performance-tests-cmdstan/cmdstan/stan
-//                             ./runTests.py src/test/integration/compile_standalone_functions_test.cpp
-//                             ./runTests.py src/test/integration/standalone_functions_test.cpp
-//                             ./runTests.py src/test/integration/multiple_translation_units_test.cpp
-//                         """
-//                     }
-//                     post { always { deleteDir() } }
-//                 }
-//                 stage('Integration Mac') {
-// //                     agent {
-// //                         docker {
-// //                             image 'stanorg/ci:ubuntu'
-// //                             label 'osx'
-// //                         }
-// //                     }
-//                     agent { label 'osx' }
-//                     when {
-//                         expression {
-// //                             ( env.BRANCH_NAME == "develop" ||
-// //                             env.BRANCH_NAME == "master" ||
-// //                             params.run_tests_all_os ) &&
-//                             !skipRemainingStages
-//                         }
-//                     }
-//                     steps {
-//                         sh """
-//                             git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
-//                         """
-//                         dir('performance-tests-cmdstan/cmdstan/stan'){
-//                             unstash 'StanSetup'
-//                         }
-//                         sh """
-//                             cd performance-tests-cmdstan/cmdstan
-//                             echo 'O=0' >> make/local
-//                             echo 'CXX=${CXX}' >> make/local
-//                             make clean-all
-//                             make -j${PARALLEL} build
-//                             cd ..
-//                             ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good
-//                             ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 example-models
-//                         """
-//                         sh """
-//                             cd performance-tests-cmdstan/cmdstan/stan
-//                             ./runTests.py src/test/integration/compile_standalone_functions_test.cpp
-//                             ./runTests.py src/test/integration/standalone_functions_test.cpp
-//                             ./runTests.py src/test/integration/multiple_translation_units_test.cpp
-//                         """
-//                     }
-//                     post { always { deleteDir() } }
-//                 }
+                stage('Integration Linux') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu'
+                            label 'linux'
+                        }
+                    }
+                    steps {
+                        sh """
+                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
+                            git clone https://github.com/stan-dev/stanc3/ performance-tests-cmdstan/stanc3
+                        """
+                        script {
+                            if (params.cmdstan_pr != 'downstream_tests') {
+                                if(params.cmdstan_pr.contains("PR-")){
+                                    pr_number = params.cmdstan_pr.split("-")[1]
+                                    sh """
+                                        cd performance-tests-cmdstan/cmdstan
+                                        git fetch origin pull/${pr_number}/head:pr/${pr_number}
+                                        git checkout pr/${pr_number}
+                                    """
+                                }else{
+                                    sh """
+                                        cd performance-tests-cmdstan/cmdstan
+                                        git checkout develop && git pull && git checkout ${params.cmdstan_pr}
+                                    """
+                                }
+                            }
+                            if (params.stanc3_bin_url != 'nightly') {
+                                sh """
+                                    cd performance-tests-cmdstan/cmdstan
+                                    echo 'STANC3_TEST_BIN_URL=${params.stanc3_bin_url}' >> make/local
+                                """
+                            }
+                        }
+                        dir('performance-tests-cmdstan/cmdstan/stan'){
+                            unstash 'StanSetup'
+                            script {
+                                if (params.stanc3_bin_url != 'nightly') {
+                                    sh """
+                                        echo 'STANC3_TEST_BIN_URL=${params.stanc3_bin_url}' >> make/local
+                                    """
+                                }
+                            }
+                        }
+                        sh """
+                            cd performance-tests-cmdstan/cmdstan
+                            echo 'O=0' >> make/local
+                            echo 'CXX=${CXX}' >> make/local
+                            make clean-all
+                            make -j${PARALLEL} build
+                            cd ..
+                            ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good
+                            ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 example-models
+                        """
+                        sh """
+                            cd performance-tests-cmdstan/cmdstan/stan
+                            ./runTests.py src/test/integration/compile_standalone_functions_test.cpp
+                            ./runTests.py src/test/integration/standalone_functions_test.cpp
+                            ./runTests.py src/test/integration/multiple_translation_units_test.cpp
+                        """
+                    }
+                    post { always { deleteDir() } }
+                }
+                stage('Integration Mac') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:gpu'
+                            label 'osx'
+                        }
+                    }
+                    agent { label 'osx' }
+                    when {
+                        expression {
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
+                            !skipRemainingStages
+                        }
+                    }
+                    steps {
+                        sh """
+                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
+                        """
+                        dir('performance-tests-cmdstan/cmdstan/stan'){
+                            unstash 'StanSetup'
+                        }
+                        sh """
+                            cd performance-tests-cmdstan/cmdstan
+                            echo 'O=0' >> make/local
+                            echo 'CXX=${CXX}' >> make/local
+                            make clean-all
+                            make -j${PARALLEL} build
+                            cd ..
+                            ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good
+                            ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 example-models
+                        """
+                        sh """
+                            cd performance-tests-cmdstan/cmdstan/stan
+                            ./runTests.py src/test/integration/compile_standalone_functions_test.cpp
+                            ./runTests.py src/test/integration/standalone_functions_test.cpp
+                            ./runTests.py src/test/integration/multiple_translation_units_test.cpp
+                        """
+                    }
+                    post { always { deleteDir() } }
+                }
                 stage('Integration Windows') {
                     agent { label 'windows' }
                     when {
                         expression {
-//                             ( env.BRANCH_NAME == "develop" ||
-//                             env.BRANCH_NAME == "master" ||
-//                             params.run_tests_all_os ) &&
+                            ( env.BRANCH_NAME == "develop" ||
+                            env.BRANCH_NAME == "master" ||
+                            params.run_tests_all_os ) &&
                             !skipRemainingStages
                         }
                     }
@@ -450,7 +453,7 @@ pipeline {
                     }
                 }
             steps {
-                build(job: "CmdStan/${cmdstan_pr()}",
+                build(job: "Stan/CmdStan/${cmdstan_pr()}",
                       parameters: [string(name: 'stan_pr', value: stan_pr()),
                                    string(name: 'math_pr', value: params.math_pr)])
             }
@@ -463,7 +466,7 @@ pipeline {
             }
             agent {
                 docker {
-                    image 'stanorg/ci:ubuntu'
+                    image 'stanorg/ci:gpu'
                     label 'osx' // oldimac
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,12 +261,13 @@ pipeline {
                     post { always { deleteDir() } }
                 }
                 stage('Mac Unit') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:ubuntu'
-                            label 'osx'
-                        }
-                    }
+                agent { label 'osx' }
+//                     agent {
+//                         docker {
+//                             image 'stanorg/ci:ubuntu'
+//                             label 'osx'
+//                         }
+//                     }
                     when {
                         expression {
                             ( env.BRANCH_NAME == "develop" ||

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -229,9 +229,9 @@ pipeline {
                     agent { label 'windows' }
                     when {
                         expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ||
-                            params.run_tests_all_os ) &&
+//                             ( env.BRANCH_NAME == "develop" ||
+//                             env.BRANCH_NAME == "master" ||
+//                             params.run_tests_all_os ) &&
                             !skipRemainingStages
                         }
                     }
@@ -245,22 +245,22 @@ pipeline {
                     }
                     post { always { deleteDirWin() } }
                 }
-                stage('Linux Unit') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:ubuntu'
-                            label 'linux'
-                            args '--pull always'
-                        }
-                    }
-                    steps {
-                        unstash 'StanSetup'
-                        setupCXX(true, GCC, stanc3_bin_url())
-                        sh "make -j${PARALLEL} test-headers"
-                        runTests("src/test/unit")
-                    }
-                    post { always { deleteDir() } }
-                }
+//                 stage('Linux Unit') {
+//                     agent {
+//                         docker {
+//                             image 'stanorg/ci:ubuntu'
+//                             label 'linux'
+//                             args '--pull always'
+//                         }
+//                     }
+//                     steps {
+//                         unstash 'StanSetup'
+//                         setupCXX(true, GCC, stanc3_bin_url())
+//                         sh "make -j${PARALLEL} test-headers"
+//                         runTests("src/test/unit")
+//                     }
+//                     post { always { deleteDir() } }
+//                 }
                 stage('Mac Unit') {
                 agent { label 'osx' }
 //                     agent {
@@ -271,9 +271,9 @@ pipeline {
 //                     }
                     when {
                         expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ||
-                            params.run_tests_all_os ) &&
+//                             ( env.BRANCH_NAME == "develop" ||
+//                             env.BRANCH_NAME == "master" ||
+//                             params.run_tests_all_os ) &&
                             !skipRemainingStages
                         }
                     }
@@ -353,17 +353,18 @@ pipeline {
                     post { always { deleteDir() } }
                 }
                 stage('Integration Mac') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:ubuntu'
-                            label 'osx'
-                        }
-                    }
+//                     agent {
+//                         docker {
+//                             image 'stanorg/ci:ubuntu'
+//                             label 'osx'
+//                         }
+//                     }
+                    agent { label 'osx' }
                     when {
                         expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ||
-                            params.run_tests_all_os ) &&
+//                             ( env.BRANCH_NAME == "develop" ||
+//                             env.BRANCH_NAME == "master" ||
+//                             params.run_tests_all_os ) &&
                             !skipRemainingStages
                         }
                     }
@@ -397,9 +398,9 @@ pipeline {
                     agent { label 'windows' }
                     when {
                         expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ||
-                            params.run_tests_all_os ) &&
+//                             ( env.BRANCH_NAME == "develop" ||
+//                             env.BRANCH_NAME == "master" ||
+//                             params.run_tests_all_os ) &&
                             !skipRemainingStages
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        CXX = 'clang++-6.0'
+        CXX = 'clang++-11.0'
         GCC = 'g++'
         PARALLEL = 8
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,7 +365,6 @@ pipeline {
                             label 'osx'
                         }
                     }
-                    agent { label 'osx' }
                     when {
                         expression {
                             ( env.BRANCH_NAME == "develop" ||

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,7 +250,7 @@ pipeline {
                         docker {
                             image 'stanorg/ci:ubuntu'
                             label 'linux'
-                            additionalBuildArgs "--pull"
+                            args "--pull"
                         }
                     }
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,9 +238,11 @@ pipeline {
                     steps {
                         deleteDirWin()
                             unstash 'StanSetup'
-                            withEnv(["MINGW_EXECUTABLE=${env.MINGW}\\bin\\mingw32-make.exe"]) {
-                                bat "\"$MINGW_EXECUTABLE\" -f lib/stan_math/make/standalone math-libs"
-                                bat "\"$MINGW_EXECUTABLE\" -j${PARALLEL} test-headers"
+                            withEnv(["MINGW_EXECUTABLE=${env.MINGW}\\bin\\mingw32-make.exe", "RTOOLS40_HOME=C:\\PROGRA~1\\R\\R-4.1.2"]) {
+                                bat "SET \"PATH=${RTOOLS40_HOME}\\usr\\bin;%PATH%\"
+                                    \"$MINGW_EXECUTABLE\" -f lib/stan_math/make/standalone math-libs
+                                    \"$MINGW_EXECUTABLE\" -j${PARALLEL} test-headers
+                                """
                             }
                             setupCXX(false, env.CXX, stanc3_bin_url())
                             runTestsWin("src/test/unit")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,7 +250,7 @@ pipeline {
                         docker {
                             image 'stanorg/ci:ubuntu'
                             label 'linux'
-                            args "--pull"
+                            args '--pull always'
                         }
                     }
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,11 +238,12 @@ pipeline {
                     steps {
                         deleteDirWin()
                             unstash 'StanSetup'
-                            withEnv(["MINGW_EXECUTABLE=${env.MINGW}\\bin\\mingw32-make.exe", "RTOOLS40_HOME=C:\\PROGRA~1\\R\\R-4.1.2"]) {
+                            withEnv(["MINGW_BIN_PATH=${env.MINGW}\\bin", "RTOOLS40_HOME=C:\\PROGRA~1\\R\\R-4.1.2"]) {
                                 bat """
-                                    SET \"PATH=${RTOOLS40_HOME}\\usr\\bin;%PATH%\"
-                                    \"$MINGW_EXECUTABLE\" -f lib/stan_math/make/standalone math-libs
-                                    \"$MINGW_EXECUTABLE\" -j${PARALLEL} test-headers
+                                    SET \"PATH=${RTOOLS40_HOME}\\bin;%PATH%\"
+                                    SET \"PATH=${MINGW_BIN_PATH}\\bin;%PATH%\"
+                                    mingw32-make -f lib/stan_math/make/standalone math-libs
+                                    mingw32-make -j${PARALLEL} test-headers
                                 """
                             }
                             setupCXX(false, env.CXX, stanc3_bin_url())

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -239,8 +239,8 @@ pipeline {
                         deleteDirWin()
                             unstash 'StanSetup'
                             withEnv(["MINGW_EXECUTABLE=${env.MINGW}\\bin\\mingw32-make.exe"]) {
-                                bat "$MINGW_EXECUTABLE -f lib/stan_math/make/standalone math-libs"
-                                bat "$MINGW_EXECUTABLE -j${PARALLEL} test-headers"
+                                bat "\"$MINGW_EXECUTABLE\" -f lib/stan_math/make/standalone math-libs"
+                                bat "\"$MINGW_EXECUTABLE\" -j${PARALLEL} test-headers"
                             }
                             setupCXX(false, env.CXX, stanc3_bin_url())
                             runTestsWin("src/test/unit")
@@ -419,7 +419,7 @@ pipeline {
                             
                             bat """
                                 cd performance-tests-cmdstan/cmdstan
-                                $MINGW_EXECUTABLE -j${PARALLEL} build
+                                \"$MINGW_EXECUTABLE\" -j${PARALLEL} build
                                 cd ..
                                 python ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good
                                 python ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 example-models

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -239,7 +239,8 @@ pipeline {
                         deleteDirWin()
                             unstash 'StanSetup'
                             withEnv(["MINGW_EXECUTABLE=${env.MINGW}\\bin\\mingw32-make.exe", "RTOOLS40_HOME=C:\\PROGRA~1\\R\\R-4.1.2"]) {
-                                bat "SET \"PATH=${RTOOLS40_HOME}\\usr\\bin;%PATH%\"
+                                bat """
+                                    SET \"PATH=${RTOOLS40_HOME}\\usr\\bin;%PATH%\"
                                     \"$MINGW_EXECUTABLE\" -f lib/stan_math/make/standalone math-libs
                                     \"$MINGW_EXECUTABLE\" -j${PARALLEL} test-headers
                                 """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,6 +250,7 @@ pipeline {
                         docker {
                             image 'stanorg/ci:ubuntu'
                             label 'linux'
+                            additionalBuildArgs "--pull"
                         }
                     }
                     steps {


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary

This PR will handle Jenkins CI migration to Flatiron Institute. Currently, WIP until we iron out errors, plugins, and other requirements.

#### Intended Effect

#### How to Verify

We will run mc-stan and flatiron Jenkins in parallel until it's stable and most of the main jobs are workings, after that, we will decommission mc-stan and migrate entirely to Flatiron Institute.

#### Side Effects

There may be side effects where two jobs would try to do the same objective like updating a submodule, will try to avoid this as much as possible.

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignees, such as a university or company): Toptal



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
