### PR TITLE
Skip m1 label when building on osx.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,7 +296,7 @@ pipeline {
                     post { always { deleteDir() } }
                 }
                 stage('Mac Unit') {
-                agent { label 'osx' }
+                agent { label 'osx && !m1' }
                     when {
                         expression {
                             ( env.BRANCH_NAME == "develop" ||
@@ -386,7 +386,7 @@ pipeline {
                     post { always { deleteDir() } }
                 }
                 stage('Integration Mac') {
-                    agent { label 'osx' }
+                    agent { label 'osx && !m1' }
                     when {
                         expression {
                             ( env.BRANCH_NAME == "develop" ||


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary

Flatiron Jenkins has added a new Mac M1 machine, it has the same osx label as we were requesting before so the pipeline started using that also when available, which might have caused some extra warnings ( above the quality gate ) and some errors in a PR.
This PR will ensure we are using the non-m1 osx machine, at least until we will properly test it and ensure everything is working fine.
Many thanks to @WardBrian for figuring this out quickly.

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Toptal



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
