### PR TITLE
Standalone GQ: Output NaNs when exception is caught

### DIFF
--- a/src/stan/services/util/gq_writer.hpp
+++ b/src/stan/services/util/gq_writer.hpp
@@ -81,7 +81,6 @@ class gq_writer {
       if (ss.str().length() > 0)
         logger_.info(ss);
       logger_.info(e.what());
-      return;
     }
     if (ss.str().length() > 0)
       logger_.info(ss);

--- a/src/stan/services/util/gq_writer.hpp
+++ b/src/stan/services/util/gq_writer.hpp
@@ -77,13 +77,13 @@ class gq_writer {
     try {
       model.write_array(rng, const_cast<std::vector<double>&>(draw), params_i,
                         values, false, true, &ss);
+      if (ss.str().length() > 0)
+        logger_.info(ss);
     } catch (const std::exception& e) {
       if (ss.str().length() > 0)
         logger_.info(ss);
       logger_.info(e.what());
     }
-    if (ss.str().length() > 0)
-      logger_.info(ss);
 
     std::vector<double> gq_values(values.begin() + num_constrained_params_,
                                   values.end());

--- a/src/test/test-models/good/services/test_gq.stan
+++ b/src/test/test-models/good/services/test_gq.stan
@@ -16,5 +16,9 @@ generated quantities {
   vector[2] y_rep;
   y_rep[1] = normal_rng(y[1], 1);
   y_rep[2] = normal_rng(y[2], 1);
+  // trigger exception/nan behavior
+  if (y[2]>5)
+    reject("exception in GQ");
+  real x2gq = 0.3;
 }
 

--- a/src/test/unit/services/util/gq_writer_test.cpp
+++ b/src/test/unit/services/util/gq_writer_test.cpp
@@ -27,6 +27,7 @@ TEST_F(ServicesUtilGQWriter, t1) {
   // model test_gq.stan gen quantities block has 3 params:  xqg, y_rep.1,
   // y_rep.2
   EXPECT_EQ(count_matches("xgq", sample_ss.str()), 1);
+  EXPECT_EQ(count_matches("x2gq", sample_ss.str()), 1);
   EXPECT_EQ(count_matches("y_rep", sample_ss.str()), 2);
 }
 
@@ -40,6 +41,23 @@ TEST_F(ServicesUtilGQWriter, t2) {
   draw.push_back(-6.789);
   stan::services::util::gq_writer writer(sample_writer, logger, 2);
   writer.write_gq_values(model, rng1, draw);
-  // model test_gq.stan generates 3 values, 2 commas
-  EXPECT_EQ(count_matches(",", sample_ss.str()), 2);
+  // model test_gq.stan generates 4 values, 3 commas
+  EXPECT_EQ(count_matches(",", sample_ss.str()), 3);
+  EXPECT_EQ(count_matches("nan", sample_ss.str()), 0);
+}
+
+TEST_F(ServicesUtilGQWriter, TestExceptions) {
+  stan::callbacks::stream_writer sample_writer(sample_ss, "");
+  stan::callbacks::stream_logger logger(logger_ss, logger_ss, logger_ss,
+                                        logger_ss, logger_ss);
+  boost::ecuyer1988 rng1 = stan::services::util::create_rng(0, 1);
+  std::vector<double> draw;
+  draw.push_back(2.345);
+  draw.push_back(6.789);
+  stan::services::util::gq_writer writer(sample_writer, logger, 2);
+  writer.write_gq_values(model, rng1, draw);
+  // model test_gq.stan generates 4 values, 3 commas
+  EXPECT_EQ(count_matches(",", sample_ss.str()), 3);
+
+  EXPECT_EQ(count_matches("nan", sample_ss.str()), 4);
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes https://github.com/stan-dev/cmdstan/issues/1007. Since https://github.com/stan-dev/stanc3/pull/1165 we have made sure that `write_array` always populates the array with NaNs, so writing it out is safe even after an exception. 

#### Intended Effect

Standalone generate quantities behavior now matches that of sampling (nans output if write_array fails) and the number of rows in the output of standalone generated quantities is now always the number of rows in the input `fitted_params`.

#### How to Verify

The example from https://github.com/stan-dev/cmdstan/issues/1007 works well

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
