### PR TITLE
Add a #define flag to enable nested autodiff in model_base class

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,3 +36,25 @@ jobs:
           echo "CXX=clang++-${{ env.clangppVersion }}" >> make/local
           echo "O=0" >> make/local
           python runTests.py -j 2 src/test/unit
+
+run-fvar-var-tests:
+    name: run stan fvar-var model tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+      fail-fast: false
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          submodules:  true
+      - name: Install clang++
+        run: sudo apt-get install clang-${{ env.clangppVersion }}++
+      - name: Run tests
+        run: |
+          echo "CXX=clang++-${{ env.clangppVersion }}" >> make/local
+          echo "CXXFLAGS+=-DSTAN_MODEL_FVAR_VAR" >> make/local
+          echo "O=0" >> make/local
+          python runTests.py -j 2 src/test/unit/model/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,7 +37,7 @@ jobs:
           echo "O=0" >> make/local
           python runTests.py -j 2 src/test/unit
 
-run-fvar-var-tests:
+  run-fvar-var-tests:
     name: run stan fvar-var model tests
     runs-on: ${{ matrix.os }}
     strategy:

--- a/src/stan/model/model_base.hpp
+++ b/src/stan/model/model_base.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/io/var_context.hpp>
 #include <stan/math/rev/core.hpp>
-#ifdef STAN_MODEL_AD_HESSIAN
+#ifdef STAN_MODEL_FVAR_VAR
 #include <stan/math/mix.hpp>
 #endif
 #include <stan/model/prob_grad.hpp>
@@ -595,7 +595,7 @@ class model_base : public prob_grad {
                            bool include_tparams = true, bool include_gqs = true,
                            std::ostream* msgs = 0) const = 0;
 
