### PR TITLE
Clean up dimension and name logic in random_var_context

### DIFF
--- a/src/stan/io/random_var_context.hpp
+++ b/src/stan/io/random_var_context.hpp
@@ -43,25 +43,8 @@ class random_var_context : public var_context {
   random_var_context(Model& model, RNG& rng, double init_radius, bool init_zero)
       : unconstrained_params_(model.num_params_r()) {
     size_t num_unconstrained_ = model.num_params_r();
-    model.get_param_names(names_);
-    model.get_dims(dims_);
-
-    // cutting names_ and dims_ down to just the constrained parameters
-    std::vector<std::string> constrained_params_names;
-    model.constrained_param_names(constrained_params_names, false, false);
-    size_t keep = constrained_params_names.size();
-    size_t i = 0;
-    size_t num = 0;
-    for (i = 0; i < dims_.size(); ++i) {
-      size_t size = 1;
-      for (size_t n = 0; n < dims_[i].size(); ++n)
-        size *= dims_[i][n];
-      num += size;
-      if (num > keep)
-        break;
-    }
-    dims_.erase(dims_.begin() + i, dims_.end());
-    names_.erase(names_.begin() + i, names_.end());
+    model.get_param_names(names_, false, false);
+    model.get_dims(dims_, false, false);
 
     if (init_zero) {
       for (size_t n = 0; n < num_unconstrained_; ++n)

--- a/src/test/unit/io/random_var_context_test.cpp
+++ b/src/test/unit/io/random_var_context_test.cpp
@@ -42,7 +42,8 @@ class mock_throwing_model_in_write_array : public stan::model::prob_grad {
     }
   }
 
-  void get_dims(std::vector<std::vector<size_t> >& dimss__) const {
+  void get_dims(std::vector<std::vector<size_t> >& dimss__,
+                bool include_tparams = true, bool include_gqs = true) const {
     dimss__.resize(0);
     std::vector<size_t> scalar_dim;
     dimss__.push_back(scalar_dim);
@@ -54,7 +55,9 @@ class mock_throwing_model_in_write_array : public stan::model::prob_grad {
     param_names__.push_back("theta");
   }
 
-  void get_param_names(std::vector<std::string>& names) const {
+  void get_param_names(std::vector<std::string>& names,
+                       bool include_tparams = true,
+                       bool include_gqs = true) const {
     constrained_param_names(names);
   }
 
@@ -104,6 +107,8 @@ class random_var_context : public testing::Test {
 TEST_F(random_var_context, contains_r) {
   stan::io::random_var_context context(model, rng, 2, false);
   EXPECT_FALSE(context.contains_r(""));
+  EXPECT_FALSE(context.contains_r("z"));    // transformed parameter
+  EXPECT_FALSE(context.contains_r("xgq"));  // generated quantity
   EXPECT_TRUE(context.contains_r("y"));
 }
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This uses the new arguments from https://github.com/stan-dev/stan/pull/3139 to avoid doing some extra work in `random_var_context`.

#### Intended Effect

The same behavior as before, with less code.

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
