### PR TITLE
Always discard at least 1 entry in new RNGs

### DIFF
--- a/src/stan/services/util/create_rng.hpp
+++ b/src/stan/services/util/create_rng.hpp
@@ -26,7 +26,9 @@ inline boost::ecuyer1988 create_rng(unsigned int seed, unsigned int chain) {
   using boost::uintmax_t;
   static constexpr uintmax_t DISCARD_STRIDE = static_cast<uintmax_t>(1) << 50;
   boost::ecuyer1988 rng(seed);
-  rng.discard(DISCARD_STRIDE * chain);
+  // always discard at least 1 to avoid issue with small seeds for certain RNG
+  // distributions. See stan#3167 and boostorg/random#92
+  rng.discard(std::max(static_cast<uintmax_t>(1), DISCARD_STRIDE * chain));
   return rng;
 }
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This makes it so at least 1 entry is discarded from new RNG instances, even when `chain == 0`

#### Intended Effect

Closes #3167 

#### How to Verify

See https://godbolt.org/z/G953v67c4 and the model/code provided in #3167

#### Side Effects

RNG seeds from previous versions of Stan will have different behavior for chain_id 0 and in the transformed data block. Users who did not use `_rng` functions in transformed data or manually set their chain id to 0 will not observe different behavior.

#### Documentation

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
