### PR TITLE
Issue/3201 boost lexical cast

### DIFF
--- a/src/stan/callbacks/writer.hpp
+++ b/src/stan/callbacks/writer.hpp
@@ -2,7 +2,6 @@
 #define STAN_CALLBACKS_WRITER_HPP
 
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <boost/lexical_cast.hpp>
 #include <string>
 #include <vector>
 

--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -5,7 +5,6 @@
 #include <stan/io/validate_dims.hpp>
 #include <stan/io/var_context.hpp>
 #include <stan/math/prim.hpp>
-#include <boost/lexical_cast.hpp>
 #include <iostream>
 #include <limits>
 #include <map>
@@ -242,8 +241,8 @@ class dump_reader {
     scan_optional_long();
     size_t d = 0;
     try {
-      d = boost::lexical_cast<size_t>(buf_);
-    } catch (const boost::bad_lexical_cast& exc) {
+      d = std::stoull(buf_);
+    } catch (const std::logic_error &e) {
       std::string msg = "value " + buf_ + " beyond array dimension range";
       throw std::invalid_argument(msg);
     }
@@ -269,8 +268,8 @@ class dump_reader {
   int get_int() {
     int n = 0;
     try {
-      n = boost::lexical_cast<int>(buf_);
-    } catch (const boost::bad_lexical_cast& exc) {
+      n = std::stol(buf_);
+    } catch (const std::logic_error &e) {
       std::string msg = "value " + buf_ + " beyond int range";
       throw std::invalid_argument(msg);
     }
@@ -280,10 +279,10 @@ class dump_reader {
   double scan_double() {
     double x = 0;
     try {
-      x = boost::lexical_cast<double>(buf_);
+      x = std::stod(buf_);
       if (x == 0)
         validate_zero_buf(buf_);
-    } catch (const boost::bad_lexical_cast& exc) {
+    } catch (const std::logic_error &e) {
       std::string msg = "value " + buf_ + " beyond numeric range";
       throw std::invalid_argument(msg);
     }

--- a/src/stan/io/dump.hpp
+++ b/src/stan/io/dump.hpp
@@ -242,7 +242,7 @@ class dump_reader {
     size_t d = 0;
     try {
       d = std::stoull(buf_);
-    } catch (const std::logic_error &e) {
+    } catch (const std::logic_error& e) {
       std::string msg = "value " + buf_ + " beyond array dimension range";
       throw std::invalid_argument(msg);
     }
@@ -269,7 +269,7 @@ class dump_reader {
     int n = 0;
     try {
       n = std::stol(buf_);
-    } catch (const std::logic_error &e) {
+    } catch (const std::logic_error& e) {
       std::string msg = "value " + buf_ + " beyond int range";
       throw std::invalid_argument(msg);
     }
@@ -282,7 +282,7 @@ class dump_reader {
       x = std::stod(buf_);
       if (x == 0)
         validate_zero_buf(buf_);
-    } catch (const std::logic_error &e) {
+    } catch (const std::logic_error& e) {
       std::string msg = "value " + buf_ + " beyond numeric range";
       throw std::invalid_argument(msg);
     }

--- a/src/stan/io/validate_zero_buf.hpp
+++ b/src/stan/io/validate_zero_buf.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_IO_VALIDATE_ZERO_BUF_HPP
 #define STAN_IO_VALIDATE_ZERO_BUF_HPP
 
-#include <boost/lexical_cast/bad_lexical_cast.hpp>
+#include <stdexcept>
 #include <string>
 
 namespace stan {
@@ -14,8 +14,8 @@ namespace io {
  * operator[](size_t)</code>.
  *
  * @tparam B Character buffer type
- * @throw <code>boost::bad_lexical_cast</code> if the buffer
- * contains non-zero characters before an exponentiation symbol.
+ * @throw <code>std::invalid_argument</code> if the buffer
+ * contains non-zero digit before an exponentiation symbol.
  */
 template <typename B>
 void validate_zero_buf(const B& buf) {
@@ -23,7 +23,7 @@ void validate_zero_buf(const B& buf) {
     if (buf[i] == 'e' || buf[i] == 'E')
       return;
     if (buf[i] >= '1' && buf[i] <= '9')
-      boost::conversion::detail::throw_bad_cast<std::string, double>();
+      throw std::invalid_argument("non-zero digit before E");
   }
 }
 

--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/callbacks/writer.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <boost/lexical_cast.hpp>
 #include <string>
 #include <vector>
 

--- a/src/stan/variational/advi.hpp
+++ b/src/stan/variational/advi.hpp
@@ -11,7 +11,6 @@
 #include <stan/variational/families/normal_fullrank.hpp>
 #include <stan/variational/families/normal_meanfield.hpp>
 #include <boost/circular_buffer.hpp>
-#include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include <chrono>
 #include <limits>

--- a/src/test/unit/io/validate_zero_buf_test.cpp
+++ b/src/test/unit/io/validate_zero_buf_test.cpp
@@ -15,8 +15,9 @@ TEST(ioValidateZeroBuf, tester) {
   EXPECT_NO_THROW(validate_zero_buf(s));
 
   s = "1.0";
-  EXPECT_THROW(validate_zero_buf(s), boost::bad_lexical_cast);
+  EXPECT_THROW(validate_zero_buf(s), std::invalid_argument);
 
   s = "1e1";
-  EXPECT_THROW(validate_zero_buf(s), boost::bad_lexical_cast);
+  EXPECT_THROW(validate_zero_buf(s), std::invalid_argument);
+
 }

--- a/src/test/unit/io/validate_zero_buf_test.cpp
+++ b/src/test/unit/io/validate_zero_buf_test.cpp
@@ -19,5 +19,4 @@ TEST(ioValidateZeroBuf, tester) {
 
   s = "1e1";
   EXPECT_THROW(validate_zero_buf(s), std::invalid_argument);
-
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Replace use of `boost::lexical_cast` with `std::strol`, etc, and remove spurious header includes.

#### Intended Effect

Code cleanup.

#### How to Verify

Unit tests.

#### Side Effects

None

#### Documentation

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
