### PR TITLE
Add multi chain for the rest of the hmc nuts samplers

### DIFF
--- a/src/stan/services/sample/hmc_nuts_dense_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e.hpp
@@ -132,6 +132,182 @@ int hmc_nuts_dense_e(Model& model, const stan::io::var_context& init,
                           sample_writer, diagnostic_writer);
 }
 
+/**
+ * Runs multiple chains of NUTS without adaptation using dense Euclidean metric
+ * with a pre-specified Euclidean metric.
+ *
+ * @tparam Model Model class
+ * @tparam InitContextPtr A pointer with underlying type derived from
+ `stan::io::var_context`
+ * @tparam InitInvContextPtr A pointer with underlying type derived from
+ `stan::io::var_context`
+ * @tparam SamplerWriter A type derived from `stan::callbacks::writer`
+ * @tparam DiagnosticWriter A type derived from `stan::callbacks::writer`
+ * @tparam InitWriter A type derived from `stan::callbacks::writer`
+ * @param[in] model Input model to test (with data already instantiated)
+ * @param[in] num_chains The number of chains to run in parallel. `init`,
+ * `init_inv_metric`, `init_writer`, `sample_writer`, and `diagnostic_writer`
+ must
+ * be the same length as this value.
+ * @param[in] init An std vector of init var contexts for initialization of each
+ * chain.
+ * @param[in] init_inv_metric An std vector of var contexts exposing an initial
+ * diagonal inverse Euclidean metric for each chain (must be positive definite)
+ * @param[in] random_seed random seed for the random number generator
+ * @param[in] init_chain_id first chain id. The pseudo random number generator
+ * will advance by for each chain by an integer sequence from `init_chain_id` to
+ * `init_chain_id+num_chains-1`
+ * @param[in] init_radius radius to initialize
+ * @param[in] num_warmup Number of warmup samples
+ * @param[in] num_samples Number of samples
+ * @param[in] num_thin Number to thin the samples
+ * @param[in] save_warmup Indicates whether to save the warmup iterations
+ * @param[in] refresh Controls the output
+ * @param[in] stepsize initial stepsize for discrete evolution
+ * @param[in] stepsize_jitter uniform random jitter of stepsize
+ * @param[in] max_depth Maximum tree depth
+ * @param[in,out] interrupt Callback for interrupts
+ * @param[in,out] logger Logger for messages
+ * @param[in,out] init_writer std vector of Writer callbacks for unconstrained
+ inits of each chain.
+ * @param[in,out] sample_writer std vector of Writers for draws of each chain.
+ * @param[in,out] diagnostic_writer std vector of Writers for diagnostic
+ * information of each chain.
+ * @return error_codes::OK if successful
+ */
+template <class Model, typename InitContextPtr, typename InitInvContextPtr,
+          typename InitWriter, typename SampleWriter, typename DiagnosticWriter>
+int hmc_nuts_dense_e(
+    Model& model, size_t num_chains, const std::vector<InitContextPtr>& init,
+    const std::vector<InitInvContextPtr>& init_inv_metric,
+                     unsigned int random_seed, unsigned int init_chain_id,
+                     double init_radius, int num_warmup, int num_samples,
+                     int num_thin, bool save_warmup, int refresh,
+                     double stepsize, double stepsize_jitter, int max_depth,
+    callbacks::interrupt& interrupt, callbacks::logger& logger,
+    std::vector<InitWriter>& init_writer,
+    std::vector<SampleWriter>& sample_writer,
+    std::vector<DiagnosticWriter>& diagnostic_writer) {
+  if (num_chains == 1) {
+    return hmc_nuts_dense_e(
+        model, *init[0], *init_inv_metric[0], random_seed, init_chain_id,
+        init_radius, num_warmup, num_samples, num_thin, save_warmup, refresh,
+        stepsize, stepsize_jitter, max_depth, interrupt, logger, init_writer[0],
+        sample_writer[0], diagnostic_writer[0]);
+  }
+  std::vector<boost::ecuyer1988> rngs;
+  rngs.reserve(num_chains);
+  std::vector<std::vector<double>> cont_vectors;
+  cont_vectors.reserve(num_chains);
+  using sample_t = stan::mcmc::dense_e_nuts<Model, boost::ecuyer1988>;
+  std::vector<sample_t> samplers;
+  samplers.reserve(num_chains);
+  try {
+    for (int i = 0; i < num_chains; ++i) {
+      rngs.emplace_back(util::create_rng(random_seed, init_chain_id + i));
+      cont_vectors.emplace_back(util::initialize(
+          model, *init[i], rngs[i], init_radius, true, logger, init_writer[i]));
+      Eigen::MatrixXd inv_metric = util::read_dense_inv_metric(
+          *init_inv_metric[i], model.num_params_r(), logger);
+      util::validate_dense_inv_metric(inv_metric, logger);
+
+      samplers.emplace_back(model, rngs[i]);
+      samplers[i].set_metric(inv_metric);
+      samplers[i].set_nominal_stepsize(stepsize);
+      samplers[i].set_stepsize_jitter(stepsize_jitter);
+      samplers[i].set_max_depth(max_depth);
+    }
+  } catch (const std::domain_error& e) {
+    return error_codes::CONFIG;
+  }
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, num_chains, 1),
+      [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
+       init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
+       &sample_writer, &cont_vectors,
+       &diagnostic_writer](const tbb::blocked_range<size_t>& r) {
+        for (size_t i = r.begin(); i != r.end(); ++i) {
+            util::run_sampler(samplers[i], model, cont_vectors[i], num_warmup, num_samples,
+                    num_thin, refresh, save_warmup, rngs[i], interrupt, logger,
+                    sample_writer[i], diagnostic_writer[i], init_chain_id + i);
+        }
+      },
+      tbb::simple_partitioner());
+  return error_codes::OK;
+}
+
+/**
+ * Runs multiple chains of NUTS without adaptation using dense Euclidean metric,
+ * with identity matrix as initial inv_metric.
+ *
+ * @tparam Model Model class
+ * @tparam InitContextPtr A pointer with underlying type derived from
+ * `stan::io::var_context`
+ * @tparam InitWriter A type derived from `stan::callbacks::writer`
+ * @tparam SamplerWriter A type derived from `stan::callbacks::writer`
+ * @tparam DiagnosticWriter A type derived from `stan::callbacks::writer`
+ * @param[in] model Input model to test (with data already instantiated)
+ * @param[in] num_chains The number of chains to run in parallel. `init`,
+ * `init_writer`, `sample_writer`, and `diagnostic_writer` must be the same
+ * length as this value.
+ * @param[in] init An std vector of init var contexts for initialization of each
+ * chain.
+ * @param[in] random_seed random seed for the random number generator
+ * @param[in] init_chain_id first chain id. The pseudo random number generator
+ * will advance by for each chain by an integer sequence from `init_chain_id` to
+ * `init_chain_id+num_chains-1`
+ * @param[in] init_radius radius to initialize
+ * @param[in] num_warmup Number of warmup samples
+ * @param[in] num_samples Number of samples
+ * @param[in] num_thin Number to thin the samples
+ * @param[in] save_warmup Indicates whether to save the warmup iterations
+ * @param[in] refresh Controls the output
+ * @param[in] stepsize initial stepsize for discrete evolution
+ * @param[in] stepsize_jitter uniform random jitter of stepsize
+ * @param[in] max_depth Maximum tree depth
+ * @param[in,out] interrupt Callback for interrupts
+ * @param[in,out] logger Logger for messages
+ * @param[in,out] init_writer std vector of Writer callbacks for unconstrained
+ * inits of each chain.
+ * @param[in,out] sample_writer std vector of Writers for draws of each chain.
+ * @param[in,out] diagnostic_writer std vector of Writers for diagnostic
+ * information of each chain.
+ * @return error_codes::OK if successful
+ */
+template <class Model, typename InitContextPtr, typename InitWriter,
+          typename SampleWriter, typename DiagnosticWriter>
+int hmc_nuts_dense_e(
+    Model& model, size_t num_chains, const std::vector<InitContextPtr>& init,
+                     unsigned int random_seed, unsigned int init_chain_id,
+                     double init_radius, int num_warmup, int num_samples,
+                     int num_thin, bool save_warmup, int refresh,
+                     double stepsize, double stepsize_jitter, int max_depth,
+    callbacks::interrupt& interrupt, callbacks::logger& logger,
+    std::vector<InitWriter>& init_writer,
+    std::vector<SampleWriter>& sample_writer,
+    std::vector<DiagnosticWriter>& diagnostic_writer) {
+  if (num_chains == 1) {
+    return hmc_nuts_dense_e(
+        model, *init[0], random_seed, init_chain_id, init_radius, num_warmup,
+        num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+        max_depth,
+        interrupt, logger, init_writer[0], sample_writer[0],
+        diagnostic_writer[0]);
+  }
+  std::vector<std::unique_ptr<stan::io::dump>> unit_e_metrics;
+  unit_e_metrics.reserve(num_chains);
+  for (size_t i = 0; i < num_chains; ++i) {
+    unit_e_metrics.emplace_back(std::make_unique<stan::io::dump>(
+        util::create_unit_e_dense_inv_metric(model.num_params_r())));
+  }
+  return hmc_nuts_dense_e(
+      model, num_chains, init, unit_e_metrics, random_seed, init_chain_id,
+      init_radius, num_warmup, num_samples, num_thin, save_warmup, refresh,
+      stepsize, stepsize_jitter, max_depth, interrupt, logger, init_writer,
+      sample_writer, diagnostic_writer);
+}
+
+
 }  // namespace sample
 }  // namespace services
 }  // namespace stan

