### PR TITLE
Removed duplicate instances of str().length()

### DIFF
--- a/src/stan/callbacks/stream_logger.hpp
+++ b/src/stan/callbacks/stream_logger.hpp
@@ -46,7 +46,8 @@ class stream_logger final : public logger {
   void info(const std::string& message) { info_ << message << std::endl; }
 
   void info(const std::stringstream& message) {
-    info_ << message.str() << std::endl;
+    if(message.str().length() > 0)
+      info_ << message.str() << std::endl;
   }
 
   void warn(const std::string& message) { warn_ << message << std::endl; }

--- a/src/stan/callbacks/stream_logger.hpp
+++ b/src/stan/callbacks/stream_logger.hpp
@@ -46,7 +46,7 @@ class stream_logger final : public logger {
   void info(const std::string& message) { info_ << message << std::endl; }
 
   void info(const std::stringstream& message) {
-    if(message.str().length() > 0)
+    if (message.str().length() > 0)
       info_ << message.str() << std::endl;
   }
 

--- a/src/stan/model/gradient.hpp
+++ b/src/stan/model/gradient.hpp
@@ -26,12 +26,10 @@ void gradient(const M& model, const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
   try {
     stan::math::gradient(model_functional<M>(model, &ss), x, f, grad_f);
   } catch (std::exception& e) {
-    if (ss.str().length() > 0)
-      logger.info(ss);
+    logger.info(ss);
     throw;
   }
-  if (ss.str().length() > 0)
-    logger.info(ss);
+  logger.info(ss);
 }
 
 }  // namespace model

--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -90,8 +90,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
     std::vector<double> values;
     std::stringstream msg;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
-    if (msg.str().length() > 0)
-      logger.info(msg);
+    logger.info(msg);
 
     values.insert(values.begin(), lp);
     parameter_writer(values);
@@ -146,8 +145,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
       model.write_array(rng, cont_vector, disc_vector, values, true, true,
                         &msg);
       // This if is here to match the pre-refactor behavior
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
 
       values.insert(values.begin(), lp);
       parameter_writer(values);
@@ -158,8 +156,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
     std::vector<double> values;
     std::stringstream msg;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
-    if (msg.str().length() > 0)
-      logger.info(msg);
+    logger.info(msg);
     values.insert(values.begin(), lp);
     parameter_writer(values);
   }

