### PR TITLE
Add validate_dims include

### DIFF
--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -2,6 +2,9 @@
 #define STAN_IO_DUMP_HPP
 
 #include <stan/io/validate_zero_buf.hpp>
+#ifdef USE_STANC3
+#include <stan/io/validate_dims.hpp>
+#endif
 #include <stan/io/var_context.hpp>
 #include <stan/math/prim.hpp>
 #include <boost/lexical_cast.hpp>


### PR DESCRIPTION
#### Summary

The `stan` source included in `StanHeaders` 2.26 does not have an `#include` statement for the `validate_dims` header, causing compile errors in some instances. This PR adds the necessary `USE_STANC3` conditional include 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