--- a/src/stan/services/sample/hmc_nuts_diag_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e.hpp
@@ -130,6 +130,182 @@ int hmc_nuts_diag_e(Model& model, const stan::io::var_context& init,
                          sample_writer, diagnostic_writer);
 }
 
+
+/**
+ * Runs multiple chains of HMC with NUTS without adaptation using diagonal
+ * Euclidean metric with a pre-specified Euclidean metric.
+ *
+ * @tparam Model Model class
+ * @tparam InitContextPtr A pointer with underlying type derived from
+ `stan::io::var_context`
+ * @tparam InitInvContextPtr A pointer with underlying type derived from
+ `stan::io::var_context`
+ * @tparam SamplerWriter A type derived from `stan::callbacks::writer`
+ * @tparam DiagnosticWriter A type derived from `stan::callbacks::writer`
+ * @tparam InitWriter A type derived from `stan::callbacks::writer`
+ * @param[in] model Input model to test (with data already instantiated)
+ * @param[in] num_chains The number of chains to run in parallel. `init`,
+ * `init_inv_metric`, `init_writer`, `sample_writer`, and `diagnostic_writer`
+ must
+ * be the same length as this value.
+ * @param[in] init An std vector of init var contexts for initialization of each
+ * chain.
+ * @param[in] init_inv_metric An std vector of var contexts exposing an initial
+ * diagonal inverse Euclidean metric for each chain (must be positive definite)
+ * @param[in] random_seed random seed for the random number generator
+ * @param[in] init_chain_id first chain id. The pseudo random number generator
+ * will advance by for each chain by an integer sequence from `init_chain_id` to
+ * `init_chain_id+num_chains-1`
+ * @param[in] init_radius radius to initialize
+ * @param[in] num_warmup Number of warmup samples
+ * @param[in] num_samples Number of samples
+ * @param[in] num_thin Number to thin the samples
+ * @param[in] save_warmup Indicates whether to save the warmup iterations
+ * @param[in] refresh Controls the output
+ * @param[in] stepsize initial stepsize for discrete evolution
+ * @param[in] stepsize_jitter uniform random jitter of stepsize
+ * @param[in] max_depth Maximum tree depth
+ * @param[in,out] interrupt Callback for interrupts
+ * @param[in,out] logger Logger for messages
+ * @param[in,out] init_writer std vector of Writer callbacks for unconstrained
+ inits of each chain.
+ * @param[in,out] sample_writer std vector of Writers for draws of each chain.
+ * @param[in,out] diagnostic_writer std vector of Writers for diagnostic
+ * information of each chain.
+ * @return error_codes::OK if successful
+ */
+template <class Model, typename InitContextPtr, typename InitInvContextPtr,
+          typename InitWriter, typename SampleWriter, typename DiagnosticWriter>
+int hmc_nuts_diag_e(
+    Model& model, size_t num_chains, const std::vector<InitContextPtr>& init,
+    const std::vector<InitInvContextPtr>& init_inv_metric,
+                     unsigned int random_seed, unsigned int init_chain_id,
+                     double init_radius, int num_warmup, int num_samples,
+                     int num_thin, bool save_warmup, int refresh,
+                     double stepsize, double stepsize_jitter, int max_depth,
+    callbacks::interrupt& interrupt, callbacks::logger& logger,
+    std::vector<InitWriter>& init_writer,
+    std::vector<SampleWriter>& sample_writer,
+    std::vector<DiagnosticWriter>& diagnostic_writer) {
+  if (num_chains == 1) {
+    return hmc_nuts_diag_e(
+        model, *init[0], *init_inv_metric[0], random_seed, init_chain_id,
+        init_radius, num_warmup, num_samples, num_thin, save_warmup, refresh,
+        stepsize, stepsize_jitter, max_depth, interrupt, logger, init_writer[0],
+        sample_writer[0], diagnostic_writer[0]);
+  }
+  std::vector<boost::ecuyer1988> rngs;
+  rngs.reserve(num_chains);
+  std::vector<std::vector<double>> cont_vectors;
+  cont_vectors.reserve(num_chains);
+  using sample_t = stan::mcmc::diag_e_nuts<Model, boost::ecuyer1988>;
+  std::vector<sample_t> samplers;
+  samplers.reserve(num_chains);
+  try {
+    for (int i = 0; i < num_chains; ++i) {
+      rngs.emplace_back(util::create_rng(random_seed, init_chain_id + i));
+      cont_vectors.emplace_back(util::initialize(
+          model, *init[i], rngs[i], init_radius, true, logger, init_writer[i]));
+      Eigen::VectorXd inv_metric = util::read_diag_inv_metric(
+          *init_inv_metric[i], model.num_params_r(), logger);
+      util::validate_diag_inv_metric(inv_metric, logger);
+
+      samplers.emplace_back(model, rngs[i]);
+      samplers[i].set_metric(inv_metric);
+      samplers[i].set_nominal_stepsize(stepsize);
+      samplers[i].set_stepsize_jitter(stepsize_jitter);
+      samplers[i].set_max_depth(max_depth);
+    }
+  } catch (const std::domain_error& e) {
+    return error_codes::CONFIG;
+  }
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, num_chains, 1),
+      [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
+       init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
+       &sample_writer, &cont_vectors,
+       &diagnostic_writer](const tbb::blocked_range<size_t>& r) {
+        for (size_t i = r.begin(); i != r.end(); ++i) {
+            util::run_sampler(samplers[i], model, cont_vectors[i], num_warmup, num_samples,
+                    num_thin, refresh, save_warmup, rngs[i], interrupt, logger,
+                    sample_writer[i], diagnostic_writer[i], init_chain_id + i);
+        }
+      },
+      tbb::simple_partitioner());
+  return error_codes::OK;
+}
+
+/**
+ * Runs HMC with NUTS with adaptation using diagonal Euclidean metric.
+ *
+ * @tparam Model Model class
+ * @tparam InitContextPtr A pointer with underlying type derived from
+ * `stan::io::var_context`
+ * @tparam InitWriter A type derived from `stan::callbacks::writer`
+ * @tparam SamplerWriter A type derived from `stan::callbacks::writer`
+ * @tparam DiagnosticWriter A type derived from `stan::callbacks::writer`
+ * @param[in] model Input model to test (with data already instantiated)
+ * @param[in] num_chains The number of chains to run in parallel. `init`,
+ * `init_writer`, `sample_writer`, and `diagnostic_writer` must be the same
+ * length as this value.
+ * @param[in] init An std vector of init var contexts for initialization of each
+ * chain.
+ * @param[in] random_seed random seed for the random number generator
+ * @param[in] init_chain_id first chain id. The pseudo random number generator
+ * will advance by for each chain by an integer sequence from `init_chain_id` to
+ * `init_chain_id+num_chains-1`
+ * @param[in] init_radius radius to initialize
+ * @param[in] num_warmup Number of warmup samples
+ * @param[in] num_samples Number of samples
+ * @param[in] num_thin Number to thin the samples
+ * @param[in] save_warmup Indicates whether to save the warmup iterations
+ * @param[in] refresh Controls the output
+ * @param[in] stepsize initial stepsize for discrete evolution
+ * @param[in] stepsize_jitter uniform random jitter of stepsize
+ * @param[in] max_depth Maximum tree depth
+ * @param[in,out] interrupt Callback for interrupts
+ * @param[in,out] logger Logger for messages
+ * @param[in,out] init_writer std vector of Writer callbacks for unconstrained
+ * inits of each chain.
+ * @param[in,out] sample_writer std vector of Writers for draws of each chain.
+ * @param[in,out] diagnostic_writer std vector of Writers for diagnostic
+ * information of each chain.
+ * @return error_codes::OK if successful
+ */
+template <class Model, typename InitContextPtr, typename InitWriter,
+          typename SampleWriter, typename DiagnosticWriter>
+int hmc_nuts_diag_e(
+    Model& model, size_t num_chains, const std::vector<InitContextPtr>& init,
+                     unsigned int random_seed, unsigned int init_chain_id,
+                     double init_radius, int num_warmup, int num_samples,
+                     int num_thin, bool save_warmup, int refresh,
+                     double stepsize, double stepsize_jitter, int max_depth,
+    callbacks::interrupt& interrupt, callbacks::logger& logger,
+    std::vector<InitWriter>& init_writer,
+    std::vector<SampleWriter>& sample_writer,
+    std::vector<DiagnosticWriter>& diagnostic_writer) {
+  if (num_chains == 1) {
+    return hmc_nuts_diag_e(
+        model, *init[0], random_seed, init_chain_id, init_radius, num_warmup,
+        num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+        max_depth,
+        interrupt, logger, init_writer[0], sample_writer[0],
+        diagnostic_writer[0]);
+  }
+  std::vector<std::unique_ptr<stan::io::dump>> unit_e_metrics;
+  unit_e_metrics.reserve(num_chains);
+  for (size_t i = 0; i < num_chains; ++i) {
+    unit_e_metrics.emplace_back(std::make_unique<stan::io::dump>(
+        util::create_unit_e_diag_inv_metric(model.num_params_r())));
+  }
+  return hmc_nuts_diag_e(
+      model, num_chains, init, unit_e_metrics, random_seed, init_chain_id,
+      init_radius, num_warmup, num_samples, num_thin, save_warmup, refresh,
+      stepsize, stepsize_jitter, max_depth, interrupt, logger, init_writer,
+      sample_writer, diagnostic_writer);
+}
+
+
 }  // namespace sample
 }  // namespace services
 }  // namespace stan

