### PR TITLE
Pinned GH Actions to use ubuntu-20.04

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: [3.8]
       fail-fast: false
     steps:
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: [3.8]
       fail-fast: false
     steps:


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Pinned GH Actions to use ubuntu-20.04 instead of ubuntu-latest which now points to ubuntu-22.04.
For more information please see: https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/

#### Intended Effect

Fix following error: https://github.com/stan-dev/stan/actions/runs/3707225050/jobs/6283381831

#### How to Verify

Pipeline should pass

#### Side Effects

None

#### Documentation

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Toptal

