### PR TITLE
Disable precompiled headers for integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -302,6 +302,7 @@ pipeline {
                             cd performance-tests-cmdstan/cmdstan
                             echo 'O=0' >> make/local
                             echo 'CXX=${env.CXX}' >> make/local
+                            echo 'PRECOMPILED_HEADERS=false' >> make/local
                             make clean-all
                             make -j${env.PARALLEL} build
                             cd ..


### PR DESCRIPTION
#### Summary

Integration tests still occasionally fail with the `.pch` error. Still haven't gotten to the bottom of why. It seems that somewhere in CI we are not cleaning up after the last run. This is a CI-only issue so I am going to try running without integration tests to see what the test runtime hit is. If its not bad, lets just do that to avoid this annoyance.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