--- a/src/stan/services/sample/hmc_nuts_diag_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e.hpp
@@ -136,26 +136,17 @@ int hmc_nuts_diag_e(Model& model, const stan::io::var_context& init,
  * Euclidean metric with a pre-specified Euclidean metric.
  *
  * @tparam Model Model class
- * @tparam InitContextPtr A pointer with underlying type derived from
- `stan::io::var_context`
- * @tparam InitInvContextPtr A pointer with underlying type derived from
- `stan::io::var_context`
+ * @tparam InitContextPtr A pointer with underlying type derived from `stan::io::var_context`
+ * @tparam InitInvContextPtr A pointer with underlying type derived from `stan::io::var_context`
  * @tparam SamplerWriter A type derived from `stan::callbacks::writer`
  * @tparam DiagnosticWriter A type derived from `stan::callbacks::writer`
  * @tparam InitWriter A type derived from `stan::callbacks::writer`
  * @param[in] model Input model to test (with data already instantiated)
- * @param[in] num_chains The number of chains to run in parallel. `init`,
- * `init_inv_metric`, `init_writer`, `sample_writer`, and `diagnostic_writer`
- must
- * be the same length as this value.
- * @param[in] init An std vector of init var contexts for initialization of each
- * chain.
- * @param[in] init_inv_metric An std vector of var contexts exposing an initial
- * diagonal inverse Euclidean metric for each chain (must be positive definite)
+ * @param[in] num_chains The number of chains to run in parallel. `init`, `init_inv_metric`, `init_writer`, `sample_writer`, and `diagnostic_writer` must be the same length as this value.
+ * @param[in] init An std vector of init var contexts for initialization of each chain.
+ * @param[in] init_inv_metric An std vector of var contexts exposing an initial diagonal inverse Euclidean metric for each chain (must be positive definite)
  * @param[in] random_seed random seed for the random number generator
- * @param[in] init_chain_id first chain id. The pseudo random number generator
- * will advance by for each chain by an integer sequence from `init_chain_id` to
- * `init_chain_id+num_chains-1`
+ * @param[in] init_chain_id first chain id. The pseudo random number generator will advance by for each chain by an integer sequence from `init_chain_id` to init_chain_id+num_chains-1`
  * @param[in] init_radius radius to initialize
  * @param[in] num_warmup Number of warmup samples
  * @param[in] num_samples Number of samples
@@ -167,11 +158,9 @@ int hmc_nuts_diag_e(Model& model, const stan::io::var_context& init,
  * @param[in] max_depth Maximum tree depth
  * @param[in,out] interrupt Callback for interrupts
  * @param[in,out] logger Logger for messages
- * @param[in,out] init_writer std vector of Writer callbacks for unconstrained
- inits of each chain.
+ * @param[in,out] init_writer std vector of Writer callbacks for unconstrained inits of each chain.
  * @param[in,out] sample_writer std vector of Writers for draws of each chain.
- * @param[in,out] diagnostic_writer std vector of Writers for diagnostic
- * information of each chain.
+ * @param[in,out] diagnostic_writer std vector of Writers for diagnostic information of each chain.
  * @return error_codes::OK if successful
  */
 template <class Model, typename InitContextPtr, typename InitInvContextPtr,

--- a/src/stan/services/sample/hmc_nuts_unit_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_unit_e.hpp
@@ -70,14 +70,42 @@ int hmc_nuts_unit_e(Model& model, const stan::io::var_context& init,
   return error_codes::OK;
 }
 
+/**
+ * Runs HMC with NUTS with unit Euclidean metric without adaptation for multiple chains.
+ *
+ * @tparam Model Model class
+ * @tparam InitContextPtr A pointer with underlying type derived from `stan::io::var_context`
+ * @tparam InitWriter A type derived from `stan::callbacks::writer`
+ * @tparam SamplerWriter A type derived from `stan::callbacks::writer`
+ * @tparam DiagnosticWriter A type derived from `stan::callbacks::writer`
+ * @param[in] model Input model to test (with data already instantiated)
+ * @param[in] num_chains The number of chains to run in parallel. `init`, zs`init_inv_metric`, `init_writer`, `sample_writer`, and `diagnostic_writer` must be the same length as this value.
+ * @param[in] init An std vector of init var contexts for initialization of each chain.
+ * @param[in] random_seed random seed for the random number generator
+ * @param[in] init_chain_id first chain id. The pseudo random number generator will advance by for each chain by an integer sequence from `init_chain_id` to init_chain_id+num_chains-1`
+ * @param[in] init_radius radius to initialize
+ * @param[in] num_warmup Number of warmup samples
+ * @param[in] num_samples Number of samples
+ * @param[in] num_thin Number to thin the samples
+ * @param[in] save_warmup Indicates whether to save the warmup iterations
+ * @param[in] refresh Controls the output
+ * @param[in] stepsize initial stepsize for discrete evolution
+ * @param[in] stepsize_jitter uniform random jitter of stepsize
+ * @param[in] max_depth Maximum tree depth
+ * @param[in,out] interrupt Callback for interrupts
+ * @param[in,out] logger Logger for messages
+ * @param[in,out] init_writer std vector of Writer callbacks for unconstrained inits of each chain.
+ * @param[in,out] sample_writer std vector of Writers for draws of each chain.
+ * @param[in,out] diagnostic_writer std vector of Writers for diagnostic information of each chain.
+ * @return error_codes::OK if successful
+ */
 template <class Model, typename InitContextPtr, typename InitWriter,
           typename SampleWriter, typename DiagnosticWriter>
 int hmc_nuts_unit_e(
     Model& model, size_t num_chains, const std::vector<InitContextPtr>& init,
     unsigned int random_seed, unsigned int init_chain_id, double init_radius, int num_warmup, int num_samples,
     int num_thin, bool save_warmup, int refresh, double stepsize,
-    double stepsize_jitter, int max_depth, double delta, double gamma,
-    double kappa, double t0, 
+    double stepsize_jitter, int max_depth, 
     callbacks::interrupt& interrupt, callbacks::logger& logger,
     std::vector<InitWriter>& init_writer,
     std::vector<SampleWriter>& sample_writer,
@@ -86,7 +114,7 @@ int hmc_nuts_unit_e(
     return hmc_nuts_unit_e(
         model, *init[0], random_seed, init_chain_id, init_radius, num_warmup,
         num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
-        max_depth, delta, gamma, kappa, t0, 
+        max_depth,
         interrupt, logger, init_writer[0], sample_writer[0],
         diagnostic_writer[0]);
   }

--- a/src/stan/services/sample/hmc_nuts_unit_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_unit_e_adapt.hpp
@@ -79,6 +79,40 @@ int hmc_nuts_unit_e_adapt(
   return error_codes::OK;
 }
 
+/**
+ * Runs HMC with NUTS with unit Euclidean metric with adaptation for multiple chains.
+ *
+ * @tparam Model Model class
+ * @tparam InitContextPtr A pointer with underlying type derived from `stan::io::var_context`
+ * @tparam InitWriter A type derived from `stan::callbacks::writer`
+ * @tparam SamplerWriter A type derived from `stan::callbacks::writer`
+ * @tparam DiagnosticWriter A type derived from `stan::callbacks::writer`
+ * @param[in] model Input model to test (with data already instantiated)
+ * @param[in] num_chains The number of chains to run in parallel. `init`,
+ * `init_inv_metric`, `init_writer`, `sample_writer`, and `diagnostic_writer` must be the same length as this value.
+ * @param[in] init An std vector of init var contexts for initialization of each chain.
+ * @param[in] random_seed random seed for the random number generator
+ * @param[in] chain chain id to advance the pseudo random number generator
+ * @param[in] init_radius radius to initialize
+ * @param[in] num_warmup Number of warmup samples
+ * @param[in] num_samples Number of samples
+ * @param[in] num_thin Number to thin the samples
+ * @param[in] save_warmup Indicates whether to save the warmup iterations
+ * @param[in] refresh Controls the output
+ * @param[in] stepsize initial stepsize for discrete evolution
+ * @param[in] stepsize_jitter uniform random jitter of stepsize
+ * @param[in] max_depth Maximum tree depth
+ * @param[in] delta adaptation target acceptance statistic
+ * @param[in] gamma adaptation regularization scale
+ * @param[in] kappa adaptation relaxation exponent
+ * @param[in] t0 adaptation iteration offset
+ * @param[in,out] interrupt Callback for interrupts
+ * @param[in,out] logger Logger for messages
+ * @param[in,out] init_writer std vector of Writer callbacks for unconstrained inits of each chain.
+ * @param[in,out] sample_writer std vector of Writers for draws of each chain.
+ * @param[in,out] diagnostic_writer std vector of Writers for diagnostic information of each chain.
+ * @return error_codes::OK if successful
+ */
 template <class Model, typename InitContextPtr, typename InitWriter,
           typename SampleWriter, typename DiagnosticWriter>
 int hmc_nuts_unit_e_adapt(

--- a/src/stan/services/sample/hmc_nuts_unit_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_unit_e_adapt.hpp
@@ -79,6 +79,70 @@ int hmc_nuts_unit_e_adapt(
   return error_codes::OK;
 }
 
+template <class Model, typename InitContextPtr, typename InitWriter,
+          typename SampleWriter, typename DiagnosticWriter>
+int hmc_nuts_unit_e_adapt(
+    Model& model, size_t num_chains, const std::vector<InitContextPtr>& init,
+    unsigned int random_seed, unsigned int init_chain_id, double init_radius, int num_warmup, int num_samples,
+    int num_thin, bool save_warmup, int refresh, double stepsize,
+    double stepsize_jitter, int max_depth, double delta, double gamma,
+    double kappa, double t0, 
+    callbacks::interrupt& interrupt, callbacks::logger& logger,
+    std::vector<InitWriter>& init_writer,
+    std::vector<SampleWriter>& sample_writer,
+    std::vector<DiagnosticWriter>& diagnostic_writer) {
+  if (num_chains == 1) {
+    return hmc_nuts_unit_e_adapt(
+        model, *init[0], random_seed, init_chain_id, init_radius, num_warmup,
+        num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+        max_depth, delta, gamma, kappa, t0, 
+        interrupt, logger, init_writer[0], sample_writer[0],
+        diagnostic_writer[0]);
+  }
+  using sample_t = stan::mcmc::adapt_unit_e_nuts<Model, boost::ecuyer1988>;
+  std::vector<boost::ecuyer1988> rngs;
+  rngs.reserve(num_chains);
+  std::vector<std::vector<double>> cont_vectors;
+  cont_vectors.reserve(num_chains);
+  std::vector<sample_t> samplers;
+  samplers.reserve(num_chains);
+  try {
+    for (int i = 0; i < num_chains; ++i) {
+      rngs.emplace_back(util::create_rng(random_seed, init_chain_id + i));
+      cont_vectors.emplace_back(util::initialize(
+          model, *init[i], rngs[i], init_radius, true, logger, init_writer[i]));
+      samplers.emplace_back(model, rngs[i]);
+
+      samplers[i].set_nominal_stepsize(stepsize);
+      samplers[i].set_stepsize_jitter(stepsize_jitter);
+      samplers[i].set_max_depth(max_depth);
+
+      samplers[i].get_stepsize_adaptation().set_mu(log(10 * stepsize));
+      samplers[i].get_stepsize_adaptation().set_delta(delta);
+      samplers[i].get_stepsize_adaptation().set_gamma(gamma);
+      samplers[i].get_stepsize_adaptation().set_kappa(kappa);
+      samplers[i].get_stepsize_adaptation().set_t0(t0);
+    }
+  } catch (const std::domain_error& e) {
+    return error_codes::CONFIG;
+  }
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, num_chains, 1),
+      [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
+       init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
+       &sample_writer, &cont_vectors,
+       &diagnostic_writer](const tbb::blocked_range<size_t>& r) {
+        for (size_t i = r.begin(); i != r.end(); ++i) {
+          util::run_adaptive_sampler(samplers[i], model, cont_vectors[i],
+           num_warmup, num_samples, num_thin, refresh, save_warmup, 
+           rngs[i], interrupt, logger, sample_writer[i], 
+           diagnostic_writer[i], init_chain_id + i, num_chains);
+        }
+      },
+      tbb::simple_partitioner());
+  return error_codes::OK;
+}
+
 }  // namespace sample
 }  // namespace services
 }  // namespace stan

