### PR TITLE
Relax requirements for 0-sized data objects in JSON

### DIFF
--- a/src/stan/io/json/json_data.hpp
+++ b/src/stan/io/json/json_data.hpp
@@ -243,32 +243,17 @@ class json_data : public stan::io::var_context {
   void validate_dims(const std::string &stage, const std::string &name,
                      const std::string &base_type,
                      const std::vector<size_t> &dims_declared) const {
-    bool is_int_type = base_type == "int";
-    if (is_int_type) {
-      if (!contains_i(name)) {
-        std::stringstream msg;
-        msg << (contains_r(name) ? "int variable contained non-int values"
-                                 : "variable does not exist")
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; base type=" << base_type;
-        throw std::runtime_error(msg.str());
-      }
-    } else {
-      if (!contains_r(name)) {
-        std::stringstream msg;
-        msg << "variable does not exist"
-            << "; processing stage=" << stage << "; variable name=" << name
-            << "; base type=" << base_type;
-        throw std::runtime_error(msg.str());
-      }
-    }
-
     std::vector<size_t> dims = dims_r(name);
 
     // JSON '[ ]' is ambiguous - any multi-dim variable with len 0 dim
     size_t num_elements = 1;
-    for (size_t i = 0; i < dims.size(); ++i) {
-      num_elements *= dims[i];
+    if (dims.size() == 0) {
+      // treat non-existent variables as size-0 objects
+      num_elements = 0;
+    } else {
+      for (size_t i = 0; i < dims.size(); ++i) {
+        num_elements *= dims[i];
+      }
     }
 
     size_t num_elements_expected = 1;
@@ -298,6 +283,26 @@ class json_data : public stan::io::var_context {
         dims_msg(msg, dims_declared);
         msg << "; dims found=";
         dims_msg(msg, dims);
+        throw std::runtime_error(msg.str());
+      }
+    }
+
+    bool is_int_type = base_type == "int";
+    if (is_int_type) {
+      if (!contains_i(name)) {
+        std::stringstream msg;
+        msg << (contains_r(name) ? "int variable contained non-int values"
+                                 : "variable does not exist")
+            << "; processing stage=" << stage << "; variable name=" << name
+            << "; base type=" << base_type;
+        throw std::runtime_error(msg.str());
+      }
+    } else {
+      if (!contains_r(name)) {
+        std::stringstream msg;
+        msg << "variable does not exist"
+            << "; processing stage=" << stage << "; variable name=" << name
+            << "; base type=" << base_type;
         throw std::runtime_error(msg.str());
       }
     }

--- a/src/test/unit/io/json/json_data_test.cpp
+++ b/src/test/unit/io/json/json_data_test.cpp
@@ -315,11 +315,9 @@ TEST(ioJson, jsonData_empty_2D_array_0_0) {
   expected_dims.push_back(0);
   expected_dims.push_back(0);
   test_empty_int_arr(jdata, "foo", expected_vals_i);
-  try {
-    jdata.validate_dims("test", "foo", "int", expected_dims);
-  } catch (const std::exception &e) {
-    FAIL();
-  }
+  EXPECT_NO_THROW(jdata.validate_dims("test", "foo", "int", expected_dims));
+  EXPECT_NO_THROW(jdata.validate_dims("test", "foo.2", "double", expected_dims));
+
 }
 
 TEST(ioJson, jsonData_x_3d_y_2d_z_0d) {
@@ -352,6 +350,12 @@ TEST(ioJson, jsonData_parse_empty_obj) {
   EXPECT_EQ(0U, var_names.size());
   jdata.names_i(var_names);
   EXPECT_EQ(0U, var_names.size());
+
+  EXPECT_THROW(
+      jdata.validate_dims("testing", "should_not_exist", "double", {3, 2}),
+      std::runtime_error);
+  EXPECT_NO_THROW(
+      jdata.validate_dims("testing", "zero_dims", "double", {3, 0, 2}));
 }
 
 // R: strings "NaN", "Inf", "-Inf"

--- a/src/test/unit/io/json/json_data_test.cpp
+++ b/src/test/unit/io/json/json_data_test.cpp
@@ -316,8 +316,8 @@ TEST(ioJson, jsonData_empty_2D_array_0_0) {
   expected_dims.push_back(0);
   test_empty_int_arr(jdata, "foo", expected_vals_i);
   EXPECT_NO_THROW(jdata.validate_dims("test", "foo", "int", expected_dims));
-  EXPECT_NO_THROW(jdata.validate_dims("test", "foo.2", "double", expected_dims));
-
+  EXPECT_NO_THROW(
+      jdata.validate_dims("test", "foo.2", "double", expected_dims));
 }
 
 TEST(ioJson, jsonData_x_3d_y_2d_z_0d) {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Follow on to #3165, this allows for any variable name to be "validated" if the expected size is `0`. 


#### Intended Effect

This is necessary because 

` { "foo" : [] }`

is a valid JSON for `array[0] tuple(real, real) foo`, but the Stan compiler will request information on `"foo.1"` and `"foo.2"` which don't exist.

#### How to Verify

Tests were added

#### Side Effects

If an object has a 0 dimension (e.g. is size 0), then it is technically no longer required to be in the JSON at all. E.g., for `matrix[0, 3] bar`, valid JSONs are now ` { "bar" : [] }`, `{ "bar" : [[]] }`, **and** simply `{ }`

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
