### PR TITLE
Laplace sampling: change output columns for consistency

### DIFF
--- a/src/stan/services/optimize/laplace_sample.hpp
+++ b/src/stan/services/optimize/laplace_sample.hpp
@@ -43,11 +43,11 @@ void laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
 
   // write names of params, tps, and gqs to sample writer
   std::vector<std::string> names;
+  names.push_back("log_p__");
+  names.push_back("log_q__");
   static const bool include_tp = true;
   static const bool include_gq = true;
   model.constrained_param_names(names, include_tp, include_gq);
-  names.push_back("log_p");
-  names.push_back("log_q");
   sample_writer(names);
 
   // create log density functor for vars and vals
@@ -110,10 +110,10 @@ void laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
     // output draw, log_p, log_q
     std::vector<double> draw(&draw_vec(0), &draw_vec(0) + draw_size);
     double log_p = log_density_fun(unc_draw).val();
-    draw.push_back(log_p);
+    draw.insert(draw.begin(), log_p);
     Eigen::VectorXd diff = unc_draw - theta_hat;
     double log_q = diff.transpose() * half_hessian * diff;
-    draw.push_back(log_q);
+    draw.insert(draw.begin() + 1, log_q);
     sample_writer(draw);
   }
 }  // namespace internal

--- a/src/test/unit/services/optimize/laplace_jacobian_test.cpp
+++ b/src/test/unit/services/optimize/laplace_jacobian_test.cpp
@@ -57,19 +57,19 @@ TEST_F(ServicesLaplaceJacobian, laplace_jacobian_adjust) {
       = stan::io::stan_csv_reader::parse(sample2_ss, &out);
 
   EXPECT_EQ(3, draws1.header.size());
-  EXPECT_EQ("sigma", draws1.header[0]);
-  EXPECT_EQ("log_p", draws1.header[1]);
-  EXPECT_EQ("log_q", draws1.header[2]);
+  EXPECT_EQ("log_p__", draws1.header[0]);
+  EXPECT_EQ("log_q__", draws1.header[1]);
+  EXPECT_EQ("sigma", draws1.header[2]);
 
   EXPECT_EQ(3, draws2.header.size());
-  EXPECT_EQ("sigma", draws2.header[0]);
-  EXPECT_EQ("log_p", draws2.header[1]);
-  EXPECT_EQ("log_q", draws2.header[2]);
+  EXPECT_EQ("log_p__", draws2.header[0]);
+  EXPECT_EQ("log_q__", draws2.header[1]);
+  EXPECT_EQ("sigma", draws2.header[2]);
 
   Eigen::MatrixXd sample1 = draws1.samples;
   Eigen::MatrixXd sample2 = draws2.samples;
 
-  EXPECT_EQ(sample1.coeff(0, 0), sample2.coeff(0, 0));
-  EXPECT_NE(sample1.coeff(0, 1), sample2.coeff(0, 1));
+  EXPECT_NE(sample1.coeff(0, 0), sample2.coeff(0, 0));
+  EXPECT_EQ(sample1.coeff(0, 1), sample2.coeff(0, 1));
   EXPECT_EQ(sample1.coeff(0, 2), sample2.coeff(0, 2));
 }

--- a/src/test/unit/services/optimize/laplace_sample_test.cpp
+++ b/src/test/unit/services/optimize/laplace_sample_test.cpp
@@ -44,30 +44,32 @@ TEST_F(ServicesLaplaceSample, values) {
       sample_writer);
   EXPECT_EQ(stan::services::error_codes::OK, return_code);
   std::string samples_str = sample_ss.str();
+  EXPECT_EQ(1, count_matches("log_p__", samples_str));
+  EXPECT_EQ(1, count_matches("log_q__", samples_str));
   EXPECT_EQ(2, count_matches("y", samples_str));
   EXPECT_EQ(1, count_matches("y.1", samples_str));
   EXPECT_EQ(1, count_matches("y.2", samples_str));
-  EXPECT_EQ(1, count_matches("log_p", samples_str));
-  EXPECT_EQ(1, count_matches("log_q", samples_str));
 
   std::stringstream out;
   stan::io::stan_csv draws_csv
       = stan::io::stan_csv_reader::parse(sample_ss, &out);
 
   EXPECT_EQ(4, draws_csv.header.size());
-  EXPECT_EQ("y[1]", draws_csv.header[0]);
-  EXPECT_EQ("y[2]", draws_csv.header[1]);
-  EXPECT_EQ("log_p", draws_csv.header[2]);
-  EXPECT_EQ("log_q", draws_csv.header[3]);
+  EXPECT_EQ("log_p__", draws_csv.header[0]);
+  EXPECT_EQ("log_q__", draws_csv.header[1]);
+  EXPECT_EQ("y[1]", draws_csv.header[2]);
+  EXPECT_EQ("y[2]", draws_csv.header[3]);
+
 
   Eigen::MatrixXd sample = draws_csv.samples;
   EXPECT_EQ(4, sample.cols());
   EXPECT_EQ(draws, sample.rows());
-  Eigen::VectorXd y1 = sample.col(0);
-  Eigen::VectorXd y2 = sample.col(1);
-  Eigen::VectorXd log_p = sample.col(2);
-  Eigen::VectorXd log_q = sample.col(2);
 
+  Eigen::VectorXd log_p = sample.col(0);
+  Eigen::VectorXd log_q = sample.col(1);
+  Eigen::VectorXd y1 = sample.col(2);
+  Eigen::VectorXd y2 = sample.col(3);
+  
   // because target is normal, laplace approx is exact
   for (int m = 0; m < draws; ++m) {
     EXPECT_FLOAT_EQ(0, log_p(m) - log_q(m));

--- a/src/test/unit/services/optimize/laplace_sample_test.cpp
+++ b/src/test/unit/services/optimize/laplace_sample_test.cpp
@@ -60,7 +60,6 @@ TEST_F(ServicesLaplaceSample, values) {
   EXPECT_EQ("y[1]", draws_csv.header[2]);
   EXPECT_EQ("y[2]", draws_csv.header[3]);
 
-
   Eigen::MatrixXd sample = draws_csv.samples;
   EXPECT_EQ(4, sample.cols());
   EXPECT_EQ(draws, sample.rows());
@@ -69,7 +68,7 @@ TEST_F(ServicesLaplaceSample, values) {
   Eigen::VectorXd log_q = sample.col(1);
   Eigen::VectorXd y1 = sample.col(2);
   Eigen::VectorXd y2 = sample.col(3);
-  
+
   // because target is normal, laplace approx is exact
   for (int m = 0; m < draws; ++m) {
     EXPECT_FLOAT_EQ(0, log_p(m) - log_q(m));


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #3183. This changes the names of the `log_p` and `log_q` output columns to `log_p__` and `log_q__`, and moves them to the start to match up with other algorithms.

Unfortunately this was not caught before release, but because cmdstanpy and cmdstanr don't have support for this built-out yet I think we can say that it is a bug fix rather than a breaking change, and release it in 2.32.1 next week (see https://github.com/stan-dev/cmdstan/issues/1154)

I believe the CmdStan implementation also assumes this ordering in its tests, so those may briefly break if we merge this.

#### Documentation

The docs page (https://mc-stan.org/docs/cmdstan-guide/laplace-sampling.html) will need to be updated

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
