### PR TITLE
update colnames for pathfinder multi so that lps are first

### DIFF
--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -96,9 +96,10 @@ inline int pathfinder_lbfgs_multi(
     ParamWriter& parameter_writer, DiagnosticWriter& diagnostic_writer) {
   const auto start_pathfinders_time = std::chrono::steady_clock::now();
   std::vector<std::string> param_names;
-  model.constrained_param_names(param_names, true, true);
   param_names.push_back("lp_approx__");
   param_names.push_back("lp__");
+  model.constrained_param_names(param_names, true, true);
+
   parameter_writer(param_names);
   const size_t num_params = param_names.size();
   tbb::concurrent_vector<Eigen::Array<double, Eigen::Dynamic, 1>>


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary
Fixes CSV names for multi pathfinder so that the lp names are first 

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
