### PR TITLE
Cleaning up instances of .str().length() for logger.info()

### DIFF
--- a/src/stan/callbacks/stream_logger.hpp
+++ b/src/stan/callbacks/stream_logger.hpp
@@ -46,7 +46,8 @@ class stream_logger final : public logger {
   void info(const std::string& message) { info_ << message << std::endl; }
 
   void info(const std::stringstream& message) {
-    info_ << message.str() << std::endl;
+    if(message.str().length() > 0)
+      info_ << message.str() << std::endl;
   }
 
   void warn(const std::string& message) { warn_ << message << std::endl; }

--- a/src/stan/model/gradient.hpp
+++ b/src/stan/model/gradient.hpp
@@ -30,8 +30,7 @@ void gradient(const M& model, const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
       logger.info(ss);
     throw;
   }
-  if (ss.str().length() > 0)
-    logger.info(ss);
+  logger.info(ss);
 }
 
 }  // namespace model

--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -90,8 +90,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
     std::vector<double> values;
     std::stringstream msg;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
-    if (msg.str().length() > 0)
-      logger.info(msg);
+    logger.info(msg);
 
     values.insert(values.begin(), lp);
     parameter_writer(values);
@@ -158,8 +157,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
     std::vector<double> values;
     std::stringstream msg;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
-    if (msg.str().length() > 0)
-      logger.info(msg);
+    logger.info(msg);
     values.insert(values.begin(), lp);
     parameter_writer(values);
   }

--- a/src/stan/services/optimize/lbfgs.hpp
+++ b/src/stan/services/optimize/lbfgs.hpp
@@ -93,8 +93,7 @@ int lbfgs(Model& model, const stan::io::var_context& init,
     std::vector<double> values;
     std::stringstream msg;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
-    if (msg.str().length() > 0)
-      logger.info(msg);
+    logger.info(msg);
 
     values.insert(values.begin(), lp);
     parameter_writer(values);
@@ -160,8 +159,7 @@ int lbfgs(Model& model, const stan::io::var_context& init,
     std::vector<double> values;
     std::stringstream msg;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
-    if (msg.str().length() > 0)
-      logger.info(msg);
+    logger.info(msg);
 
     values.insert(values.begin(), lp);
     parameter_writer(values);

--- a/src/stan/services/optimize/newton.hpp
+++ b/src/stan/services/optimize/newton.hpp
@@ -88,8 +88,7 @@ int newton(Model& model, const stan::io::var_context& init,
       std::vector<double> values;
       std::stringstream ss;
       model.write_array(rng, cont_vector, disc_vector, values, true, true, &ss);
-      if (ss.str().length() > 0)
-        logger.info(ss);
+      logger.info(ss);
       values.insert(values.begin(), lp);
       parameter_writer(values);
     }
@@ -111,8 +110,7 @@ int newton(Model& model, const stan::io::var_context& init,
     std::vector<double> values;
     std::stringstream ss;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &ss);
-    if (ss.str().length() > 0)
-      logger.info(ss);
+    logger.info(ss);
     values.insert(values.begin(), lp);
     parameter_writer(values);
   }

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -102,8 +102,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
         model.transform_inits(context, disc_vector, unconstrained, &msg);
       }
     } catch (std::domain_error& e) {
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
       logger.info("Rejecting initial value:");
       logger.info(
           "  Error evaluating the log probability"
@@ -111,8 +110,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
       logger.info(e.what());
       continue;
     } catch (std::exception& e) {
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
       logger.info(
           "Unrecoverable error evaluating the log probability"
           " at the initial value.");
@@ -128,11 +126,9 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
       // the parameters.
       log_prob = model.template log_prob<false, Jacobian>(unconstrained,
                                                           disc_vector, &msg);
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
     } catch (std::domain_error& e) {
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
       logger.info("Rejecting initial value:");
       logger.info(
           "  Error evaluating the log probability"
@@ -140,8 +136,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
       logger.info(e.what());
       continue;
     } catch (std::exception& e) {
-      if (msg.str().length() > 0)
-        logger.info(msg);
+      logger.info(msg);
       logger.info(
           "Unrecoverable error evaluating the log probability"
           " at the initial value.");
@@ -167,8 +162,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
       log_prob = stan::model::log_prob_grad<true, Jacobian>(
           model, unconstrained, disc_vector, gradient, &log_prob_msg);
     } catch (const std::exception& e) {
-      if (log_prob_msg.str().length() > 0)
-        logger.info(log_prob_msg);
+      logger.info(log_prob_msg);
       logger.info(e.what());
       throw;
     }
@@ -177,8 +171,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
         = std::chrono::duration_cast<std::chrono::microseconds>(end - start)
               .count()
           / 1000000.0;
-    if (log_prob_msg.str().length() > 0)
-      logger.info(log_prob_msg);
+    logger.info(log_prob_msg);
 
     bool gradient_ok = std::isfinite(stan::math::sum(gradient));
 

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -103,8 +103,7 @@ class advi {
       try {
         std::stringstream ss;
         double log_prob = model_.template log_prob<false, true>(zeta, &ss);
-        if (ss.str().length() > 0)
-          logger.info(ss);
+        logger.info(ss);
         stan::math::check_finite(function, "log_prob", log_prob);
         elbo += log_prob;
         ++i;

--- a/src/stan/variational/families/normal_fullrank.hpp
+++ b/src/stan/variational/families/normal_fullrank.hpp
@@ -428,8 +428,7 @@ class normal_fullrank : public base_family {
       try {
         std::stringstream ss;
         stan::model::gradient(m, zeta, tmp_lp, tmp_mu_grad, &ss);
-        if (ss.str().length() > 0)
-          logger.info(ss);
+        logger.info(ss);
         stan::math::check_finite(function, "Gradient of mu", tmp_mu_grad);
 
         mu_grad += tmp_mu_grad;

--- a/src/stan/variational/families/normal_meanfield.hpp
+++ b/src/stan/variational/families/normal_meanfield.hpp
@@ -363,8 +363,7 @@ class normal_meanfield : public base_family {
       try {
         std::stringstream ss;
         stan::model::gradient(m, zeta, tmp_lp, tmp_mu_grad, &ss);
-        if (ss.str().length() > 0)
-          logger.info(ss);
+        logger.info(ss);
         stan::math::check_finite(function, "Gradient of mu", tmp_mu_grad);
         mu_grad += tmp_mu_grad;
         omega_grad.array() += tmp_mu_grad.array().cwiseProduct(eta.array());


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary
This fixes stan-dev#2577 which is cleaning up code instances that has .str().length() for logger.info(). This cleans up a lot of "if (msg.str().length() > 0)" instances from the code block that follows
if (msg.str().length() > 0)
logger.info(msg);
patterns. However, there are still a lot of instances "if (msg.str().length() > 0)" left because it was connected with another logger implementation beside logger.info(). Therefore, some of the instances of that could not be removed. There were some left in writer.hpp which was not removed.
#### Intended Effect
Removes a lot of duplicate codes.

#### How to Verify
Need to run tests on the existing testing library (In Progress).

#### Side Effects
Followed @WardBrian's suggestions

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
