### PR TITLE
Feature/3146 laplace approx

### DIFF
--- a/src/stan/services/optimize/laplace_sample.hpp
+++ b/src/stan/services/optimize/laplace_sample.hpp
@@ -124,7 +124,6 @@ void laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
   }
 }
 }  // namespace internal
-
   
 /**
  * Take the specified number of draws from the Laplace approximation

--- a/src/stan/services/optimize/laplace_sample.hpp
+++ b/src/stan/services/optimize/laplace_sample.hpp
@@ -1,0 +1,112 @@
+#ifndef STAN_SERVICES_OPTIMIZE_LAPLACE_SAMPLE_HPP
+#define STAN_SERVICES_OPTIMIZE_LAPLACE_SAMPLE_HPP
+
+#include <stan/callbacks/interrupt.hpp>
+#include <stan/callbacks/logger.hpp>
+#include <stan/callbacks/writer.hpp>
+#include <stan/math/rev.hpp>
+#include <stan/services/error_codes.hpp>
+#include <stan/services/util/create_rng.hpp>
+#include <string>
+#include <vector>
+
+namespace stan {
+namespace services {
+
+/**
+ * Take the specified number of draws from the Laplace approximation 
+ * for the model at the specified mode, writing the draws to the
+ * sample writer and writing messages to the logger, returning a
+ * return code of 0 if successful.
+ *
+ * @tparam Model a Stan model
+ * @tparam jacobian `true` to include Jacobian adjustment for
+ * constrained parameters
+ * @parma[in] m model from which to sample from the Laplace approximation
+ * @parma[in] theta_hat mode at which to center the Laplace approximate
+ */
+template <class Model, bool jacobian>
+int laplace_sample(const Model& m, const Eigen::VectorXd& theta_hat,
+		   int draws, unsigned int random_seed,
+		   int refresh, callbacks::interrupt& interrupt,
+		   callbacks::logger& logger,
+		   callbacks::writer& sample_writer) {
+  using stan::math::var;
+
+  // validate number of draws >= 0
+  if (draws.size() <= 0) {
+     std::stringstream msg;
+     msg << "Number of draws must be > 0, found " << draws.size() << std::endl;
+     msg_str = msg.str();
+     logger.error(msg_str);
+     return error_codes::DATAERR;
+   }
+
+  // validate mode is correct size
+  std::vector<std::string> unc_param_names;
+  model.unconstrained_param_names(unc_param_names, !include_tp, !include_gq);
+  int num_unc_params = unc_param_names.size();
+  if (theta.size() != num_unc_params) {
+    std::stringstream msg;
+    msg << "Specified mode is wrong size; expected "
+	<< num_unc_params << " unconstrained parameters"
+	<< ", but specified mode has size " << theta.size()
+	<< std::endl;
+    ste::string msg_str = msg.str();
+    logger.error(msg_str);
+    return error_codes::DATAERR;
+  }
+
+  // write names of params, tps, and gqs to sample writer
+  std::vector<std::string> names;
+  static const bool include_tp = true;
+  static const bool include_gq = true;
+  model.constrained_param_names(names, include_tp, include_gq);
+  sample_writer(names);
+
+  // TODO: figure out how to get msgs out of logger and write
+  // construct model functor for autodiff based on jacobian
+  std::stringstream log_q_msgs;
+  auto log_q = [&](const Eigen::Matrix<var, -1, 1>& theta) {
+    return model.template log_prob<true, jacobian, var>(
+      const_cast<Eigen::Matrix<T, -1, 1>&>(theta),
+      msgs);
+  }
+
+  logger.info("Calculating Cholesky factor of inverse negative Hessian");
+  double log_p;  // dummy
+  Eigen::VectorXd grad;  // dummy
+  Eigen::MatrixXd hessian;
+  logger.info("    Calculating Hessian");
+  math::finite_diff_hessian_auto(log_q(theta), log_p, grad, hessian);
+  std::string log_q_msgs_str = log_q_msgs.str();
+  if (log_q_msgs_str.size() > 0) logger.info(log_q_msgs_str);
+  logger.info("    Calculating inverse of Cholesky factor of negative Hessian");
+  Eigen::MatrixXd inv_L_hessian = (-hessian).llt().matrixL().inverse();
+
+  boost::ecuyer1988 rng = util::create_rng(seed, 0);
+  for (int m = 0; m < draws; ++m) {
+    interrupt();  // allow interpution each iteration
+    if (refresh > 0 && m % refresh == 0) {
+      std::stringstream log_msg;
+      log_msg << "iteration " << m;
+      logger.info(log_msg);
+    }
+    Eigen::VectorXd z(num_unc_params);
+    for (n = 0; n < num_unc_params; ++n) {
+      z(n) = math::std_normal_rng(rng);
+    }
+    auto unc_draw = theta_hat + z * inv_L_hessian;
+    Eigen::VectorXd draw;
+    std::stringstream msgs;
+    model.write_array(rng, unc_draw, draw, include_tp, include_gq, msgs);
+    std::string msgs_str = msgs.str();
+    if (msgs_str.size() > 0) logger.info(msgs_str);
+  }
+  return error_codes::OK;
+}
+  
+}  // namespace services
+}  // namespace stan
+  
+#endif