--- a/src/stan/services/optimize/lbfgs.hpp
+++ b/src/stan/services/optimize/lbfgs.hpp
@@ -93,8 +93,7 @@ int lbfgs(Model& model, const stan::io::var_context& init,
     std::vector<double> values;
     std::stringstream msg;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
-    if (msg.str().length() > 0)
-      logger.info(msg);
+    logger.info(msg);
 
     values.insert(values.begin(), lp);
     parameter_writer(values);
@@ -148,8 +147,7 @@ int lbfgs(Model& model, const stan::io::var_context& init,
       std::stringstream msg;
       model.write_array(rng, cont_vector, disc_vector, values, true, true,
                         &msg);
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
 
       values.insert(values.begin(), lp);
       parameter_writer(values);
@@ -160,8 +158,7 @@ int lbfgs(Model& model, const stan::io::var_context& init,
     std::vector<double> values;
     std::stringstream msg;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
-    if (msg.str().length() > 0)
-      logger.info(msg);
+    logger.info(msg);
 
     values.insert(values.begin(), lp);
     parameter_writer(values);

--- a/src/stan/services/optimize/newton.hpp
+++ b/src/stan/services/optimize/newton.hpp
@@ -88,8 +88,7 @@ int newton(Model& model, const stan::io::var_context& init,
       std::vector<double> values;
       std::stringstream ss;
       model.write_array(rng, cont_vector, disc_vector, values, true, true, &ss);
-      if (ss.str().length() > 0)
-        logger.info(ss);
+      logger.info(ss);
       values.insert(values.begin(), lp);
       parameter_writer(values);
     }
@@ -111,8 +110,7 @@ int newton(Model& model, const stan::io::var_context& init,
     std::vector<double> values;
     std::stringstream ss;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &ss);
-    if (ss.str().length() > 0)
-      logger.info(ss);
+    logger.info(ss);
     values.insert(values.begin(), lp);
     parameter_writer(values);
   }

--- a/src/stan/services/util/gq_writer.hpp
+++ b/src/stan/services/util/gq_writer.hpp
@@ -78,13 +78,11 @@ class gq_writer {
       model.write_array(rng, const_cast<std::vector<double>&>(draw), params_i,
                         values, false, true, &ss);
     } catch (const std::exception& e) {
-      if (ss.str().length() > 0)
-        logger_.info(ss);
+      logger_.info(ss);
       logger_.info(e.what());
       return;
     }
-    if (ss.str().length() > 0)
-      logger_.info(ss);
+    logger_.info(ss);
 
     std::vector<double> gq_values(values.begin() + num_constrained_params_,
                                   values.end());

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -102,8 +102,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
         model.transform_inits(context, disc_vector, unconstrained, &msg);
       }
     } catch (std::domain_error& e) {
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
       logger.info("Rejecting initial value:");
       logger.info(
           "  Error evaluating the log probability"
@@ -111,8 +110,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
       logger.info(e.what());
       continue;
     } catch (std::exception& e) {
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
       logger.info(
           "Unrecoverable error evaluating the log probability"
           " at the initial value.");
@@ -128,11 +126,9 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
       // the parameters.
       log_prob = model.template log_prob<false, Jacobian>(unconstrained,
                                                           disc_vector, &msg);
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
     } catch (std::domain_error& e) {
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
       logger.info("Rejecting initial value:");
       logger.info(
           "  Error evaluating the log probability"
@@ -140,8 +136,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
       logger.info(e.what());
       continue;
     } catch (std::exception& e) {
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
       logger.info(
           "Unrecoverable error evaluating the log probability"
           " at the initial value.");
@@ -167,8 +162,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
       log_prob = stan::model::log_prob_grad<true, Jacobian>(
           model, unconstrained, disc_vector, gradient, &log_prob_msg);
     } catch (const std::exception& e) {
-      if (log_prob_msg.str().length() > 0)
-        logger.info(log_prob_msg);
+      logger.info(log_prob_msg);
       logger.info(e.what());
       throw;
     }
@@ -177,8 +171,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
         = std::chrono::duration_cast<std::chrono::microseconds>(end - start)
               .count()
           / 1000000.0;
-    if (log_prob_msg.str().length() > 0)
-      logger.info(log_prob_msg);
+    logger.info(log_prob_msg);
 
     bool gradient_ok = std::isfinite(stan::math::sum(gradient));
 

--- a/src/stan/services/util/mcmc_writer.hpp
+++ b/src/stan/services/util/mcmc_writer.hpp
@@ -111,13 +111,11 @@ class mcmc_writer {
       model.write_array(rng, cont_params, params_i, model_values, true, true,
                         &ss);
     } catch (const std::exception& e) {
-      if (ss.str().length() > 0)
-        logger_.info(ss);
+      logger_.info(ss);
       ss.str("");
       logger_.info(e.what());
     }
-    if (ss.str().length() > 0)
-      logger_.info(ss);
+    logger_.info(ss);
 
     if (model_values.size() > 0)
       values.insert(values.end(), model_values.begin(), model_values.end());

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -103,8 +103,7 @@ class advi {
       try {
         std::stringstream ss;
         double log_prob = model_.template log_prob<false, true>(zeta, &ss);
-        if (ss.str().length() > 0)
-          logger.info(ss);
+        logger.info(ss);
         stan::math::check_finite(function, "log_prob", log_prob);
         elbo += log_prob;
         ++i;
@@ -486,8 +485,7 @@ class advi {
     std::stringstream msg;
     model_.write_array(rng_, cont_vector, disc_vector, values, true, true,
                        &msg);
-    if (msg.str().length() > 0)
-      logger.info(msg);
+    logger.info(msg);
 
     // The first row of lp_, log_p, and log_g.
     values.insert(values.begin(), {0, 0, 0});
@@ -512,8 +510,7 @@ class advi {
                          &msg2);
       //  log_p: Log probability in the unconstrained space
       log_p = model_.template log_prob<false, true>(cont_params_, &msg2);
-      if (msg2.str().length() > 0)
-        logger.info(msg2);
+      logger.info(msg2);
       // Write lp__, log_p, and log_g.
       values.insert(values.begin(), {0, log_p, log_g});
       parameter_writer(values);

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -428,8 +428,7 @@ class normal_fullrank : public base_family {
       try {
         std::stringstream ss;
         stan::model::gradient(m, zeta, tmp_lp, tmp_mu_grad, &ss);
-        if (ss.str().length() > 0)
-          logger.info(ss);
+        logger.info(ss);
         stan::math::check_finite(function, "Gradient of mu", tmp_mu_grad);
 
         mu_grad += tmp_mu_grad;

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -363,8 +363,7 @@ class normal_meanfield : public base_family {
       try {
         std::stringstream ss;
         stan::model::gradient(m, zeta, tmp_lp, tmp_mu_grad, &ss);
-        if (ss.str().length() > 0)
-          logger.info(ss);
+        logger.info(ss);
         stan::math::check_finite(function, "Gradient of mu", tmp_mu_grad);
         mu_grad += tmp_mu_grad;
         omega_grad.array() += tmp_mu_grad.array().cwiseProduct(eta.array());


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary
This fixes stan-dev#2577 which is cleaning up code instances that has .str().length() for logger.info(). This cleans up a lot of "if (msg.str().length() > 0)" instances from the code block that follows
if (msg.str().length() > 0)
logger.info(msg);
patterns. However, there are still a lot of instances "if (msg.str().length() > 0)" left because it was connected with another logger implementation beside logger.info(). Therefore, some of the instances of that could not be removed.

#### Intended Effect
Removes a lot of duplicate codes.

#### How to Verify
Need to run tests on the existing testing library (In Progress).

#### Side Effects
Followed @WardBrian's suggestions.

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
