### PR TITLE
Feature/3149 jacobian optimize

### DIFF
--- a/src/stan/optimization/bfgs.hpp
+++ b/src/stan/optimization/bfgs.hpp
@@ -289,7 +289,7 @@ class BFGSMinimizer {
   }
 };
 
-template <class M>
+template <class M, bool jacobian=false>
 class ModelAdaptor {
  private:
   M &_model;
@@ -315,7 +315,7 @@ class ModelAdaptor {
       _x[i] = x[i];
 
     try {
-      f = -log_prob_propto<false>(_model, _x, _params_i, _msgs);
+      f = -log_prob_propto<jacobian>(_model, _x, _params_i, _msgs);
     } catch (const std::exception &e) {
       if (_msgs)
         (*_msgs) << e.what() << std::endl;
@@ -347,7 +347,7 @@ class ModelAdaptor {
     _fevals++;
 
     try {
-      f = -log_prob_grad<true, false>(_model, _x, _params_i, _g, _msgs);
+      f = -log_prob_grad<true, jacobian>(_model, _x, _params_i, _g, _msgs);
     } catch (const std::exception &e) {
       if (_msgs)
         (*_msgs) << e.what() << std::endl;
@@ -382,15 +382,18 @@ class ModelAdaptor {
   }
 };
 
+/**
+ * @tparam jacobian `true` to include Jacobian adjustment (default `false`)
+ */  
 template <typename M, typename QNUpdateType, typename Scalar = double,
-          int DimAtCompile = Eigen::Dynamic>
-class BFGSLineSearch : public BFGSMinimizer<ModelAdaptor<M>, QNUpdateType,
+          int DimAtCompile = Eigen::Dynamic, bool jacobian = false>
+class BFGSLineSearch : public BFGSMinimizer<ModelAdaptor<M, jacobian>, QNUpdateType,
                                             Scalar, DimAtCompile> {
  private:
-  ModelAdaptor<M> _adaptor;
+  ModelAdaptor<M, jacobian> _adaptor;
 
  public:
-  typedef BFGSMinimizer<ModelAdaptor<M>, QNUpdateType, Scalar, DimAtCompile>
+  typedef BFGSMinimizer<ModelAdaptor<M, jacobian>, QNUpdateType, Scalar, DimAtCompile>
       BFGSBase;
   typedef typename BFGSBase::VectorT vector_t;
   typedef typename stan::math::index_type<vector_t>::type idx_t;

--- a/src/stan/optimization/newton.hpp
+++ b/src/stan/optimization/newton.hpp
@@ -26,14 +26,14 @@ inline void make_negative_definite_and_solve(matrix_d& H, vector_d& g) {
   g = eigenvectors * eigenprojections;
 }
 
-template <typename M>
+template <typename M, bool jacobian = false>
 double newton_step(M& model, std::vector<double>& params_r,
                    std::vector<int>& params_i,
                    std::ostream* output_stream = 0) {
   std::vector<double> gradient;
   std::vector<double> hessian;
 
-  double f0 = stan::model::grad_hess_log_prob<true, false>(
+  double f0 = stan::model::grad_hess_log_prob<true, jacobian>(
       model, params_r, params_i, gradient, hessian);
   matrix_d H(params_r.size(), params_r.size());
   for (size_t i = 0; i < hessian.size(); i++) {
@@ -58,8 +58,8 @@ double newton_step(M& model, std::vector<double>& params_r,
     for (size_t i = 0; i < params_r.size(); i++)
       new_params_r[i] = params_r[i] - step_size * g[i];
     try {
-      f1 = stan::model::log_prob_grad<true, false>(model, new_params_r,
-                                                   params_i, gradient);
+      f1 = stan::model::log_prob_grad<true, jacobian>(model, new_params_r,
+						      params_i, gradient);
     } catch (std::exception& e) {
       // FIXME:  this is not a good way to handle a general exception
       f1 = -1e100;

--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -23,6 +23,7 @@ namespace optimize {
  * Runs the BFGS algorithm for a model.
  *
  * @tparam Model A model implementation
+ * @tparam jacobian `true` to include Jacobian adjust (default `false`)
  * @param[in] model Input model to test (with data already instantiated)
  * @param[in] init var context for initialization
  * @param[in] random_seed random seed for the random number generator
@@ -48,7 +49,7 @@ namespace optimize {
  * @param[in,out] parameter_writer output for parameter values
  * @return error_codes::OK if successful
  */
-template <class Model>
+template <class Model, bool jacobian=false>
 int bfgs(Model& model, const stan::io::var_context& init,
          unsigned int random_seed, unsigned int chain, double init_radius,
          double init_alpha, double tol_obj, double tol_rel_obj, double tol_grad,
@@ -64,7 +65,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
 
   std::stringstream bfgs_ss;
   typedef stan::optimization::BFGSLineSearch<
-      Model, stan::optimization::BFGSUpdate_HInv<> >
+    Model, stan::optimization::BFGSUpdate_HInv<>, double, Eigen::Dynamic, jacobian>
       Optimizer;
   Optimizer bfgs(model, cont_vector, disc_vector, &bfgs_ss);
   bfgs._ls_opts.alpha0 = init_alpha;

--- a/src/stan/services/optimize/lbfgs.hpp
+++ b/src/stan/services/optimize/lbfgs.hpp
@@ -23,6 +23,7 @@ namespace optimize {
  * Runs the L-BFGS algorithm for a model.
  *
  * @tparam Model A model implementation
+ * @tparam jacobian `true` to include Jacobian adjustment (default `false`)
  * @param[in] model Input model to test (with data already instantiated)
  * @param[in] init var context for initialization
  * @param[in] random_seed random seed for the random number generator
@@ -49,7 +50,7 @@ namespace optimize {
  * @param[in,out] parameter_writer output for parameter values
  * @return error_codes::OK if successful
  */
-template <class Model>
+template <class Model, bool jacobian=false>
 int lbfgs(Model& model, const stan::io::var_context& init,
           unsigned int random_seed, unsigned int chain, double init_radius,
           int history_size, double init_alpha, double tol_obj,
@@ -66,8 +67,8 @@ int lbfgs(Model& model, const stan::io::var_context& init,
 
   std::stringstream lbfgs_ss;
   typedef stan::optimization::BFGSLineSearch<Model,
-                                             stan::optimization::LBFGSUpdate<> >
-      Optimizer;
+                                             stan::optimization::LBFGSUpdate<>,
+					     double, Eigen::Dynamic, jacobian> Optimizer;
   Optimizer lbfgs(model, cont_vector, disc_vector, &lbfgs_ss);
   lbfgs.get_qnupdate().set_history_size(history_size);
   lbfgs._ls_opts.alpha0 = init_alpha;

--- a/src/stan/services/optimize/newton.hpp
+++ b/src/stan/services/optimize/newton.hpp
@@ -22,6 +22,7 @@ namespace optimize {
  * Runs the Newton algorithm for a model.
  *
  * @tparam Model A model implementation
+ * @tparam jacobian `true` to include Jacobian adjustment (default `false`)
  * @param[in] model the Stan model instantiated with data
  * @param[in] init var context for initialization
  * @param[in] random_seed random seed for the random number generator
@@ -36,7 +37,7 @@ namespace optimize {
  * @param[in,out] parameter_writer output for parameter values
  * @return error_codes::OK if successful
  */
-template <class Model>
+template <class Model, bool jacobian = false>
 int newton(Model& model, const stan::io::var_context& init,
            unsigned int random_seed, unsigned int chain, double init_radius,
            int num_iterations, bool save_iterations,
@@ -52,13 +53,13 @@ int newton(Model& model, const stan::io::var_context& init,
   double lp(0);
   try {
     std::stringstream message;
-    lp = model.template log_prob<false, false>(cont_vector, disc_vector,
-                                               &message);
+    lp = model.template log_prob<false, jacobian>(cont_vector, disc_vector,
+						  &message);
     logger.info(message);
   } catch (const std::exception& e) {
     logger.info("");
     logger.info(
-        "Informational Message: The current Metropolis"
+        "Informational Message: The current"
         " proposal is about to be rejected because of"
         " the following issue:");
     logger.info(e.what());
@@ -95,7 +96,8 @@ int newton(Model& model, const stan::io::var_context& init,
     }
     interrupt();
     lastlp = lp;
-    lp = stan::optimization::newton_step(model, cont_vector, disc_vector);
+    lp = stan::optimization::newton_step<Model, jacobian>(model, cont_vector,
+							  disc_vector);
 
     std::stringstream msg2;
     msg2 << "Iteration " << std::setw(2) << (m + 1) << "."

--- a/src/test/test-models/good/optimization/simple_jacobian.stan
+++ b/src/test/test-models/good/optimization/simple_jacobian.stan
@@ -1,0 +1,11 @@
+/**
+ * log Jacobian adjustment: log exp'(log(sigma)) = log sigma
+ * optimum w/o Jacobian:  sigma = 3
+ * optimum w Jacobian: (3 + sqrt(13))/2
+ */
+parameters {
+  real<lower=0> sigma;
+}
+model {
+  sigma ~ normal(3, 1);
+}

--- a/src/test/unit/services/instrumented_callbacks.hpp
+++ b/src/test/unit/services/instrumented_callbacks.hpp
@@ -1,16 +1,18 @@
 #ifndef TEST__UNIT__INSTRUMENTED_CALLBACKS_HPP
 #define TEST__UNIT__INSTRUMENTED_CALLBACKS_HPP
 
+#include <stan/callbacks/interrupt.hpp>
+#include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 #include <stan/callbacks/writer.hpp>
-#include <stan/callbacks/interrupt.hpp>
+#include <stan/io/empty_var_context.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <map>
-#include <string>
-#include <iostream>
-#include <exception>
 #include <atomic>
+#include <exception>
+#include <iostream>
+#include <map>
 #include <mutex>
+#include <string>
 
 
 namespace stan {
@@ -288,26 +290,9 @@ class instrumented_logger : public stan::callbacks::logger {
   std::vector<std::string> error_;
   std::vector<std::string> fatal_;
 };
-
 }  // namespace unit
 }  // namespace test
 }  // namespace stan
-
-/**
- * Container class for holding model, callbacks, and streams on which
- * callbacks are based.
- */
-struct ServicesOptimize : public testing::Test {
-  ServicesOptimize()
-      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
-
-  std::stringstream init_ss, parameter_ss, model_ss;
-  stan::test::unit::instrumented_logger logger;
-  stan::callbacks::stream_writer init;
-  stan::test::unit::values_writer parameter;
-  stan::io::empty_var_context context;
-  stan_model model;
-};
 
 
 

--- a/src/test/unit/services/optimize/bfgs_jacobian_test.cpp
+++ b/src/test/unit/services/optimize/bfgs_jacobian_test.cpp
@@ -1,12 +1,11 @@
-#include <stan/services/optimize/lbfgs.hpp>
+#include <stan/services/optimize/bfgs.hpp>
 #include <gtest/gtest.h>
 #include <stan/io/empty_var_context.hpp>
 #include <test/test-models/good/optimization/simple_jacobian.hpp>
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
-#include <cmath>
 
-TEST_F(ServicesOptimize, with_jacobian) {
+TEST_F(ServicesOptimize, withJacobian) {
   unsigned int seed = 0;
   unsigned int chain = 1;
   double init_radius = 0;
@@ -15,8 +14,8 @@ TEST_F(ServicesOptimize, with_jacobian) {
   int refresh = 0;
   stan::test::unit::instrumented_interrupt interrupt;
 
-  int return_code = stan::services::optimize::lbfgs<stan_model, true>(
-      model, context, seed, chain, init_radius, 5, 0.001, 1e-12, 10000, 1e-8,
+  int return_code = stan::services::optimize::bfgs<stan_model, true>(
+      model, context, seed, chain, init_radius, 0.001, 1e-12, 10000, 1e-8,
       10000000, 1e-8, 2000, save_iterations, refresh, interrupt, logger, init,
       parameter);
 
@@ -27,9 +26,10 @@ TEST_F(ServicesOptimize, with_jacobian) {
   EXPECT_EQ("lp__", parameter.names_[0]);
   EXPECT_EQ("sigma", parameter.names_[1]);
   EXPECT_NEAR((3 + std::sqrt(13)) / 2, parameter.states_.back()[1], 0.0001);
+  EXPECT_GT(interrupt.call_count(), 0);
 }
 
-TEST_F(ServicesOptimize, without_jacobian) {
+TEST_F(ServicesOptimize, withoutJacobian) {
   unsigned int seed = 0;
   unsigned int chain = 1;
   double init_radius = 0;
@@ -38,8 +38,8 @@ TEST_F(ServicesOptimize, without_jacobian) {
   int refresh = 0;
   stan::test::unit::instrumented_interrupt interrupt;
 
-  int return_code = stan::services::optimize::lbfgs<stan_model, false>(
-      model, context, seed, chain, init_radius, 5, 0.001, 1e-12, 10000, 1e-8,
+  int return_code = stan::services::optimize::bfgs<stan_model, false>(
+      model, context, seed, chain, init_radius, 0.001, 1e-12, 10000, 1e-8,
       10000000, 1e-8, 2000, save_iterations, refresh, interrupt, logger, init,
       parameter);
 
@@ -50,4 +50,5 @@ TEST_F(ServicesOptimize, without_jacobian) {
   EXPECT_EQ("lp__", parameter.names_[0]);
   EXPECT_EQ("sigma", parameter.names_[1]);
   EXPECT_NEAR(3, parameter.states_.back()[1], 0.0001);
+  EXPECT_GT(interrupt.call_count(), 1);
 }

--- a/src/test/unit/services/optimize/bfgs_jacobian_test.cpp
+++ b/src/test/unit/services/optimize/bfgs_jacobian_test.cpp
@@ -5,6 +5,18 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
+struct ServicesOptimize : public testing::Test {
+  ServicesOptimize()
+      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
+
+  std::stringstream init_ss, parameter_ss, model_ss;
+  stan::test::unit::instrumented_logger logger;
+  stan::callbacks::stream_writer init;
+  stan::test::unit::values_writer parameter;
+  stan::io::empty_var_context context;
+  stan_model model;
+};
+
 TEST_F(ServicesOptimize, withJacobian) {
   unsigned int seed = 0;
   unsigned int chain = 1;

--- a/src/test/unit/services/optimize/bfgs_test.cpp
+++ b/src/test/unit/services/optimize/bfgs_test.cpp
@@ -5,44 +5,7 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
-class values : public stan::callbacks::stream_writer {
- public:
-  std::vector<std::string> names_;
-  std::vector<std::vector<double> > states_;
-
-  values(std::ostream& stream) : stan::callbacks::stream_writer(stream) {}
-
-  /**
-   * Writes a set of names.
-   *
-   * @param[in] names Names in a std::vector
-   */
-  void operator()(const std::vector<std::string>& names) { names_ = names; }
-
-  /**
-   * Writes a set of values.
-   *
-   * @param[in] state Values in a std::vector
-   */
-  void operator()(const std::vector<double>& state) {
-    states_.push_back(state);
-  }
-};
-
-class ServicesOptimizeBfgs : public testing::Test {
- public:
-  ServicesOptimizeBfgs()
-      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
-
-  std::stringstream init_ss, parameter_ss, model_ss;
-  stan::callbacks::stream_writer init;
-  stan::test::unit::instrumented_logger logger;
-  values parameter;
-  stan::io::empty_var_context context;
-  stan_model model;
-};
-
-TEST_F(ServicesOptimizeBfgs, rosenbrock) {
+TEST_F(ServicesOptimize, rosenbrock) {
   unsigned int seed = 0;
   unsigned int chain = 1;
   double init_radius = 0;

--- a/src/test/unit/services/optimize/bfgs_test.cpp
+++ b/src/test/unit/services/optimize/bfgs_test.cpp
@@ -5,13 +5,6 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
-struct mock_callback : public stan::callbacks::interrupt {
-  int n;
-  mock_callback() : n(0) {}
-
-  void operator()() { n++; }
-};
-
 class values : public stan::callbacks::stream_writer {
  public:
   std::vector<std::string> names_;
@@ -56,11 +49,11 @@ TEST_F(ServicesOptimizeBfgs, rosenbrock) {
 
   bool save_iterations = true;
   int refresh = 0;
-  mock_callback callback;
+  stan::test::unit::instrumented_interrupt interrupt;
 
   int return_code = stan::services::optimize::bfgs(
       model, context, seed, chain, init_radius, 0.001, 1e-12, 10000, 1e-8,
-      10000000, 1e-8, 2000, save_iterations, refresh, callback, logger, init,
+      10000000, 1e-8, 2000, save_iterations, refresh, interrupt, logger, init,
       parameter);
 
   EXPECT_EQ(logger.call_count(), logger.call_count_info())
@@ -87,5 +80,5 @@ TEST_F(ServicesOptimizeBfgs, rosenbrock) {
   EXPECT_FLOAT_EQ(1, parameter.states_.back()[2])
       << "optimal value should be (1, 1)";
   EXPECT_FLOAT_EQ(return_code, 0);
-  EXPECT_EQ(19, callback.n);
+  EXPECT_EQ(19, interrupt.call_count());
 }

--- a/src/test/unit/services/optimize/bfgs_test.cpp
+++ b/src/test/unit/services/optimize/bfgs_test.cpp
@@ -5,6 +5,18 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
+struct ServicesOptimize : public testing::Test {
+  ServicesOptimize()
+      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
+
+  std::stringstream init_ss, parameter_ss, model_ss;
+  stan::test::unit::instrumented_logger logger;
+  stan::callbacks::stream_writer init;
+  stan::test::unit::values_writer parameter;
+  stan::io::empty_var_context context;
+  stan_model model;
+};
+
 TEST_F(ServicesOptimize, rosenbrock) {
   unsigned int seed = 0;
   unsigned int chain = 1;

--- a/src/test/unit/services/optimize/lbfgs_jacobian_test.cpp
+++ b/src/test/unit/services/optimize/lbfgs_jacobian_test.cpp
@@ -1,0 +1,91 @@
+#include <stan/services/optimize/lbfgs.hpp>
+#include <gtest/gtest.h>
+#include <stan/io/empty_var_context.hpp>
+#include <test/test-models/good/optimization/simple_jacobian.hpp>
+#include <test/unit/services/instrumented_callbacks.hpp>
+#include <stan/callbacks/stream_writer.hpp>
+#include <cmath>
+
+class values : public stan::callbacks::stream_writer {
+ public:
+  std::vector<std::string> names_;
+  std::vector<std::vector<double> > states_;
+
+  values(std::ostream& stream) : stan::callbacks::stream_writer(stream) {}
+
+  /**
+   * Writes a set of names.
+   *
+   * @param[in] names Names in a std::vector
+   */
+  void operator()(const std::vector<std::string>& names) { names_ = names; }
+
+  /**
+   * Writes a set of values.
+   *
+   * @param[in] state Values in a std::vector
+   */
+  void operator()(const std::vector<double>& state) {
+    states_.push_back(state);
+  }
+};
+
+class ServicesOptimizeLbfgs : public testing::Test {
+ public:
+  ServicesOptimizeLbfgs()
+      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
+
+  std::stringstream init_ss, parameter_ss, model_ss;
+  stan::callbacks::stream_writer init;
+  stan::test::unit::instrumented_logger logger;
+  values parameter;
+  stan::io::empty_var_context context;
+  stan_model model;
+};
+
+TEST_F(ServicesOptimizeLbfgs, with_jacobian) {
+  unsigned int seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 1;
+
+  bool save_iterations = true;
+  int refresh = 0;
+  stan::test::unit::instrumented_interrupt interrupt;
+
+  int return_code = stan::services::optimize::lbfgs<stan_model, true>(
+      model, context, seed, chain, init_radius, 5, 0.001, 1e-12, 10000, 1e-8,
+      10000000, 1e-8, 2000, save_iterations, refresh, interrupt, logger, init,
+      parameter);
+
+  EXPECT_TRUE(logger.find("Optimization terminated normally: "));
+  EXPECT_FLOAT_EQ(return_code, 0);
+
+  ASSERT_EQ(2, parameter.names_.size());
+  EXPECT_EQ("lp__", parameter.names_[0]);
+  EXPECT_EQ("sigma", parameter.names_[1]);
+  EXPECT_NEAR((3 + std::sqrt(13)) / 2, parameter.states_.back()[1], 0.0001);
+}
+
+
+TEST_F(ServicesOptimizeLbfgs, without_jacobian) {
+  unsigned int seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 1;
+
+  bool save_iterations = true;
+  int refresh = 0;
+  stan::test::unit::instrumented_interrupt interrupt;
+
+  int return_code = stan::services::optimize::lbfgs<stan_model, false>(
+      model, context, seed, chain, init_radius, 5, 0.001, 1e-12, 10000, 1e-8,
+      10000000, 1e-8, 2000, save_iterations, refresh, interrupt, logger, init,
+      parameter);
+
+  EXPECT_TRUE(logger.find("Optimization terminated normally: "));
+  EXPECT_FLOAT_EQ(return_code, 0);
+
+  ASSERT_EQ(2, parameter.names_.size());
+  EXPECT_EQ("lp__", parameter.names_[0]);
+  EXPECT_EQ("sigma", parameter.names_[1]);
+  EXPECT_NEAR(3, parameter.states_.back()[1], 0.0001);
+}

--- a/src/test/unit/services/optimize/lbfgs_jacobian_test.cpp
+++ b/src/test/unit/services/optimize/lbfgs_jacobian_test.cpp
@@ -6,6 +6,18 @@
 #include <stan/callbacks/stream_writer.hpp>
 #include <cmath>
 
+struct ServicesOptimize : public testing::Test {
+  ServicesOptimize()
+      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
+
+  std::stringstream init_ss, parameter_ss, model_ss;
+  stan::test::unit::instrumented_logger logger;
+  stan::callbacks::stream_writer init;
+  stan::test::unit::values_writer parameter;
+  stan::io::empty_var_context context;
+  stan_model model;
+};
+
 TEST_F(ServicesOptimize, with_jacobian) {
   unsigned int seed = 0;
   unsigned int chain = 1;

--- a/src/test/unit/services/optimize/lbfgs_test.cpp
+++ b/src/test/unit/services/optimize/lbfgs_test.cpp
@@ -5,44 +5,7 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
-class values : public stan::callbacks::stream_writer {
- public:
-  std::vector<std::string> names_;
-  std::vector<std::vector<double> > states_;
-
-  values(std::ostream& stream) : stan::callbacks::stream_writer(stream) {}
-
-  /**
-   * Writes a set of names.
-   *
-   * @param[in] names Names in a std::vector
-   */
-  void operator()(const std::vector<std::string>& names) { names_ = names; }
-
-  /**
-   * Writes a set of values.
-   *
-   * @param[in] state Values in a std::vector
-   */
-  void operator()(const std::vector<double>& state) {
-    states_.push_back(state);
-  }
-};
-
-class ServicesOptimizeLbfgs : public testing::Test {
- public:
-  ServicesOptimizeLbfgs()
-      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
-
-  std::stringstream init_ss, parameter_ss, model_ss;
-  stan::callbacks::stream_writer init;
-  stan::test::unit::instrumented_logger logger;
-  values parameter;
-  stan::io::empty_var_context context;
-  stan_model model;
-};
-
-TEST_F(ServicesOptimizeLbfgs, rosenbrock) {
+TEST_F(ServicesOptimize, rosenbrock) {
   unsigned int seed = 0;
   unsigned int chain = 1;
   double init_radius = 0;

--- a/src/test/unit/services/optimize/lbfgs_test.cpp
+++ b/src/test/unit/services/optimize/lbfgs_test.cpp
@@ -5,6 +5,18 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
+struct ServicesOptimize : public testing::Test {
+  ServicesOptimize()
+      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
+
+  std::stringstream init_ss, parameter_ss, model_ss;
+  stan::test::unit::instrumented_logger logger;
+  stan::callbacks::stream_writer init;
+  stan::test::unit::values_writer parameter;
+  stan::io::empty_var_context context;
+  stan_model model;
+};
+
 TEST_F(ServicesOptimize, rosenbrock) {
   unsigned int seed = 0;
   unsigned int chain = 1;

--- a/src/test/unit/services/optimize/lbfgs_test.cpp
+++ b/src/test/unit/services/optimize/lbfgs_test.cpp
@@ -5,13 +5,6 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
-struct mock_callback : public stan::callbacks::interrupt {
-  int n;
-  mock_callback() : n(0) {}
-
-  void operator()() { n++; }
-};
-
 class values : public stan::callbacks::stream_writer {
  public:
   std::vector<std::string> names_;
@@ -56,11 +49,11 @@ TEST_F(ServicesOptimizeLbfgs, rosenbrock) {
 
   bool save_iterations = true;
   int refresh = 0;
-  mock_callback callback;
+  stan::test::unit::instrumented_interrupt interrupt;
 
   int return_code = stan::services::optimize::lbfgs(
       model, context, seed, chain, init_radius, 5, 0.001, 1e-12, 10000, 1e-8,
-      10000000, 1e-8, 2000, save_iterations, refresh, callback, logger, init,
+      10000000, 1e-8, 2000, save_iterations, refresh, interrupt, logger, init,
       parameter);
 
   EXPECT_EQ(logger.call_count(), logger.call_count_info())
@@ -87,5 +80,5 @@ TEST_F(ServicesOptimizeLbfgs, rosenbrock) {
   EXPECT_FLOAT_EQ(0.99996597, parameter.states_.back()[2])
       << "optimal value should be (1, 1)";
   EXPECT_FLOAT_EQ(return_code, 0);
-  EXPECT_EQ(22, callback.n);
+  EXPECT_EQ(22, interrupt.call_count());
 }

--- a/src/test/unit/services/optimize/newton_jacobian_test.cpp
+++ b/src/test/unit/services/optimize/newton_jacobian_test.cpp
@@ -1,0 +1,51 @@
+#include <stan/services/optimize/newton.hpp>
+#include <gtest/gtest.h>
+#include <stan/io/empty_var_context.hpp>
+#include <test/test-models/good/optimization/simple_jacobian.hpp>
+#include <test/unit/services/instrumented_callbacks.hpp>
+#include <stan/callbacks/stream_writer.hpp>
+
+
+TEST_F(ServicesOptimize, withJacobian) {
+  unsigned int seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+
+  int num_iterations = 1000;
+  bool save_iterations = true;
+  stan::test::unit::instrumented_interrupt interrupt;
+
+  int return_code = stan::services::optimize::newton<stan_model, true>(
+      model, context, seed, chain, init_radius, num_iterations, save_iterations,
+      interrupt, logger, init, parameter);
+
+  EXPECT_FLOAT_EQ(return_code, 0);
+
+  ASSERT_EQ(2, parameter.names_.size());
+  EXPECT_EQ("lp__", parameter.names_[0]);
+  EXPECT_EQ("sigma", parameter.names_[1]);
+  EXPECT_NEAR((3 + std::sqrt(13)) / 2, parameter.states_.back()[1], 0.001);
+  EXPECT_GT(interrupt.call_count(), 0);
+}
+
+TEST_F(ServicesOptimize, withoutJacobian) {
+  unsigned int seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+
+  int num_iterations = 1000;
+  bool save_iterations = true;
+  stan::test::unit::instrumented_interrupt interrupt;
+
+  int return_code = stan::services::optimize::newton<stan_model, false>(
+      model, context, seed, chain, init_radius, num_iterations, save_iterations,
+      interrupt, logger, init, parameter);
+
+  EXPECT_FLOAT_EQ(return_code, 0);
+
+  ASSERT_EQ(2, parameter.names_.size());
+  EXPECT_EQ("lp__", parameter.names_[0]);
+  EXPECT_EQ("sigma", parameter.names_[1]);
+  EXPECT_NEAR(3, parameter.states_.back()[1], 0.001);
+  EXPECT_GT(interrupt.call_count(), 0);
+}

--- a/src/test/unit/services/optimize/newton_jacobian_test.cpp
+++ b/src/test/unit/services/optimize/newton_jacobian_test.cpp
@@ -5,6 +5,17 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
+struct ServicesOptimize : public testing::Test {
+  ServicesOptimize()
+      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
+
+  std::stringstream init_ss, parameter_ss, model_ss;
+  stan::test::unit::instrumented_logger logger;
+  stan::callbacks::stream_writer init;
+  stan::test::unit::values_writer parameter;
+  stan::io::empty_var_context context;
+  stan_model model;
+};
 
 TEST_F(ServicesOptimize, withJacobian) {
   unsigned int seed = 0;

--- a/src/test/unit/services/optimize/newton_test.cpp
+++ b/src/test/unit/services/optimize/newton_test.cpp
@@ -5,44 +5,8 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
-class values : public stan::callbacks::stream_writer {
- public:
-  std::vector<std::string> names_;
-  std::vector<std::vector<double> > states_;
 
-  values(std::ostream& stream) : stan::callbacks::stream_writer(stream) {}
-
-  /**
-   * Writes a set of names.
-   *
-   * @param[in] names Names in a std::vector
-   */
-  void operator()(const std::vector<std::string>& names) { names_ = names; }
-
-  /**
-   * Writes a set of values.
-   *
-   * @param[in] state Values in a std::vector
-   */
-  void operator()(const std::vector<double>& state) {
-    states_.push_back(state);
-  }
-};
-
-class ServicesOptimizeNewton : public testing::Test {
- public:
-  ServicesOptimizeNewton()
-      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
-
-  std::stringstream init_ss, parameter_ss, model_ss;
-  stan::test::unit::instrumented_logger logger;
-  stan::callbacks::stream_writer init;
-  values parameter;
-  stan::io::empty_var_context context;
-  stan_model model;
-};
-
-TEST_F(ServicesOptimizeNewton, rosenbrock) {
+TEST_F(ServicesOptimize, rosenbrock) {
   unsigned int seed = 0;
   unsigned int chain = 1;
   double init_radius = 0;
@@ -79,7 +43,7 @@ TEST_F(ServicesOptimizeNewton, rosenbrock) {
   EXPECT_LT(0, interrupt.call_count());
 }
 
-TEST_F(ServicesOptimizeNewton, rosenbrock_no_save_iterations) {
+TEST_F(ServicesOptimize, rosenbrock_no_save_iterations) {
   unsigned int seed = 0;
   unsigned int chain = 1;
   double init_radius = 0;

--- a/src/test/unit/services/optimize/newton_test.cpp
+++ b/src/test/unit/services/optimize/newton_test.cpp
@@ -5,6 +5,17 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
+struct ServicesOptimize : public testing::Test {
+  ServicesOptimize()
+      : init(init_ss), parameter(parameter_ss), model(context, 0, &model_ss) {}
+
+  std::stringstream init_ss, parameter_ss, model_ss;
+  stan::test::unit::instrumented_logger logger;
+  stan::callbacks::stream_writer init;
+  stan::test::unit::values_writer parameter;
+  stan::io::empty_var_context context;
+  stan_model model;
+};
 
 TEST_F(ServicesOptimize, rosenbrock) {
   unsigned int seed = 0;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint` [can't figure out how to do this as it hardcodes `python` and I need to use `python3` on Mac OS X and it doesn't seem to take aliases or a specification of `PYTHON2` environment variable]
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add a template parameter to all optimization functions (Newton, BFGS, L-BFGS) to indicate whether or not to include Jacobian adjustments.  Until now, we had hard coded turning the Jacobian off to provide maximum likelihood estimates.  With the Jacobian turned on, we will now support an option for max a posteriori (MAP) estimates.

#### Intended Effect

Use MAP estimates in Laplace approximation.

#### How to Verify

Unit tests with a new model with the Jacobian calculated and optimized explicitly.

#### Side Effects

Shouldn't be any because I made it the last argument and gave it a default of `false` so that it falls back on existing behavior.

#### Documentation

Yes, in code.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
