### PR TITLE
Fix warning: unused variable `num_params`

### DIFF
--- a/src/stan/services/sample/standalone_gqs.hpp
+++ b/src/stan/services/sample/standalone_gqs.hpp
@@ -44,7 +44,6 @@ void get_model_parameters(const Model &model,
   }
   std::vector<std::string> all_param_names;
   model.get_param_names(all_param_names);
-  size_t num_params = param_names.size();
   std::vector<std::vector<size_t>> dimss;
   model.get_dims(dimss);
   for (size_t i = 0; i < param_names.size(); i++) {


### PR DESCRIPTION
Fixes:
```c++
src/stan/services/sample/standalone_gqs.hpp:47:10: warning: unused variable 'num_params' [-Wunused-variable]
   47 |   size_t num_params = param_names.size();
      |          ^~~~~~~~~~
```
after #3070.