### PR TITLE
Add assignment for tuples

### DIFF
--- a/src/stan/model/indexing/access_helpers.hpp
+++ b/src/stan/model/indexing/access_helpers.hpp
@@ -143,6 +143,23 @@ void assign_impl(Mat1&& x, Mat2&& y, const char* name) {
     x = stan::math::var_value<plain_type_t<Mat2>>(std::forward<Mat2>(y));
   }
 }
+
+template <typename... Types>
+struct is_tuple_impl : std::false_type {};
+template <typename... Types>
+struct is_tuple_impl<std::tuple<Types...>> : std::true_type {};
+
+template <typename T>
+struct is_tuple : is_tuple_impl<std::decay_t<T>> {};
+
+
+template <typename Tuple1, typename Tuple2,
+ require_all_t<internal::is_tuple<Tuple1>, internal::is_tuple<Tuple2>>* = nullptr>
+inline void assign_impl(Tuple1&& x, Tuple2&& y, const char* name) {
+  x = std::forward<Tuple2>(y);
+}
+
+
 }  // namespace internal
 }  // namespace model
 }  // namespace stan

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
+#include <stan/math/prim/functor.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/model/indexing/access_helpers.hpp>
 #include <stan/model/indexing/index.hpp>
@@ -891,19 +892,11 @@ inline void assign(T&& x, U&& y, const char* name, const Idx1& idx1,
   }
 }
 
-namespace internal {
-  template <typename... Types>
-  struct is_tuple_impl : std::false_type {};
-  template <typename... Types>
-  struct is_tuple_impl<std::tuple<Types...>> : std::true_type {};
-
-  template <typename T>
-  struct is_tuple : is_tuple_imple<std::decay_t<T>> {};
-
-}
 
 template <typename Tuple1, typename Tuple2,