--- a/src/stan/services/util/run_sampler.hpp
+++ b/src/stan/services/util/run_sampler.hpp
@@ -31,6 +31,9 @@ namespace util {
  * @param[in,out] logger logger for messages
  * @param[in,out] sample_writer writer for draws
  * @param[in,out] diagnostic_writer writer for diagnostic information
+ * @param[in] chain_id The id for a given chain.
+ * @param[in] num_chains The number of chains used in the program. This
+ *  is used in generate transitions to print out the chain number.
  */
 template <class Model, class RNG>
 void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,

--- a/src/stan/services/util/run_sampler.hpp
+++ b/src/stan/services/util/run_sampler.hpp
@@ -38,7 +38,8 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
                  int num_samples, int num_thin, int refresh, bool save_warmup,
                  RNG& rng, callbacks::interrupt& interrupt,
                  callbacks::logger& logger, callbacks::writer& sample_writer,
-                 callbacks::writer& diagnostic_writer) {
+                 callbacks::writer& diagnostic_writer,
+                 size_t chain_id = 1, size_t num_chains = 1) {
   Eigen::Map<Eigen::VectorXd> cont_params(cont_vector.data(),
                                           cont_vector.size());
   services::util::mcmc_writer writer(sample_writer, diagnostic_writer, logger);
@@ -51,7 +52,7 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
   auto start_warm = std::chrono::steady_clock::now();
   util::generate_transitions(sampler, num_warmup, 0, num_warmup + num_samples,
                              num_thin, refresh, save_warmup, true, writer, s,
-                             model, rng, interrupt, logger);
+                             model, rng, interrupt, logger, chain_id, num_chains);
   auto end_warm = std::chrono::steady_clock::now();
   double warm_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(
                             end_warm - start_warm)
@@ -63,7 +64,7 @@ void run_sampler(stan::mcmc::base_mcmc& sampler, Model& model,
   auto start_sample = std::chrono::steady_clock::now();
   util::generate_transitions(sampler, num_samples, num_warmup,
                              num_warmup + num_samples, num_thin, refresh, true,
-                             false, writer, s, model, rng, interrupt, logger);
+                             false, writer, s, model, rng, interrupt, logger, chain_id, num_chains);
   auto end_sample = std::chrono::steady_clock::now();
   double sample_delta_t = std::chrono::duration_cast<std::chrono::milliseconds>(
                               end_sample - start_sample)

