### PR TITLE
[base_hmc] add 'const noexcept' to stepsize accessors

### DIFF
--- a/src/stan/mcmc/hmc/base_hmc.hpp
+++ b/src/stan/mcmc/hmc/base_hmc.hpp
@@ -163,16 +163,16 @@ class base_hmc : public base_mcmc {
       nom_epsilon_ = e;
   }
 
-  double get_nominal_stepsize() { return this->nom_epsilon_; }
+  double get_nominal_stepsize() const noexcept { return this->nom_epsilon_; }
 
-  double get_current_stepsize() { return this->epsilon_; }
+  double get_current_stepsize() const noexcept { return this->epsilon_; }
 
   virtual void set_stepsize_jitter(double j) {
     if (j > 0 && j < 1)
       epsilon_jitter_ = j;
   }
 
-  double get_stepsize_jitter() { return this->epsilon_jitter_; }
+  double get_stepsize_jitter() const noexcept { return this->epsilon_jitter_; }
 
   void sample_stepsize() {
     this->epsilon_ = this->nom_epsilon_;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add `const noexcept` modifiers to the three accessors related to step-size (nominal, current, and jitter).

#### Intended Effect

Allow retrieving those values from a `const` object.

#### How to Verify

Trivial.

#### Side Effects

None.

#### Documentation

N/A.

#### Copyright and Licensing

Tal Kedar

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