- require_all_t<internal::is_tuple<Tuple1>, internal::is_tuple<Tuple2>>* = nullptr>
+ require_all_t<internal::is_tuple<Tuple1>, internal::is_tuple<Tuple2>>* = nullptr,
+ require_not_t<
+     std::is_assignable<std::decay_t<Tuple1>&, std::decay_t<Tuple2>>>* = nullptr>
 inline void assign(Tuple1&& x, Tuple2&& y, const char* name) {
   stan::math::for_each([name](auto&& x_sub, auto&& y_sub) mutable {
     assign(std::forward<decltype(x_sub)>(x_sub), std::forward<decltype(y_sub)>(y_sub), name);

--- a/src/test/unit/model/indexing/assign_test.cpp
+++ b/src/test/unit/model/indexing/assign_test.cpp
@@ -29,6 +29,7 @@ void test_throw_ia(T1& lhs, const T2& rhs, const I&... idxs) {
                std::invalid_argument);
 }
 
+
 TEST(ModelIndexing, lvalueNil) {
   double x = 3;
   double y = 5;
@@ -739,14 +740,6 @@ TEST(ModelIndexing, resultSizeNegIndexingEigen) {
   lhs << 1, 2, 3, 4, 5;
   Eigen::VectorXd rhs(4);
   rhs << 1, 2, 3, 4;
-  /*
-  assign(lhs, rhs, "", index_min_max(4, 1));
-  EXPECT_FLOAT_EQ(lhs(0), 4);
-  EXPECT_FLOAT_EQ(lhs(1), 3);
-  EXPECT_FLOAT_EQ(lhs(2), 2);
-  EXPECT_FLOAT_EQ(lhs(3), 1);
-  EXPECT_FLOAT_EQ(lhs(4), 5);
-  */
   test_throw_ia(lhs, rhs, index_min_max(4, 1));
 }
 
@@ -790,20 +783,6 @@ TEST(ModelIndexing, resultSizePosMinMaxNegMinMaxEigenMatrix) {
   for (int i = 1; i < x.rows(); ++i) {
     test_throw_ia(x, x_rev.block(0, 0, i + 1, i + 1), index_min_max(1, i + 1),
                   index_min_max(i + 1, 1));
-    /*
-    Eigen::MatrixXd x_rowwise_reverse
-        = x_rev.block(0, 0, i + 1, i + 1).rowwise().reverse();
-    assign(x, x_rev.block(0, 0, i + 1, i + 1), "", index_min_max(1, i + 1),
-           index_min_max(i + 1, 1));
-    for (int kk = 0; kk < i; ++kk) {
-      for (int jj = 0; jj < i; ++jj) {
-        EXPECT_FLOAT_EQ(x(kk, jj), x_rowwise_reverse(kk, jj));
-      }
-    }
-    for (int j = 0; j < x.size(); ++j) {
-      x(j) = j;
-    }
-    */
   }
 }
 
@@ -821,20 +800,6 @@ TEST(ModelIndexing, resultSizeNigMinMaxPosMinMaxEigenMatrix) {
   for (int i = 1; i < x.rows(); ++i) {
     test_throw_ia(x, x_rev.block(0, 0, i + 1, i + 1), index_min_max(i + 1, 1),
                   index_min_max(1, i + 1));
-    /*
-    Eigen::MatrixXd x_colwise_reverse
-        = x_rev.block(0, 0, i + 1, i + 1).colwise().reverse();
-    assign(x, x_rev.block(0, 0, i + 1, i + 1), "", index_min_max(i + 1, 1),
-           index_min_max(1, i + 1));
-    for (int kk = 0; kk < i; ++kk) {
-      for (int jj = 0; jj < i; ++jj) {
-        EXPECT_FLOAT_EQ(x(kk, jj), x_colwise_reverse(kk, jj));
-      }
-    }
-    for (int j = 0; j < x.size(); ++j) {
-      x(j) = j;
-    }
-    */
   }
 }
 
@@ -852,19 +817,6 @@ TEST(ModelIndexing, resultSizeNegMinMaxNegMinMaxEigenMatrix) {
   for (int i = 1; i < x.rows(); ++i) {
     test_throw_ia(x, x_rev.block(0, 0, i + 1, i + 1), index_min_max(i + 1, 1),
                   index_min_max(i + 1, 1));
-    /*
-    Eigen::MatrixXd x_reverse = x_rev.block(0, 0, i + 1, i + 1).reverse();
-    assign(x, x_rev.block(0, 0, i + 1, i + 1), "", index_min_max(i + 1, 1),
-           index_min_max(i + 1, 1));
-    for (int kk = 0; kk < i; ++kk) {
-      for (int jj = 0; jj < i; ++jj) {
-        EXPECT_FLOAT_EQ(x(kk, jj), x_reverse(kk, jj));
-      }
-    }
-    for (int j = 0; j < x.size(); ++j) {
-      x(j) = j;
-    }
-    */
   }
 }
 
@@ -1192,4 +1144,35 @@ TEST(model_indexing, assign_densemat_densemat_multi_index_multi_index) {
 
   ns[ns.size() - 1] = 10;
   test_throw(x, y, index_multi(ms), index_multi(ns));
+}
+
+
+TEST(model_indexing, tuples) {
+  std::tuple<Eigen::VectorXd, Eigen::VectorXd, std::vector<double>> A;
+  std::tuple<Eigen::VectorXd, Eigen::VectorXd, std::vector<double>> B =
+   std::make_tuple(Eigen::VectorXd::Random(2), Eigen::VectorXd::Random(2), std::vector<double>{2, 2, 2});
+  assign(A, B, "tuple_basic");
+  stan::math::for_each([](auto&& a, auto&& b) {
+    for (int i = 0; i < a.size(); i++) {
+      EXPECT_FLOAT_EQ(a[i], b[i]);
+    }
+  }, A, B);
+}
+
+
+TEST(model_indexing, tuples_non_trivially_assignable) {
+  std::tuple<Eigen::Matrix<stan::math::var, -1, 1>,
+   Eigen::Matrix<stan::math::var, -1, 1>,
+   std::vector<stan::math::var>> A
+    = std::make_tuple(Eigen::Matrix<stan::math::var, -1, 1>::Random(2),
+        Eigen::Matrix<stan::math::var, -1, 1>::Random(2),
+        std::vector<stan::math::var>{3, 3, 3});
+  std::tuple<Eigen::VectorXd, Eigen::VectorXd, std::vector<double>> B =
+   std::make_tuple(Eigen::VectorXd::Random(2), Eigen::VectorXd::Random(2), std::vector<double>{2, 2, 2});
+  assign(A, B, "tuple_basic");
+  stan::math::for_each([](auto&& a, auto&& b) {
+    for (int i = 0; i < a.size(); i++) {
+      EXPECT_FLOAT_EQ(a[i].val(), b[i]);
+    }
+  }, A, B);
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

## Summary

This adds an assign signature for tuples like `stan::assign(tuple, tuple, tuple_name)`

#### Intended Effect

As stated above

#### How to Verify

Tests for tuples of same and mixed types have been added to the tests and can be run with 

```
./runTests.py ./src/test/unit/model/indexing/assign_test.cpp 
```

#### Side Effects

There's one odd thing to call out which is that we cannot use standard assignment via the `assign` on line 59 of `assign.hpp`. So what we do instead of just have one assign for tuples with the exact same inner types and another where the inner types can differ (which would be like the lhs has a `matrix<var>` inside but the rhs is `matrix<double>`

#### Documentation

Documentation added for each of the tuple assignments.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
