### PR TITLE
Use the new get_param_names bool arguments in initialize

### DIFF
--- a/src/stan/model/model_base.hpp
+++ b/src/stan/model/model_base.hpp
@@ -72,6 +72,22 @@ class model_base : public prob_grad {
   virtual void get_param_names(std::vector<std::string>& names) const = 0;
 
   /**
+   * Set the specified argument to sequence of parameters, transformed
+   * parameters, and generated quantities in the order in which they
+   * were declared.  The input sequence is cleared and resized.
+   *
+   * @param[in,out] names sequence of names parameters, transformed
+   * parameters, and generated quantities
+   * @param[in] emit_transformed_parameters whether to add transformed
+   *  parameters names to the `names` vector
+   * @param[in] emit_generated_quantities whether to add generated quantities
+   *  names to the `names` vector.
+   */
+  virtual void get_param_names(std::vector<std::string>& names,
+   const bool emit_transformed_parameters = true,
+   const bool emit_generated_quantities = true) const = 0;
+
+  /**
    * Set the dimensionalities of constrained parameters, transformed
    * parameters, and generated quantities.  The input sequence is
    * cleared and resized.  The dimensions of each parameter

--- a/src/stan/model/model_base.hpp
+++ b/src/stan/model/model_base.hpp
@@ -84,8 +84,9 @@ class model_base : public prob_grad {
    *  names to the `names` vector.
    */
   virtual void get_param_names(std::vector<std::string>& names,
-   const bool emit_transformed_parameters = true,
-   const bool emit_generated_quantities = true) const = 0;
+                               const bool emit_transformed_parameters = true,
+                               const bool emit_generated_quantities
+                               = true) const = 0;
 
   /**
    * Set the dimensionalities of constrained parameters, transformed

--- a/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
@@ -220,7 +220,7 @@ int hmc_nuts_dense_e_adapt(
     std::vector<DiagnosticWriter>& diagnostic_writer) {
   if (num_chains == 1) {
     return hmc_nuts_dense_e_adapt(
-        model, *init[0], *init_inv_metric[0], random_seed, init_chain_id,
+        model, *(init[0]), *(init_inv_metric[0]), random_seed, init_chain_id,
         init_radius, num_warmup, num_samples, num_thin, save_warmup, refresh,
         stepsize, stepsize_jitter, max_depth, delta, gamma, kappa, t0,
         init_buffer, term_buffer, window, interrupt, logger, init_writer[0],
@@ -337,7 +337,7 @@ int hmc_nuts_dense_e_adapt(
     std::vector<DiagnosticWriter>& diagnostic_writer) {
   if (num_chains == 1) {
     return hmc_nuts_dense_e_adapt(
-        model, *init[0], random_seed, init_chain_id, init_radius, num_warmup,
+        model, *(init[0]), random_seed, init_chain_id, init_radius, num_warmup,
         num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
         max_depth, delta, gamma, kappa, t0, init_buffer, term_buffer, window,
         interrupt, logger, init_writer[0], sample_writer[0],

--- a/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
@@ -221,7 +221,7 @@ int hmc_nuts_diag_e_adapt(
     std::vector<DiagnosticWriter>& diagnostic_writer) {
   if (num_chains == 1) {
     return hmc_nuts_diag_e_adapt(
-        model, *init[0], *init_inv_metric[0], random_seed, init_chain_id,
+        model, *(init[0]), *(init_inv_metric[0]), random_seed, init_chain_id,
         init_radius, num_warmup, num_samples, num_thin, save_warmup, refresh,
         stepsize, stepsize_jitter, max_depth, delta, gamma, kappa, t0,
         init_buffer, term_buffer, window, interrupt, logger, init_writer[0],
@@ -338,7 +338,7 @@ int hmc_nuts_diag_e_adapt(
     std::vector<DiagnosticWriter>& diagnostic_writer) {
   if (num_chains == 1) {
     return hmc_nuts_diag_e_adapt(
-        model, *init[0], random_seed, init_chain_id, init_radius, num_warmup,
+        model, *(init[0]), random_seed, init_chain_id, init_radius, num_warmup,
         num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
         max_depth, delta, gamma, kappa, t0, init_buffer, term_buffer, window,
         interrupt, logger, init_writer[0], sample_writer[0],

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -77,7 +77,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
   bool is_fully_initialized = true;
   bool any_initialized = false;
   std::vector<std::string> param_names;
-  model.get_param_names(param_names);
+  model.get_param_names(param_names, false, false);
   for (size_t n = 0; n < param_names.size(); n++) {
     is_fully_initialized &= init.contains_r(param_names[n]);
     any_initialized |= init.contains_r(param_names[n]);


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Uses https://github.com/stan-dev/stanc3/pull/1241 to get back only the parameter names when setting initial values, Fixes https://github.com/stan-dev/stanc3/issues/1240 so that when the user specifies initial values they are only run once.

This PR will fail until https://github.com/stan-dev/stanc3/pull/1241 is merged
 
#### Intended Effect

Fixes https://github.com/stan-dev/stanc3/issues/1240

#### How to Verify

Do I need additional tests for this? I'm not sure what kind of test we would want.

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