--- a/src/stan/services/optimize/laplace_sample.hpp
+++ b/src/stan/services/optimize/laplace_sample.hpp
@@ -26,7 +26,7 @@ namespace services {
  * @parma[in] theta_hat mode at which to center the Laplace approximate
  */
 template <class Model, bool jacobian>
-int laplace_sample(const Model& m, const Eigen::VectorXd& theta_hat,
+int laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
 		   int draws, unsigned int random_seed,
 		   int refresh, callbacks::interrupt& interrupt,
 		   callbacks::logger& logger,
@@ -34,25 +34,25 @@ int laplace_sample(const Model& m, const Eigen::VectorXd& theta_hat,
   using stan::math::var;
 
   // validate number of draws >= 0
-  if (draws.size() <= 0) {
+  if (draws <= 0) {
      std::stringstream msg;
-     msg << "Number of draws must be > 0, found " << draws.size() << std::endl;
-     msg_str = msg.str();
+     msg << "Number of draws must be > 0, found " << draws << std::endl;
+     std::string msg_str = msg.str();
      logger.error(msg_str);
      return error_codes::DATAERR;
    }
 
   // validate mode is correct size
   std::vector<std::string> unc_param_names;
-  model.unconstrained_param_names(unc_param_names, !include_tp, !include_gq);
+  model.unconstrained_param_names(unc_param_names, false, false);
   int num_unc_params = unc_param_names.size();
-  if (theta.size() != num_unc_params) {
+  if (theta_hat.size() != num_unc_params) {
     std::stringstream msg;
     msg << "Specified mode is wrong size; expected "
 	<< num_unc_params << " unconstrained parameters"
-	<< ", but specified mode has size " << theta.size()
+	<< ", but specified mode has size " << theta_hat.size()
 	<< std::endl;
-    ste::string msg_str = msg.str();
+    std::string msg_str = msg.str();
     logger.error(msg_str);
     return error_codes::DATAERR;
   }
@@ -66,25 +66,29 @@ int laplace_sample(const Model& m, const Eigen::VectorXd& theta_hat,
 
   // TODO: figure out how to get msgs out of logger and write
   // construct model functor for autodiff based on jacobian
-  std::stringstream log_q_msgs;
-  auto log_q = [&](const Eigen::Matrix<var, -1, 1>& theta) {
+  std::stringstream log_density_msgs;
+  auto log_density_fun = [&](const Eigen::Matrix<var, -1, 1>& theta) {
     return model.template log_prob<true, jacobian, var>(
-      const_cast<Eigen::Matrix<T, -1, 1>&>(theta),
-      msgs);
-  }
+      const_cast<Eigen::Matrix<var, -1, 1>&>(theta),
+      log_density_msgs);
+  };
 
   logger.info("Calculating Cholesky factor of inverse negative Hessian");
   double log_p;  // dummy
   Eigen::VectorXd grad;  // dummy
   Eigen::MatrixXd hessian;
   logger.info("    Calculating Hessian");
-  math::finite_diff_hessian_auto(log_q(theta), log_p, grad, hessian);
-  std::string log_q_msgs_str = log_q_msgs.str();
-  if (log_q_msgs_str.size() > 0) logger.info(log_q_msgs_str);
+  math::internal::finite_diff_hessian_auto(log_density_fun, theta_hat, log_p,
+					   grad, hessian);
+  std::string log_density_msgs_str = log_density_msgs.str();
+  if (log_density_msgs_str.size() > 0) {
+    logger.info(log_density_msgs_str);
+  }
   logger.info("    Calculating inverse of Cholesky factor of negative Hessian");
-  Eigen::MatrixXd inv_L_hessian = (-hessian).llt().matrixL().inverse();
+  Eigen::MatrixXd L_neg_hessian = (-hessian).llt().matrixL();
+  Eigen::MatrixXd inv_sqrt_neg_hessian = L_neg_hessian.inverse();
 
-  boost::ecuyer1988 rng = util::create_rng(seed, 0);
+  boost::ecuyer1988 rng = util::create_rng(random_seed, 0);
   for (int m = 0; m < draws; ++m) {
     interrupt();  // allow interpution each iteration
     if (refresh > 0 && m % refresh == 0) {
@@ -93,10 +97,10 @@ int laplace_sample(const Model& m, const Eigen::VectorXd& theta_hat,
       logger.info(log_msg);
     }
     Eigen::VectorXd z(num_unc_params);
-    for (n = 0; n < num_unc_params; ++n) {
+    for (int n = 0; n < num_unc_params; ++n) {
       z(n) = math::std_normal_rng(rng);
     }
-    auto unc_draw = theta_hat + z * inv_L_hessian;
+    auto unc_draw = theta_hat + z * inv_sqrt_neg_hessian;
     Eigen::VectorXd draw;
     std::stringstream msgs;
     model.write_array(rng, unc_draw, draw, include_tp, include_gq, msgs);

--- a/src/stan/services/optimize/laplace_sample.hpp
+++ b/src/stan/services/optimize/laplace_sample.hpp
@@ -8,6 +8,7 @@
 #include <stan/services/error_codes.hpp>
 #include <stan/services/util/create_rng.hpp>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace stan {
@@ -20,7 +21,10 @@ namespace services {
  * approximation to the sample writer and writing messages to the
  * logger, returning a return code of 0 if successful.
  *
- * Interrupts are called 
+ * Interrupts are called between every compute-intensive operation.
+ *
+ * To turn off all console messages sent to the logger, set refresh to
+ * 0. 
  *
  * @tparam jacobian `true` to include Jacobian adjustment for
  * constrained parameters
@@ -32,7 +36,7 @@ namespace services {
  * @param[in] random_seed seed for generating random numbers in the
  * Stan program and in sampling  
  * @param[in] refresh period between iterations at which updates are
- * given 
+ * given, with a value of 0 turning off all messages
  * @param[in] interrupt callback for interrupting sampling
  * @param[in,out] logger callback for writing console messages from
  * sampler and from Stan programs
@@ -50,10 +54,11 @@ int laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
 		   callbacks::writer& sample_writer) {
   // validate number of draws >= 0
   if (draws <= 0) {
-    std::stringstream msg;
-    msg << "Number of draws must be > 0, found " << draws << std::endl;
-    std::string msg_str = msg.str();
-    logger.error(msg_str);
+    if (refresh >= 0) {
+      logger.error("Number of draws must be > 0, found ");
+      logger.error(std::to_string(draws));
+      logger.error("\n");
+    }
     return error_codes::DATAERR;
   }
 
@@ -62,13 +67,14 @@ int laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
   model.unconstrained_param_names(unc_param_names, false, false);
   int num_unc_params = unc_param_names.size();
   if (theta_hat.size() != num_unc_params) {
-    std::stringstream msg;
-    msg << "Specified mode is wrong size; expected "
-	<< num_unc_params << " unconstrained parameters"
-	<< ", but specified mode has size " << theta_hat.size()
-	<< std::endl;
-    std::string msg_str = msg.str();
-    logger.error(msg_str);
+    if (refresh > 0) {
+      logger.error("Specified mode is wrong size; expected ");
+      logger.error(std::to_string(num_unc_params));
+      logger.error(" unconstrained parameters,");
+      logger.error(" but specified mode has size ");
+      logger.error(std::to_string(theta_hat.size()));
+      logger.error("\n");
+    }
     return error_codes::DATAERR;
   }
 
@@ -95,38 +101,50 @@ int laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
   };
 
   // calculate inverse negative Hessian's Cholesky factor
-  logger.info("Calculating Hessian\n");
+  if (refresh > 0) {
+    logger.info("Calculating Hessian");
+    logger.info("\n");
+  }
   double log_p;  // dummy
   Eigen::VectorXd grad;  // dummy
   Eigen::MatrixXd hessian;
   interrupt();
   math::internal::finite_diff_hessian_auto(log_density_fun, theta_hat, log_p,
 					   grad, hessian);
-  std::string log_density_msgs_str = log_density_msgs.str();
-  logger.info(log_density_msgs_str);
+  if (refresh > 0) {
+    logger.info(log_density_msgs);
+    logger.info("\n");
+  }
 
   // calculate Cholesky factor and inverse
   interrupt();
-  logger.info("\nCalculating inverse of Cholesky factor\n");
+  if (refresh > 0) {
+    logger.info("Calculating inverse of Cholesky factor");
+    logger.info("\n");
+  }
   Eigen::MatrixXd L_neg_hessian = (-hessian).llt().matrixL();
   interrupt();
   Eigen::MatrixXd inv_sqrt_neg_hessian = L_neg_hessian.inverse();
   interrupt();
   Eigen::MatrixXd neg_half_inv = -0.5 * inv_sqrt_neg_hessian * inv_sqrt_neg_hessian.transpose();
+
   // don't need log-determinant because log_q is unnormalized
   // double log_det = 2 * L_neg_hessian.diagonal().array().log().sum();
 
-  // generate draws
+  // generate draws and output to sample writer
   interrupt();
-  logger.info("\nGenerating draws\n");
+  if (refresh > 0) {
+    logger.info("Generating draws");
+    logger.info("\n");
+  }
   boost::ecuyer1988 rng = util::create_rng(random_seed, 0);
   Eigen::VectorXd draw_vec;  // declare draw_vec, msgs here to avoid re-alloc
   for (int m = 0; m < draws; ++m) {
     interrupt();  // allow interpution each iteration
     if (refresh > 0 && m % refresh == 0) {
-      std::stringstream log_msg;
-      log_msg << "iteration " << m << std::endl;
-      logger.info(log_msg);
+      logger.info("iteration: ");
+      logger.info(std::to_string(m));
+      logger.info("\n");
     }
     Eigen::VectorXd z(num_unc_params);
     for (int n = 0; n < num_unc_params; ++n) {
@@ -141,7 +159,10 @@ int laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
     
     std::stringstream msgs;
     model.write_array(rng, unc_draw, draw_vec, include_tp, include_gq, &msgs);
-    logger.info(msgs);
+    if (refresh > 0) {
+      logger.info(msgs);
+      logger.info("\n");
+    }
     std::vector<double> draw(&draw_vec(0), &draw_vec(0) + draw_size);
     draw.push_back(log_p);
     draw.push_back(log_q);

--- a/src/test/test-models/good/services/multi_normal.stan
+++ b/src/test/test-models/good/services/multi_normal.stan
@@ -1,0 +1,10 @@
+transformed data {
+  vector[2] mu = [2, 3]';
+  cov_matrix[2] Sigma = [[1, 0.8], [0.8, 1]];
+}
+parameters {
+  vector[2] y;	   
+}
+model {
+  y ~ multi_normal(mu, Sigma);
+}

--- a/src/test/unit/services/optimize/laplace_sample_test.cpp
+++ b/src/test/unit/services/optimize/laplace_sample_test.cpp
@@ -1,16 +1,16 @@
-// #include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string.hpp>
 #include <gtest/gtest.h>
-#include <stan/io/empty_var_context.hpp>
 #include <stan/callbacks/stream_logger.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 #include <stan/io/dump.hpp>
+#include <stan/io/empty_var_context.hpp>
 #include <stan/io/stan_csv_reader.hpp>
 #include <stan/services/error_codes.hpp>
 #include <stan/services/optimize/laplace_sample.hpp>
 #include <test/test-models/good/services/multi_normal.hpp>
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <test/unit/util.hpp>
-
+#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -31,16 +31,92 @@ class ServicesLaplaceSample: public ::testing::Test {
   stan::test::unit::instrumented_interrupt interrupt;
 };
 
-TEST_F(ServicesLaplaceSample, bar) {
-  EXPECT_EQ(1,1);
-
-
+TEST_F(ServicesLaplaceSample, values) {
   Eigen::VectorXd theta_hat(2);
   theta_hat << 2, 3;
+  int draws = 50000;  // big to enable mean, var & covar test precision
+  unsigned int seed = 1234;
+  int refresh = 1;
+  std::stringstream sample_ss;
+  stan::callbacks::stream_writer sample_writer(sample_ss, "");
+  int return_code = stan::services::laplace_sample<true>(*model, theta_hat,
+		      draws, seed, refresh, interrupt, logger, sample_writer);
+  EXPECT_EQ(stan::services::error_codes::OK, return_code);
+  std::string samples_str = sample_ss.str();
+  EXPECT_EQ(2, count_matches("y", samples_str));
+  EXPECT_EQ(1, count_matches("y.1", samples_str));
+  EXPECT_EQ(1, count_matches("y.2", samples_str));
+  EXPECT_EQ(1, count_matches("log_p", samples_str));
+  EXPECT_EQ(1, count_matches("log_q", samples_str));
+
+  std::stringstream out;
+  stan::io::stan_csv draws_csv = stan::io::stan_csv_reader::parse(sample_ss, &out);
+
+  EXPECT_EQ(4, draws_csv.header.size());
+  EXPECT_EQ("y[1]", draws_csv.header[0]);
+  EXPECT_EQ("y[2]", draws_csv.header[1]);
+  EXPECT_EQ("log_p", draws_csv.header[2]);
+  EXPECT_EQ("log_q", draws_csv.header[3]);
+
+  Eigen::MatrixXd sample = draws_csv.samples;
+  EXPECT_EQ(4, sample.cols());
+  EXPECT_EQ(draws, sample.rows());
+  Eigen::VectorXd y1 = sample.col(0);
+  Eigen::VectorXd y2 = sample.col(1);
+  Eigen::VectorXd log_p = sample.col(2);
+  Eigen::VectorXd log_q = sample.col(2);
+
+  // because target is normal, laplace approx is exact
+  for (int m = 0; m < draws; ++m) {
+    EXPECT_FLOAT_EQ(0, log_p(m) - log_q(m));
+  }
+
+  // expect mean draws to be location params +/0 MC error
+  EXPECT_NEAR(2, stan::math::mean(y1), 0.05);
+  EXPECT_NEAR(3, stan::math::mean(y2), 0.05);
+
+  double sum1 = 0;
+  for (int m = 0; m < draws; ++m) {
+    sum1 += std::pow(y1(m) - 2, 2);
+  }
+  double var1 = sum1 / draws;
+  EXPECT_NEAR(1, var1, 0.05);
+
+  double sum2 = 0;
+  for (int m = 0; m < draws; ++m) {
+    sum2 += std::pow(y2(m) - 3, 2);
+  }
+  double var2 = sum2 / draws;
+  EXPECT_NEAR(1, var2, 0.05);
+
+  double sum12 = 0;
+  for (int m = 0; m < draws; ++m) {
+    sum12 += (y1(m) - 2) * (y2(m) - 3);
+  }
+  double cov = sum12 / draws;
+  EXPECT_NEAR(0.8, cov, 0.05);
+}
+
+TEST_F(ServicesLaplaceSample, wrongSizeModeError) {
+  Eigen::VectorXd theta_hat(3);
+  theta_hat << 2, 3, 4;
   int draws = 10;
   unsigned int seed = 1234;
   int refresh = 1;
   std::stringstream sample_ss;
   stan::callbacks::stream_writer sample_writer(sample_ss, "");
-  stan::services::laplace_sample<true>(*model, theta_hat, draws, seed, refresh, interrupt, logger, sample_writer);
+  int RC = stan::services::laplace_sample<true>(*model, theta_hat, draws, seed, refresh, interrupt, logger, sample_writer);
+  EXPECT_EQ(stan::services::error_codes::DATAERR, RC);
+}
+
+TEST_F(ServicesLaplaceSample, nonPositiveDrawsError) {
+  Eigen::VectorXd theta_hat(2);
+  theta_hat << 2, 3;
+  int draws = 0;
+  unsigned int seed = 1234;
+  int refresh = 1;
+  std::stringstream sample_ss;
+  stan::callbacks::stream_writer sample_writer(sample_ss, "");
+  int RC = stan::services::laplace_sample<true>(*model, theta_hat, draws, seed, refresh, interrupt, logger, sample_writer);
+  EXPECT_EQ(stan::services::error_codes::DATAERR, RC);
 }

--- a/src/test/unit/services/optimize/laplace_sample_test.cpp
+++ b/src/test/unit/services/optimize/laplace_sample_test.cpp
@@ -20,17 +20,27 @@ class ServicesLaplaceSample: public ::testing::Test {
 
   void SetUp() {
     stan::io::empty_var_context var_context;
-    model = new stan_model(var_context);
+    model = new stan_model(var_context);  // typedef from multi_normal.hpp
   }
 
   void TearDown() { delete model; }
 
-  stan::test::unit::instrumented_interrupt interrupt;
+  stan_model* model;
   std::stringstream msgs;
   stan::callbacks::stream_logger logger;
-  stan_model* model;
+  stan::test::unit::instrumented_interrupt interrupt;
 };
 
 TEST_F(ServicesLaplaceSample, bar) {
-  EXPECT_EQ(1, 1);
+  EXPECT_EQ(1,1);
+
+
+  Eigen::VectorXd theta_hat(2);
+  theta_hat << 2, 3;
+  int draws = 10;
+  unsigned int seed = 1234;
+  int refresh = 1;
+  std::stringstream sample_ss;
+  stan::callbacks::stream_writer sample_writer(sample_ss, "");
+  stan::services::laplace_sample<true>(*model, theta_hat, draws, seed, refresh, interrupt, logger, sample_writer);
 }

--- a/src/test/unit/services/optimize/laplace_sample_test.cpp
+++ b/src/test/unit/services/optimize/laplace_sample_test.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+#include <stan/services/optimize/laplace_sample.hpp>
+
+TEST(foo, bar) {
+  EXPECT_EQ(1, 1);
+}

--- a/src/test/unit/services/optimize/laplace_sample_test.cpp
+++ b/src/test/unit/services/optimize/laplace_sample_test.cpp
@@ -1,6 +1,36 @@
+// #include <boost/algorithm/string.hpp>
 #include <gtest/gtest.h>
+#include <stan/io/empty_var_context.hpp>
+#include <stan/callbacks/stream_logger.hpp>
+#include <stan/callbacks/stream_writer.hpp>
+#include <stan/io/dump.hpp>
+#include <stan/io/stan_csv_reader.hpp>
+#include <stan/services/error_codes.hpp>
 #include <stan/services/optimize/laplace_sample.hpp>
+#include <test/test-models/good/services/multi_normal.hpp>
+#include <test/unit/services/instrumented_callbacks.hpp>
+#include <test/unit/util.hpp>
 
-TEST(foo, bar) {
+#include <iostream>
+#include <vector>
+
+class ServicesLaplaceSample: public ::testing::Test {
+ public:
+  ServicesLaplaceSample() : logger(msgs, msgs, msgs, msgs, msgs) { }
+
+  void SetUp() {
+    stan::io::empty_var_context var_context;
+    model = new stan_model(var_context);
+  }
+
+  void TearDown() { delete model; }
+
+  stan::test::unit::instrumented_interrupt interrupt;
+  std::stringstream msgs;
+  stan::callbacks::stream_logger logger;
+  stan_model* model;
+};
+
+TEST_F(ServicesLaplaceSample, bar) {
   EXPECT_EQ(1, 1);
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint` **COULD NOT DO THIS BECAUSE I GET THIS ERROR:**

```
~/github/stan-dev/cmdstan/stan (feature/3146-laplace-approx)$ make cpplint
make: python: No such file or directory
make: *** [cpplint] Error 1
~/github/stan-dev/cmdstan/stan (feature/3146-laplace-approx)$ which python
python: aliased to /usr/bin/python3
```

- [x] Declare copyright holder and open-source license: see below

#### Summary

Implements Laplace approximations as a service function for Stan models taking an unconstrained mode and returning draws from the Laplace approximation calculated using the Hessian derived by central finite differences.

#### Intended Effect

Set up the service function so interfaces can offer Laplace approximation.

#### How to Verify

Unit tests

#### Side Effects

No

#### Documentation

Yes

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
