### PR TITLE
Improve CI times

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ String stan_pr() {
         env.BRANCH_NAME
     }
 }
-String integration_tests_flags() { 
+String integration_tests_flags() {
     if (params.compile_all_model) {
         '--no-ignore-models '
     } else {
@@ -97,7 +97,7 @@ pipeline {
     }
     environment {
         GCC = 'g++'
-        PARALLEL = 8
+        PARALLEL = 4
         MAC_CXX = 'clang++'
         LINUX_CXX = 'clang++-6.0'
         WIN_CXX = 'g++'
@@ -366,7 +366,6 @@ pipeline {
                             cd performance-tests-cmdstan/cmdstan
                             echo 'O=0' >> make/local
                             echo 'CXX=${LINUX_CXX}' >> make/local
-                            echo 'PRECOMPILED_HEADERS=false' >> make/local
                             make clean-all
                             make -j${PARALLEL} build
                             cd ..


### PR DESCRIPTION
#### Summary

The step "Integration Linux" is identical to two steps in stanc3's CI ("Compile tests - good" and "Compile tests - example models") but takes ~3 hours while those two combined take 65 minutes. So far as @serban-nicusor-toptal and I can tell, the only difference between the two setups is PRECOMPILED_HEADERS and the misspecified PARALLEL setting.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