--- a/src/test/unit/services/sample/hmc_nuts_dense_e_parallel_test.cpp
+++ b/src/test/unit/services/sample/hmc_nuts_dense_e_parallel_test.cpp
@@ -1,0 +1,175 @@
+#include <stan/services/sample/hmc_nuts_dense_e.hpp>
+#include <gtest/gtest.h>
+#include <stan/io/empty_var_context.hpp>
+#include <test/test-models/good/optimization/rosenbrock.hpp>
+#include <test/unit/services/instrumented_callbacks.hpp>
+#include <iostream>
+
+auto&& blah = stan::math::init_threadpool_tbb();
+
+static constexpr size_t num_chains = 4;
+class ServicesSampleHmcNutsDenseEPar : public testing::Test {
+ public:
+  ServicesSampleHmcNutsDenseEPar() : model(data_context, 0, &model_log) {
+    for (int i = 0; i < num_chains; ++i) {
+      init.push_back(stan::test::unit::instrumented_writer{});
+      parameter.push_back(stan::test::unit::instrumented_writer{});
+      diagnostic.push_back(stan::test::unit::instrumented_writer{});
+      context.push_back(std::make_shared<stan::io::empty_var_context>());
+    }
+  }
+  stan::io::empty_var_context data_context;
+  std::stringstream model_log;
+  stan::test::unit::instrumented_logger logger;
+  std::vector<stan::test::unit::instrumented_writer> init;
+  std::vector<stan::test::unit::instrumented_writer> parameter;
+  std::vector<stan::test::unit::instrumented_writer> diagnostic;
+  std::vector<std::shared_ptr<stan::io::empty_var_context>> context;
+  stan_model model;
+};
+
+TEST_F(ServicesSampleHmcNutsDenseEPar, call_count) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  double delta = .1;
+  double gamma = .1;
+  double kappa = .1;
+  double t0 = .1;
+  unsigned int init_buffer = 50;
+  unsigned int term_buffer = 50;
+  unsigned int window = 100;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  int return_code = stan::services::sample::hmc_nuts_dense_e(
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, 
+      interrupt, logger, init, parameter, diagnostic);
+
+  EXPECT_EQ(0, return_code);
+
+  int num_output_lines = (num_warmup + num_samples) / num_thin;
+  EXPECT_EQ((num_warmup + num_samples) * num_chains, interrupt.call_count());
+  for (int i = 0; i < num_chains; ++i) {
+    EXPECT_EQ(1, parameter[i].call_count("vector_string"));
+    EXPECT_EQ(num_output_lines, parameter[i].call_count("vector_double"));
+    EXPECT_EQ(1, diagnostic[i].call_count("vector_string"));
+    EXPECT_EQ(num_output_lines, diagnostic[i].call_count("vector_double"));
+  }
+}
+
+TEST_F(ServicesSampleHmcNutsDenseEPar, parameter_checks) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  double delta = .1;
+  double gamma = .1;
+  double kappa = .1;
+  double t0 = .1;
+  unsigned int init_buffer = 50;
+  unsigned int term_buffer = 50;
+  unsigned int window = 100;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  int return_code = stan::services::sample::hmc_nuts_dense_e(
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, 
+      interrupt, logger, init, parameter, diagnostic);
+
+  for (size_t i = 0; i < num_chains; ++i) {
+    std::vector<std::vector<std::string>> parameter_names;
+    parameter_names = parameter[i].vector_string_values();
+    std::vector<std::vector<double>> parameter_values;
+    parameter_values = parameter[i].vector_double_values();
+    std::vector<std::vector<std::string>> diagnostic_names;
+    diagnostic_names = diagnostic[i].vector_string_values();
+    std::vector<std::vector<double>> diagnostic_values;
+    diagnostic_values = diagnostic[i].vector_double_values();
+
+    // Expectations of parameter parameter names.
+    ASSERT_EQ(9, parameter_names[0].size());
+    EXPECT_EQ("lp__", parameter_names[0][0]);
+    EXPECT_EQ("accept_stat__", parameter_names[0][1]);
+    EXPECT_EQ("stepsize__", parameter_names[0][2]);
+    EXPECT_EQ("treedepth__", parameter_names[0][3]);
+    EXPECT_EQ("n_leapfrog__", parameter_names[0][4]);
+    EXPECT_EQ("divergent__", parameter_names[0][5]);
+    EXPECT_EQ("energy__", parameter_names[0][6]);
+    EXPECT_EQ("x", parameter_names[0][7]);
+    EXPECT_EQ("y", parameter_names[0][8]);
+
+    // Expect one name per parameter value.
+    EXPECT_EQ(parameter_names[0].size(), parameter_values[0].size());
+    EXPECT_EQ(diagnostic_names[0].size(), diagnostic_values[0].size());
+
+    EXPECT_EQ((num_warmup + num_samples) / num_thin, parameter_values.size());
+
+    // Expect one call to set parameter names, and one set of output per
+    // iteration.
+    EXPECT_EQ("lp__", diagnostic_names[0][0]);
+    EXPECT_EQ("accept_stat__", diagnostic_names[0][1]);
+  }
+  EXPECT_EQ(return_code, 0);
+}
+
+TEST_F(ServicesSampleHmcNutsDenseEPar, output_regression) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  double delta = .1;
+  double gamma = .1;
+  double kappa = .1;
+  double t0 = .1;
+  unsigned int init_buffer = 50;
+  unsigned int term_buffer = 50;
+  unsigned int window = 100;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  stan::services::sample::hmc_nuts_dense_e(
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, 
+      interrupt, logger, init, parameter, diagnostic);
+
+  for (auto&& init_it : init) {
+    std::vector<std::string> init_values;
+    init_values = init_it.string_values();
+
+    EXPECT_EQ(0, init_values.size());
+  }
+
+  EXPECT_EQ(num_chains, logger.find_info("Elapsed Time:"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Warm-up)"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Sampling)"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Total)"));
+  EXPECT_EQ(0, logger.call_count_error());
+}

--- a/src/test/unit/services/sample/hmc_nuts_diag_e_parallel_test.cpp
+++ b/src/test/unit/services/sample/hmc_nuts_diag_e_parallel_test.cpp
@@ -1,0 +1,151 @@
+#include <stan/services/sample/hmc_nuts_diag_e.hpp>
+#include <gtest/gtest.h>
+#include <stan/io/empty_var_context.hpp>
+#include <test/test-models/good/optimization/rosenbrock.hpp>
+#include <test/unit/services/instrumented_callbacks.hpp>
+#include <iostream>
+
+auto&& blah = stan::math::init_threadpool_tbb();
+
+static constexpr size_t num_chains = 4;
+class ServicesSampleHmcNutsDiagEAdaptPar : public testing::Test {
+ public:
+  ServicesSampleHmcNutsDiagEAdaptPar() : model(data_context, 0, &model_log) {
+    for (int i = 0; i < num_chains; ++i) {
+      init.push_back(stan::test::unit::instrumented_writer{});
+      parameter.push_back(stan::test::unit::instrumented_writer{});
+      diagnostic.push_back(stan::test::unit::instrumented_writer{});
+      context.push_back(std::make_shared<stan::io::empty_var_context>());
+    }
+  }
+  stan::io::empty_var_context data_context;
+  std::stringstream model_log;
+  stan::test::unit::instrumented_logger logger;
+  std::vector<stan::test::unit::instrumented_writer> init;
+  std::vector<stan::test::unit::instrumented_writer> parameter;
+  std::vector<stan::test::unit::instrumented_writer> diagnostic;
+  std::vector<std::shared_ptr<stan::io::empty_var_context>> context;
+  stan_model model;
+};
+
+TEST_F(ServicesSampleHmcNutsDiagEAdaptPar, call_count) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  int return_code = stan::services::sample::hmc_nuts_diag_e(
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, interrupt, logger, init, parameter, diagnostic);
+
+  EXPECT_EQ(0, return_code);
+
+  int num_output_lines = (num_warmup + num_samples) / num_thin;
+  EXPECT_EQ((num_warmup + num_samples) * num_chains, interrupt.call_count());
+  for (int i = 0; i < num_chains; ++i) {
+    EXPECT_EQ(1, parameter[i].call_count("vector_string"));
+    EXPECT_EQ(num_output_lines, parameter[i].call_count("vector_double"));
+    EXPECT_EQ(1, diagnostic[i].call_count("vector_string"));
+    EXPECT_EQ(num_output_lines, diagnostic[i].call_count("vector_double"));
+  }
+}
+
+TEST_F(ServicesSampleHmcNutsDiagEAdaptPar, parameter_checks) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  int return_code = stan::services::sample::hmc_nuts_diag_e(
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, interrupt, logger, init, parameter, diagnostic);
+
+  for (size_t i = 0; i < num_chains; ++i) {
+    std::vector<std::vector<std::string>> parameter_names;
+    parameter_names = parameter[i].vector_string_values();
+    std::vector<std::vector<double>> parameter_values;
+    parameter_values = parameter[i].vector_double_values();
+    std::vector<std::vector<std::string>> diagnostic_names;
+    diagnostic_names = diagnostic[i].vector_string_values();
+    std::vector<std::vector<double>> diagnostic_values;
+    diagnostic_values = diagnostic[i].vector_double_values();
+
+    // Expectations of parameter parameter names.
+    ASSERT_EQ(9, parameter_names[0].size());
+    EXPECT_EQ("lp__", parameter_names[0][0]);
+    EXPECT_EQ("accept_stat__", parameter_names[0][1]);
+    EXPECT_EQ("stepsize__", parameter_names[0][2]);
+    EXPECT_EQ("treedepth__", parameter_names[0][3]);
+    EXPECT_EQ("n_leapfrog__", parameter_names[0][4]);
+    EXPECT_EQ("divergent__", parameter_names[0][5]);
+    EXPECT_EQ("energy__", parameter_names[0][6]);
+    EXPECT_EQ("x", parameter_names[0][7]);
+    EXPECT_EQ("y", parameter_names[0][8]);
+
+    // Expect one name per parameter value.
+    EXPECT_EQ(parameter_names[0].size(), parameter_values[0].size());
+    EXPECT_EQ(diagnostic_names[0].size(), diagnostic_values[0].size());
+
+    EXPECT_EQ((num_warmup + num_samples) / num_thin, parameter_values.size());
+
+    // Expect one call to set parameter names, and one set of output per
+    // iteration.
+    EXPECT_EQ("lp__", diagnostic_names[0][0]);
+    EXPECT_EQ("accept_stat__", diagnostic_names[0][1]);
+  }
+  EXPECT_EQ(return_code, 0);
+}
+
+TEST_F(ServicesSampleHmcNutsDiagEAdaptPar, output_regression) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  stan::services::sample::hmc_nuts_diag_e(
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, interrupt, logger, init, parameter, diagnostic);
+
+  for (auto&& init_it : init) {
+    std::vector<std::string> init_values;
+    init_values = init_it.string_values();
+
+    EXPECT_EQ(0, init_values.size());
+  }
+
+  EXPECT_EQ(num_chains, logger.find_info("Elapsed Time:"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Warm-up)"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Sampling)"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Total)"));
+  EXPECT_EQ(0, logger.call_count_error());
+}