-#ifdef STAN_MODEL_AD_HESSIAN
+#ifdef STAN_MODEL_FVAR_VAR
 
   /**
    * Return the log density for the specified unconstrained

--- a/src/stan/model/model_base.hpp
+++ b/src/stan/model/model_base.hpp
@@ -3,6 +3,9 @@
 
 #include <stan/io/var_context.hpp>
 #include <stan/math/rev/core.hpp>
+#ifdef STAN_MODEL_AD_HESSIAN
+#include <stan/math/mix.hpp>
+#endif
 #include <stan/model/prob_grad.hpp>
 #include <boost/random/additive_combine.hpp>
 #include <ostream>
@@ -591,6 +594,69 @@ class model_base : public prob_grad {
                            std::vector<double>& params_r_constrained,
                            bool include_tparams = true, bool include_gqs = true,
                            std::ostream* msgs = 0) const = 0;
+
+#ifdef STAN_MODEL_AD_HESSIAN
+
+  /**
+   * Return the log density for the specified unconstrained
+   * parameters, without Jacobian and with normalizing constants for
+   * probability functions.
+   *
+   * @param[in] params_r unconstrained parameters
+   * @param[in,out] msgs message stream
+   * @return log density for specified parameters
+   */
+  virtual math::fvar<math::var> log_prob(
+      Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const = 0;
+
+  /**
+   * Return the log density for the specified unconstrained
+   * parameters, with Jacobian correction for constraints and with
+   * normalizing constants for probability functions.
+   *
+   * <p>The Jacobian is of the inverse transform from unconstrained
+   * parameters to constrained parameters; full details for Stan
+   * language types can be found in the language reference manual.
+   *
+   * @param[in] params_r unconstrained parameters
+   * @param[in,out] msgs message stream
+   * @return log density for specified parameters
+   */
+  virtual math::fvar<math::var> log_prob_jacobian(
+      Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const = 0;
+
+  /**
+   * Return the log density for the specified unconstrained
+   * parameters, without Jacobian correction for constraints and
+   * dropping normalizing constants.
+   *
+   * @param[in] params_r unconstrained parameters
+   * @param[in,out] msgs message stream
+   * @return log density for specified parameters
+   */
+  virtual math::fvar<math::var> log_prob_propto(
+      Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const = 0;
+
+  /**
+   * Return the log density for the specified unconstrained
+   * parameters, with Jacobian correction for constraints and dropping
+   * normalizing constants.
+   *
+   * <p>The Jacobian is of the inverse transform from unconstrained
+   * parameters to constrained parameters; full details for Stan
+   * language types can be found in the language reference manual.
+   *
+   * @param[in] params_r unconstrained parameters
+   * @param[in,out] msgs message stream
+   * @return log density for specified parameters
+   */
+  virtual math::fvar<math::var> log_prob_propto_jacobian(
+      Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const = 0;
+#endif
 };
 
 }  // namespace model

--- a/src/stan/model/model_base_crtp.hpp
+++ b/src/stan/model/model_base_crtp.hpp
@@ -2,7 +2,7 @@
 #define STAN_MODEL_MODEL_BASE_CRTP_HPP
 
 #include <stan/model/model_base.hpp>
-#ifdef STAN_MODEL_AD_HESSIAN
+#ifdef STAN_MODEL_FVAR_VAR
 #include <stan/math/mix.hpp>
 #endif
 #include <iostream>
@@ -210,7 +210,7 @@ class model_base_crtp : public stan::model::model_base {
                                                         msgs);
   }
 
-#ifdef STAN_MODEL_AD_HESSIAN
+#ifdef STAN_MODEL_FVAR_VAR
 
   /**
    * Return the log density for the specified unconstrained

--- a/src/stan/model/model_base_crtp.hpp
+++ b/src/stan/model/model_base_crtp.hpp
@@ -223,7 +223,7 @@ class model_base_crtp : public stan::model::model_base {
    */
   inline math::fvar<math::var> log_prob(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const {
+      std::ostream* msgs) const override {
     return static_cast<const M*>(this)->template log_prob<false, false>(
         params_r, msgs);
   }
@@ -243,7 +243,7 @@ class model_base_crtp : public stan::model::model_base {
    */
   inline math::fvar<math::var> log_prob_jacobian(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const {
+      std::ostream* msgs) const override {
     return static_cast<const M*>(this)->template log_prob<false, true>(params_r,
                                                                        msgs);
   }
@@ -259,7 +259,7 @@ class model_base_crtp : public stan::model::model_base {
    */
   inline math::fvar<math::var> log_prob_propto(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const {
+      std::ostream* msgs) const override {
     return static_cast<const M*>(this)->template log_prob<true, false>(params_r,
                                                                        msgs);
   }
@@ -279,7 +279,7 @@ class model_base_crtp : public stan::model::model_base {
    */
   inline math::fvar<math::var> log_prob_propto_jacobian(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const {
+      std::ostream* msgs) const override {
     return static_cast<const M*>(this)->template log_prob<true, true>(params_r,
                                                                       msgs);
   }

--- a/src/stan/model/model_base_crtp.hpp
+++ b/src/stan/model/model_base_crtp.hpp
@@ -2,6 +2,9 @@
 #define STAN_MODEL_MODEL_BASE_CRTP_HPP
 
 #include <stan/model/model_base.hpp>
+#ifdef STAN_MODEL_AD_HESSIAN
+#include <stan/math/mix.hpp>
+#endif
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -206,6 +209,81 @@ class model_base_crtp : public stan::model::model_base {
     return static_cast<const M*>(this)->transform_inits(context, params_r,
                                                         msgs);
   }
+
+#ifdef STAN_MODEL_AD_HESSIAN
+
+  /**
+   * Return the log density for the specified unconstrained
+   * parameters, without Jacobian and with normalizing constants for
+   * probability functions.
+   *
+   * @param[in] params_r unconstrained parameters
+   * @param[in,out] msgs message stream
+   * @return log density for specified parameters
+   */
+  inline math::fvar<math::var> log_prob(
+      Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const {
+    return static_cast<const M*>(this)->template log_prob<false, false>(
+        params_r, msgs);
+  }
+
+  /**
+   * Return the log density for the specified unconstrained
+   * parameters, with Jacobian correction for constraints and with
+   * normalizing constants for probability functions.
+   *
+   * <p>The Jacobian is of the inverse transform from unconstrained
+   * parameters to constrained parameters; full details for Stan
+   * language types can be found in the language reference manual.
+   *
+   * @param[in] params_r unconstrained parameters
+   * @param[in,out] msgs message stream
+   * @return log density for specified parameters
+   */
+  inline math::fvar<math::var> log_prob_jacobian(
+      Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const {
+    return static_cast<const M*>(this)->template log_prob<false, true>(params_r,
+                                                                       msgs);
+  }
+
+  /**
+   * Return the log density for the specified unconstrained
+   * parameters, without Jacobian correction for constraints and
+   * dropping normalizing constants.
+   *
+   * @param[in] params_r unconstrained parameters
+   * @param[in,out] msgs message stream
+   * @return log density for specified parameters
+   */
+  inline math::fvar<math::var> log_prob_propto(
+      Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const {
+    return static_cast<const M*>(this)->template log_prob<true, false>(params_r,
+                                                                       msgs);
+  }
+
+  /**
+   * Return the log density for the specified unconstrained
+   * parameters, with Jacobian correction for constraints and dropping
+   * normalizing constants.
+   *
+   * <p>The Jacobian is of the inverse transform from unconstrained
+   * parameters to constrained parameters; full details for Stan
+   * language types can be found in the language reference manual.
+   *
+   * @param[in] params_r unconstrained parameters
+   * @param[in,out] msgs message stream
+   * @return log density for specified parameters
+   */
+  inline math::fvar<math::var> log_prob_propto_jacobian(
+      Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const {
+    return static_cast<const M*>(this)->template log_prob<true, true>(params_r,
+                                                                      msgs);
+  }
+#endif
 };
 
 }  // namespace model

--- a/src/test/unit/model/model_base_test.cpp
+++ b/src/test/unit/model/model_base_test.cpp
@@ -143,25 +143,25 @@ struct mock_model : public stan::model::model_base {
 
   stan::math::fvar<stan::math::var> log_prob(
       Eigen::Matrix<stan::math::fvar<stan::math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const {
+      std::ostream* msgs) const override {
     return 18;
   }
 
   stan::math::fvar<stan::math::var> log_prob_jacobian(
       Eigen::Matrix<stan::math::fvar<stan::math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const {
+      std::ostream* msgs) const override {
     return 19;
   }
 
   stan::math::fvar<stan::math::var> log_prob_propto(
       Eigen::Matrix<stan::math::fvar<stan::math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const {
+      std::ostream* msgs) const override {
     return 20;
   }
 
   stan::math::fvar<stan::math::var> log_prob_propto_jacobian(
       Eigen::Matrix<stan::math::fvar<stan::math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const {
+      std::ostream* msgs) const override {
     return 21;
   }
 #endif

--- a/src/test/unit/model/model_base_test.cpp
+++ b/src/test/unit/model/model_base_test.cpp
@@ -218,7 +218,8 @@ TEST(model, modelTemplateLogProb) {
   EXPECT_FLOAT_EQ(18, bm.log_prob(params_r_fv, msgs).val().val());
   EXPECT_FLOAT_EQ(19, bm.log_prob_jacobian(params_r_fv, msgs).val().val());
   EXPECT_FLOAT_EQ(20, bm.log_prob_propto(params_r_fv, msgs).val().val());
-  EXPECT_FLOAT_EQ(21, bm.log_prob_propto_jacobian(params_r_fv, msgs).val().val());
+  EXPECT_FLOAT_EQ(21,
+                  bm.log_prob_propto_jacobian(params_r_fv, msgs).val().val());
 
   double v9 = bm.template log_prob<false, false>(params_r_fv, msgs).val().val();
   EXPECT_FLOAT_EQ(18, v9);

--- a/src/test/unit/model/model_base_test.cpp
+++ b/src/test/unit/model/model_base_test.cpp
@@ -138,6 +138,33 @@ struct mock_model : public stan::model::model_base {
                    std::vector<double>& params_r_constrained,
                    bool include_tparams, bool include_gqs,
                    std::ostream* msgs) const override {}
+
+#ifdef STAN_MODEL_FVAR_VAR
+
+  stan::math::fvar<stan::math::var> log_prob(
+      Eigen::Matrix<stan::math::fvar<stan::math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const {
+    return 18;
+  }
+
+  stan::math::fvar<stan::math::var> log_prob_jacobian(
+      Eigen::Matrix<stan::math::fvar<stan::math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const {
+    return 19;
+  }
+
+  stan::math::fvar<stan::math::var> log_prob_propto(
+      Eigen::Matrix<stan::math::fvar<stan::math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const {
+    return 20;
+  }
+
+  stan::math::fvar<stan::math::var> log_prob_propto_jacobian(
+      Eigen::Matrix<stan::math::fvar<stan::math::var>, -1, 1>& params_r,
+      std::ostream* msgs) const {
+    return 21;
+  }
+#endif
 };
 
 TEST(model, modelBaseInheritance) {
@@ -185,4 +212,24 @@ TEST(model, modelTemplateLogProb) {
   EXPECT_FLOAT_EQ(7, v7);
   double v8 = bm.template log_prob<true, true>(params_r_v, msgs).val();
   EXPECT_FLOAT_EQ(8, v8);
+
+#ifdef STAN_MODEL_FVAR_VAR
+  Eigen::Matrix<stan::math::fvar<stan::math::var>, -1, 1> params_r_fv(3);
+  EXPECT_FLOAT_EQ(18, bm.log_prob(params_r_fv, msgs).val().val());
+  EXPECT_FLOAT_EQ(19, bm.log_prob_jacobian(params_r_fv, msgs).val().val());
+  EXPECT_FLOAT_EQ(20, bm.log_prob_propto(params_r_fv, msgs).val().val());
+  EXPECT_FLOAT_EQ(21, bm.log_prob_propto_jacobian(params_r_fv, msgs).val().val());
+
+  double v9 = bm.template log_prob<false, false>(params_r_fv, msgs).val().val();
+  EXPECT_FLOAT_EQ(18, v9);
+
+  double v10 = bm.template log_prob<false, true>(params_r_fv, msgs).val().val();
+  EXPECT_FLOAT_EQ(19, v10);
+
+  double v11 = bm.template log_prob<true, false>(params_r_fv, msgs).val().val();
+  EXPECT_FLOAT_EQ(20, v11);
+
+  double v12 = bm.template log_prob<true, true>(params_r_fv, msgs).val().val();
+  EXPECT_FLOAT_EQ(21, v12);
+#endif
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

The model base class exposes overloads to all the log_prob functions for `double` and `math::var`. It would be useful to expose `math::fvar<var>` overloads to allow higher-order autodiff from base class instances, but this does not work with all Stan models (particularly ODE models and other uses of implicit functions).

This PR introduces opt-in only overloads. This allows downstream users, who want to provide model Hessians or Hessian-vector products, to still use `stan::model::model_base` as a type. Currently, the Hessian functionality in (e.g.) `stan::model::hessian` relies on a template type which can never be filled by `stan::model::model_base`; after this PR it would be possible if the define `STAN_MODEL_AD_HESSIAN` is used.

These signatures are identical to the previously existing ones except for their scalar type. 

To make this even more concrete, in an interface like [bridgestan](https://github.com/roualdes/bridgestan), we can use this same flag to switch from using finite difference Hessians to full-AD for models which support it.

#### Intended Effect

The ability to use `model_base` instances in `stan::model::hessian` on an opt-in basis.

#### Side Effects

Hopefully none.

#### Documentation

I'm not sure where this would be best to document

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
