### PR TITLE
Allow providing external dependencies

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,8 +14,17 @@ help:
 -include $(HOME)/.config/stan/make.local  # user-defined variables
 -include make/local                       # user-defined variables
 
-MATH ?= lib/stan_math/
-RAPIDJSON ?= lib/rapidjson_1.1.0/
+ifdef MATH_INC
+  MATH ?= $(MATH_INC)
+else
+  MATH ?= lib/stan_math/
+endif
+
+ifdef RAPIDJSON_INC
+  RAPIDJSON ?= $(RAPIDJSON_INC)
+else
+  RAPIDJSON ?= lib/rapidjson_1.1.0/
+endif
 
 -include $(MATH)make/compiler_flags
 -include $(MATH)make/dependencies


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR follows the work in the [Math library](https://github.com/stan-dev/math/pull/2834) to allow users to provide external dependencies for Stan (instead of the bundled `rapidjson` and `stan_math`).

The PR introduces the following makeflags:

- `MATH_INC`
- `RAPIDJSON_INC`

Which can be used to provide paths to external dependencies

#### Intended Effect

Allow for increased portability and future options for packaging with [homebrew](https://github.com/stan-dev/math/issues/2723) and [linux repos](https://github.com/stan-dev/math/pull/2834#issuecomment-1344112159)

#### How to Verify

##### Install `rapidjson`: 

###### Homebrew

```
brew install rapidjson
```

###### Debian/Ubuntu

```
sudo apt install rapidjson-dev
```

#####

Add to `make/local`: 

###### Homebrew
```
RAPIDJSON_INC = /opt/homebrew/Cellar/rapidjson/1.1.0/include
```

###### Debian/Ubuntu
```
RAPIDJSON_INC = /usr/include/
```

#### Side Effects

N/A

#### Documentation

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