--- a/src/test/unit/services/sample/hmc_nuts_unit_e_adapt_parallel_test.cpp
+++ b/src/test/unit/services/sample/hmc_nuts_unit_e_adapt_parallel_test.cpp
@@ -1,0 +1,163 @@
+#include <stan/services/sample/hmc_nuts_unit_e_adapt.hpp>
+#include <gtest/gtest.h>
+#include <stan/io/empty_var_context.hpp>
+#include <test/test-models/good/optimization/rosenbrock.hpp>
+#include <test/unit/services/instrumented_callbacks.hpp>
+#include <iostream>
+
+auto&& blah = stan::math::init_threadpool_tbb();
+
+static constexpr size_t num_chains = 4;
+class ServicesSampleHmcNutsUnitEAdaptPar : public testing::Test {
+ public:
+  ServicesSampleHmcNutsUnitEAdaptPar() : model(data_context, 0, &model_log) {
+    for (int i = 0; i < num_chains; ++i) {
+      init.push_back(stan::test::unit::instrumented_writer{});
+      parameter.push_back(stan::test::unit::instrumented_writer{});
+      diagnostic.push_back(stan::test::unit::instrumented_writer{});
+      context.push_back(std::make_shared<stan::io::empty_var_context>());
+    }
+  }
+  stan::io::empty_var_context data_context;
+  std::stringstream model_log;
+  stan::test::unit::instrumented_logger logger;
+  std::vector<stan::test::unit::instrumented_writer> init;
+  std::vector<stan::test::unit::instrumented_writer> parameter;
+  std::vector<stan::test::unit::instrumented_writer> diagnostic;
+  std::vector<std::shared_ptr<stan::io::empty_var_context>> context;
+  stan_model model;
+};
+
+TEST_F(ServicesSampleHmcNutsUnitEAdaptPar, call_count) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  double delta = .1;
+  double gamma = .1;
+  double kappa = .1;
+  double t0 = .1;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  int return_code = stan::services::sample::hmc_nuts_unit_e_adapt(
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, delta, gamma, kappa, t0, interrupt, logger, init, parameter, diagnostic);
+
+  EXPECT_EQ(0, return_code);
+
+  int num_output_lines = (num_warmup + num_samples) / num_thin;
+  EXPECT_EQ((num_warmup + num_samples) * num_chains, interrupt.call_count());
+  for (int i = 0; i < num_chains; ++i) {
+    EXPECT_EQ(1, parameter[i].call_count("vector_string"));
+    EXPECT_EQ(num_output_lines, parameter[i].call_count("vector_double"));
+    EXPECT_EQ(1, diagnostic[i].call_count("vector_string"));
+    EXPECT_EQ(num_output_lines, diagnostic[i].call_count("vector_double"));
+  }
+}
+
+TEST_F(ServicesSampleHmcNutsUnitEAdaptPar, parameter_checks) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  double delta = .1;
+  double gamma = .1;
+  double kappa = .1;
+  double t0 = .1;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  int return_code = stan::services::sample::hmc_nuts_unit_e_adapt(
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, delta, gamma, kappa, t0, interrupt, logger, init, parameter, diagnostic);
+
+  for (size_t i = 0; i < num_chains; ++i) {
+    std::vector<std::vector<std::string>> parameter_names;
+    parameter_names = parameter[i].vector_string_values();
+    std::vector<std::vector<double>> parameter_values;
+    parameter_values = parameter[i].vector_double_values();
+    std::vector<std::vector<std::string>> diagnostic_names;
+    diagnostic_names = diagnostic[i].vector_string_values();
+    std::vector<std::vector<double>> diagnostic_values;
+    diagnostic_values = diagnostic[i].vector_double_values();
+
+    // Expectations of parameter parameter names.
+    ASSERT_EQ(9, parameter_names[0].size());
+    EXPECT_EQ("lp__", parameter_names[0][0]);
+    EXPECT_EQ("accept_stat__", parameter_names[0][1]);
+    EXPECT_EQ("stepsize__", parameter_names[0][2]);
+    EXPECT_EQ("treedepth__", parameter_names[0][3]);
+    EXPECT_EQ("n_leapfrog__", parameter_names[0][4]);
+    EXPECT_EQ("divergent__", parameter_names[0][5]);
+    EXPECT_EQ("energy__", parameter_names[0][6]);
+    EXPECT_EQ("x", parameter_names[0][7]);
+    EXPECT_EQ("y", parameter_names[0][8]);
+
+    // Expect one name per parameter value.
+    EXPECT_EQ(parameter_names[0].size(), parameter_values[0].size());
+    EXPECT_EQ(diagnostic_names[0].size(), diagnostic_values[0].size());
+
+    EXPECT_EQ((num_warmup + num_samples) / num_thin, parameter_values.size());
+
+    // Expect one call to set parameter names, and one set of output per
+    // iteration.
+    EXPECT_EQ("lp__", diagnostic_names[0][0]);
+    EXPECT_EQ("accept_stat__", diagnostic_names[0][1]);
+  }
+  EXPECT_EQ(return_code, 0);
+}
+
+TEST_F(ServicesSampleHmcNutsUnitEAdaptPar, output_regression) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  double delta = .1;
+  double gamma = .1;
+  double kappa = .1;
+  double t0 = .1;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  stan::services::sample::hmc_nuts_unit_e_adapt(
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, delta, gamma, kappa, t0, interrupt, logger, init, parameter, diagnostic);
+
+  for (auto&& init_it : init) {
+    std::vector<std::string> init_values;
+    init_values = init_it.string_values();
+
+    EXPECT_EQ(0, init_values.size());
+  }
+
+  EXPECT_EQ(num_chains, logger.find_info("Elapsed Time:"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Warm-up)"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Sampling)"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Total)"));
+  EXPECT_EQ(0, logger.call_count_error());
+}

