### PR TITLE
Fix assign and lvalue to return 0 row/col/size objects for negative indexing

### DIFF
--- a/src/stan/io/serializer.hpp
+++ b/src/stan/io/serializer.hpp
@@ -29,9 +29,17 @@ class serializer {
    */
   void check_r_capacity(size_t m) const {
     if (pos_r_ + m > r_size_) {
-      [](auto r_size_, auto pos_r_, auto m) STAN_COLD_PATH {
-        throw std::runtime_error(std::string("In serializer: Storage capacity [") + std::to_string(r_size_) + "] exceeded while writing value of size [" + std::to_string(m) + "] from position [" + std::to_string(pos_r_) + "]. This is an internal error, if you see it please report it as an issue on the Stan github repository.");
-      }(r_size_, pos_r_, m);
+      [](auto r_size_, auto pos_r_, auto m)
+          STAN_COLD_PATH {
+            throw std::runtime_error(
+          std::string("In serializer: Storage capacity [") +
+          std::to_string(r_size_) +
+          "] exceeded while writing value of size [" +
+           std::to_string(m) + "] from position [" +
+            std::to_string(pos_r_) +
+             "]. This is an internal error, if you see it please report it as" +
+             " an issue on the Stan github repository.");
+          }(r_size_, pos_r_, m);
     }
   }
 

--- a/src/stan/io/serializer.hpp
+++ b/src/stan/io/serializer.hpp
@@ -29,9 +29,9 @@ class serializer {
    */
   void check_r_capacity(size_t m) const {
     if (pos_r_ + m > r_size_) {
-      []() STAN_COLD_PATH {
+      [](auto r_size_, auto pos_r_, auto m) STAN_COLD_PATH {
         throw std::runtime_error(std::string("In serializer: Storage capacity [") + std::to_string(r_size_) + "] exceeded while writing value of size [" + std::to_string(m) + "] from position [" + std::to_string(pos_r_) + "]. This is an internal error, if you see it please report it as an issue on the Stan github repository.");
-      }();
+      }(r_size_, pos_r_, m);
     }
   }
 

--- a/src/stan/io/serializer.hpp
+++ b/src/stan/io/serializer.hpp
@@ -30,7 +30,7 @@ class serializer {
   void check_r_capacity(size_t m) const {
     if (pos_r_ + m > r_size_) {
       []() STAN_COLD_PATH {
-        throw std::runtime_error(std::string("In serializer: Storage capacity [" + std::to_string(r_size_) + "] exceeded while writing value of size [" + std::to_string(m) + "] from position [" + std::to_string(pos_r_) + "]. This is an internal error, if you see it please report it as an issue on the Stan github repository.");
+        throw std::runtime_error(std::string("In serializer: Storage capacity [") + std::to_string(r_size_) + "] exceeded while writing value of size [" + std::to_string(m) + "] from position [" + std::to_string(pos_r_) + "]. This is an internal error, if you see it please report it as an issue on the Stan github repository.");
       }();
     }
   }

--- a/src/stan/io/serializer.hpp
+++ b/src/stan/io/serializer.hpp
@@ -30,7 +30,7 @@ class serializer {
   void check_r_capacity(size_t m) const {
     if (pos_r_ + m > r_size_) {
       []() STAN_COLD_PATH {
-        throw std::runtime_error("no more storage available to write");
+        throw std::runtime_error(std::string("In serializer: Storage capacity [" + std::to_string(r_size_) + "] exceeded while writing value of size [" + std::to_string(m) + "] from position [" + std::to_string(pos_r_) + "]. This is an internal error, if you see it please report it as an issue on the Stan github repository.");
       }();
     }
   }

--- a/src/stan/model/indexing/access_helpers.hpp
+++ b/src/stan/model/indexing/access_helpers.hpp
@@ -59,13 +59,13 @@ void assign_impl(T1&& x, T2&& y, const char* name) {
   // We are allowed to assign to fully uninitialized matrix
   if (x.rows() != 0 && x.cols() != 0) {
     static constexpr const char* obj_type
-        = is_vector<T1>::value ? "vector" : "matrix";
+        = is_vector<Mat1>::value ? "vector" : "matrix";
     stan::math::check_size_match(
         (std::string(obj_type) + " assign columns").c_str(),
-        "left hand side columns", x.cols(), name, y.cols());
+        name, x.cols(), "right hand side columns", y.cols());
     stan::math::check_size_match(
-        (std::string(obj_type) + " assign rows").c_str(), "left hand side rows",
-        x.rows(), name, y.rows());
+        (std::string(obj_type) + " assign rows").c_str(), name,
+        x.rows(), "right hand side rows", y.rows());
   }
   x = std::forward<T2>(y);
 }
@@ -91,10 +91,10 @@ void assign_impl(Mat1&& x, Mat2&& y, const char* name) {
         = is_vector<Mat1>::value ? "vector" : "matrix";
     stan::math::check_size_match(
         (std::string(obj_type) + " assign columns").c_str(),
-        "left hand side columns", x.cols(), name, y.cols());
+        name, x.cols(), "right hand side columns", y.cols());
     stan::math::check_size_match(
-        (std::string(obj_type) + " assign rows").c_str(), "left hand side rows",
-        x.rows(), name, y.rows());
+        (std::string(obj_type) + " assign rows").c_str(), name,
+        x.rows(), "right hand side rows", y.rows());
   }
   auto prev_vals = stan::math::to_arena(x.val());
   x.vi_->val_ = std::forward<Mat2>(y);

--- a/src/stan/model/indexing/access_helpers.hpp
+++ b/src/stan/model/indexing/access_helpers.hpp
@@ -59,7 +59,7 @@ void assign_impl(T1&& x, T2&& y, const char* name) {
   // We are allowed to assign to fully uninitialized matrix
   if (x.rows() != 0 && x.cols() != 0) {
     static constexpr const char* obj_type
-        = is_vector<Mat1>::value ? "vector" : "matrix";
+        = is_vector<T1>::value ? "vector" : "matrix";
     stan::math::check_size_match(
         (std::string(obj_type) + " assign columns").c_str(), name, x.cols(),
         "right hand side columns", y.cols());

--- a/src/stan/model/indexing/access_helpers.hpp
+++ b/src/stan/model/indexing/access_helpers.hpp
@@ -70,7 +70,6 @@ void assign_impl(T1&& x, T2&& y, const char* name) {
   x = std::forward<T2>(y);
 }
 
-
 /**
  * Base case of assignment
  * @tparam T1 Any type that's not a var matrix.
@@ -84,7 +83,7 @@ void assign_impl(T1&& x, T2&& y, const char* name) {
   // We are allowed to assign to fully uninitialized matrix
   if (unlikely(x.size() != 0)) {
     stan::math::check_size_match("assign array size", name, x.size(),
-        "right hand side", y.size());
+                                 "right hand side", y.size());
   }
   x = std::forward<T2>(y);
 }

--- a/src/stan/model/indexing/access_helpers.hpp
+++ b/src/stan/model/indexing/access_helpers.hpp
@@ -40,7 +40,7 @@ inline auto colwise_reverse(const T& x) {
  * @param y The value to assign from.
  */
 template <typename T1, typename T2,
-          require_all_not_t<is_matrix<T1>, is_matrix<T2>>* = nullptr>
+          require_all_t<is_stan_scalar<T1>, is_stan_scalar<T2>>* = nullptr>
 void assign_impl(T1&& x, T2&& y, const char* name) {
   x = std::forward<T2>(y);
 }
@@ -57,7 +57,7 @@ template <typename T1, typename T2,
           require_all_t<is_matrix<T1>, is_matrix<T2>>* = nullptr>
 void assign_impl(T1&& x, T2&& y, const char* name) {
   // We are allowed to assign to fully uninitialized matrix
-  if (x.rows() != 0 && x.cols() != 0) {
+  if (x.size() != 0) {
     static constexpr const char* obj_type
         = is_vector<T1>::value ? "vector" : "matrix";
     stan::math::check_size_match(
@@ -66,6 +66,25 @@ void assign_impl(T1&& x, T2&& y, const char* name) {
     stan::math::check_size_match(
         (std::string(obj_type) + " assign rows").c_str(), name, x.rows(),
         "right hand side rows", y.rows());
+  }
+  x = std::forward<T2>(y);
+}
+
+
+/**
+ * Base case of assignment
+ * @tparam T1 Any type that's not a var matrix.
+ * @tparam T2 Any type that's not a var matrix.
+ * @param x The value to assign to
+ * @param y The value to assign from.
+ */
+template <typename T1, typename T2,
+          require_all_t<is_std_vector<T1>, is_std_vector<T2>>* = nullptr>
+void assign_impl(T1&& x, T2&& y, const char* name) {
+  // We are allowed to assign to fully uninitialized matrix
+  if (unlikely(x.size() != 0)) {
+    stan::math::check_size_match("assign array size", name, x.size(),
+        "right hand side", y.size());
   }
   x = std::forward<T2>(y);
 }
@@ -86,7 +105,7 @@ void assign_impl(T1&& x, T2&& y, const char* name) {
 template <typename Mat1, typename Mat2, require_var_matrix_t<Mat1>* = nullptr,
           require_eigen_st<std::is_arithmetic, Mat2>* = nullptr>
 void assign_impl(Mat1&& x, Mat2&& y, const char* name) {
-  if (x.rows() != 0 && x.cols() != 0) {
+  if (x.size() != 0) {
     static constexpr const char* obj_type
         = is_vector<Mat1>::value ? "vector" : "matrix";
     stan::math::check_size_match(

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -126,7 +126,7 @@ template <typename Vec1, typename Vec2,
           require_all_not_std_vector_t<Vec1, Vec2>* = nullptr>
 inline void assign(Vec1&& x, const Vec2& y, const char* name,
                    index_min_max idx) {
-  if (idx.max_ >= idx.min_) {
+  if (likely(idx.max_ >= idx.min_)) {
     stan::math::check_range("vector[min_max] min assign", name, x.size(),
                             idx.min_);
     stan::math::check_range("vector[min_max] max assign", name, x.size(),
@@ -187,7 +187,7 @@ template <typename Vec1, typename Vec2,
           require_all_vector_t<Vec1, Vec2>* = nullptr,
           require_all_not_std_vector_t<Vec1, Vec2>* = nullptr>
 inline void assign(Vec1&& x, const Vec2& y, const char* name, index_max idx) {
-  if (idx.max_ > 0) {
+  if (likely(idx.max_ > 0)) {
     stan::math::check_range("vector[max] assign", name, x.size(), idx.max_);
     stan::math::check_size_match("vector[max] assign", name, idx.max_,
                                  "right hand side", y.size());
@@ -351,7 +351,7 @@ template <typename Mat1, typename Mat2,
 inline void assign(Mat1&& x, const Mat2& y, const char* name, index_max idx) {
   stan::math::check_size_match("matrix[max] assign columns", name, x.cols(),
                                "right hand side columns", y.cols());
-  if (idx.max_ > 0) {
+  if (likely(idx.max_ > 0)) {
     stan::math::check_range("matrix[max] assign row", name, x.rows(), idx.max_);
     stan::math::check_size_match("matrix[max] assign rows", name, idx.max_,
                                  "right hand side rows", y.rows());
@@ -383,7 +383,7 @@ template <typename Mat1, typename Mat2,
 inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max idx) {
   stan::math::check_size_match("matrix[min_max] assign columns", name, x.cols(),
                                "right hand side columns", y.cols());
-  if (idx.max_ >= idx.min_) {
+  if (likely(idx.max_ >= idx.min_)) {
     stan::math::check_range("matrix[min_max] min row indexing", name, x.rows(),
                             idx.min_);
     stan::math::check_range("matrix[min_max] max row indexing", name, x.rows(),
@@ -418,7 +418,7 @@ template <typename Mat1, typename Mat2,
           require_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
                    index_min_max col_idx) {
-  if ((row_idx.max_ >= row_idx.min_) && (col_idx.max_ >= col_idx.min_)) {
+  if (likely((row_idx.max_ >= row_idx.min_) && (col_idx.max_ >= col_idx.min_))) {
     stan::math::check_range("matrix[min_max, min_max] assign min row", name,
                             x.rows(), row_idx.min_);
 
@@ -707,7 +707,7 @@ template <typename Mat1, typename Mat2, typename Idx,
           require_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const Idx& row_idx, index_max col_idx) {
-  if (col_idx.max_ > 0) {
+  if (likely(col_idx.max_ > 0)) {
     stan::math::check_range("matrix[..., max] assign", name, x.cols(),
                             col_idx.max_);
     stan::math::check_size_match("matrix[..., max] assign columns", name,
@@ -741,7 +741,7 @@ template <typename Mat1, typename Mat2, typename Idx,
           require_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, const Idx& row_idx,
                    index_min_max col_idx) {
-  if (col_idx.max_ >= col_idx.min_) {
+  if (likely(col_idx.max_ >= col_idx.min_)) {
     stan::math::check_range("matrix[..., min_max] assign min column", name,
                             x.cols(), col_idx.min_);
     stan::math::check_range("matrix[..., min_max] assign max column", name,
@@ -772,7 +772,10 @@ template <typename T, typename U, require_all_std_vector_t<T, U>* = nullptr,
           require_not_t<
               std::is_assignable<std::decay_t<T>&, std::decay_t<U>>>* = nullptr>
 inline void assign(T&& x, U&& y, const char* name) {
-  x.resize(y.size());
+  if (unlikely(x.size() != 0)) {
+    stan::math::check_size_match("assign array size", name, x.size(),
+        "right hand side", y.size());
+  }
   if (std::is_rvalue_reference<U&&>::value) {
     for (size_t i = 0; i < y.size(); ++i) {
       assign(x[i], std::move(y[i]), name);

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -358,7 +358,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name, index_max idx) {
   } else {
     stan::math::check_size_match("matrix[max] assign", "left hand side rows",
                                  0, name, y.rows());
-    internal::assign_impl(x.template topRows<0>(), y, name);
+    internal::assign_impl(x.topRows(0), y, name);
   }
 }
 
@@ -432,6 +432,11 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
   if ((row_idx.max_ >= row_idx.min_) && (col_idx.max_ >= col_idx.min_)) {
       auto row_size = row_idx.max_ - (row_idx.min_ - 1);
       auto col_size = col_idx.max_ - (col_idx.min_ - 1);
+      stan::math::check_range("matrix[min_max, min_max] assign max row", name,
+                              x.rows(), row_idx.max_);
+      stan::math::check_range("matrix[min_max, min_max] assign max column", name,
+                              x.cols(), col_idx.max_);
+
       stan::math::check_size_match("matrix[min_max, min_max] assign",
                                    "left hand side rows", row_size, name,
                                    y.rows());
@@ -704,7 +709,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
   } else {
     stan::math::check_size_match("matrix[..., max] assign column size",
                                  "left hand side", 0, name, y.cols());
-    assign(x.template leftCols<0>(), y, name, row_idx);
+    assign(x.leftCols(0), y, name, row_idx);
   }
 }
 
@@ -742,7 +747,7 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, const Idx& row_idx,
   } else {
     stan::math::check_size_match("matrix[..., min_max] assign column size",
                                  "left hand side", 0, name, y.cols());
-    assign(x.template middleCols<0>(0), y, name, row_idx);
+    assign(x.middleCols(0, 0), y, name, row_idx);
   }
 }
 

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -97,8 +97,8 @@ template <typename Vec1, typename Vec2,
 inline void assign(Vec1&& x, const Vec2& y, const char* name,
                    const index_multi& idx) {
   const auto& y_ref = stan::math::to_ref(y);
-  stan::math::check_size_match("vector[multi] assign", name,
-                               idx.ns_.size(), "right hand side", y_ref.size());
+  stan::math::check_size_match("vector[multi] assign", name, idx.ns_.size(),
+                               "right hand side", y_ref.size());
   const auto x_size = x.size();
   for (int n = 0; n < y_ref.size(); ++n) {
     stan::math::check_range("vector[multi] assign", name, x_size, idx.ns_[n]);
@@ -133,12 +133,12 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name,
                             idx.max_);
     const auto slice_start = idx.min_ - 1;
     const auto slice_size = idx.max_ - slice_start;
-    stan::math::check_size_match("vector[min_max] assign", name,
-                                 slice_size, "right hand side", y.size());
+    stan::math::check_size_match("vector[min_max] assign", name, slice_size,
+                                 "right hand side", y.size());
     internal::assign_impl(x.segment(slice_start, slice_size), y, name);
   } else {
-    stan::math::check_size_match("vector[negative_min_max] assign", name, x.size(),
-                                 "right hand side", 0);
+    stan::math::check_size_match("vector[negative_min_max] assign", name,
+                                 x.size(), "right hand side", 0);
     stan::math::check_size_match("vector[negative_min_max] assign", name, 0,
                                  "right hand side", y.size());
   }
@@ -165,7 +165,8 @@ template <typename Vec1, typename Vec2,
 inline void assign(Vec1&& x, const Vec2& y, const char* name, index_min idx) {
   stan::math::check_range("vector[min] assign", name, x.size(), idx.min_);
   stan::math::check_size_match("vector[min] assign", name,
-                               x.size() - idx.min_ + 1, "right hand side", y.size());
+                               x.size() - idx.min_ + 1, "right hand side",
+                               y.size());
   internal::assign_impl(x.tail(x.size() - idx.min_ + 1), y, name);
 }
 
@@ -190,8 +191,8 @@ template <typename Vec1, typename Vec2,
 inline void assign(Vec1&& x, const Vec2& y, const char* name, index_max idx) {
   if (idx.max_ > 0) {
     stan::math::check_range("vector[max] assign", name, x.size(), idx.max_);
-    stan::math::check_size_match("vector[max] assign", name,
-                                 idx.max_, "right hand side", y.size());
+    stan::math::check_size_match("vector[max] assign", name, idx.max_,
+                                 "right hand side", y.size());
     internal::assign_impl(x.head(idx.max_), y, name);
   } else {
     stan::math::check_size_match("vector[max < 1] assign", name, x.size(),
@@ -218,8 +219,8 @@ template <typename Vec1, typename Vec2,
           require_all_vector_t<Vec1, Vec2>* = nullptr,
           require_all_not_std_vector_t<Vec1, Vec2>* = nullptr>
 inline void assign(Vec1&& x, Vec2&& y, const char* name, index_omni /* idx */) {
-  stan::math::check_size_match("vector[omni] assign", name,
-                               x.size(), "right hand side", y.size());
+  stan::math::check_size_match("vector[omni] assign", name, x.size(),
+                               "right hand side", y.size());
   internal::assign_impl(x, std::forward<Vec2>(y), name);
 }
 
@@ -244,8 +245,8 @@ template <typename Mat, typename RowVec,
           require_row_vector_t<RowVec>* = nullptr>
 inline void assign(Mat&& x, const RowVec& y, const char* name, index_uni idx) {
   stan::math::check_range("matrix[uni] assign row", name, x.rows(), idx.n_);
-  stan::math::check_size_match("matrix[uni] assign columns", name,
-                               x.cols(), "right hand side size", y.size());
+  stan::math::check_size_match("matrix[uni] assign columns", name, x.cols(),
+                               "right hand side size", y.size());
   internal::assign_impl(x.row(idx.n_ - 1), y, name);
 }
 
@@ -270,9 +271,10 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const index_multi& idx) {
   const auto& y_ref = stan::math::to_ref(y);
   stan::math::check_size_match("matrix[multi] assign rows", name,
-                               idx.ns_.size(), "right hand side rows", y.rows());
-  stan::math::check_size_match("matrix[multi] assign columns", name,
-                               x.cols(), "right hand side columns", y.cols());
+                               idx.ns_.size(), "right hand side rows",
+                               y.rows());
+  stan::math::check_size_match("matrix[multi] assign columns", name, x.cols(),
+                               "right hand side columns", y.cols());
   for (int i = 0; i < idx.ns_.size(); ++i) {
     const int n = idx.ns_[i];
     stan::math::check_range("matrix[multi] assign row", name, x.rows(), n);
@@ -297,10 +299,10 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
 template <typename Mat1, typename Mat2,
           require_all_dense_dynamic_t<Mat1, Mat2>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, index_omni /* idx */) {
-  stan::math::check_size_match("matrix[omni] assign rows", name,
-                               x.rows(), "right hand side rows", y.rows());
-  stan::math::check_size_match("matrix[omni] assign columns", name,
-                               x.cols(), "right hand side columns", y.cols());
+  stan::math::check_size_match("matrix[omni] assign rows", name, x.rows(),
+                               "right hand side rows", y.rows());
+  stan::math::check_size_match("matrix[omni] assign columns", name, x.cols(),
+                               "right hand side columns", y.cols());
   internal::assign_impl(x, std::forward<Mat2>(y), name);
 }
 
@@ -325,10 +327,10 @@ template <typename Mat1, typename Mat2,
 inline void assign(Mat1&& x, const Mat2& y, const char* name, index_min idx) {
   const auto row_size = x.rows() - (idx.min_ - 1);
   stan::math::check_range("matrix[min] assign row", name, x.rows(), idx.min_);
-  stan::math::check_size_match("matrix[min] assign rows", name,
-                               row_size, "right hand side rows", y.rows());
-  stan::math::check_size_match("matrix[min] assign columns", name,
-                               x.cols(), "right hand side columns", y.cols());
+  stan::math::check_size_match("matrix[min] assign rows", name, row_size,
+                               "right hand side rows", y.rows());
+  stan::math::check_size_match("matrix[min] assign columns", name, x.cols(),
+                               "right hand side columns", y.cols());
   internal::assign_impl(x.bottomRows(row_size), y, name);
 }
 
@@ -351,12 +353,12 @@ template <typename Mat1, typename Mat2,
           require_dense_dynamic_t<Mat1>* = nullptr,
           require_matrix_t<Mat2>* = nullptr>
 inline void assign(Mat1&& x, const Mat2& y, const char* name, index_max idx) {
-  stan::math::check_size_match("matrix[max] assign columns", name,
-                               x.cols(), "right hand side columns", y.cols());
+  stan::math::check_size_match("matrix[max] assign columns", name, x.cols(),
+                               "right hand side columns", y.cols());
   if (idx.max_ > 0) {
     stan::math::check_range("matrix[max] assign row", name, x.rows(), idx.max_);
-    stan::math::check_size_match("matrix[max] assign rows", name,
-                                 idx.max_, "right hand side rows", y.rows());
+    stan::math::check_size_match("matrix[max] assign rows", name, idx.max_,
+                                 "right hand side rows", y.rows());
     internal::assign_impl(x.topRows(idx.max_), y, name);
   } else {
     stan::math::check_size_match("matrix[max < 1] assign rows", name, x.rows(),
@@ -385,22 +387,20 @@ template <typename Mat1, typename Mat2,
           require_dense_dynamic_t<Mat1>* = nullptr,
           require_matrix_t<Mat2>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max idx) {
-  stan::math::check_size_match("matrix[min_max] assign columns",
-                               name, x.cols(), "right hand side columns",
-                               y.cols());
+  stan::math::check_size_match("matrix[min_max] assign columns", name, x.cols(),
+                               "right hand side columns", y.cols());
   if (idx.max_ >= idx.min_) {
     stan::math::check_range("matrix[min_max] min row indexing", name, x.rows(),
                             idx.min_);
     stan::math::check_range("matrix[min_max] max row indexing", name, x.rows(),
                             idx.max_);
     const auto row_size = idx.max_ - idx.min_ + 1;
-    stan::math::check_size_match("matrix[min_max] assign rows",
-                                 name, row_size, "right hand side rows",
-                                 y.rows());
+    stan::math::check_size_match("matrix[min_max] assign rows", name, row_size,
+                                 "right hand side rows", y.rows());
     internal::assign_impl(x.middleRows(idx.min_ - 1, row_size), y, name);
   } else {
-    stan::math::check_size_match("matrix[negative_min_max] assign rows",
-                                 name, 0, "right hand side", y.rows());
+    stan::math::check_size_match("matrix[negative_min_max] assign rows", name,
+                                 0, "right hand side", y.rows());
   }
 }
 
@@ -424,7 +424,6 @@ template <typename Mat1, typename Mat2,
           require_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
                    index_min_max col_idx) {
-
   if ((row_idx.max_ >= row_idx.min_) && (col_idx.max_ >= col_idx.min_)) {
     stan::math::check_range("matrix[min_max, min_max] assign min row", name,
                             x.rows(), row_idx.min_);
@@ -437,9 +436,8 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
                             x.cols(), col_idx.max_);
     auto row_size = row_idx.max_ - (row_idx.min_ - 1);
     auto col_size = col_idx.max_ - (col_idx.min_ - 1);
-    stan::math::check_size_match("matrix[min_max, min_max] assign rows",
-                                 name, row_size, "right hand side rows",
-                                 y.rows());
+    stan::math::check_size_match("matrix[min_max, min_max] assign rows", name,
+                                 row_size, "right hand side rows", y.rows());
     stan::math::check_size_match("matrix[min_max, min_max] assign columns",
                                  name, col_size, "right hand side columns",
                                  y.cols());
@@ -449,31 +447,40 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
   } else {
     // Check the indexing is valid but don't actually do assignment
     if (row_idx.max_ >= row_idx.min_) {
-      stan::math::check_range("matrix[min_max, negative_min_max] assign min row", name,
-                              x.rows(), row_idx.min_);
-      stan::math::check_range("matrix[min_max, negative_min_max] assign max row", name,
-                              x.rows(), row_idx.max_);
+      stan::math::check_range(
+          "matrix[min_max, negative_min_max] assign min row", name, x.rows(),
+          row_idx.min_);
+      stan::math::check_range(
+          "matrix[min_max, negative_min_max] assign max row", name, x.rows(),
+          row_idx.max_);
       stan::math::check_size_match("matrix[min_max, negative_min_max] assign",
-                                   name, 0, "right hand side columns", y.cols());
+                                   name, 0, "right hand side columns",
+                                   y.cols());
 
     } else if (col_idx.max_ >= col_idx.min_) {
-      stan::math::check_range("matrix[negative_min_max, min_max] assign min column", name,
-                              x.cols(), col_idx.min_);
-      stan::math::check_range("matrix[negative_min_max, min_max] assign max column",
-                              name, x.cols(), col_idx.max_);
-      stan::math::check_size_match("matrix[min_max, min_max] assign rows",
-                                   name, x.rows(), "right hand side", 0);
-      stan::math::check_size_match("matrix[min_max, min_max] assign rows",
-                                   name, 0, "right hand side", y.rows());
+      stan::math::check_range(
+          "matrix[negative_min_max, min_max] assign min column", name, x.cols(),
+          col_idx.min_);
+      stan::math::check_range(
+          "matrix[negative_min_max, min_max] assign max column", name, x.cols(),
+          col_idx.max_);
+      stan::math::check_size_match("matrix[min_max, min_max] assign rows", name,
+                                   x.rows(), "right hand side", 0);
+      stan::math::check_size_match("matrix[min_max, min_max] assign rows", name,
+                                   0, "right hand side", y.rows());
     } else {
-      stan::math::check_size_match("matrix[negative_min_max, negative_min_max] assign rows",
-                                   name, x.rows(), "right hand side", 0);
-      stan::math::check_size_match("matrix[negative_min_max, negative_min_max] assign rows",
-                                   name, 0, "right hand side", y.rows());
-     stan::math::check_size_match("matrix[negative_min_max, negative_min_max] assign cols",
-                                  name, x.cols(), "right hand side", 0);
-     stan::math::check_size_match("matrix[negative_min_max, negative_min_max] assign cols",
-                                  name, 0, "right hand side", y.cols());
+      stan::math::check_size_match(
+          "matrix[negative_min_max, negative_min_max] assign rows", name,
+          x.rows(), "right hand side", 0);
+      stan::math::check_size_match(
+          "matrix[negative_min_max, negative_min_max] assign rows", name, 0,
+          "right hand side", y.rows());
+      stan::math::check_size_match(
+          "matrix[negative_min_max, negative_min_max] assign cols", name,
+          x.cols(), "right hand side", 0);
+      stan::math::check_size_match(
+          "matrix[negative_min_max, negative_min_max] assign cols", name, 0,
+          "right hand side", y.cols());
     }
   }
 }
@@ -529,7 +536,8 @@ inline void assign(Mat1&& x, const Vec& y, const char* name, index_uni row_idx,
   stan::math::check_range("matrix[uni, multi] assign row", name, x.rows(),
                           row_idx.n_);
   stan::math::check_size_match("matrix[uni, multi] assign", name,
-                               col_idx.ns_.size(), "right hand side", y_ref.size());
+                               col_idx.ns_.size(), "right hand side",
+                               y_ref.size());
   for (int i = 0; i < col_idx.ns_.size(); ++i) {
     stan::math::check_range("matrix[uni, multi] assign column", name, x.cols(),
                             col_idx.ns_[i]);
@@ -559,11 +567,11 @@ template <typename Mat1, typename Mat2,
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const index_multi& row_idx, const index_multi& col_idx) {
   const auto& y_ref = stan::math::to_ref(y);
-  stan::math::check_size_match("matrix[multi,multi] assign rows",
-                               name, row_idx.ns_.size(), "right hand side rows",
+  stan::math::check_size_match("matrix[multi,multi] assign rows", name,
+                               row_idx.ns_.size(), "right hand side rows",
                                y_ref.rows());
-  stan::math::check_size_match("matrix[multi,multi] assign columns",
-                               name, col_idx.ns_.size(), "right hand side columns",
+  stan::math::check_size_match("matrix[multi,multi] assign columns", name,
+                               col_idx.ns_.size(), "right hand side columns",
                                y_ref.cols());
   for (int j = 0; j < y_ref.cols(); ++j) {
     const int n = col_idx.ns_[j];
@@ -626,8 +634,8 @@ template <typename Mat1, typename Mat2, typename Idx,
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const Idx& row_idx, const index_multi& col_idx) {
   const auto& y_ref = stan::math::to_ref(y);
-  stan::math::check_size_match("matrix[..., multi] assign column sizes",
-                               name, col_idx.ns_.size(), "right hand side columns",
+  stan::math::check_size_match("matrix[..., multi] assign column sizes", name,
+                               col_idx.ns_.size(), "right hand side columns",
                                y_ref.cols());
   for (int j = 0; j < col_idx.ns_.size(); ++j) {
     const int n = col_idx.ns_[j];
@@ -686,8 +694,8 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
   const auto col_size = x.cols() - start_col;
   stan::math::check_range("matrix[..., min] assign column", name, x.cols(),
                           col_idx.min_);
-  stan::math::check_size_match("matrix[..., min] assign columns",
-                               name, col_size, "right hand side columns", y.cols());
+  stan::math::check_size_match("matrix[..., min] assign columns", name,
+                               col_size, "right hand side columns", y.cols());
   assign(x.rightCols(col_size), y, name, row_idx);
 }
 
@@ -716,15 +724,15 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
   if (col_idx.max_ > 0) {
     stan::math::check_range("matrix[..., max] assign", name, x.cols(),
                             col_idx.max_);
-    stan::math::check_size_match("matrix[..., max] assign columns",
-                                 name, col_idx.max_, "right hand side columns",
+    stan::math::check_size_match("matrix[..., max] assign columns", name,
+                                 col_idx.max_, "right hand side columns",
                                  y.cols());
     assign(x.leftCols(col_idx.max_), y, name, row_idx);
   } else {
-    stan::math::check_size_match("matrix[..., max] assign columns",
-                                 name, x.cols(), "right hand side columns", 0);
-    stan::math::check_size_match("matrix[..., max] assign columns",
-                                 name, 0, "right hand side columns", y.cols());
+    stan::math::check_size_match("matrix[..., max] assign columns", name,
+                                 x.cols(), "right hand side columns", 0);
+    stan::math::check_size_match("matrix[..., max] assign columns", name, 0,
+                                 "right hand side columns", y.cols());
   }
 }
 
@@ -874,21 +882,21 @@ inline void assign(T&& x, U&& y, const char* name, const Idx1& idx1,
       || std::is_same<std::decay_t<Idx1>, index_max>::value) {
     if (x_idx_size == 0) {
       if (std::is_same<std::decay_t<Idx1>, index_min_max>::value) {
-        stan::math::check_size_match("array[negative_min_max, ...] assign", name,
-                                     x.size(), "right hand side", 0);
-        stan::math::check_size_match("array[negative_min_max, ...] assign", name,
-                                     0, "right hand side", y.size());
+        stan::math::check_size_match("array[negative_min_max, ...] assign",
+                                     name, x.size(), "right hand side", 0);
+        stan::math::check_size_match("array[negative_min_max, ...] assign",
+                                     name, 0, "right hand side", y.size());
       } else {
         stan::math::check_size_match("array[max < 1, ...] assign", name,
                                      x.size(), "right hand side", 0);
-        stan::math::check_size_match("array[max < 1, ...] assign", name,
-                                     0, "right hand side", y.size());
+        stan::math::check_size_match("array[max < 1, ...] assign", name, 0,
+                                     "right hand side", y.size());
       }
       return;
     }
   }
-  stan::math::check_size_match("array[multi, ...] assign", name,
-                               x_idx_size, "right hand side size", y.size());
+  stan::math::check_size_match("array[multi, ...] assign", name, x_idx_size,
+                               "right hand side size", y.size());
   for (size_t n = 0; n < y.size(); ++n) {
     size_t i = rvalue_at(n, idx1);
     stan::math::check_range("array[multi, ...] assign", name, x.size(), i);

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -97,8 +97,8 @@ template <typename Vec1, typename Vec2,
 inline void assign(Vec1&& x, const Vec2& y, const char* name,
                    const index_multi& idx) {
   const auto& y_ref = stan::math::to_ref(y);
-  stan::math::check_size_match("vector[multi] assign", "left hand side",
-                               idx.ns_.size(), name, y_ref.size());
+  stan::math::check_size_match("vector[multi] assign", name,
+                               idx.ns_.size(), "right hand side", y_ref.size());
   const auto x_size = x.size();
   for (int n = 0; n < y_ref.size(); ++n) {
     stan::math::check_range("vector[multi] assign", name, x_size, idx.ns_[n]);
@@ -126,19 +126,21 @@ template <typename Vec1, typename Vec2,
           require_all_not_std_vector_t<Vec1, Vec2>* = nullptr>
 inline void assign(Vec1&& x, const Vec2& y, const char* name,
                    index_min_max idx) {
-   stan::math::check_range("vector[min_max] min assign", name, x.size(),
-                           idx.min_);
   if (idx.max_ >= idx.min_) {
+    stan::math::check_range("vector[min_max] min assign", name, x.size(),
+                            idx.min_);
     stan::math::check_range("vector[min_max] max assign", name, x.size(),
                             idx.max_);
     const auto slice_start = idx.min_ - 1;
     const auto slice_size = idx.max_ - slice_start;
-    stan::math::check_size_match("vector[min_max] assign", "left hand side",
-                                 slice_size, name, y.size());
+    stan::math::check_size_match("vector[min_max] assign", name,
+                                 slice_size, "right hand side", y.size());
     internal::assign_impl(x.segment(slice_start, slice_size), y, name);
   } else {
-    stan::math::check_size_match("vector[min_max] assign", "left hand side", 0,
-                                 name, y.size());
+    stan::math::check_size_match("vector[negative_min_max] assign", name, x.size(),
+                                 "right hand side", 0);
+    stan::math::check_size_match("vector[negative_min_max] assign", name, 0,
+                                 "right hand side", y.size());
   }
 }
 
@@ -162,8 +164,8 @@ template <typename Vec1, typename Vec2,
           require_all_not_std_vector_t<Vec1, Vec2>* = nullptr>
 inline void assign(Vec1&& x, const Vec2& y, const char* name, index_min idx) {
   stan::math::check_range("vector[min] assign", name, x.size(), idx.min_);
-  stan::math::check_size_match("vector[min] assign", "left hand side",
-                               x.size() - idx.min_ + 1, name, y.size());
+  stan::math::check_size_match("vector[min] assign", name,
+                               x.size() - idx.min_ + 1, "right hand side", y.size());
   internal::assign_impl(x.tail(x.size() - idx.min_ + 1), y, name);
 }
 
@@ -188,12 +190,14 @@ template <typename Vec1, typename Vec2,
 inline void assign(Vec1&& x, const Vec2& y, const char* name, index_max idx) {
   if (idx.max_ > 0) {
     stan::math::check_range("vector[max] assign", name, x.size(), idx.max_);
-    stan::math::check_size_match("vector[max] assign", "left hand side",
-                                 idx.max_, name, y.size());
+    stan::math::check_size_match("vector[max] assign", name,
+                                 idx.max_, "right hand side", y.size());
     internal::assign_impl(x.head(idx.max_), y, name);
   } else {
-    stan::math::check_size_match("vector[max] assign", "left hand side", 0,
-                                 name, y.size());
+    stan::math::check_size_match("vector[max < 1] assign", name, x.size(),
+                                 "right hand side", 0);
+    stan::math::check_size_match("vector[max < 1] assign", name, 0,
+                                 "right hand side", y.size());
   }
 }
 
@@ -214,8 +218,8 @@ template <typename Vec1, typename Vec2,
           require_all_vector_t<Vec1, Vec2>* = nullptr,
           require_all_not_std_vector_t<Vec1, Vec2>* = nullptr>
 inline void assign(Vec1&& x, Vec2&& y, const char* name, index_omni /* idx */) {
-  stan::math::check_size_match("vector[omni] assign", "left hand side",
-                               x.size(), name, y.size());
+  stan::math::check_size_match("vector[omni] assign", name,
+                               x.size(), "right hand side", y.size());
   internal::assign_impl(x, std::forward<Vec2>(y), name);
 }
 
@@ -240,8 +244,8 @@ template <typename Mat, typename RowVec,
           require_row_vector_t<RowVec>* = nullptr>
 inline void assign(Mat&& x, const RowVec& y, const char* name, index_uni idx) {
   stan::math::check_range("matrix[uni] assign row", name, x.rows(), idx.n_);
-  stan::math::check_size_match("matrix[uni] assign", "left hand side columns",
-                               x.cols(), name, y.size());
+  stan::math::check_size_match("matrix[uni] assign columns", name,
+                               x.cols(), "right hand side size", y.size());
   internal::assign_impl(x.row(idx.n_ - 1), y, name);
 }
 
@@ -265,10 +269,10 @@ template <typename Mat1, typename Mat2,
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const index_multi& idx) {
   const auto& y_ref = stan::math::to_ref(y);
-  stan::math::check_size_match("matrix[multi] assign", "left hand side rows",
-                               idx.ns_.size(), name, y.rows());
-  stan::math::check_size_match("matrix[multi] assign", "left hand side columns",
-                               x.cols(), name, y.cols());
+  stan::math::check_size_match("matrix[multi] assign rows", name,
+                               idx.ns_.size(), "right hand side rows", y.rows());
+  stan::math::check_size_match("matrix[multi] assign columns", name,
+                               x.cols(), "right hand side columns", y.cols());
   for (int i = 0; i < idx.ns_.size(); ++i) {
     const int n = idx.ns_[i];
     stan::math::check_range("matrix[multi] assign row", name, x.rows(), n);
@@ -293,10 +297,10 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
 template <typename Mat1, typename Mat2,
           require_all_dense_dynamic_t<Mat1, Mat2>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, index_omni /* idx */) {
-  stan::math::check_size_match("matrix[omni] assign", "left hand side rows",
-                               x.rows(), name, y.rows());
-  stan::math::check_size_match("matrix[omni] assign", "left hand side columns",
-                               x.cols(), name, y.cols());
+  stan::math::check_size_match("matrix[omni] assign rows", name,
+                               x.rows(), "right hand side rows", y.rows());
+  stan::math::check_size_match("matrix[omni] assign columns", name,
+                               x.cols(), "right hand side columns", y.cols());
   internal::assign_impl(x, std::forward<Mat2>(y), name);
 }
 
@@ -321,10 +325,10 @@ template <typename Mat1, typename Mat2,
 inline void assign(Mat1&& x, const Mat2& y, const char* name, index_min idx) {
   const auto row_size = x.rows() - (idx.min_ - 1);
   stan::math::check_range("matrix[min] assign row", name, x.rows(), idx.min_);
-  stan::math::check_size_match("matrix[min] assign", "left hand side rows",
-                               row_size, name, y.rows());
-  stan::math::check_size_match("matrix[min] assign", "left hand side columns",
-                               x.cols(), name, y.cols());
+  stan::math::check_size_match("matrix[min] assign rows", name,
+                               row_size, "right hand side rows", y.rows());
+  stan::math::check_size_match("matrix[min] assign columns", name,
+                               x.cols(), "right hand side columns", y.cols());
   internal::assign_impl(x.bottomRows(row_size), y, name);
 }
 
@@ -347,17 +351,18 @@ template <typename Mat1, typename Mat2,
           require_dense_dynamic_t<Mat1>* = nullptr,
           require_matrix_t<Mat2>* = nullptr>
 inline void assign(Mat1&& x, const Mat2& y, const char* name, index_max idx) {
-  stan::math::check_size_match("matrix[max] assign", "left hand side columns",
-                               x.cols(), name, y.cols());
+  stan::math::check_size_match("matrix[max] assign columns", name,
+                               x.cols(), "right hand side columns", y.cols());
   if (idx.max_ > 0) {
     stan::math::check_range("matrix[max] assign row", name, x.rows(), idx.max_);
-    stan::math::check_size_match("matrix[max] assign", "left hand side rows",
-                                 idx.max_, name, y.rows());
+    stan::math::check_size_match("matrix[max] assign rows", name,
+                                 idx.max_, "right hand side rows", y.rows());
     internal::assign_impl(x.topRows(idx.max_), y, name);
   } else {
-    stan::math::check_size_match("matrix[max] assign", "left hand side rows", 0,
-                                 name, y.rows());
-    internal::assign_impl(x.topRows(0), y, name);
+    stan::math::check_size_match("matrix[max < 1] assign rows", name, x.rows(),
+                                 "right hand side rows", 0);
+    stan::math::check_size_match("matrix[max < 1] assign rows", name, 0,
+                                 "right hand side rows", y.rows());
   }
 }
 
@@ -380,22 +385,22 @@ template <typename Mat1, typename Mat2,
           require_dense_dynamic_t<Mat1>* = nullptr,
           require_matrix_t<Mat2>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max idx) {
-  stan::math::check_range("matrix[min_max] min row indexing", name, x.rows(),
-                          idx.min_);
-  stan::math::check_size_match("matrix[min_max] assign",
-                               "left hand side columns", x.cols(), name,
+  stan::math::check_size_match("matrix[min_max] assign columns",
+                               name, x.cols(), "right hand side columns",
                                y.cols());
   if (idx.max_ >= idx.min_) {
+    stan::math::check_range("matrix[min_max] min row indexing", name, x.rows(),
+                            idx.min_);
     stan::math::check_range("matrix[min_max] max row indexing", name, x.rows(),
                             idx.max_);
     const auto row_size = idx.max_ - idx.min_ + 1;
-    stan::math::check_size_match("matrix[min_max] assign",
-                                 "left hand side rows", row_size, name,
+    stan::math::check_size_match("matrix[min_max] assign rows",
+                                 name, row_size, "right hand side rows",
                                  y.rows());
     internal::assign_impl(x.middleRows(idx.min_ - 1, row_size), y, name);
   } else {
-    stan::math::check_size_match("matrix[min_max] assign",
-                                 "left hand side rows", 0, name, y.rows());
+    stan::math::check_size_match("matrix[negative_min_max] assign rows",
+                                 name, 0, "right hand side", y.rows());
   }
 }
 
@@ -419,25 +424,24 @@ template <typename Mat1, typename Mat2,
           require_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
                    index_min_max col_idx) {
-  stan::math::check_range("matrix[min_max, min_max] assign min row", name,
-                          x.rows(), row_idx.min_);
-
-  stan::math::check_range("matrix[min_max, min_max] assign min column", name,
-                          x.cols(), col_idx.min_);
 
   if ((row_idx.max_ >= row_idx.min_) && (col_idx.max_ >= col_idx.min_)) {
-    auto row_size = row_idx.max_ - (row_idx.min_ - 1);
-    auto col_size = col_idx.max_ - (col_idx.min_ - 1);
+    stan::math::check_range("matrix[min_max, min_max] assign min row", name,
+                            x.rows(), row_idx.min_);
+
+    stan::math::check_range("matrix[min_max, min_max] assign min column", name,
+                            x.cols(), col_idx.min_);
     stan::math::check_range("matrix[min_max, min_max] assign max row", name,
                             x.rows(), row_idx.max_);
     stan::math::check_range("matrix[min_max, min_max] assign max column", name,
                             x.cols(), col_idx.max_);
-
-    stan::math::check_size_match("matrix[min_max, min_max] assign",
-                                 "left hand side rows", row_size, name,
+    auto row_size = row_idx.max_ - (row_idx.min_ - 1);
+    auto col_size = col_idx.max_ - (col_idx.min_ - 1);
+    stan::math::check_size_match("matrix[min_max, min_max] assign rows",
+                                 name, row_size, "right hand side rows",
                                  y.rows());
-    stan::math::check_size_match("matrix[min_max, min_max] assign",
-                                 "left hand side columns", col_size, name,
+    stan::math::check_size_match("matrix[min_max, min_max] assign columns",
+                                 name, col_size, "right hand side columns",
                                  y.cols());
     internal::assign_impl(
         x.block(row_idx.min_ - 1, col_idx.min_ - 1, row_size, col_size), y,
@@ -445,16 +449,31 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
   } else {
     // Check the indexing is valid but don't actually do assignment
     if (row_idx.max_ >= row_idx.min_) {
-      stan::math::check_range("matrix[min_max, min_max] assign max row", name,
+      stan::math::check_range("matrix[min_max, negative_min_max] assign min row", name,
+                              x.rows(), row_idx.min_);
+      stan::math::check_range("matrix[min_max, negative_min_max] assign max row", name,
                               x.rows(), row_idx.max_);
-      stan::math::check_size_match("matrix[min_max, min_max] assign",
-                                   "left hand side columns", 0, name, y.cols());
+      stan::math::check_size_match("matrix[min_max, negative_min_max] assign",
+                                   name, 0, "right hand side columns", y.cols());
 
-    } else {
-      stan::math::check_range("matrix[min_max, min_max] assign max column",
+    } else if (col_idx.max_ >= col_idx.min_) {
+      stan::math::check_range("matrix[negative_min_max, min_max] assign min column", name,
+                              x.cols(), col_idx.min_);
+      stan::math::check_range("matrix[negative_min_max, min_max] assign max column",
                               name, x.cols(), col_idx.max_);
-      stan::math::check_size_match("matrix[min_max, min_max] assign",
-                                   "left hand side rows", 0, name, y.rows());
+      stan::math::check_size_match("matrix[min_max, min_max] assign rows",
+                                   name, x.rows(), "right hand side", 0);
+      stan::math::check_size_match("matrix[min_max, min_max] assign rows",
+                                   name, 0, "right hand side", y.rows());
+    } else {
+      stan::math::check_size_match("matrix[negative_min_max, negative_min_max] assign rows",
+                                   name, x.rows(), "right hand side", 0);
+      stan::math::check_size_match("matrix[negative_min_max, negative_min_max] assign rows",
+                                   name, 0, "right hand side", y.rows());
+     stan::math::check_size_match("matrix[negative_min_max, negative_min_max] assign cols",
+                                  name, x.cols(), "right hand side", 0);
+     stan::math::check_size_match("matrix[negative_min_max, negative_min_max] assign cols",
+                                  name, 0, "right hand side", y.cols());
     }
   }
 }
@@ -509,8 +528,8 @@ inline void assign(Mat1&& x, const Vec& y, const char* name, index_uni row_idx,
   const auto& y_ref = stan::math::to_ref(y);
   stan::math::check_range("matrix[uni, multi] assign row", name, x.rows(),
                           row_idx.n_);
-  stan::math::check_size_match("matrix[uni, multi] assign", "left hand side",
-                               col_idx.ns_.size(), name, y_ref.size());
+  stan::math::check_size_match("matrix[uni, multi] assign", name,
+                               col_idx.ns_.size(), "right hand side", y_ref.size());
   for (int i = 0; i < col_idx.ns_.size(); ++i) {
     stan::math::check_range("matrix[uni, multi] assign column", name, x.cols(),
                             col_idx.ns_[i]);
@@ -540,11 +559,11 @@ template <typename Mat1, typename Mat2,
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const index_multi& row_idx, const index_multi& col_idx) {
   const auto& y_ref = stan::math::to_ref(y);
-  stan::math::check_size_match("matrix[multi,multi] assign row sizes",
-                               "left hand side", row_idx.ns_.size(), name,
+  stan::math::check_size_match("matrix[multi,multi] assign rows",
+                               name, row_idx.ns_.size(), "right hand side rows",
                                y_ref.rows());
-  stan::math::check_size_match("matrix[multi,multi] assign column sizes",
-                               "left hand side", col_idx.ns_.size(), name,
+  stan::math::check_size_match("matrix[multi,multi] assign columns",
+                               name, col_idx.ns_.size(), "right hand side columns",
                                y_ref.cols());
   for (int j = 0; j < y_ref.cols(); ++j) {
     const int n = col_idx.ns_[j];
@@ -608,7 +627,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const Idx& row_idx, const index_multi& col_idx) {
   const auto& y_ref = stan::math::to_ref(y);
   stan::math::check_size_match("matrix[..., multi] assign column sizes",
-                               "left hand side", col_idx.ns_.size(), name,
+                               name, col_idx.ns_.size(), "right hand side columns",
                                y_ref.cols());
   for (int j = 0; j < col_idx.ns_.size(); ++j) {
     const int n = col_idx.ns_[j];
@@ -667,8 +686,8 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
   const auto col_size = x.cols() - start_col;
   stan::math::check_range("matrix[..., min] assign column", name, x.cols(),
                           col_idx.min_);
-  stan::math::check_size_match("matrix[..., min] assign column sizes",
-                               "left hand side", col_size, name, y.cols());
+  stan::math::check_size_match("matrix[..., min] assign columns",
+                               name, col_size, "right hand side columns", y.cols());
   assign(x.rightCols(col_size), y, name, row_idx);
 }
 
@@ -697,14 +716,15 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
   if (col_idx.max_ > 0) {
     stan::math::check_range("matrix[..., max] assign", name, x.cols(),
                             col_idx.max_);
-    stan::math::check_size_match("matrix[..., max] assign column size",
-                                 "left hand side", col_idx.max_, name,
+    stan::math::check_size_match("matrix[..., max] assign columns",
+                                 name, col_idx.max_, "right hand side columns",
                                  y.cols());
     assign(x.leftCols(col_idx.max_), y, name, row_idx);
   } else {
-    stan::math::check_size_match("matrix[..., max] assign column size",
-                                 "left hand side", 0, name, y.cols());
-    assign(x.leftCols(0), y, name, row_idx);
+    stan::math::check_size_match("matrix[..., max] assign columns",
+                                 name, x.cols(), "right hand side columns", 0);
+    stan::math::check_size_match("matrix[..., max] assign columns",
+                                 name, 0, "right hand side columns", y.cols());
   }
 }
 
@@ -729,20 +749,21 @@ template <typename Mat1, typename Mat2, typename Idx,
           require_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, const Idx& row_idx,
                    index_min_max col_idx) {
-  stan::math::check_range("matrix[..., min_max] assign min column", name,
-                          x.cols(), col_idx.min_);
   if (col_idx.max_ >= col_idx.min_) {
+    stan::math::check_range("matrix[..., min_max] assign min column", name,
+                            x.cols(), col_idx.min_);
     stan::math::check_range("matrix[..., min_max] assign max column", name,
                             x.cols(), col_idx.max_);
     const auto col_start = col_idx.min_ - 1;
     const auto col_size = col_idx.max_ - col_start;
     stan::math::check_size_match("matrix[..., min_max] assign column size",
-                                 "left hand side", col_size, name, y.cols());
+                                 name, col_size, "right hand side", y.cols());
     assign(x.middleCols(col_start, col_size), y, name, row_idx);
   } else {
-    stan::math::check_size_match("matrix[..., min_max] assign column size",
-                                 "left hand side", 0, name, y.cols());
-    assign(x.middleCols(0, 0), y, name, row_idx);
+    stan::math::check_size_match("matrix[..., negative_min_max] assign columns",
+                                 name, x.cols(), "right hand side columns", 0);
+    stan::math::check_size_match("matrix[..., negative_min_max] assign columns",
+                                 name, 0, "right hand side columns", y.cols());
   }
 }
 
@@ -795,7 +816,7 @@ template <typename StdVec, typename U, typename... Idxs,
           require_std_vector_t<StdVec>* = nullptr>
 inline void assign(StdVec&& x, U&& y, const char* name, index_uni idx1,
                    const Idxs&... idxs) {
-  stan::math::check_range("vector[uni,...] assign", name, x.size(), idx1.n_);
+  stan::math::check_range("array[uni,...] assign", name, x.size(), idx1.n_);
   assign(x[idx1.n_ - 1], std::forward<U>(y), name, idxs...);
 }
 
@@ -818,7 +839,7 @@ inline void assign(StdVec&& x, U&& y, const char* name, index_uni idx1,
 template <typename StdVec, typename U, require_std_vector_t<StdVec>* = nullptr,
           require_t<std::is_assignable<value_type_t<StdVec>&, U>>* = nullptr>
 inline void assign(StdVec&& x, U&& y, const char* name, index_uni idx) {
-  stan::math::check_range("vector[uni,...] assign", name, x.size(), idx.n_);
+  stan::math::check_range("array[uni,...] assign", name, x.size(), idx.n_);
   x[idx.n_ - 1] = std::forward<U>(y);
 }
 
@@ -852,13 +873,22 @@ inline void assign(T&& x, U&& y, const char* name, const Idx1& idx1,
   if (std::is_same<std::decay_t<Idx1>, index_min_max>::value
       || std::is_same<std::decay_t<Idx1>, index_max>::value) {
     if (x_idx_size == 0) {
-      stan::math::check_size_match("array[multi, ...] assign", "left hand side",
-                                   0, name, y.size());
+      if (std::is_same<std::decay_t<Idx1>, index_min_max>::value) {
+        stan::math::check_size_match("array[negative_min_max, ...] assign", name,
+                                     x.size(), "right hand side", 0);
+        stan::math::check_size_match("array[negative_min_max, ...] assign", name,
+                                     0, "right hand side", y.size());
+      } else {
+        stan::math::check_size_match("array[max < 1, ...] assign", name,
+                                     x.size(), "right hand side", 0);
+        stan::math::check_size_match("array[max < 1, ...] assign", name,
+                                     0, "right hand side", y.size());
+      }
       return;
     }
   }
-  stan::math::check_size_match("array[multi, ...] assign", "left hand side",
-                               x_idx_size, name, y.size());
+  stan::math::check_size_match("array[multi, ...] assign", name,
+                               x_idx_size, "right hand side size", y.size());
   for (size_t n = 0; n < y.size(); ++n) {
     size_t i = rvalue_at(n, idx1);
     stan::math::check_range("array[multi, ...] assign", name, x.size(), i);

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -126,9 +126,9 @@ template <typename Vec1, typename Vec2,
           require_all_not_std_vector_t<Vec1, Vec2>* = nullptr>
 inline void assign(Vec1&& x, const Vec2& y, const char* name,
                    index_min_max idx) {
+   stan::math::check_range("vector[min_max] min assign", name, x.size(),
+                           idx.min_);
   if (idx.max_ >= idx.min_) {
-    stan::math::check_range("vector[min_max] min assign", name, x.size(),
-                            idx.min_);
     stan::math::check_range("vector[min_max] max assign", name, x.size(),
                             idx.max_);
     const auto slice_start = idx.min_ - 1;
@@ -381,22 +381,20 @@ template <typename Mat1, typename Mat2,
           require_dense_dynamic_t<Mat1>* = nullptr,
           require_matrix_t<Mat2>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max idx) {
+  stan::math::check_range("matrix[min_max] min row indexing", name, x.rows(),
+                          idx.min_);
   stan::math::check_size_match("matrix[min_max] assign",
                                "left hand side columns", x.cols(), name,
                                y.cols());
   if (idx.max_ >= idx.min_) {
     stan::math::check_range("matrix[min_max] max row indexing", name, x.rows(),
                             idx.max_);
-    stan::math::check_range("matrix[min_max] min row indexing", name, x.rows(),
-                            idx.min_);
     const auto row_size = idx.max_ - idx.min_ + 1;
     stan::math::check_size_match("matrix[min_max] assign",
                                  "left hand side rows", row_size, name,
                                  y.rows());
     internal::assign_impl(x.middleRows(idx.min_ - 1, row_size), y, name);
   } else {
-    stan::math::check_range("matrix[min_max] min row indexing", name, x.rows(),
-                            idx.min_);
     stan::math::check_size_match("matrix[min_max] assign",
                                  "left hand side rows", 0, name,
                                  y.rows());

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -418,7 +418,8 @@ template <typename Mat1, typename Mat2,
           require_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
                    index_min_max col_idx) {
-  if (likely((row_idx.max_ >= row_idx.min_) && (col_idx.max_ >= col_idx.min_))) {
+  if (likely((row_idx.max_ >= row_idx.min_)
+             && (col_idx.max_ >= col_idx.min_))) {
     stan::math::check_range("matrix[min_max, min_max] assign min row", name,
                             x.rows(), row_idx.min_);
 
@@ -774,7 +775,7 @@ template <typename T, typename U, require_all_std_vector_t<T, U>* = nullptr,
 inline void assign(T&& x, U&& y, const char* name) {
   if (unlikely(x.size() != 0)) {
     stan::math::check_size_match("assign array size", name, x.size(),
-        "right hand side", y.size());
+                                 "right hand side", y.size());
   }
   if (std::is_rvalue_reference<U&&>::value) {
     for (size_t i = 0; i < y.size(); ++i) {

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -884,7 +884,7 @@ inline void assign(T&& x, U&& y, const char* name, const Idx1& idx1,
   for (size_t n = 0; n < y.size(); ++n) {
     size_t i = rvalue_at(n, idx1);
     stan::math::check_range("array[multi, ...] assign", name, x.size(), i);
-    if (std::is_rvalue_reference<U>::value) {
+    if (std::is_rvalue_reference<U&&>::value) {
       assign(x[i - 1], std::move(y[n]), name, idxs...);
     } else {
       assign(x[i - 1], y[n], name, idxs...);

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -137,8 +137,6 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name,
                                  "right hand side", y.size());
     internal::assign_impl(x.segment(slice_start, slice_size), y, name);
   } else {
-    stan::math::check_size_match("vector[negative_min_max] assign", name,
-                                 x.size(), "right hand side", 0);
     stan::math::check_size_match("vector[negative_min_max] assign", name, 0,
                                  "right hand side", y.size());
   }
@@ -195,8 +193,6 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name, index_max idx) {
                                  "right hand side", y.size());
     internal::assign_impl(x.head(idx.max_), y, name);
   } else {
-    stan::math::check_size_match("vector[max < 1] assign", name, x.size(),
-                                 "right hand side", 0);
     stan::math::check_size_match("vector[max < 1] assign", name, 0,
                                  "right hand side", y.size());
   }
@@ -361,8 +357,6 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name, index_max idx) {
                                  "right hand side rows", y.rows());
     internal::assign_impl(x.topRows(idx.max_), y, name);
   } else {
-    stan::math::check_size_match("matrix[max < 1] assign rows", name, x.rows(),
-                                 "right hand side rows", 0);
     stan::math::check_size_match("matrix[max < 1] assign rows", name, 0,
                                  "right hand side rows", y.rows());
   }
@@ -465,19 +459,11 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, index_min_max row_idx,
           "matrix[negative_min_max, min_max] assign max column", name, x.cols(),
           col_idx.max_);
       stan::math::check_size_match("matrix[min_max, min_max] assign rows", name,
-                                   x.rows(), "right hand side", 0);
-      stan::math::check_size_match("matrix[min_max, min_max] assign rows", name,
                                    0, "right hand side", y.rows());
     } else {
       stan::math::check_size_match(
-          "matrix[negative_min_max, negative_min_max] assign rows", name,
-          x.rows(), "right hand side", 0);
-      stan::math::check_size_match(
           "matrix[negative_min_max, negative_min_max] assign rows", name, 0,
           "right hand side", y.rows());
-      stan::math::check_size_match(
-          "matrix[negative_min_max, negative_min_max] assign cols", name,
-          x.cols(), "right hand side", 0);
       stan::math::check_size_match(
           "matrix[negative_min_max, negative_min_max] assign cols", name, 0,
           "right hand side", y.cols());
@@ -729,8 +715,6 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
                                  y.cols());
     assign(x.leftCols(col_idx.max_), y, name, row_idx);
   } else {
-    stan::math::check_size_match("matrix[..., max] assign columns", name,
-                                 x.cols(), "right hand side columns", 0);
     stan::math::check_size_match("matrix[..., max] assign columns", name, 0,
                                  "right hand side columns", y.cols());
   }
@@ -768,8 +752,6 @@ inline void assign(Mat1&& x, Mat2&& y, const char* name, const Idx& row_idx,
                                  name, col_size, "right hand side", y.cols());
     assign(x.middleCols(col_start, col_size), y, name, row_idx);
   } else {
-    stan::math::check_size_match("matrix[..., negative_min_max] assign columns",
-                                 name, x.cols(), "right hand side columns", 0);
     stan::math::check_size_match("matrix[..., negative_min_max] assign columns",
                                  name, 0, "right hand side columns", y.cols());
   }
@@ -887,8 +869,6 @@ inline void assign(T&& x, U&& y, const char* name, const Idx1& idx1,
         stan::math::check_size_match("array[negative_min_max, ...] assign",
                                      name, 0, "right hand side", y.size());
       } else {
-        stan::math::check_size_match("array[max < 1, ...] assign", name,
-                                     x.size(), "right hand side", 0);
         stan::math::check_size_match("array[max < 1, ...] assign", name, 0,
                                      "right hand side", y.size());
       }

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -869,8 +869,6 @@ inline void assign(T&& x, U&& y, const char* name, const Idx1& idx1,
     if (x_idx_size == 0) {
       if (std::is_same<std::decay_t<Idx1>, index_min_max>::value) {
         stan::math::check_size_match("array[negative_min_max, ...] assign",
-                                     name, x.size(), "right hand side", 0);
-        stan::math::check_size_match("array[negative_min_max, ...] assign",
                                      name, 0, "right hand side", y.size());
       } else {
         stan::math::check_size_match("array[max < 1, ...] assign", name, 0,

--- a/src/stan/model/indexing/assign_varmat.hpp
+++ b/src/stan/model/indexing/assign_varmat.hpp
@@ -111,8 +111,8 @@ template <typename Vec1, typename Vec2, require_var_vector_t<Vec1>* = nullptr,
           internal::require_var_vector_or_arithmetic_eigen<Vec2>* = nullptr>
 inline void assign(Vec1&& x, const Vec2& y, const char* name,
                    const index_multi& idx) {
-  stan::math::check_size_match("vector[multi] assign", name,
-                               idx.ns_.size(), "right hand side", y.size());
+  stan::math::check_size_match("vector[multi] assign", name, idx.ns_.size(),
+                               "right hand side", y.size());
   const auto x_size = x.size();
   const auto assign_size = idx.ns_.size();
   arena_t<std::vector<int>> x_idx(assign_size);
@@ -310,10 +310,10 @@ template <typename Mat1, typename Mat2,
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const index_multi& idx) {
   const auto assign_rows = idx.ns_.size();
-  stan::math::check_size_match("matrix[multi] assign rows", name,
-                               assign_rows, "right hand side rows", y.rows());
-  stan::math::check_size_match("matrix[multi] assign columns", name,
-                               x.cols(), "right hand side rows", y.cols());
+  stan::math::check_size_match("matrix[multi] assign rows", name, assign_rows,
+                               "right hand side rows", y.rows());
+  stan::math::check_size_match("matrix[multi] assign columns", name, x.cols(),
+                               "right hand side rows", y.cols());
   arena_t<std::vector<int>> x_idx(assign_rows);
   arena_t<Eigen::Matrix<double, -1, -1>> prev_vals(assign_rows, x.cols());
   Eigen::Matrix<double, -1, -1> y_val_idx(assign_rows, x.cols());
@@ -395,7 +395,8 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
   stan::math::check_size_match("matrix[multi,multi] assign rows", name,
                                assign_rows, "right hand side rows", y.rows());
   stan::math::check_size_match("matrix[multi,multi] assign columns", name,
-                               assign_cols, "right hand side columns", y.cols());
+                               assign_cols, "right hand side columns",
+                               y.cols());
   using arena_vec = std::vector<int, stan::math::arena_allocator<int>>;
   using pair_type = std::pair<int, arena_vec>;
   arena_vec x_col_idx(assign_cols);
@@ -515,7 +516,8 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const Idx& row_idx, const index_multi& col_idx) {
   const auto assign_cols = col_idx.ns_.size();
   stan::math::check_size_match("matrix[..., multi] assign columns", name,
-                               assign_cols, "right hand side columns", y.cols());
+                               assign_cols, "right hand side columns",
+                               y.cols());
   std::unordered_set<int> x_set;
   const auto& y_eval = y.eval();
   x_set.reserve(assign_cols);

--- a/src/stan/model/indexing/assign_varmat.hpp
+++ b/src/stan/model/indexing/assign_varmat.hpp
@@ -111,8 +111,8 @@ template <typename Vec1, typename Vec2, require_var_vector_t<Vec1>* = nullptr,
           internal::require_var_vector_or_arithmetic_eigen<Vec2>* = nullptr>
 inline void assign(Vec1&& x, const Vec2& y, const char* name,
                    const index_multi& idx) {
-  stan::math::check_size_match("vector[multi] assign", "left hand side",
-                               idx.ns_.size(), name, y.size());
+  stan::math::check_size_match("vector[multi] assign", name,
+                               idx.ns_.size(), "right hand side", y.size());
   const auto x_size = x.size();
   const auto assign_size = idx.ns_.size();
   arena_t<std::vector<int>> x_idx(assign_size);
@@ -229,8 +229,8 @@ inline void assign(Mat1&& x, const Vec& y, const char* name, index_uni row_idx,
   stan::math::check_range("matrix[uni, multi] assign", name, x.rows(),
                           row_idx.n_);
   const auto assign_cols = col_idx.ns_.size();
-  stan::math::check_size_match("matrix[uni, multi] assign", "left hand side",
-                               assign_cols, name, y.size());
+  stan::math::check_size_match("matrix[uni, multi] assign columns", name,
+                               assign_cols, "right hand side", y.size());
   const int row_idx_val = row_idx.n_ - 1;
   arena_t<std::vector<int>> x_idx(assign_cols);
   arena_t<Eigen::Matrix<double, -1, 1>> prev_val(assign_cols);
@@ -310,10 +310,10 @@ template <typename Mat1, typename Mat2,
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const index_multi& idx) {
   const auto assign_rows = idx.ns_.size();
-  stan::math::check_size_match("matrix[multi] assign", "left hand side rows",
-                               assign_rows, name, y.rows());
-  stan::math::check_size_match("matrix[multi] assign", "left hand side columns",
-                               x.cols(), name, y.cols());
+  stan::math::check_size_match("matrix[multi] assign rows", name,
+                               assign_rows, "right hand side rows", y.rows());
+  stan::math::check_size_match("matrix[multi] assign columns", name,
+                               x.cols(), "right hand side rows", y.cols());
   arena_t<std::vector<int>> x_idx(assign_rows);
   arena_t<Eigen::Matrix<double, -1, -1>> prev_vals(assign_rows, x.cols());
   Eigen::Matrix<double, -1, -1> y_val_idx(assign_rows, x.cols());
@@ -392,10 +392,10 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const index_multi& row_idx, const index_multi& col_idx) {
   const auto assign_rows = row_idx.ns_.size();
   const auto assign_cols = col_idx.ns_.size();
-  stan::math::check_size_match("matrix[multi,multi] assign", "left hand side",
-                               assign_rows, name, y.rows());
-  stan::math::check_size_match("matrix[multi,multi] assign", "left hand side",
-                               assign_cols, name, y.cols());
+  stan::math::check_size_match("matrix[multi,multi] assign rows", name,
+                               assign_rows, "right hand side rows", y.rows());
+  stan::math::check_size_match("matrix[multi,multi] assign columns", name,
+                               assign_cols, "right hand side columns", y.cols());
   using arena_vec = std::vector<int, stan::math::arena_allocator<int>>;
   using pair_type = std::pair<int, arena_vec>;
   arena_vec x_col_idx(assign_cols);
@@ -514,8 +514,8 @@ template <typename Mat1, typename Mat2, typename Idx,
 inline void assign(Mat1&& x, const Mat2& y, const char* name,
                    const Idx& row_idx, const index_multi& col_idx) {
   const auto assign_cols = col_idx.ns_.size();
-  stan::math::check_size_match("matrix[..., multi] assign", "left hand side",
-                               assign_cols, name, y.cols());
+  stan::math::check_size_match("matrix[..., multi] assign columns", name,
+                               assign_cols, "right hand side columns", y.cols());
   std::unordered_set<int> x_set;
   const auto& y_eval = y.eval();
   x_set.reserve(assign_cols);

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -52,7 +52,7 @@ namespace model {
  * @return Input value.
  */
 template <typename T>
-inline T rvalue(T&& x, const char* /*name*/) {
+inline std::decay_t<T> rvalue(T&& x, const char* /*name*/) {
   return std::forward<T>(x);
 }
 
@@ -77,7 +77,7 @@ inline const T& rvalue(const T& x, const char* /*name*/) {
  * @return Result of indexing matrix.
  */
 template <typename T>
-inline T rvalue(T&& x, const char* /*name*/, index_omni /*idx*/) {
+inline std::decay_t<T> rvalue(T&& x, const char* /*name*/, index_omni /*idx*/) {
   return std::forward<T>(x);
 }
 
@@ -102,7 +102,7 @@ inline const T& rvalue(const T& x, const char* /*name*/, index_omni /*idx*/) {
  * @return Result of indexing matrix.
  */
 template <typename T>
-inline T rvalue(T&& x, const char* name, index_omni /*idx1*/,
+inline std::decay_t<T> rvalue(T&& x, const char* name, index_omni /*idx1*/,
                 index_omni /*idx2*/) {
   return std::forward<T>(x);
 }
@@ -180,15 +180,13 @@ template <typename Vec, require_vector_t<Vec>* = nullptr,
           require_not_std_vector_t<Vec>* = nullptr>
 inline auto rvalue(Vec&& v, const char* name, index_min_max idx) {
   math::check_range("vector[min_max] min indexing", name, v.size(), idx.min_);
-  math::check_range("vector[min_max] max indexing", name, v.size(), idx.max_);
-  if (idx.is_ascending()) {
-    const auto slice_start = idx.min_ - 1;
-    const auto slice_size = idx.max_ - slice_start;
-    return v.segment(slice_start, slice_size).eval();
+  const Eigen::Index slice_start = idx.min_ - 1;
+  if (idx.max_ >= idx.min_) {
+    math::check_range("vector[min_max] max indexing", name, v.size(), idx.max_);
+    const Eigen::Index slice_size = idx.max_ - slice_start;
+    return v.segment(slice_start, slice_size);
   } else {
-    const auto slice_start = idx.max_ - 1;
-    const auto slice_size = idx.min_ - slice_start;
-    return v.segment(slice_start, slice_size).reverse().eval();
+    return v.segment(slice_start, 0);
   }
 }
 
@@ -226,8 +224,12 @@ inline auto rvalue(Vec&& x, const char* name, index_min idx) {
 template <typename Vec, require_vector_t<Vec>* = nullptr,
           require_not_std_vector_t<Vec>* = nullptr>
 inline auto rvalue(Vec&& x, const char* name, index_max idx) {
-  stan::math::check_range("vector[max] indexing", name, x.size(), idx.max_);
-  return x.head(idx.max_);
+  if (idx.max_ > 0) {
+    stan::math::check_range("vector[max] indexing", name, x.size(), idx.max_);
+    return x.head(idx.max_);
+  } else {
+    return x.head(0);
+  }
 }
 
 /**
@@ -312,8 +314,12 @@ inline auto rvalue(Mat&& x, const char* name, index_min idx) {
  */
 template <typename Mat, require_dense_dynamic_t<Mat>* = nullptr>
 inline auto rvalue(Mat&& x, const char* name, index_max idx) {
-  math::check_range("matrix[max] row indexing", name, x.rows(), idx.max_);
-  return x.topRows(idx.max_);
+  if (idx.max_ > 0) {
+    math::check_range("matrix[max] row indexing", name, x.rows(), idx.max_);
+    return x.topRows(idx.max_);
+  } else {
+    return x.topRows(0);
+  }
 }
 
 /**
@@ -330,17 +336,14 @@ inline auto rvalue(Mat&& x, const char* name, index_max idx) {
  */
 template <typename Mat, require_dense_dynamic_t<Mat>* = nullptr>
 inline auto rvalue(Mat&& x, const char* name, index_min_max idx) {
-  math::check_range("matrix[min_max] max row indexing", name, x.rows(),
-                    idx.max_);
   math::check_range("matrix[min_max] min row indexing", name, x.rows(),
                     idx.min_);
-  if (idx.is_ascending()) {
-    const auto row_size = idx.max_ - idx.min_ + 1;
-    return x.middleRows(idx.min_ - 1, row_size).eval();
+  if (idx.max_ > idx.min_) {
+    math::check_range("matrix[min_max] max row indexing", name, x.rows(),
+                      idx.max_);
+    return x.middleRows(idx.min_ - 1, idx.max_ - idx.min_ + 1);
   } else {
-    const auto row_size = idx.min_ - idx.max_ + 1;
-    return internal::colwise_reverse(x.middleRows(idx.max_ - 1, row_size))
-        .eval();
+    return x.middleRows(idx.min_ - 1, 0);
   }
 }
 
@@ -361,43 +364,32 @@ inline auto rvalue(Mat&& x, const char* name, index_min_max idx) {
 template <typename Mat, require_dense_dynamic_t<Mat>* = nullptr>
 inline auto rvalue(Mat&& x, const char* name, index_min_max row_idx,
                    index_min_max col_idx) {
-  math::check_range("matrix[min_max, min_max] min row indexing", name, x.rows(),
-                    row_idx.min_);
-  math::check_range("matrix[min_max, min_max] max row indexing", name, x.rows(),
-                    row_idx.max_);
-  math::check_range("matrix[min_max, min_max] min column indexing", name,
-                    x.cols(), col_idx.min_);
-  math::check_range("matrix[min_max, min_max] max column indexing", name,
-                    x.cols(), col_idx.max_);
-  if (row_idx.is_ascending()) {
-    if (col_idx.is_ascending()) {
-      return x
-          .block(row_idx.min_ - 1, col_idx.min_ - 1,
+   math::check_range("matrix[min_max, min_max] min row indexing", name, x.rows(),
+                     row_idx.min_);
+   math::check_range("matrix[min_max, min_max] min column indexing", name,
+                     x.cols(), col_idx.min_);
+  if (row_idx.max_ >= row_idx.min_ && col_idx.max_ >= col_idx.min_) {
+      math::check_range("matrix[min_max, min_max] max row indexing", name, x.rows(),
+                        row_idx.max_);
+      math::check_range("matrix[min_max, min_max] max column indexing", name,
+                        x.cols(), col_idx.max_);
+      return x.block(row_idx.min_ - 1, col_idx.min_ - 1,
                  row_idx.max_ - (row_idx.min_ - 1),
-                 col_idx.max_ - (col_idx.min_ - 1))
-          .eval();
-    } else {
-      return internal::rowwise_reverse(
-                 x.block(row_idx.min_ - 1, col_idx.max_ - 1,
-                         row_idx.max_ - (row_idx.min_ - 1),
-                         col_idx.min_ - (col_idx.max_ - 1)))
-          .eval();
-    }
+                 col_idx.max_ - (col_idx.min_ - 1));
+  } else if (row_idx.max_ >= row_idx.min_) {
+    math::check_range("matrix[min_max, min_max] max row indexing", name, x.rows(),
+                      row_idx.max_);
+    return x.block(row_idx.min_ - 1, col_idx.min_ - 1,
+               row_idx.max_ - (row_idx.min_ - 1),
+               0);
+  } else if (col_idx.max_ >= col_idx.min_) {
+    math::check_range("matrix[min_max, min_max] max column indexing", name,
+                      x.cols(), col_idx.max_);
+    return x.block(row_idx.min_ - 1, col_idx.min_ - 1,
+               0,
+               col_idx.max_ - (col_idx.min_ - 1));
   } else {
-    if (col_idx.is_ascending()) {
-      return internal::colwise_reverse(
-                 x.block(row_idx.max_ - 1, col_idx.min_ - 1,
-                         row_idx.min_ - (row_idx.max_ - 1),
-                         col_idx.max_ - (col_idx.min_ - 1)))
-          .eval();
-    } else {
-      return x
-          .block(row_idx.max_ - 1, col_idx.max_ - 1,
-                 row_idx.min_ - (row_idx.max_ - 1),
-                 col_idx.min_ - (col_idx.max_ - 1))
-          .reverse()
-          .eval();
-    }
+    return x.block(row_idx.min_ - 1, col_idx.min_ - 1, 0, 0);
   }
 }
 
@@ -441,7 +433,6 @@ inline Eigen::Matrix<value_type_t<EigMat>, 1, Eigen::Dynamic> rvalue(
     const index_multi& col_idx) {
   math::check_range("matrix[uni, multi] row indexing", name, x.rows(),
                     row_idx.n_);
-
   return stan::math::make_holder(
       [name, row_idx, &col_idx](auto& x_ref) {
         return Eigen::Matrix<value_type_t<EigMat>, 1, Eigen::Dynamic>::
@@ -507,13 +498,13 @@ inline plain_type_t<EigMat> rvalue(EigMat&& x, const char* name,
                                    const index_multi& row_idx,
                                    const index_multi& col_idx) {
   const auto& x_ref = stan::math::to_ref(x);
-  const int rows = row_idx.ns_.size();
-  const int cols = col_idx.ns_.size();
+  const Eigen::Index rows = row_idx.ns_.size();
+  const Eigen::Index cols = col_idx.ns_.size();
   plain_type_t<EigMat> x_ret(rows, cols);
-  for (int j = 0; j < cols; ++j) {
-    for (int i = 0; i < rows; ++i) {
-      const int m = row_idx.ns_[i];
-      const int n = col_idx.ns_[j];
+  for (Eigen::Index j = 0; j < cols; ++j) {
+    for (Eigen::Index i = 0; i < rows; ++i) {
+      const Eigen::Index m = row_idx.ns_[i];
+      const Eigen::Index n = col_idx.ns_[j];
       math::check_range("matrix[multi,multi] row indexing", name, x_ref.rows(),
                         m);
       math::check_range("matrix[multi,multi] column indexing", name,
@@ -569,7 +560,7 @@ inline plain_type_t<EigMat> rvalue(EigMat&& x, const char* name,
   const int cols = rvalue_index_size(col_idx, x_ref.cols());
   plain_type_t<EigMat> x_ret(rows, col_idx.ns_.size());
   for (int j = 0; j < col_idx.ns_.size(); ++j) {
-    const int n = col_idx.ns_[j];
+    const Eigen::Index n = col_idx.ns_[j];
     math::check_range("matrix[..., multi] column indexing", name, x_ref.cols(),
                       n);
     x_ret.col(j) = rvalue(x_ref.col(n - 1), name, row_idx);
@@ -613,7 +604,7 @@ inline auto rvalue(Mat&& x, const char* name, const Idx& row_idx,
 template <typename Mat, typename Idx, require_dense_dynamic_t<Mat>* = nullptr>
 inline auto rvalue(Mat&& x, const char* name, const Idx& row_idx,
                    index_min col_idx) {
-  const auto col_size = x.cols() - (col_idx.min_ - 1);
+  const Eigen::Index col_size = x.cols() - (col_idx.min_ - 1);
   math::check_range("matrix[..., min] column indexing", name, x.cols(),
                     col_idx.min_);
   return rvalue(x.rightCols(col_size), name, row_idx);
@@ -662,19 +653,13 @@ inline auto rvalue(Mat&& x, const char* name, const Idx& row_idx,
                    index_min_max col_idx) {
   math::check_range("matrix[..., min_max] min column indexing", name, x.cols(),
                     col_idx.min_);
-  math::check_range("matrix[..., min_max] max column indexing", name, x.cols(),
-                    col_idx.max_);
-  if (col_idx.is_ascending()) {
-    const auto col_start = col_idx.min_ - 1;
-    return rvalue(x.middleCols(col_start, col_idx.max_ - col_start), name,
-                  row_idx)
-        .eval();
+  const Eigen::Index col_start = col_idx.min_ - 1;
+  if (col_idx.max_ >= col_idx.min_) {
+    math::check_range("matrix[..., min_max] max column indexing", name, x.cols(),
+                      col_idx.max_);
+    return rvalue(x.middleCols(col_start, col_idx.max_ - col_start), name, row_idx);
   } else {
-    const auto col_start = col_idx.max_ - 1;
-    return rvalue(internal::rowwise_reverse(
-                      x.middleCols(col_start, col_idx.min_ - col_start)),
-                  name, row_idx)
-        .eval();
+    return rvalue(x.middleCols(col_start, 0), name, row_idx);
   }
 }
 

--- a/src/stan/model/indexing/rvalue_index_size.hpp
+++ b/src/stan/model/indexing/rvalue_index_size.hpp
@@ -50,7 +50,11 @@ inline int rvalue_index_size(const index_min& idx, int size) {
  * @return Size of result.
  */
 inline int rvalue_index_size(const index_max& idx, int size) {
-  return idx.max_;
+  if (idx.max_ > 0) {
+    return idx.max_;
+  } else {
+    return 0;
+  }
 }
 
 /**

--- a/src/test/unit/model/indexing/assign_test.cpp
+++ b/src/test/unit/model/indexing/assign_test.cpp
@@ -198,7 +198,9 @@ TEST(ModelIndexing, lvalueMultiEigen) {
   EXPECT_FLOAT_EQ(y[1], x[1]);
   EXPECT_FLOAT_EQ(2, x[2]);
   test_throw_ia(x, y, index_max(10));
-
+  test_throw_ia(x, y, index_max(0));
+  Eigen::VectorXd z_empty(0);
+  EXPECT_NO_THROW(assign(z_empty, Eigen::VectorXd(0), "", index_max(0)));
   vector<int> ns;
   ns.push_back(4);
   ns.push_back(6);
@@ -214,6 +216,11 @@ TEST(ModelIndexing, lvalueMultiEigen) {
 
   ns.push_back(3);
   test_throw_ia(x, y, index_multi(ns));
+
+  std::vector<double> z_std_empty(0);
+  EXPECT_NO_THROW(assign(z_std_empty, std::vector<double>{}, "", index_max(-5)));
+  EXPECT_NO_THROW(assign(z_std_empty, std::vector<double>{}, "", index_min_max(1, -1)));
+
 }
 
 TEST(ModelIndexing, lvalueMultiMulti) {
@@ -241,6 +248,10 @@ TEST(ModelIndexing, lvalueMultiMulti) {
 
   test_throw_ia(xs, ys, index_min(7), index_max(3));
   test_throw_ia(xs, ys, index_min(9), index_max(2));
+  std::vector<std::vector<double>> lhs_empty(11, std::vector<double>{});
+  std::vector<std::vector<double>> rhs_empty(3, std::vector<double>{});
+  EXPECT_NO_THROW(assign(lhs_empty, rhs_empty, "", index_min(9), index_max(-4)));
+  EXPECT_NO_THROW(assign(lhs_empty, rhs_empty, "", index_min(9), index_min_max(3, -4)));
 }
 
 TEST(ModelIndexing, lvalueMultiMultiEigen) {
@@ -270,6 +281,14 @@ TEST(ModelIndexing, lvalueMultiMultiEigen) {
 
   test_throw_ia(xs, ys, index_min(7), index_max(3));
   test_throw_ia(xs, ys, index_min(9), index_max(2));
+  std::vector<Eigen::VectorXd> lhs_empty(11, Eigen::VectorXd(0));
+  std::vector<Eigen::VectorXd> rhs_inner_empty(3, Eigen::VectorXd(0));
+  EXPECT_NO_THROW(assign(lhs_empty, rhs_inner_empty, "", index_min(9), index_max(-4)));
+  EXPECT_NO_THROW(assign(lhs_empty, rhs_inner_empty, "", index_min(9), index_min_max(3, -4)));
+  std::vector<Eigen::VectorXd> rhs_empty(0);
+  EXPECT_NO_THROW(assign(lhs_empty, rhs_empty, "", index_max(-4), index_min(9)));
+  EXPECT_NO_THROW(assign(lhs_empty, rhs_empty, "", index_min_max(3, -4), index_min(9)));
+
 }
 
 TEST(ModelIndexing, lvalueUniMulti) {
@@ -452,14 +471,18 @@ TEST(ModelIndexing, lvalueMatrixMax) {
   for (int i = 0; i < 2; ++i)
     for (int j = 0; j < 4; ++j)
       EXPECT_FLOAT_EQ(y(i, j), x(i, j));
-  test_throw(x, y, index_max(0));
+
   test_throw(x, y, index_max(8));
+  test_throw_ia(x, y, index_max(0));
   test_throw_ia(x, y, index_max(1));
 
   MatrixXd z(1, 2);
   z << 10, 20;
   test_throw_ia(x, z, index_max(1));
   test_throw_ia(x, z, index_max(2));
+  Eigen::MatrixXd z_empty(0, 4);
+  EXPECT_NO_THROW(assign(z_empty, Eigen::MatrixXd(0, 4), "empty", index_max(-8)));
+  test_throw(z_empty, Eigen::MatrixXd(0, 2), index_min(-8));
 }
 
 TEST(ModelIndexing, lvalueMatrixUniUni) {
@@ -534,14 +557,9 @@ TEST(ModelIndexing, lvalueMatrixNegativeMinMaxRow) {
       3.2, 3.3, 4.0, 4.1, 4.2, 4.3;
 
   MatrixXd y = MatrixXd::Ones(3, 4);
-  assign(x, y, "", index_min_max(3, 1));
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 4; ++j) {
-      EXPECT_EQ(x(i, j), y(i, j));
-    }
-  }
+  test_throw_ia(x, y, index_min_max(3, 1));
   test_throw(x, y, index_min_max(2, 6));
-  test_throw(x, y, index_min_max(1, 0));
+  test_throw_ia(x, y, index_min_max(1, 0));
   test_throw_ia(x, y, index_min_max(2, 1));
 }
 
@@ -713,12 +731,15 @@ TEST(ModelIndexing, resultSizeNegIndexingEigen) {
   lhs << 1, 2, 3, 4, 5;
   Eigen::VectorXd rhs(4);
   rhs << 1, 2, 3, 4;
+  /*
   assign(lhs, rhs, "", index_min_max(4, 1));
   EXPECT_FLOAT_EQ(lhs(0), 4);
   EXPECT_FLOAT_EQ(lhs(1), 3);
   EXPECT_FLOAT_EQ(lhs(2), 2);
   EXPECT_FLOAT_EQ(lhs(3), 1);
   EXPECT_FLOAT_EQ(lhs(4), 5);
+  */
+  test_throw_ia(lhs, rhs, index_min_max(4, 1));
 }
 
 TEST(ModelIndexing, resultSizePosMinMaxPosMinMaxEigenMatrix) {
@@ -758,7 +779,10 @@ TEST(ModelIndexing, resultSizePosMinMaxNegMinMaxEigenMatrix) {
     x_rev(i) = x.size() - i - 1;
   }
 
-  for (int i = 0; i < x.rows(); ++i) {
+  for (int i = 1; i < x.rows(); ++i) {
+    test_throw_ia(x, x_rev.block(0, 0, i + 1, i + 1), index_min_max(1, i + 1),
+           index_min_max(i + 1, 1));
+    /*
     Eigen::MatrixXd x_rowwise_reverse
         = x_rev.block(0, 0, i + 1, i + 1).rowwise().reverse();
     assign(x, x_rev.block(0, 0, i + 1, i + 1), "", index_min_max(1, i + 1),
@@ -771,6 +795,7 @@ TEST(ModelIndexing, resultSizePosMinMaxNegMinMaxEigenMatrix) {
     for (int j = 0; j < x.size(); ++j) {
       x(j) = j;
     }
+    */
   }
 }
 
@@ -785,7 +810,10 @@ TEST(ModelIndexing, resultSizeNigMinMaxPosMinMaxEigenMatrix) {
     x_rev(i) = x.size() - i - 1;
   }
 
-  for (int i = 0; i < x.rows(); ++i) {
+  for (int i = 1; i < x.rows(); ++i) {
+    test_throw_ia(x, x_rev.block(0, 0, i + 1, i + 1), index_min_max(i + 1, 1),
+           index_min_max(1, i + 1));
+    /*
     Eigen::MatrixXd x_colwise_reverse
         = x_rev.block(0, 0, i + 1, i + 1).colwise().reverse();
     assign(x, x_rev.block(0, 0, i + 1, i + 1), "", index_min_max(i + 1, 1),
@@ -798,6 +826,7 @@ TEST(ModelIndexing, resultSizeNigMinMaxPosMinMaxEigenMatrix) {
     for (int j = 0; j < x.size(); ++j) {
       x(j) = j;
     }
+    */
   }
 }
 
@@ -812,7 +841,10 @@ TEST(ModelIndexing, resultSizeNegMinMaxNegMinMaxEigenMatrix) {
     x_rev(i) = x.size() - i - 1;
   }
 
-  for (int i = 0; i < x.rows(); ++i) {
+  for (int i = 1; i < x.rows(); ++i) {
+    test_throw_ia(x, x_rev.block(0, 0, i + 1, i + 1), index_min_max(i + 1, 1),
+           index_min_max(i + 1, 1));
+    /*
     Eigen::MatrixXd x_reverse = x_rev.block(0, 0, i + 1, i + 1).reverse();
     assign(x, x_rev.block(0, 0, i + 1, i + 1), "", index_min_max(i + 1, 1),
            index_min_max(i + 1, 1));
@@ -824,6 +856,7 @@ TEST(ModelIndexing, resultSizeNegMinMaxNegMinMaxEigenMatrix) {
     for (int j = 0; j < x.size(); ++j) {
       x(j) = j;
     }
+    */
   }
 }
 
@@ -834,7 +867,7 @@ TEST(modelIndexing, doubleToVarSimple) {
 
   mat_d a(2, 2);
   a << 1, 2, 3, 4;
-  mat_v b;
+  mat_v b(2, 2);
   assign(b, a, "");
   for (int i = 0; i < a.size(); ++i)
     EXPECT_FLOAT_EQ(a(i), b(i).val());

--- a/src/test/unit/model/indexing/assign_test.cpp
+++ b/src/test/unit/model/indexing/assign_test.cpp
@@ -284,12 +284,12 @@ TEST(ModelIndexing, lvalueMultiMultiEigen) {
 
   test_throw_ia(xs, ys, index_min(7), index_max(3));
   test_throw_ia(xs, ys, index_min(9), index_max(2));
-  std::vector<Eigen::VectorXd> lhs_empty(11, Eigen::VectorXd(0));
+  std::vector<Eigen::VectorXd> lhs_inner_empty(11, Eigen::VectorXd(0));
   std::vector<Eigen::VectorXd> rhs_inner_empty(3, Eigen::VectorXd(0));
+  EXPECT_NO_THROW(assign(lhs_inner_empty, rhs_inner_empty, "", index_min(9), index_min_max(1, -4)));
   EXPECT_NO_THROW(
-      assign(lhs_empty, rhs_inner_empty, "", index_min(9), index_max(-4)));
-  EXPECT_NO_THROW(assign(lhs_empty, rhs_inner_empty, "", index_min(9),
-                         index_min_max(3, -4)));
+      assign(lhs_inner_empty, rhs_inner_empty, "", index_min(9), index_max(-4)));
+  std::vector<Eigen::VectorXd> lhs_empty(0, Eigen::VectorXd(0));
   std::vector<Eigen::VectorXd> rhs_empty(0);
   EXPECT_NO_THROW(
       assign(lhs_empty, rhs_empty, "", index_max(-4), index_min(9)));
@@ -710,7 +710,7 @@ TEST(ModelIndexing, resultSizeNegIndexing) {
   rhs.push_back(-125);
 
   vector<double> lhs;
-  assign(rhs, lhs, "", index_min_max(1, 0));
+  test_throw_ia(rhs, lhs, index_min_max(1, 0));
   EXPECT_EQ(0, lhs.size());
 }
 

--- a/src/test/unit/model/indexing/assign_test.cpp
+++ b/src/test/unit/model/indexing/assign_test.cpp
@@ -711,7 +711,7 @@ TEST(ModelIndexing, resultSizeNegIndexing) {
   rhs.push_back(-125);
 
   vector<double> lhs;
-  test_throw_ia(rhs, lhs, index_min_max(1, 0));
+  test_throw_ia(lhs, rhs, index_min_max(1, 0));
   EXPECT_EQ(0, lhs.size());
 }
 

--- a/src/test/unit/model/indexing/assign_test.cpp
+++ b/src/test/unit/model/indexing/assign_test.cpp
@@ -286,9 +286,10 @@ TEST(ModelIndexing, lvalueMultiMultiEigen) {
   test_throw_ia(xs, ys, index_min(9), index_max(2));
   std::vector<Eigen::VectorXd> lhs_inner_empty(11, Eigen::VectorXd(0));
   std::vector<Eigen::VectorXd> rhs_inner_empty(3, Eigen::VectorXd(0));
-  EXPECT_NO_THROW(assign(lhs_inner_empty, rhs_inner_empty, "", index_min(9), index_min_max(1, -4)));
-  EXPECT_NO_THROW(
-      assign(lhs_inner_empty, rhs_inner_empty, "", index_min(9), index_max(-4)));
+  EXPECT_NO_THROW(assign(lhs_inner_empty, rhs_inner_empty, "", index_min(9),
+                         index_min_max(1, -4)));
+  EXPECT_NO_THROW(assign(lhs_inner_empty, rhs_inner_empty, "", index_min(9),
+                         index_max(-4)));
   std::vector<Eigen::VectorXd> lhs_empty(0, Eigen::VectorXd(0));
   std::vector<Eigen::VectorXd> rhs_empty(0);
   EXPECT_NO_THROW(

--- a/src/test/unit/model/indexing/assign_varmat_test.cpp
+++ b/src/test/unit/model/indexing/assign_varmat_test.cpp
@@ -54,7 +54,8 @@ inline bool check_multi_duplicate(const stan::arena_t<std::vector<int>>& x_idx,
 
 template <typename T1, typename T2, typename... I>
 void test_throw_out_of_range(T1& lhs, const T2& rhs, const I&... idxs) {
-  EXPECT_THROW(stan::model::assign(lhs, rhs, "rhs", idxs...), std::out_of_range);
+  EXPECT_THROW(stan::model::assign(lhs, rhs, "rhs", idxs...),
+               std::out_of_range);
 }
 
 template <typename T1, typename T2, typename... I>
@@ -295,7 +296,6 @@ void test_max_vec() {
                          index_max(2));
   test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(1),
                          index_max(2));
-
 }
 
 TEST_F(VarAssign, max_vec) {
@@ -1276,11 +1276,12 @@ void negative_minmax_matrix_test() {
                        var_value<Eigen::MatrixXd>, Eigen::MatrixXd>
         x_rev(x_rev_val);
     const int ii = i + 1;
-    EXPECT_NO_THROW(assign(x, x_rev.block(0, 0, 0, 5), "", index_min_max(ii, 1)));
+    EXPECT_NO_THROW(
+        assign(x, x_rev.block(0, 0, 0, 5), "", index_min_max(ii, 1)));
     test_throw_invalid_arg(x, x_rev.block(0, 0, ii, 5), index_min_max(ii, 1));
     test_throw_invalid_arg(x, x_rev.block(0, 0, ii, 5), index_min_max(ii, 0));
     test_throw_invalid_arg(x, x_rev.block(0, 0, ii, 5),
-                            index_min_max(ii + x.rows(), 1));
+                           index_min_max(ii + x.rows(), 1));
     stan::math::recover_memory();
   }
 }

--- a/src/test/unit/model/indexing/assign_varmat_test.cpp
+++ b/src/test/unit/model/indexing/assign_varmat_test.cpp
@@ -358,7 +358,7 @@ void test_negative_minmax_varvector() {
 
   test_throw_invalid_arg(x, y, index_min_max(4, 1));
   test_throw_invalid_arg(x, y, index_min_max(3, 0));
-  test_throw_invalid_arg(x, y, index_min_max(6, 1));
+  test_throw_out_of_range(x, y, index_min_max(6, 1));
   test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(5),
                          index_min_max(4, 1));
   test_throw_invalid_arg(x, conditionally_generate_linear_var_vector<Vec>(3),

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -150,7 +150,7 @@ TEST(ModelIndexing, rvalue_eigen_vector_max_nil) {
       EXPECT_FLOAT_EQ(x[n], rx[n]);
   }
 
-  test_out_of_range(x, index_max(0));
+  EXPECT_NO_THROW(rvalue(x, "", index_max(0)));
 
   test_out_of_range(x, index_max(4));
 }
@@ -197,9 +197,15 @@ TEST(ModelIndexing, rvalue_eigenvec_min_max_nil) {
     for (int mx = mn; mx > -1; --mx) {
       Eigen::Matrix<double, -1, 1> rx
           = rvalue(x, "", index_min_max(mn + 1, mx + 1));
-      EXPECT_FLOAT_EQ(mn - mx + 1, rx.size());
+      if (mn == mx) {
+        EXPECT_FLOAT_EQ(1, rx.size());                
+      } else {
+        EXPECT_FLOAT_EQ(0, rx.size());
+      }
+      /*
       for (int n = mn; n <= mx; ++n)
         EXPECT_FLOAT_EQ(x[n], rx[n - mn]);
+        */
     }
   }
 
@@ -770,19 +776,22 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(4.2, a(1, 2));
 
   a = rvalue(m, "", index_min_max(3, 2));
-  EXPECT_EQ(2, a.rows());
+  EXPECT_EQ(0, a.rows());
   EXPECT_EQ(3, a.cols());
+  /*
   EXPECT_FLOAT_EQ(2, a(0, 0));
   EXPECT_FLOAT_EQ(2.1, a(0, 1));
   EXPECT_FLOAT_EQ(2.2, a(0, 2));
   EXPECT_FLOAT_EQ(1, a(1, 0));
   EXPECT_FLOAT_EQ(1.1, a(1, 1));
   EXPECT_FLOAT_EQ(1.2, a(1, 2));
-  test_out_of_range(m.array(), index_min_max(0, 3));
+  */
+  //test_out_of_range(m.array(), index_min_max(0, 3));
   test_out_of_range(m.array(), index_min_max(2, 15));
 
   a = rvalue(m.block(0, 0, 4, 3).array() + 2, "", index_min_max(3, 2));
-  EXPECT_EQ(2, a.rows());
+  EXPECT_EQ(0, a.rows());
+  /*
   EXPECT_EQ(3, a.cols());
   EXPECT_FLOAT_EQ(4, a(0, 0));
   EXPECT_FLOAT_EQ(4.1, a(0, 1));
@@ -792,7 +801,7 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(3.2, a(1, 2));
   test_out_of_range(m.array(), index_min_max(0, 3));
   test_out_of_range(m.array(), index_min_max(2, 15));
-
+*/
   a = rvalue(m, "", index_omni(), index_min_max(2, 3));
   EXPECT_EQ(2, a.cols());
   EXPECT_EQ(4, a.rows());
@@ -806,8 +815,9 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(3.2, a(3, 1));
 
   a = rvalue(m, "", index_omni(), index_min_max(3, 2));
-  EXPECT_EQ(2, a.cols());
+  EXPECT_EQ(0, a.cols());
   EXPECT_EQ(4, a.rows());
+  /*
   EXPECT_FLOAT_EQ(0.2, a(0, 0));
   EXPECT_FLOAT_EQ(1.2, a(1, 0));
   EXPECT_FLOAT_EQ(2.2, a(2, 0));
@@ -818,7 +828,7 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(3.1, a(3, 1));
   test_out_of_range(m.array(), index_min_max(0, 3));
   test_out_of_range(m.array(), index_min_max(2, 15));
-
+*/
   a = rvalue(m, "", index_omni());
   EXPECT_EQ(4, a.rows());
   EXPECT_EQ(3, a.cols());

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -100,10 +100,9 @@ TEST(ModelIndexing, rvalue_vector_min_nil) {
       EXPECT_FLOAT_EQ(x[n + k], rx[n]);
   }
 
-  std::vector<double> ry = rvalue(x, "", index_min(7));
-  EXPECT_EQ(0U, ry.size());
+  EXPECT_THROW(rvalue(x, "", index_min(7)), std::domain_error);
 
-  test_out_of_range(x, index_min(0));
+  //test_out_of_range(x, index_min(0));
 }
 
 TEST(ModelIndexing, rvalue_eigen_vector_min_nil) {
@@ -133,8 +132,10 @@ TEST(ModelIndexing, rvalue_vector_max_nil) {
       EXPECT_FLOAT_EQ(x[n], rx[n]);
   }
 
-  std::vector<double> ry = rvalue(x, "", index_max(0));
-  EXPECT_EQ(0U, ry.size());
+  std::vector<double> empty_ry = rvalue(x, "", index_max(0));
+  EXPECT_EQ(0U, empty_ry.size());
+  empty_ry = rvalue(x, "", index_max(-8));
+  EXPECT_EQ(0U, empty_ry.size());
 
   test_out_of_range(x, index_max(4));
 }
@@ -150,7 +151,10 @@ TEST(ModelIndexing, rvalue_eigen_vector_max_nil) {
       EXPECT_FLOAT_EQ(x[n], rx[n]);
   }
 
-  EXPECT_NO_THROW(rvalue(x, "", index_max(0)));
+  Eigen::VectorXd empty_rx = rvalue(x, "", index_max(0));
+  EXPECT_EQ(0U, empty_rx.size());
+  empty_rx = rvalue(x, "", index_max(-8));
+  EXPECT_EQ(0U, empty_rx.size());
 
   test_out_of_range(x, index_max(4));
 }
@@ -198,14 +202,10 @@ TEST(ModelIndexing, rvalue_eigenvec_min_max_nil) {
       Eigen::Matrix<double, -1, 1> rx
           = rvalue(x, "", index_min_max(mn + 1, mx + 1));
       if (mn == mx) {
-        EXPECT_FLOAT_EQ(1, rx.size());                
+        EXPECT_FLOAT_EQ(1, rx.size());
       } else {
         EXPECT_FLOAT_EQ(0, rx.size());
       }
-      /*
-      for (int n = mn; n <= mx; ++n)
-        EXPECT_FLOAT_EQ(x[n], rx[n - mn]);
-        */
     }
   }
 
@@ -273,6 +273,8 @@ TEST(ModelIndexing, rvalue_doubless_uni_multi) {
   EXPECT_EQ(2, y.size());
   EXPECT_FLOAT_EQ(1.0, y[0]);
   EXPECT_FLOAT_EQ(1.1, y[1]);
+  vector<double> empty_y = rvalue(x, "", index_uni(1), index_max(-1));
+  EXPECT_EQ(0U, empty_y.size());
   test_out_of_range(x, index_uni(0), index_max(2));
   test_out_of_range(x, index_uni(1), index_max(15));
 
@@ -288,6 +290,9 @@ TEST(ModelIndexing, rvalue_doubless_uni_multi) {
   y = rvalue(x, "", index_uni(2), index_min_max(2, 2));
   EXPECT_EQ(1, y.size());
   EXPECT_FLOAT_EQ(1.1, y[0]);
+
+  empty_y = rvalue(x, "", index_uni(1), index_min_max(3, 1));
+  EXPECT_EQ(0U, empty_y.size());
 
   y = rvalue(x, "", index_uni(3), index_omni());
   EXPECT_EQ(3, y.size());
@@ -330,6 +335,10 @@ TEST(ModelIndexing, rvalue_doubless_uni_multi_eigen) {
   test_out_of_range(x, index_uni(0), index_max(2));
   test_out_of_range(x, index_uni(1), index_max(15));
 
+  auto empty_y = rvalue(x, "", index_uni(2), index_max(-3));
+  EXPECT_EQ(1, empty_y.rows());
+  EXPECT_EQ(0, empty_y.cols());
+
   y = rvalue(x, "", index_uni(2), index_min_max(2, 3));
   EXPECT_EQ(2, y.size());
   EXPECT_FLOAT_EQ(1.1, y[0]);
@@ -342,6 +351,9 @@ TEST(ModelIndexing, rvalue_doubless_uni_multi_eigen) {
   y = rvalue(x, "", index_uni(2), index_min_max(2, 2));
   EXPECT_EQ(1, y.size());
   EXPECT_FLOAT_EQ(1.1, y[0]);
+
+  empty_y = rvalue(x, "", index_uni(2), index_min_max(3, 1));
+  EXPECT_EQ(0U, empty_y.size());
 
   y = rvalue(x, "", index_uni(3), index_omni());
   EXPECT_EQ(3, y.size());
@@ -376,6 +388,16 @@ TEST(ModelIndexing, rvalue_doubless_minmax_minmax_eigen) {
   EXPECT_FLOAT_EQ(0.2, y[1]);
   test_out_of_range(x, index_uni(0), index_min(2));
   test_out_of_range(x, index_uni(1), index_min(0));
+
+  auto normal_y = rvalue(x, "", index_min_max(1, 2), index_min_max(1, 2));
+  EXPECT_EQ(2, normal_y.rows());
+  EXPECT_EQ(2, normal_y.cols());
+  auto empty_row_y = rvalue(x, "", index_min_max(2, 1), index_min_max(1, 2));
+  EXPECT_EQ(0, empty_row_y.rows());
+  EXPECT_EQ(2, empty_row_y.cols());
+  auto empty_col_y = rvalue(x, "", index_min_max(1, 2), index_min_max(2, 1));
+  EXPECT_EQ(2, empty_col_y.rows());
+  EXPECT_EQ(0, empty_col_y.cols());
 }
 
 TEST(ModelIndexing, rvalue_doubless_multi_uni) {
@@ -417,6 +439,9 @@ TEST(ModelIndexing, rvalue_doubless_multi_uni) {
   test_out_of_range(x, index_max(2), index_uni(0));
   test_out_of_range(x, index_max(2), index_uni(15));
 
+  std::vector<double> empty_y = rvalue(x, "", index_max(-1), index_uni(3));
+  EXPECT_EQ(0, empty_y.size());
+
   y = rvalue(x, "", index_min_max(2, 3), index_uni(2));
   EXPECT_EQ(2, y.size());
   EXPECT_FLOAT_EQ(1.1, y[0]);
@@ -433,6 +458,9 @@ TEST(ModelIndexing, rvalue_doubless_multi_uni) {
   test_out_of_range(x, index_min_max(2, 12), index_uni(2));
   test_out_of_range(x, index_min_max(2, 2), index_uni(0));
   test_out_of_range(x, index_min_max(2, 2), index_uni(15));
+
+  empty_y = rvalue(x, "", index_min_max(2, 1), index_uni(2));
+  EXPECT_EQ(0, empty_y.size());
 
   y = rvalue(x, "", index_omni(), index_uni(3));
   EXPECT_EQ(3, y.size());
@@ -477,6 +505,9 @@ TEST(ModelIndexing, rvalue_doubless_multi_uni_eigen) {
   test_out_of_range(x, index_max(2), index_uni(0));
   test_out_of_range(x, index_max(2), index_uni(15));
 
+  auto empty_y = rvalue(x, "", index_max(-1), index_uni(2));
+  EXPECT_EQ(0, empty_y.rows());
+  EXPECT_EQ(1, empty_y.cols());
   y = rvalue(x, "", index_min_max(2, 3), index_uni(2));
   EXPECT_EQ(2, y.size());
   EXPECT_FLOAT_EQ(1.1, y[0]);
@@ -493,6 +524,10 @@ TEST(ModelIndexing, rvalue_doubless_multi_uni_eigen) {
   test_out_of_range(x, index_min_max(2, 12), index_uni(2));
   test_out_of_range(x, index_min_max(2, 2), index_uni(0));
   test_out_of_range(x, index_min_max(2, 2), index_uni(15));
+
+  auto empty_y2 = rvalue(x, "", index_min_max(2, 1), index_uni(2));
+  EXPECT_EQ(0, empty_y2.rows());
+  EXPECT_EQ(1, empty_y2.cols());
 
   y = rvalue(x, "", index_omni(), index_uni(3));
   EXPECT_EQ(3, y.size());
@@ -550,6 +585,8 @@ TEST(ModelIndexing, rvalue_doubless_multi_multi) {
   EXPECT_FLOAT_EQ(1.2, y[1][1]);
   test_out_of_range(x, index_max(20), index_min(2));
   test_out_of_range(x, index_max(2), index_min(0));
+  vector<vector<double>> empty_y = rvalue(x, "", index_max(-1), index_min(2));
+  EXPECT_EQ(0, empty_y.size());
 }
 
 TEST(ModelIndexing, rvalue_doubless_multi_multi_eigen) {
@@ -566,6 +603,9 @@ TEST(ModelIndexing, rvalue_doubless_multi_multi_eigen) {
   EXPECT_FLOAT_EQ(1.2, y(1, 1));
   test_out_of_range(x, index_max(20), index_min(2));
   test_out_of_range(x, index_max(2), index_min(0));
+  auto empty_row_vals = rvalue(x, "", index_max(-1), index_min(2));
+  EXPECT_EQ(0U, (empty_row_vals.rows()));
+  EXPECT_EQ(2U, (empty_row_vals.cols()));
 }
 
 template <typename T>
@@ -619,6 +659,9 @@ void vector_multi_test() {
   EXPECT_FLOAT_EQ(2, vi(2));
   test_out_of_range(v, index_max(15));
 
+  auto empty_vi = rvalue(v, "", index_max(-1));
+  EXPECT_EQ(0U, (empty_vi.size()));
+
   vi = rvalue(v.array() + 2, "", index_max(3));
   EXPECT_EQ(3, vi.size());
   EXPECT_FLOAT_EQ(2, vi(0));
@@ -630,6 +673,8 @@ void vector_multi_test() {
   EXPECT_FLOAT_EQ(3, vi(2));
   test_out_of_range(v, index_min_max(0, 4));
   test_out_of_range(v, index_min_max(2, 15));
+  auto empty_vi_min_max = rvalue(v, "", index_min_max(3, 2));
+  EXPECT_EQ(0U, (empty_vi_min_max.size()));
 
   vi = rvalue(v.array() + 2, "", index_min_max(2, 4));
   EXPECT_EQ(3, vi.size());
@@ -744,6 +789,9 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(1.1, a(1, 1));
   EXPECT_FLOAT_EQ(1.2, a(1, 2));
   test_out_of_range(m, index_max(15));
+  auto empty_a_max = rvalue(m, "", index_max(-1));
+  EXPECT_EQ(0U, (empty_a_max.rows()));
+  EXPECT_EQ(3U, (empty_a_max.cols()));
 
   a = rvalue(m.array() + 2, "", index_max(2));
   EXPECT_EQ(2, a.rows());
@@ -764,6 +812,9 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   EXPECT_FLOAT_EQ(2.0, a(1, 0));
   EXPECT_FLOAT_EQ(2.1, a(1, 1));
   EXPECT_FLOAT_EQ(2.2, a(1, 2));
+  auto empty_a_min_max = rvalue(m, "", index_min_max(3, 2));
+  EXPECT_EQ(0U, (empty_a_min_max.rows()));
+  EXPECT_EQ(3U, (empty_a_min_max.cols()));
 
   a = rvalue(m.array() + 2, "", index_min_max(2, 3));
   EXPECT_EQ(2, a.rows());
@@ -778,30 +829,14 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   a = rvalue(m, "", index_min_max(3, 2));
   EXPECT_EQ(0, a.rows());
   EXPECT_EQ(3, a.cols());
-  /*
-  EXPECT_FLOAT_EQ(2, a(0, 0));
-  EXPECT_FLOAT_EQ(2.1, a(0, 1));
-  EXPECT_FLOAT_EQ(2.2, a(0, 2));
-  EXPECT_FLOAT_EQ(1, a(1, 0));
-  EXPECT_FLOAT_EQ(1.1, a(1, 1));
-  EXPECT_FLOAT_EQ(1.2, a(1, 2));
-  */
-  //test_out_of_range(m.array(), index_min_max(0, 3));
-  test_out_of_range(m.array(), index_min_max(2, 15));
-
-  a = rvalue(m.block(0, 0, 4, 3).array() + 2, "", index_min_max(3, 2));
-  EXPECT_EQ(0, a.rows());
-  /*
-  EXPECT_EQ(3, a.cols());
-  EXPECT_FLOAT_EQ(4, a(0, 0));
-  EXPECT_FLOAT_EQ(4.1, a(0, 1));
-  EXPECT_FLOAT_EQ(4.2, a(0, 2));
-  EXPECT_FLOAT_EQ(3, a(1, 0));
-  EXPECT_FLOAT_EQ(3.1, a(1, 1));
-  EXPECT_FLOAT_EQ(3.2, a(1, 2));
   test_out_of_range(m.array(), index_min_max(0, 3));
   test_out_of_range(m.array(), index_min_max(2, 15));
-*/
+
+  auto a_no_rows_slice = rvalue(m.block(0, 0, 4, 3).array() + 2, "", index_min_max(3, 2));
+  EXPECT_EQ(0, a_no_rows_slice.rows());
+  EXPECT_EQ(3, a_no_rows_slice.cols());
+  test_out_of_range(m.array(), index_min_max(0, 3));
+  test_out_of_range(m.array(), index_min_max(2, 15));
   a = rvalue(m, "", index_omni(), index_min_max(2, 3));
   EXPECT_EQ(2, a.cols());
   EXPECT_EQ(4, a.rows());
@@ -817,18 +852,8 @@ TEST(ModelIndexing, rvalueMatrixMulti) {
   a = rvalue(m, "", index_omni(), index_min_max(3, 2));
   EXPECT_EQ(0, a.cols());
   EXPECT_EQ(4, a.rows());
-  /*
-  EXPECT_FLOAT_EQ(0.2, a(0, 0));
-  EXPECT_FLOAT_EQ(1.2, a(1, 0));
-  EXPECT_FLOAT_EQ(2.2, a(2, 0));
-  EXPECT_FLOAT_EQ(3.2, a(3, 0));
-  EXPECT_FLOAT_EQ(0.1, a(0, 1));
-  EXPECT_FLOAT_EQ(1.1, a(1, 1));
-  EXPECT_FLOAT_EQ(2.1, a(2, 1));
-  EXPECT_FLOAT_EQ(3.1, a(3, 1));
   test_out_of_range(m.array(), index_min_max(0, 3));
   test_out_of_range(m.array(), index_min_max(2, 15));
-*/
   a = rvalue(m, "", index_omni());
   EXPECT_EQ(4, a.rows());
   EXPECT_EQ(3, a.cols());

--- a/src/test/unit/model/indexing/rvalue_varmat_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_varmat_test.cpp
@@ -247,19 +247,23 @@ TEST_F(RvalueRev, negative_min_max_vec) {
       var_value<Eigen::VectorXd> x(x_val);
       var_value<Eigen::VectorXd> rx
           = rvalue(x, "", index_min_max(mn + 1, mx + 1));
-      EXPECT_FLOAT_EQ(mn - mx + 1, rx.size());
-      for (int n = mn; n <= mx; ++n) {
-        EXPECT_FLOAT_EQ(x.val()[n], rx.val()[n - mn]);
-      }
-      sum(rx).grad();
-      for (int n = mn; n <= mx; ++n) {
-        EXPECT_FLOAT_EQ(x.adj()[n], rx.adj()[n - mn]);
+      if (mn == mx) {
+        EXPECT_EQ(1U, rx.size());
+        for (int n = mn; n <= mx; ++n) {
+          EXPECT_FLOAT_EQ(x.val()[n], rx.val()[n - mn]);
+        }
+        sum(rx).grad();
+        for (int n = mn; n <= mx; ++n) {
+          EXPECT_FLOAT_EQ(x.adj()[n], rx.adj()[n - mn]);
+        }
+      } else {
+        EXPECT_EQ(0U, rx.size());
       }
       stan::math::recover_memory();
     }
   }
   var_value<Eigen::VectorXd> x(x_val);
-  test_throw_out_of_range(x, index_min_max(2, 0));
+  EXPECT_NO_THROW(rvalue(x, "", index_min_max(2, 0)));
   test_throw_out_of_range(x, index_min_max(5, 2));
 }
 
@@ -368,13 +372,8 @@ TEST_F(RvalueRev, uni_stdvec_negative_minmax_vec) {
   auto x = make_std_varvec();
   var_value<Eigen::VectorXd> y
       = rvalue(x, "", index_uni(2), index_min_max(2, 1));
-  EXPECT_EQ(2, y.size());
-  EXPECT_FLOAT_EQ(1.1, y.val()[0]);
-  sum(y).grad();
-  auto i_check = [](Eigen::Index i) { return i == 1; };
-  auto j_check = [](Eigen::Index j) { return j == 0 || j == 1; };
-  check_std_vec_adjs(i_check, j_check, x);
-  test_throw_out_of_range(x, index_uni(1), index_min_max(3, 0));
+  EXPECT_EQ(0U, y.size());
+  EXPECT_NO_THROW(rvalue(x, "", index_uni(1), index_min_max(3, 0)));
   test_throw_out_of_range(x, index_uni(1), index_min_max(15, 2));
 }
 TEST_F(RvalueRev, uni_stdvec_omni_vec) {
@@ -558,16 +557,12 @@ TEST_F(RvalueRev, negative_minmax_uni_matrix) {
   auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::VectorXd> y
       = rvalue(x, "", index_min_max(3, 2), index_uni(4));
-  EXPECT_MATRIX_EQ(y.val(), x.val().col(3).segment(1, 2).reverse());
-  sum(y).grad();
-  Eigen::MatrixXd exp_adj = Eigen::MatrixXd::Zero(3, 4);
-  exp_adj.col(3).segment(1, 2).reverse().array() += 1;
-  EXPECT_MATRIX_EQ(x.adj(), exp_adj);
-  EXPECT_MATRIX_EQ(y.adj(), Eigen::VectorXd::Ones(2));
+  EXPECT_EQ(0U, y.rows());
+  EXPECT_EQ(1U, y.cols());
   test_throw_out_of_range(x, index_min_max(3, 2), index_uni(0));
   test_throw_out_of_range(x, index_min_max(3, 2), index_uni(5));
-  test_throw_out_of_range(x, index_min_max(1, 0), index_uni(4));
   test_throw_out_of_range(x, index_min_max(6, 1), index_uni(4));
+  EXPECT_NO_THROW(rvalue(x, "", index_min_max(1, 0), index_uni(4)));
 }
 
 // multi
@@ -881,7 +876,7 @@ TEST_F(RvalueRev, max_mat) {
   x_exp_adj.block(0, 0, 2, 3) = y_exp_adj;
   EXPECT_MATRIX_EQ(x.adj(), x_exp_adj);
   EXPECT_MATRIX_EQ(y.adj(), y_exp_adj);
-  test_throw_out_of_range(x, index_max(0));
+  EXPECT_NO_THROW(rvalue(x, "", index_max(0)));
   test_throw_out_of_range(x, index_max(15));
 }
 
@@ -901,8 +896,8 @@ TEST_F(RvalueRev, min_max_matrix) {
   EXPECT_MATRIX_EQ(y.adj(), y_exp_adj);
   test_throw_out_of_range(x, index_min(0), index_max(2));
   test_throw_out_of_range(x, index_min(12), index_max(3));
-  test_throw_out_of_range(x, index_min(2), index_max(0));
   test_throw_out_of_range(x, index_min(2), index_max(12));
+  EXPECT_NO_THROW(rvalue(x, "", index_min(2), index_max(0)));
 }
 
 // minmax
@@ -940,16 +935,9 @@ TEST_F(RvalueRev, negative_min_max_mat) {
 
   auto x = conditionally_generate_linear_var_matrix(3, 4);
   var_value<Eigen::MatrixXd> y = rvalue(x, "", index_min_max(3, 2));
-  EXPECT_EQ(2, y.rows());
+  EXPECT_EQ(0, y.rows());
   EXPECT_EQ(4, y.cols());
-  EXPECT_MATRIX_EQ(y.val(), x.val().block(1, 0, 2, 4).colwise().reverse());
-  sum(y).grad();
-  Eigen::MatrixXd x_exp_adj = Eigen::MatrixXd::Zero(3, 4);
-  Eigen::MatrixXd y_exp_adj = Eigen::MatrixXd::Ones(2, 4);
-  x_exp_adj.block(1, 0, 2, 4).colwise().reverse() = y_exp_adj;
-  EXPECT_MATRIX_EQ(x.adj(), x_exp_adj);
-  EXPECT_MATRIX_EQ(y.adj(), y_exp_adj);
-  test_throw_out_of_range(x, index_min_max(3, 0));
+  EXPECT_NO_THROW(rvalue(x, "", index_min_max(3, 0)));
   test_throw_out_of_range(x, index_min_max(15, 2));
 }
 
@@ -992,14 +980,12 @@ TEST_F(RvalueRev, positive_minmax_negative_minmax_matrix) {
     const int ii = i + 1;
     var_value<Eigen::MatrixXd> y
         = rvalue(x, "", index_min_max(1, ii), index_min_max(ii, 1));
-    EXPECT_MATRIX_EQ(y.val(), x.val().block(0, 0, ii, ii).rowwise().reverse());
-    sum(y).grad();
-    Eigen::MatrixXd x_exp_adjs = Eigen::MatrixXd::Zero(5, 5);
-    Eigen::MatrixXd y_exp_adjs = Eigen::MatrixXd::Ones(ii, ii);
-    x_exp_adjs.block(0, 0, ii, ii) = y_exp_adjs;
-    EXPECT_MATRIX_EQ(x.adj(), x_exp_adjs);
-    EXPECT_MATRIX_EQ(y.adj(), y_exp_adjs);
-    stan::math::recover_memory();
+    EXPECT_EQ(ii, y.rows());
+    if (ii == 1) {
+      EXPECT_EQ(1, y.cols());
+    } else {
+      EXPECT_EQ(0, y.cols());
+    }
   }
 }
 
@@ -1017,14 +1003,12 @@ TEST_F(RvalueRev, negative_minmax_positive_minmax_matrix) {
     const int ii = i + 1;
     var_value<Eigen::MatrixXd> y
         = rvalue(x, "", index_min_max(ii, 1), index_min_max(1, ii));
-    EXPECT_MATRIX_EQ(y.val(), x.val().block(0, 0, ii, ii).colwise().reverse());
-    sum(y).grad();
-    Eigen::MatrixXd x_exp_adjs = Eigen::MatrixXd::Zero(5, 5);
-    Eigen::MatrixXd y_exp_adjs = Eigen::MatrixXd::Ones(ii, ii);
-    x_exp_adjs.block(0, 0, ii, ii) = y_exp_adjs;
-    EXPECT_MATRIX_EQ(x.adj(), x_exp_adjs);
-    EXPECT_MATRIX_EQ(y.adj(), y_exp_adjs);
-    stan::math::recover_memory();
+    if (ii == 1) {
+      EXPECT_EQ(1U, y.rows());
+    } else {
+      EXPECT_EQ(0U, y.rows());
+    }
+    EXPECT_EQ(ii, y.cols());
   }
 }
 
@@ -1042,16 +1026,14 @@ TEST_F(RvalueRev, negative_minmax_negative_minmax_matrix) {
     const int ii = i + 1;
     var_value<Eigen::MatrixXd> y
         = rvalue(x, "", index_min_max(ii, 1), index_min_max(ii, 1));
-    EXPECT_MATRIX_EQ(
-        y.val(),
-        x.val().block(0, 0, ii, ii).colwise().reverse().rowwise().reverse());
-    sum(y).grad();
-    Eigen::MatrixXd x_exp_adjs = Eigen::MatrixXd::Zero(5, 5);
-    Eigen::MatrixXd y_exp_adjs = Eigen::MatrixXd::Ones(ii, ii);
-    x_exp_adjs.block(0, 0, ii, ii) = y_exp_adjs;
-    EXPECT_MATRIX_EQ(x.adj(), x_exp_adjs);
-    EXPECT_MATRIX_EQ(y.adj(), y_exp_adjs);
-    stan::math::recover_memory();
+    if (ii == 1) {
+      EXPECT_EQ(1, y.rows());
+      EXPECT_EQ(1, y.cols());
+    } else {
+      EXPECT_EQ(0, y.rows());
+      EXPECT_EQ(0, y.cols());
+    }
+
   }
 }
 
@@ -1086,17 +1068,12 @@ TEST_F(RvalueRev, uni_negative_minmax_matrix) {
   auto x = conditionally_generate_linear_var_matrix(5, 5);
   var_value<Eigen::RowVectorXd> y
       = rvalue(x, "", index_uni(2), index_min_max(4, 2));
-  EXPECT_MATRIX_EQ(y.val(), x.val().row(1).segment(1, 3).reverse());
-  sum(y).grad();
-  Eigen::MatrixXd x_exp_adjs = Eigen::MatrixXd::Zero(5, 5);
-  Eigen::RowVectorXd y_exp_adjs = Eigen::RowVectorXd::Ones(3);
-  x_exp_adjs.row(1).segment(1, 3) = y_exp_adjs;
-  EXPECT_MATRIX_EQ(x.adj(), x_exp_adjs);
-  EXPECT_MATRIX_EQ(y.adj(), y_exp_adjs);
+  EXPECT_EQ(1U, y.rows());
+  EXPECT_EQ(0U, y.cols());
   test_throw_out_of_range(x, index_uni(0), index_min_max(4, 2));
   test_throw_out_of_range(x, index_uni(7), index_min_max(4, 2));
-  test_throw_out_of_range(x, index_uni(2), index_min_max(2, 0));
   test_throw_out_of_range(x, index_uni(2), index_min_max(15, 0));
+  EXPECT_NO_THROW(rvalue(x, "", index_uni(2), index_min_max(2, 0)));
 }
 
 // nil only shows up as a single index


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This Fixes #3076 so that negative length min_max and max indices return a slice of size 0 instead of returning a reversing index. This also Fixes #3084 so that matrices can only be assigned matrices of the same size (unless the assigning matrix has 0 rows and 0 columns which means it is uninitialized and okay to override.

#### Intended Effect

Provide backwards compatibility for negative indexing

#### How to Verify

Tests have been added to `src/test/unit/model/indexing/rvalue_test.cpp` and `src/test/unit/model/indexing/assign_test.cpp` to check that negative sized max and min_max indices return objects of the correct size.

#### Side Effects

I followed from @bob-carpenter 's answers from https://github.com/stan-dev/stan/issues/3076#issuecomment-954265563. The main thing that needs to be checked for a review is that 


#### Documentation

We should probably update the docs to be more clear about this behavior. I feel like this is a more advanced user feature so it may also be useful in the exception messages for the size zero returns that the user tried to call a decreasing index in case they did not intend to.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