--- a/src/test/unit/services/sample/hmc_nuts_unit_e_parallel_test.cpp
+++ b/src/test/unit/services/sample/hmc_nuts_unit_e_parallel_test.cpp
@@ -1,0 +1,164 @@
+#include <stan/services/sample/hmc_nuts_unit_e.hpp>
+#include <gtest/gtest.h>
+#include <stan/io/empty_var_context.hpp>
+#include <test/test-models/good/optimization/rosenbrock.hpp>
+#include <test/unit/services/instrumented_callbacks.hpp>
+#include <iostream>
+
+class ServicesSampleHmcNutsUnitE : public testing::Test {
+ public:
+  ServicesSampleHmcNutsUnitE() : model(context, 0, &model_log) {}
+
+  std::stringstream model_log;
+  stan::test::unit::instrumented_logger logger;
+  stan::test::unit::instrumented_writer init, parameter, diagnostic;
+  stan::io::empty_var_context context;
+  stan_model model;
+};
+
+TEST_F(ServicesSampleHmcNutsUnitE, call_count) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  int return_code = stan::services::sample::hmc_nuts_unit_e(
+      model, context, random_seed, chain, init_radius, num_warmup, num_samples,
+      num_thin, save_warmup, refresh, stepsize, stepsize_jitter, max_depth,
+      interrupt, logger, init, parameter, diagnostic);
+
+  EXPECT_EQ(0, return_code);
+
+  int num_output_lines = (num_warmup + num_samples) / num_thin;
+  EXPECT_EQ(num_warmup + num_samples, interrupt.call_count());
+  EXPECT_EQ(1, parameter.call_count("vector_string"));
+  EXPECT_EQ(num_output_lines, parameter.call_count("vector_double"));
+  EXPECT_EQ(1, diagnostic.call_count("vector_string"));
+  EXPECT_EQ(num_output_lines, diagnostic.call_count("vector_double"));
+}
+
+TEST_F(ServicesSampleHmcNutsUnitE, parameter_checks) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  stan::services::sample::hmc_nuts_unit_e(
+      model, context, random_seed, chain, init_radius, num_warmup, num_samples,
+      num_thin, save_warmup, refresh, stepsize, stepsize_jitter, max_depth,
+      interrupt, logger, init, parameter, diagnostic);
+
+  std::vector<std::vector<std::string> > parameter_names;
+  parameter_names = parameter.vector_string_values();
+  std::vector<std::vector<double> > parameter_values;
+  parameter_values = parameter.vector_double_values();
+  std::vector<std::vector<std::string> > diagnostic_names;
+  diagnostic_names = diagnostic.vector_string_values();
+  std::vector<std::vector<double> > diagnostic_values;
+  diagnostic_values = diagnostic.vector_double_values();
+
+  // Expectations of parameter parameter names.
+  ASSERT_EQ(9, parameter_names[0].size());
+  EXPECT_EQ("lp__", parameter_names[0][0]);
+  EXPECT_EQ("accept_stat__", parameter_names[0][1]);
+  EXPECT_EQ("stepsize__", parameter_names[0][2]);
+  EXPECT_EQ("treedepth__", parameter_names[0][3]);
+  EXPECT_EQ("n_leapfrog__", parameter_names[0][4]);
+  EXPECT_EQ("divergent__", parameter_names[0][5]);
+  EXPECT_EQ("energy__", parameter_names[0][6]);
+  EXPECT_EQ("x", parameter_names[0][7]);
+  EXPECT_EQ("y", parameter_names[0][8]);
+
+  // Expect one name per parameter value.
+  EXPECT_EQ(parameter_names[0].size(), parameter_values[0].size());
+  EXPECT_EQ(diagnostic_names[0].size(), diagnostic_values[0].size());
+
+  EXPECT_EQ((num_warmup + num_samples) / num_thin, parameter_values.size());
+
+  // Expect one call to set parameter names, and one set of output per
+  // iteration.
+  EXPECT_EQ("lp__", diagnostic_names[0][0]);
+  EXPECT_EQ("accept_stat__", diagnostic_names[0][1]);
+}
+
+TEST_F(ServicesSampleHmcNutsUnitE, output_sizes) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  int return_code = stan::services::sample::hmc_nuts_unit_e(
+      model, context, random_seed, chain, init_radius, num_warmup, num_samples,
+      num_thin, save_warmup, refresh, stepsize, stepsize_jitter, max_depth,
+      interrupt, logger, init, parameter, diagnostic);
+
+  std::vector<std::vector<std::string> > parameter_names;
+  parameter_names = parameter.vector_string_values();
+  std::vector<std::vector<double> > parameter_values;
+  parameter_values = parameter.vector_double_values();
+  std::vector<std::vector<std::string> > diagnostic_names;
+  diagnostic_names = diagnostic.vector_string_values();
+  std::vector<std::vector<double> > diagnostic_values;
+  diagnostic_values = diagnostic.vector_double_values();
+
+  EXPECT_EQ(return_code, 0);
+}
+
+TEST_F(ServicesSampleHmcNutsUnitE, output_regression) {
+  unsigned int random_seed = 0;
+  unsigned int chain = 1;
+  double init_radius = 0;
+  int num_warmup = 200;
+  int num_samples = 400;
+  int num_thin = 5;
+  bool save_warmup = true;
+  int refresh = 0;
+  double stepsize = 0.1;
+  double stepsize_jitter = 0;
+  int max_depth = 8;
+  stan::test::unit::instrumented_interrupt interrupt;
+  EXPECT_EQ(interrupt.call_count(), 0);
+
+  stan::services::sample::hmc_nuts_unit_e(
+      model, context, random_seed, chain, init_radius, num_warmup, num_samples,
+      num_thin, save_warmup, refresh, stepsize, stepsize_jitter, max_depth,
+      interrupt, logger, init, parameter, diagnostic);
+
+  std::vector<std::string> init_values;
+  init_values = init.string_values();
+
+  EXPECT_EQ(0, init_values.size());
+
+  EXPECT_EQ(1, logger.find_info("Elapsed Time:"));
+  EXPECT_EQ(1, logger.find_info("seconds (Warm-up)"));
+  EXPECT_EQ(1, logger.find_info("seconds (Sampling)"));
+  EXPECT_EQ(1, logger.find_info("seconds (Total)"));
+  EXPECT_EQ(0, logger.call_count_error());
+}

--- a/src/test/unit/services/sample/hmc_nuts_unit_e_parallel_test.cpp
+++ b/src/test/unit/services/sample/hmc_nuts_unit_e_parallel_test.cpp
@@ -5,18 +5,31 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <iostream>
 
-class ServicesSampleHmcNutsUnitE : public testing::Test {
- public:
-  ServicesSampleHmcNutsUnitE() : model(context, 0, &model_log) {}
+auto&& blah = stan::math::init_threadpool_tbb();
+static constexpr size_t num_chains = 4;
 
+class ServicesSampleHmcNutsUnitEPar : public testing::Test {
+ public:
+  ServicesSampleHmcNutsUnitEPar() : model(data_context, 0, &model_log) {
+    for (int i = 0; i < num_chains; ++i) {
+      init.push_back(stan::test::unit::instrumented_writer{});
+      parameter.push_back(stan::test::unit::instrumented_writer{});
+      diagnostic.push_back(stan::test::unit::instrumented_writer{});
+      context.push_back(std::make_shared<stan::io::empty_var_context>());
+    }
+  }
+  stan::io::empty_var_context data_context;
   std::stringstream model_log;
   stan::test::unit::instrumented_logger logger;
-  stan::test::unit::instrumented_writer init, parameter, diagnostic;
-  stan::io::empty_var_context context;
+  std::vector<stan::test::unit::instrumented_writer> init;
+  std::vector<stan::test::unit::instrumented_writer> parameter;
+  std::vector<stan::test::unit::instrumented_writer> diagnostic;
+  std::vector<std::shared_ptr<stan::io::empty_var_context>> context;
   stan_model model;
 };
 
-TEST_F(ServicesSampleHmcNutsUnitE, call_count) {
+
+TEST_F(ServicesSampleHmcNutsUnitEPar, call_count) {
   unsigned int random_seed = 0;
   unsigned int chain = 1;
   double init_radius = 0;
@@ -28,25 +41,35 @@ TEST_F(ServicesSampleHmcNutsUnitE, call_count) {
   double stepsize = 0.1;
   double stepsize_jitter = 0;
   int max_depth = 8;
+  double delta = .1;
+  double gamma = .1;
+  double kappa = .1;
+  double t0 = .1;
+  unsigned int init_buffer = 50;
+  unsigned int term_buffer = 50;
+  unsigned int window = 100;
   stan::test::unit::instrumented_interrupt interrupt;
   EXPECT_EQ(interrupt.call_count(), 0);
 
   int return_code = stan::services::sample::hmc_nuts_unit_e(
-      model, context, random_seed, chain, init_radius, num_warmup, num_samples,
-      num_thin, save_warmup, refresh, stepsize, stepsize_jitter, max_depth,
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, 
       interrupt, logger, init, parameter, diagnostic);
 
   EXPECT_EQ(0, return_code);
 
   int num_output_lines = (num_warmup + num_samples) / num_thin;
-  EXPECT_EQ(num_warmup + num_samples, interrupt.call_count());
-  EXPECT_EQ(1, parameter.call_count("vector_string"));
-  EXPECT_EQ(num_output_lines, parameter.call_count("vector_double"));
-  EXPECT_EQ(1, diagnostic.call_count("vector_string"));
-  EXPECT_EQ(num_output_lines, diagnostic.call_count("vector_double"));
+  EXPECT_EQ((num_warmup + num_samples) * num_chains, interrupt.call_count());
+  for (int i = 0; i < num_chains; ++i) {
+    EXPECT_EQ(1, parameter[i].call_count("vector_string"));
+    EXPECT_EQ(num_output_lines, parameter[i].call_count("vector_double"));
+    EXPECT_EQ(1, diagnostic[i].call_count("vector_string"));
+    EXPECT_EQ(num_output_lines, diagnostic[i].call_count("vector_double"));
+  }
 }
 
-TEST_F(ServicesSampleHmcNutsUnitE, parameter_checks) {
+TEST_F(ServicesSampleHmcNutsUnitEPar, parameter_checks) {
   unsigned int random_seed = 0;
   unsigned int chain = 1;
   double init_radius = 0;
@@ -58,80 +81,59 @@ TEST_F(ServicesSampleHmcNutsUnitE, parameter_checks) {
   double stepsize = 0.1;
   double stepsize_jitter = 0;
   int max_depth = 8;
-  stan::test::unit::instrumented_interrupt interrupt;
-  EXPECT_EQ(interrupt.call_count(), 0);
-
-  stan::services::sample::hmc_nuts_unit_e(
-      model, context, random_seed, chain, init_radius, num_warmup, num_samples,
-      num_thin, save_warmup, refresh, stepsize, stepsize_jitter, max_depth,
-      interrupt, logger, init, parameter, diagnostic);
-
-  std::vector<std::vector<std::string> > parameter_names;
-  parameter_names = parameter.vector_string_values();
-  std::vector<std::vector<double> > parameter_values;
-  parameter_values = parameter.vector_double_values();
-  std::vector<std::vector<std::string> > diagnostic_names;
-  diagnostic_names = diagnostic.vector_string_values();
-  std::vector<std::vector<double> > diagnostic_values;
-  diagnostic_values = diagnostic.vector_double_values();
-
-  // Expectations of parameter parameter names.
-  ASSERT_EQ(9, parameter_names[0].size());
-  EXPECT_EQ("lp__", parameter_names[0][0]);
-  EXPECT_EQ("accept_stat__", parameter_names[0][1]);
-  EXPECT_EQ("stepsize__", parameter_names[0][2]);
-  EXPECT_EQ("treedepth__", parameter_names[0][3]);
-  EXPECT_EQ("n_leapfrog__", parameter_names[0][4]);
-  EXPECT_EQ("divergent__", parameter_names[0][5]);
-  EXPECT_EQ("energy__", parameter_names[0][6]);
-  EXPECT_EQ("x", parameter_names[0][7]);
-  EXPECT_EQ("y", parameter_names[0][8]);
-
-  // Expect one name per parameter value.
-  EXPECT_EQ(parameter_names[0].size(), parameter_values[0].size());
-  EXPECT_EQ(diagnostic_names[0].size(), diagnostic_values[0].size());
-
-  EXPECT_EQ((num_warmup + num_samples) / num_thin, parameter_values.size());
-
-  // Expect one call to set parameter names, and one set of output per
-  // iteration.
-  EXPECT_EQ("lp__", diagnostic_names[0][0]);
-  EXPECT_EQ("accept_stat__", diagnostic_names[0][1]);
-}
-
-TEST_F(ServicesSampleHmcNutsUnitE, output_sizes) {
-  unsigned int random_seed = 0;
-  unsigned int chain = 1;
-  double init_radius = 0;
-  int num_warmup = 200;
-  int num_samples = 400;
-  int num_thin = 5;
-  bool save_warmup = true;
-  int refresh = 0;
-  double stepsize = 0.1;
-  double stepsize_jitter = 0;
-  int max_depth = 8;
+  double delta = .1;
+  double gamma = .1;
+  double kappa = .1;
+  double t0 = .1;
+  unsigned int init_buffer = 50;
+  unsigned int term_buffer = 50;
+  unsigned int window = 100;
   stan::test::unit::instrumented_interrupt interrupt;
   EXPECT_EQ(interrupt.call_count(), 0);
 
   int return_code = stan::services::sample::hmc_nuts_unit_e(
-      model, context, random_seed, chain, init_radius, num_warmup, num_samples,
-      num_thin, save_warmup, refresh, stepsize, stepsize_jitter, max_depth,
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth, 
       interrupt, logger, init, parameter, diagnostic);
 
-  std::vector<std::vector<std::string> > parameter_names;
-  parameter_names = parameter.vector_string_values();
-  std::vector<std::vector<double> > parameter_values;
-  parameter_values = parameter.vector_double_values();
-  std::vector<std::vector<std::string> > diagnostic_names;
-  diagnostic_names = diagnostic.vector_string_values();
-  std::vector<std::vector<double> > diagnostic_values;
-  diagnostic_values = diagnostic.vector_double_values();
+  for (size_t i = 0; i < num_chains; ++i) {
+    std::vector<std::vector<std::string>> parameter_names;
+    parameter_names = parameter[i].vector_string_values();
+    std::vector<std::vector<double>> parameter_values;
+    parameter_values = parameter[i].vector_double_values();
+    std::vector<std::vector<std::string>> diagnostic_names;
+    diagnostic_names = diagnostic[i].vector_string_values();
+    std::vector<std::vector<double>> diagnostic_values;
+    diagnostic_values = diagnostic[i].vector_double_values();
 
+    // Expectations of parameter parameter names.
+    ASSERT_EQ(9, parameter_names[0].size());
+    EXPECT_EQ("lp__", parameter_names[0][0]);
+    EXPECT_EQ("accept_stat__", parameter_names[0][1]);
+    EXPECT_EQ("stepsize__", parameter_names[0][2]);
+    EXPECT_EQ("treedepth__", parameter_names[0][3]);
+    EXPECT_EQ("n_leapfrog__", parameter_names[0][4]);
+    EXPECT_EQ("divergent__", parameter_names[0][5]);
+    EXPECT_EQ("energy__", parameter_names[0][6]);
+    EXPECT_EQ("x", parameter_names[0][7]);
+    EXPECT_EQ("y", parameter_names[0][8]);
+
+    // Expect one name per parameter value.
+    EXPECT_EQ(parameter_names[0].size(), parameter_values[0].size());
+    EXPECT_EQ(diagnostic_names[0].size(), diagnostic_values[0].size());
+
+    EXPECT_EQ((num_warmup + num_samples) / num_thin, parameter_values.size());
+
+    // Expect one call to set parameter names, and one set of output per
+    // iteration.
+    EXPECT_EQ("lp__", diagnostic_names[0][0]);
+    EXPECT_EQ("accept_stat__", diagnostic_names[0][1]);
+  }
   EXPECT_EQ(return_code, 0);
 }
 
-TEST_F(ServicesSampleHmcNutsUnitE, output_regression) {
+TEST_F(ServicesSampleHmcNutsUnitEPar, output_regression) {
   unsigned int random_seed = 0;
   unsigned int chain = 1;
   double init_radius = 0;
@@ -143,22 +145,32 @@ TEST_F(ServicesSampleHmcNutsUnitE, output_regression) {
   double stepsize = 0.1;
   double stepsize_jitter = 0;
   int max_depth = 8;
+  double delta = .1;
+  double gamma = .1;
+  double kappa = .1;
+  double t0 = .1;
+  unsigned int init_buffer = 50;
+  unsigned int term_buffer = 50;
+  unsigned int window = 100;
   stan::test::unit::instrumented_interrupt interrupt;
   EXPECT_EQ(interrupt.call_count(), 0);
 
   stan::services::sample::hmc_nuts_unit_e(
-      model, context, random_seed, chain, init_radius, num_warmup, num_samples,
-      num_thin, save_warmup, refresh, stepsize, stepsize_jitter, max_depth,
+      model, num_chains, context, random_seed, chain, init_radius, num_warmup,
+      num_samples, num_thin, save_warmup, refresh, stepsize, stepsize_jitter,
+      max_depth,
       interrupt, logger, init, parameter, diagnostic);
 
-  std::vector<std::string> init_values;
-  init_values = init.string_values();
+  for (auto&& init_it : init) {
+    std::vector<std::string> init_values;
+    init_values = init_it.string_values();
 
-  EXPECT_EQ(0, init_values.size());
+    EXPECT_EQ(0, init_values.size());
+  }
 
-  EXPECT_EQ(1, logger.find_info("Elapsed Time:"));
-  EXPECT_EQ(1, logger.find_info("seconds (Warm-up)"));
-  EXPECT_EQ(1, logger.find_info("seconds (Sampling)"));
-  EXPECT_EQ(1, logger.find_info("seconds (Total)"));
+  EXPECT_EQ(num_chains, logger.find_info("Elapsed Time:"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Warm-up)"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Sampling)"));
+  EXPECT_EQ(num_chains, logger.find_info("seconds (Total)"));
   EXPECT_EQ(0, logger.call_count_error());
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This adds multi chain service functions for hmc nuts for adapatation and nonadaption for the unit e, diag, and dense metrics.

#### Intended Effect

Allow users of the service layer to use tbb multithreading to spin up multiple chains via the service layer

#### How to Verify

Tests added to show usage

#### Side Effects

#### Documentation

New docs added for each function 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Steve Bronder



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
