### PR TITLE
Service functions: Consistent exception handling and error logging

### DIFF
--- a/src/stan/callbacks/structured_writer.hpp
+++ b/src/stan/callbacks/structured_writer.hpp
@@ -29,7 +29,7 @@ class structured_writer {
    * Writes key followed by start token of a structured record.
    * @param[in] key The name of the record.
    */
-  virtual void begin_record(const std::string&, bool newline = false) {}
+  virtual void begin_record(const std::string& key, bool newline = false) {}
 
   /**
    * Writes end token of a structured record.

--- a/src/stan/services/experimental/advi/fullrank.hpp
+++ b/src/stan/services/experimental/advi/fullrank.hpp
@@ -65,9 +65,9 @@ int fullrank(Model& model, const stan::io::var_context& init,
   std::vector<int> disc_vector;
   std::vector<double> cont_vector;
 
-  try{
-    cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
+  try {
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
   } catch (const std::exception& e) {
     logger.error(e.what());
     return stan::services::error_codes::CONFIG;

--- a/src/stan/services/experimental/advi/fullrank.hpp
+++ b/src/stan/services/experimental/advi/fullrank.hpp
@@ -7,6 +7,7 @@
 #include <stan/services/util/experimental_message.hpp>
 #include <stan/services/util/initialize.hpp>
 #include <stan/services/util/create_rng.hpp>
+#include <stan/services/error_codes.hpp>
 #include <stan/io/var_context.hpp>
 #include <stan/variational/advi.hpp>
 #include <boost/random/additive_combine.hpp>
@@ -62,8 +63,15 @@ int fullrank(Model& model, const stan::io::var_context& init,
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize(
+  std::vector<double> cont_vector;
+
+  try{
+    cont_vector = util::initialize(
       model, init, rng, init_radius, true, logger, init_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return stan::services::error_codes::CONFIG;
+  }
 
   std::vector<std::string> names;
   names.push_back("lp__");
@@ -82,7 +90,7 @@ int fullrank(Model& model, const stan::io::var_context& init,
   cmd_advi.run(eta, adapt_engaged, adapt_iterations, tol_rel_obj,
                max_iterations, logger, parameter_writer, diagnostic_writer);
 
-  return 0;
+  return stan::services::error_codes::OK;
 }
 }  // namespace advi
 }  // namespace experimental

--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -60,9 +60,14 @@ int bfgs(Model& model, const stan::io::var_context& init,
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize<false>(
-      model, init, rng, init_radius, false, logger, init_writer);
-
+  std::vector<double> cont_vector;
+  try {
+    cont_vector = util::initialize<false>(model, init, rng, init_radius, false,
+                                          logger, init_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::CONFIG;
+  }
   std::stringstream bfgs_ss;
   typedef stan::optimization::BFGSLineSearch<
       Model, stan::optimization::BFGSUpdate_HInv<>, double, Eigen::Dynamic,

--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -171,7 +171,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
     logger.info("Optimization terminated normally: ");
     return_code = error_codes::OK;
   } else {
-    logger.info("Optimization terminated with error: ");
+    logger.error("Optimization terminated with error: ");
     return_code = error_codes::SOFTWARE;
   }
   logger.info("  " + bfgs.get_code_string(ret));

--- a/src/stan/services/optimize/laplace_sample.hpp
+++ b/src/stan/services/optimize/laplace_sample.hpp
@@ -91,7 +91,7 @@ void laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
   boost::ecuyer1988 rng = util::create_rng(random_seed, 0);
   Eigen::VectorXd draw_vec;  // declare draw_vec, msgs here to avoid re-alloc
   for (int m = 0; m < draws; ++m) {
-    interrupt();             // allow interpution each iteration
+    interrupt();  // allow interpution each iteration
     if (refresh > 0 && m % refresh == 0) {
       refresh_msg << "iteration: " << std::to_string(m);
       logger.info(refresh_msg);

--- a/src/stan/services/optimize/laplace_sample.hpp
+++ b/src/stan/services/optimize/laplace_sample.hpp
@@ -91,7 +91,7 @@ void laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
   boost::ecuyer1988 rng = util::create_rng(random_seed, 0);
   Eigen::VectorXd draw_vec;  // declare draw_vec, msgs here to avoid re-alloc
   for (int m = 0; m < draws; ++m) {
-    interrupt();  // allow interpution each iteration
+    interrupt();             // allow interpution each iteration
     if (refresh > 0 && m % refresh == 0) {
       refresh_msg << "iteration: " << std::to_string(m);
       logger.info(refresh_msg);
@@ -159,17 +159,11 @@ int laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
     internal::laplace_sample<jacobian>(model, theta_hat, draws, random_seed,
                                        refresh, interrupt, logger,
                                        sample_writer);
-    return error_codes::OK;
   } catch (const std::exception& e) {
-    if (refresh >= 0) {
-      logger.error(e.what());
-    }
-  } catch (...) {
-    if (refresh >= 0) {
-      logger.error("unknown exception during execution");
-    }
+    logger.error(e.what());
+    return error_codes::CONFIG;
   }
-  return error_codes::DATAERR;
+  return error_codes::OK;
 }
 }  // namespace services
 }  // namespace stan

--- a/src/stan/services/optimize/lbfgs.hpp
+++ b/src/stan/services/optimize/lbfgs.hpp
@@ -174,7 +174,7 @@ int lbfgs(Model& model, const stan::io::var_context& init,
     logger.info("Optimization terminated normally: ");
     return_code = error_codes::OK;
   } else {
-    logger.info("Optimization terminated with error: ");
+    logger.error("Optimization terminated with error: ");
     return_code = error_codes::SOFTWARE;
   }
   logger.info("  " + lbfgs.get_code_string(ret));

--- a/src/stan/services/optimize/lbfgs.hpp
+++ b/src/stan/services/optimize/lbfgs.hpp
@@ -62,9 +62,15 @@ int lbfgs(Model& model, const stan::io::var_context& init,
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize<false>(
-      model, init, rng, init_radius, false, logger, init_writer);
+  std::vector<double> cont_vector;
 
+  try {
+    cont_vector = util::initialize<false>(model, init, rng, init_radius, false,
+                                          logger, init_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::CONFIG;
+  }
   std::stringstream lbfgs_ss;
   typedef stan::optimization::BFGSLineSearch<Model,
                                              stan::optimization::LBFGSUpdate<>,

--- a/src/stan/services/optimize/newton.hpp
+++ b/src/stan/services/optimize/newton.hpp
@@ -47,9 +47,15 @@ int newton(Model& model, const stan::io::var_context& init,
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize<false>(
-      model, init, rng, init_radius, false, logger, init_writer);
+  std::vector<double> cont_vector;
 
+  try {
+    cont_vector = util::initialize<false>(model, init, rng, init_radius, false,
+                                          logger, init_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::CONFIG;
+  }
   double lp(0);
   try {
     std::stringstream message;

--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -122,7 +122,7 @@ inline int pathfinder_lbfgs_multi(
                   single_path_parameter_writer[iter],
                   single_path_diagnostic_writer[iter]);
           if (unlikely(std::get<0>(pathfinder_ret) == error_codes::SOFTWARE)) {
-            logger.info(std::string("Pathfinder iteration: ")
+            logger.warn(std::string("Pathfinder iteration: ")
                         + std::to_string(iter) + " failed.");
             return;
           }

--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -121,8 +121,8 @@ inline int pathfinder_lbfgs_multi(
                   interrupt, logger, init_writers[iter],
                   single_path_parameter_writer[iter],
                   single_path_diagnostic_writer[iter]);
-          if (unlikely(std::get<0>(pathfinder_ret) == error_codes::SOFTWARE)) {
-            logger.warn(std::string("Pathfinder iteration: ")
+          if (unlikely(std::get<0>(pathfinder_ret) != error_codes::OK)) {
+            logger.error(std::string("Pathfinder iteration: ")
                         + std::to_string(iter) + " failed.");
             return;
           }

--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -123,7 +123,7 @@ inline int pathfinder_lbfgs_multi(
                   single_path_diagnostic_writer[iter]);
           if (unlikely(std::get<0>(pathfinder_ret) != error_codes::OK)) {
             logger.error(std::string("Pathfinder iteration: ")
-                        + std::to_string(iter) + " failed.");
+                         + std::to_string(iter) + " failed.");
             return;
           }
           individual_lp_ratios.emplace_back(

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -577,8 +577,8 @@ auto pathfinder_impl(RNG&& rng, LPFun&& lp_fun, ConstrainFun&& constrain_fun,
  * @param[in,out] diagnostic_writer output for diagnostics values
  * @return If `ReturnLpSamples` is `true`, returns a tuple of the error code,
  * approximate draws, and a vector of the lp ratio. If `false`, only returns an
- * error code `error_codes::OK` if successful, `error_codes::SOFTWARE` for
- * failures
+ * error code `error_codes::OK` if successful, `error_codes::SOFTWARE`
+ * or `error_codes::CONFIG` for failures
  */
 template <bool ReturnLpSamples = false, class Model, typename DiagnosticWriter,
           typename ParamWriter>
@@ -595,8 +595,18 @@ inline auto pathfinder_lbfgs_single(
   boost::ecuyer1988 rng
       = util::create_rng<boost::ecuyer1988>(random_seed, stride_id);
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize<false>(
-      model, init, rng, init_radius, false, logger, init_writer);
+  std::vector<double> cont_vector;
+
+  try {
+    cont_vector = util::initialize<false>(model, init, rng, init_radius, false,
+                                          logger, init_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return internal::ret_pathfinder<ReturnLpSamples>(
+        error_codes::SOFTWARE, Eigen::Array<double, Eigen::Dynamic, 1>(0),
+        Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>(0, 0), 0);
+  }
+
   const auto num_parameters = cont_vector.size();
   // Setup LBFGS
   std::stringstream lbfgs_ss;
@@ -806,8 +816,9 @@ inline auto pathfinder_lbfgs_single(
     std::string prefix_err_msg
         = "Optimization terminated with error: " + lbfgs.get_code_string(ret);
     if (lbfgs.iter_num() < 2) {
-      logger.error(prefix_err_msg
-                  + " Optimization failed to start, pathfinder cannot be run.");
+      logger.error(
+          prefix_err_msg
+          + " Optimization failed to start, pathfinder cannot be run.");
       return internal::ret_pathfinder<ReturnLpSamples>(
           error_codes::SOFTWARE, Eigen::Array<double, Eigen::Dynamic, 1>(0),
           Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>(0, 0),

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -523,7 +523,7 @@ auto pathfinder_impl(RNG&& rng, LPFun&& lp_fun, ConstrainFun&& constrain_fun,
                               num_elbo_draws, alpha, iter_msg, logger),
                           taylor_appx);
   } catch (const std::exception& e) {
-    logger.info(iter_msg + "ELBO estimation failed "
+    logger.warn(iter_msg + "ELBO estimation failed "
                 + " with error: " + e.what());
     return std::make_pair(internal::elbo_est_t{}, internal::taylor_approx_t{});
   }
@@ -806,20 +806,20 @@ inline auto pathfinder_lbfgs_single(
     std::string prefix_err_msg
         = "Optimization terminated with error: " + lbfgs.get_code_string(ret);
     if (lbfgs.iter_num() < 2) {
-      logger.info(prefix_err_msg
+      logger.error(prefix_err_msg
                   + " Optimization failed to start, pathfinder cannot be run.");
       return internal::ret_pathfinder<ReturnLpSamples>(
           error_codes::SOFTWARE, Eigen::Array<double, Eigen::Dynamic, 1>(0),
           Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>(0, 0),
           std::atomic<size_t>{num_evals + lbfgs.grad_evals()});
     } else {
-      logger.info(prefix_err_msg +
+      logger.warn(prefix_err_msg +
           " Stan will still attempt pathfinder but may fail or produce "
           "incorrect results.");
     }
   }
   if (unlikely(best_iteration == -1)) {
-    logger.info(path_num +
+    logger.error(path_num +
         "Failure: None of the LBFGS iterations completed "
         "successfully");
     return internal::ret_pathfinder<ReturnLpSamples>(
@@ -875,7 +875,7 @@ inline auto pathfinder_lbfgs_single(
       }
     } catch (const std::exception& e) {
       std::string err_msg = e.what();
-      logger.info(path_num + "Final sampling approximation failed with error: "
+      logger.warn(path_num + "Final sampling approximation failed with error: "
                   + err_msg);
       logger.info(
           path_num

--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -113,8 +113,8 @@ int fixed_param(Model& model, const stan::io::var_context& init,
  * @param[in,out] logger Logger for messages
  * @param[in,out] init_writer std vector of Writer callbacks for unconstrained
  * inits of each chain.
- * @param[in,out] sample_writer std vector of Writers for draws of each chain.
- * @param[in,out] diagnostic_writer std vector of Writers for diagnostic
+ * @param[in,out] sample_writers std vector of Writers for draws of each chain.
+ * @param[in,out] diagnostic_writers std vector of Writers for diagnostic
  * information of each chain.
  * @return error_codes::OK if successful
  */

--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -52,8 +52,15 @@ int fixed_param(Model& model, const stan::io::var_context& init,
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize(
+  std::vector<double> cont_vector;
+
+  try {
+    cont_vector = util::initialize(
       model, init, rng, init_radius, false, logger, init_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::CONFIG;
+  }
 
   stan::mcmc::fixed_param_sampler sampler;
   util::mcmc_writer writer(sample_writer, diagnostic_writer, logger);

--- a/src/stan/services/sample/fixed_param.hpp
+++ b/src/stan/services/sample/fixed_param.hpp
@@ -55,8 +55,8 @@ int fixed_param(Model& model, const stan::io::var_context& init,
   std::vector<double> cont_vector;
 
   try {
-    cont_vector = util::initialize(
-      model, init, rng, init_radius, false, logger, init_writer);
+    cont_vector = util::initialize(model, init, rng, init_radius, false, logger,
+                                   init_writer);
   } catch (const std::exception& e) {
     logger.error(e.what());
     return error_codes::CONFIG;

--- a/src/stan/services/sample/hmc_nuts_dense_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e.hpp
@@ -59,15 +59,17 @@ int hmc_nuts_dense_e(Model& model, const stan::io::var_context& init,
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
+  std::vector<double> cont_vector;
 
   Eigen::MatrixXd inv_metric;
   try {
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
     inv_metric = util::read_dense_inv_metric(init_inv_metric,
                                              model.num_params_r(), logger);
     util::validate_dense_inv_metric(inv_metric, logger);
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
 
@@ -217,7 +219,8 @@ int hmc_nuts_dense_e(Model& model, size_t num_chains,
       samplers[i].set_stepsize_jitter(stepsize_jitter);
       samplers[i].set_max_depth(max_depth);
     }
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
   tbb::parallel_for(

--- a/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
@@ -65,15 +65,17 @@ int hmc_nuts_dense_e_adapt(
     callbacks::writer& sample_writer, callbacks::writer& diagnostic_writer) {
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
-  std::vector<double> cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
+  std::vector<double> cont_vector;
 
   Eigen::MatrixXd inv_metric;
   try {
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
     inv_metric = util::read_dense_inv_metric(init_inv_metric,
                                              model.num_params_r(), logger);
     util::validate_dense_inv_metric(inv_metric, logger);
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
 
@@ -256,7 +258,8 @@ int hmc_nuts_dense_e_adapt(
       samplers[i].set_window_params(num_warmup, init_buffer, term_buffer,
                                     window, logger);
     }
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
   tbb::parallel_for(

--- a/src/stan/services/sample/hmc_nuts_diag_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e.hpp
@@ -58,15 +58,17 @@ int hmc_nuts_diag_e(Model& model, const stan::io::var_context& init,
                     callbacks::writer& diagnostic_writer) {
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
+  std::vector<double> cont_vector;
 
   Eigen::VectorXd inv_metric;
   try {
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
     inv_metric = util::read_diag_inv_metric(init_inv_metric,
                                             model.num_params_r(), logger);
     util::validate_diag_inv_metric(inv_metric, logger);
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
 
@@ -214,7 +216,8 @@ int hmc_nuts_diag_e(Model& model, size_t num_chains,
       samplers[i].set_stepsize_jitter(stepsize_jitter);
       samplers[i].set_max_depth(max_depth);
     }
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
   tbb::parallel_for(

--- a/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
@@ -70,15 +70,18 @@ int hmc_nuts_diag_e_adapt(
     callbacks::writer& sample_writer, callbacks::writer& diagnostic_writer) {
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
-  std::vector<double> cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
+  std::vector<double> cont_vector;
 
   Eigen::VectorXd inv_metric;
   try {
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
+
     inv_metric = util::read_diag_inv_metric(init_inv_metric,
                                             model.num_params_r(), logger);
     util::validate_diag_inv_metric(inv_metric, logger);
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
 
@@ -257,7 +260,8 @@ int hmc_nuts_diag_e_adapt(
       samplers[i].set_window_params(num_warmup, init_buffer, term_buffer,
                                     window, logger);
     }
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
   tbb::parallel_for(

--- a/src/stan/services/sample/hmc_static_dense_e.hpp
+++ b/src/stan/services/sample/hmc_static_dense_e.hpp
@@ -56,15 +56,17 @@ int hmc_static_dense_e(
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
+  std::vector<double> cont_vector;
 
   Eigen::MatrixXd inv_metric;
   try {
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
     inv_metric = util::read_dense_inv_metric(init_inv_metric,
                                              model.num_params_r(), logger);
     util::validate_dense_inv_metric(inv_metric, logger);
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
 

--- a/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
@@ -66,15 +66,17 @@ int hmc_static_dense_e_adapt(
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
+  std::vector<double> cont_vector;
 
   Eigen::MatrixXd inv_metric;
   try {
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
     inv_metric = util::read_dense_inv_metric(init_inv_metric,
                                              model.num_params_r(), logger);
     util::validate_dense_inv_metric(inv_metric, logger);
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
 

--- a/src/stan/services/sample/hmc_static_diag_e.hpp
+++ b/src/stan/services/sample/hmc_static_diag_e.hpp
@@ -59,15 +59,17 @@ int hmc_static_diag_e(Model& model, const stan::io::var_context& init,
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
+  std::vector<double> cont_vector;
 
   Eigen::VectorXd inv_metric;
   try {
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
     inv_metric = util::read_diag_inv_metric(init_inv_metric,
                                             model.num_params_r(), logger);
     util::validate_diag_inv_metric(inv_metric, logger);
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
 

--- a/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
@@ -69,8 +69,8 @@ int hmc_static_diag_e_adapt(
   std::vector<double> cont_vector;
   Eigen::VectorXd inv_metric;
   try {
-    cont_vector = = util::initialize(model, init, rng, init_radius, true,
-                                     logger, init_writer);
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
     inv_metric = util::read_diag_inv_metric(init_inv_metric,
                                             model.num_params_r(), logger);
     util::validate_diag_inv_metric(inv_metric, logger);

--- a/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
@@ -66,15 +66,16 @@ int hmc_static_diag_e_adapt(
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
-
+  std::vector<double> cont_vector;
   Eigen::VectorXd inv_metric;
   try {
+    cont_vector = = util::initialize(model, init, rng, init_radius, true,
+                                     logger, init_writer);
     inv_metric = util::read_diag_inv_metric(init_inv_metric,
                                             model.num_params_r(), logger);
     util::validate_diag_inv_metric(inv_metric, logger);
-  } catch (const std::domain_error& e) {
+  } catch (const std::exception& e) {
+    logger.error(e.what());
     return error_codes::CONFIG;
   }
 

--- a/src/stan/services/sample/hmc_static_unit_e.hpp
+++ b/src/stan/services/sample/hmc_static_unit_e.hpp
@@ -55,9 +55,15 @@ int hmc_static_unit_e(Model& model, const stan::io::var_context& init,
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
+  std::vector<double> cont_vector;
 
+  try {
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::CONFIG;
+  }
   stan::mcmc::unit_e_static_hmc<Model, boost::ecuyer1988> sampler(model, rng);
   sampler.set_nominal_stepsize_and_T(stepsize, int_time);
   sampler.set_stepsize_jitter(stepsize_jitter);

--- a/src/stan/services/sample/hmc_static_unit_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_unit_e_adapt.hpp
@@ -58,9 +58,15 @@ int hmc_static_unit_e_adapt(
   boost::ecuyer1988 rng = util::create_rng(random_seed, chain);
 
   std::vector<int> disc_vector;
-  std::vector<double> cont_vector = util::initialize(
-      model, init, rng, init_radius, true, logger, init_writer);
+  std::vector<double> cont_vector;
 
+  try {
+    cont_vector = util::initialize(model, init, rng, init_radius, true, logger,
+                                   init_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::CONFIG;
+  }
   stan::mcmc::adapt_unit_e_static_hmc<Model, boost::ecuyer1988> sampler(model,
                                                                         rng);
   sampler.set_nominal_stepsize_and_T(stepsize, int_time);

--- a/src/stan/services/util/initialize.hpp
+++ b/src/stan/services/util/initialize.hpp
@@ -104,19 +104,18 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
     } catch (std::domain_error& e) {
       if (msg.str().length() > 0)
         logger.info(msg);
-      logger.info("Rejecting initial value:");
-      logger.info(
+      logger.warn("Rejecting initial value:");
+      logger.warn(
           "  Error evaluating the log probability"
           " at the initial value.");
-      logger.info(e.what());
+      logger.warn(e.what());
       continue;
     } catch (std::exception& e) {
       if (msg.str().length() > 0)
         logger.info(msg);
-      logger.info(
+      logger.error(
           "Unrecoverable error evaluating the log probability"
           " at the initial value.");
-      logger.info(e.what());
       throw;
     }
 
@@ -133,27 +132,26 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
     } catch (std::domain_error& e) {
       if (msg.str().length() > 0)
         logger.info(msg);
-      logger.info("Rejecting initial value:");
-      logger.info(
+      logger.warn("Rejecting initial value:");
+      logger.warn(
           "  Error evaluating the log probability"
           " at the initial value.");
-      logger.info(e.what());
+      logger.warn(e.what());
       continue;
     } catch (std::exception& e) {
       if (msg.str().length() > 0)
         logger.info(msg);
-      logger.info(
+      logger.error(
           "Unrecoverable error evaluating the log probability"
           " at the initial value.");
-      logger.info(e.what());
       throw;
     }
     if (!std::isfinite(log_prob)) {
-      logger.info("Rejecting initial value:");
-      logger.info(
+      logger.warn("Rejecting initial value:");
+      logger.warn(
           "  Log probability evaluates to log(0),"
           " i.e. negative infinity.");
-      logger.info(
+      logger.warn(
           "  Stan can't start sampling from this"
           " initial value.");
       continue;
@@ -169,7 +167,7 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
     } catch (const std::exception& e) {
       if (log_prob_msg.str().length() > 0)
         logger.info(log_prob_msg);
-      logger.info(e.what());
+      logger.error(e.what());
       throw;
     }
     auto end = std::chrono::steady_clock::now();
@@ -183,11 +181,11 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
     bool gradient_ok = std::isfinite(stan::math::sum(gradient));
 
     if (!gradient_ok) {
-      logger.info("Rejecting initial value:");
-      logger.info(
+      logger.warn("Rejecting initial value:");
+      logger.warn(
           "  Gradient evaluated at the initial value"
           " is not finite.");
-      logger.info(
+      logger.warn(
           "  Stan can't start sampling from this"
           " initial value.");
     }
@@ -219,8 +217,8 @@ std::vector<double> initialize(Model& model, const InitContext& init, RNG& rng,
     msg << "Initialization between (-" << init_radius << ", " << init_radius
         << ") failed after"
         << " " << MAX_INIT_TRIES << " attempts. ";
-    logger.info(msg);
-    logger.info(
+    logger.error(msg);
+    logger.error(
         " Try specifying initial values,"
         " reducing ranges of constrained values,"
         " or reparameterizing the model.");

--- a/src/stan/services/util/run_adaptive_sampler.hpp
+++ b/src/stan/services/util/run_adaptive_sampler.hpp
@@ -56,8 +56,8 @@ void run_adaptive_sampler(Sampler& sampler, Model& model,
     sampler.z().q = cont_params;
     sampler.init_stepsize(logger);
   } catch (const std::exception& e) {
-    logger.info("Exception initializing step size.");
-    logger.info(e.what());
+    logger.error("Exception initializing step size.");
+    logger.error(e.what());
     return;
   }
 

--- a/src/test/unit/services/optimize/laplace_sample_test.cpp
+++ b/src/test/unit/services/optimize/laplace_sample_test.cpp
@@ -111,7 +111,7 @@ TEST_F(ServicesLaplaceSample, wrongSizeModeError) {
   int RC = stan::services::laplace_sample<true>(*model, theta_hat, draws, seed,
                                                 refresh, interrupt, logger,
                                                 sample_writer);
-  EXPECT_EQ(stan::services::error_codes::DATAERR, RC);
+  EXPECT_EQ(stan::services::error_codes::CONFIG, RC);
 }
 
 TEST_F(ServicesLaplaceSample, nonPositiveDrawsError) {
@@ -125,7 +125,7 @@ TEST_F(ServicesLaplaceSample, nonPositiveDrawsError) {
   int RC = stan::services::laplace_sample<true>(*model, theta_hat, draws, seed,
                                                 refresh, interrupt, logger,
                                                 sample_writer);
-  EXPECT_EQ(stan::services::error_codes::DATAERR, RC);
+  EXPECT_EQ(stan::services::error_codes::CONFIG, RC);
 }
 
 TEST_F(ServicesLaplaceSample, consoleOutput) {

--- a/src/test/unit/services/sample/hmc_nuts_dense_e_adapt_parallel_match_test.cpp
+++ b/src/test/unit/services/sample/hmc_nuts_dense_e_adapt_parallel_match_test.cpp
@@ -19,10 +19,10 @@ struct deleter_noop {
 class ServicesSampleHmcNutsDenseEAdaptParMatch : public testing::Test {
  public:
   ServicesSampleHmcNutsDenseEAdaptParMatch()
-      : model(std::make_unique<rosenbrock_model_namespace::rosenbrock_model>(
-          data_context, 0, &model_log)),
-        ss_par(num_chains),
-        ss_seq(num_chains) {
+      : ss_par(num_chains),
+        ss_seq(num_chains),
+        model(std::make_unique<rosenbrock_model_namespace::rosenbrock_model>(
+            data_context, 0, &model_log)) {
     for (int i = 0; i < num_chains; ++i) {
       init.push_back(stan::test::unit::instrumented_writer{});
       par_parameters.emplace_back(

--- a/src/test/unit/services/sample/hmc_nuts_diag_e_adapt_parallel_match_test.cpp
+++ b/src/test/unit/services/sample/hmc_nuts_diag_e_adapt_parallel_match_test.cpp
@@ -18,10 +18,10 @@ struct deleter_noop {
 class ServicesSampleHmcNutsDiagEAdaptParMatch : public testing::Test {
  public:
   ServicesSampleHmcNutsDiagEAdaptParMatch()
-      : model(std::make_unique<rosenbrock_model_namespace::rosenbrock_model>(
-          data_context, 0, &model_log)),
-        ss_par(num_chains),
-        ss_seq(num_chains) {
+      : ss_par(num_chains),
+        ss_seq(num_chains),
+        model(std::make_unique<rosenbrock_model_namespace::rosenbrock_model>(
+            data_context, 0, &model_log)) {
     for (int i = 0; i < num_chains; ++i) {
       init.push_back(stan::test::unit::instrumented_writer{});
       par_parameters.emplace_back(

--- a/src/test/unit/services/util/initialize_test.cpp
+++ b/src/test/unit/services/util/initialize_test.cpp
@@ -260,8 +260,8 @@ TEST_F(ServicesUtilInitialize, model_throws__radius_zero) {
       std::domain_error);
 
   EXPECT_EQ(3, logger.call_count());
-  EXPECT_EQ(3, logger.call_count_info());
-  EXPECT_EQ(1, logger.find_info("throwing within log_prob"));
+  EXPECT_EQ(3, logger.call_count_warn());
+  EXPECT_EQ(1, logger.find_warn("throwing within log_prob"));
 }
 
 TEST_F(ServicesUtilInitialize, model_throws__radius_two) {
@@ -274,8 +274,8 @@ TEST_F(ServicesUtilInitialize, model_throws__radius_two) {
                                        init_radius, print_timing, logger, init),
       std::domain_error);
   EXPECT_EQ(303, logger.call_count());
-  EXPECT_EQ(303, logger.call_count_info());
-  EXPECT_EQ(100, logger.find_info("throwing within log_prob"));
+  EXPECT_EQ(300, logger.call_count_warn());
+  EXPECT_EQ(100, logger.find_warn("throwing within log_prob"));
 }
 
 TEST_F(ServicesUtilInitialize, model_throws__full_init) {
@@ -299,8 +299,8 @@ TEST_F(ServicesUtilInitialize, model_throws__full_init) {
                                        init_radius, print_timing, logger, init),
       std::domain_error);
   EXPECT_EQ(303, logger.call_count());
-  EXPECT_EQ(303, logger.call_count_info());
-  EXPECT_EQ(100, logger.find_info("throwing within log_prob"));
+  EXPECT_EQ(300, logger.call_count_warn());
+  EXPECT_EQ(100, logger.find_warn("throwing within log_prob"));
 }
 
 namespace test {
@@ -395,10 +395,9 @@ TEST_F(ServicesUtilInitialize, model_errors__radius_zero) {
       stan::services::util::initialize(error_model, empty_context, rng,
                                        init_radius, print_timing, logger, init),
       std::out_of_range, "out_of_range error in log_prob");
-  EXPECT_EQ(2, logger.call_count());
-  EXPECT_EQ(2, logger.call_count_info());
-  EXPECT_EQ(1, logger.find_info("out_of_range error in log_prob"));
-  EXPECT_EQ(1, logger.find_info("Unrecoverable error evaluating the log "
+  EXPECT_EQ(1, logger.call_count());
+  EXPECT_EQ(1, logger.call_count_error());
+  EXPECT_EQ(1, logger.find_error("Unrecoverable error evaluating the log "
                                 "probability at the initial value."));
 }
 
@@ -411,9 +410,8 @@ TEST_F(ServicesUtilInitialize, model_errors__radius_two) {
       stan::services::util::initialize(error_model, empty_context, rng,
                                        init_radius, print_timing, logger, init),
       std::out_of_range, "out_of_range error in log_prob");
-  EXPECT_EQ(2, logger.call_count());
-  EXPECT_EQ(2, logger.call_count_info());
-  EXPECT_EQ(1, logger.find_info("out_of_range error in log_prob"));
+  EXPECT_EQ(1, logger.call_count());
+  EXPECT_EQ(1, logger.call_count_error());
 }
 
 TEST_F(ServicesUtilInitialize, model_errors__full_init) {
@@ -436,9 +434,8 @@ TEST_F(ServicesUtilInitialize, model_errors__full_init) {
       stan::services::util::initialize(error_model, init_context, rng,
                                        init_radius, print_timing, logger, init),
       std::out_of_range, "out_of_range error in log_prob");
-  EXPECT_EQ(2, logger.call_count());
-  EXPECT_EQ(2, logger.call_count_info());
-  EXPECT_EQ(1, logger.find_info("out_of_range error in log_prob"));
+  EXPECT_EQ(1, logger.call_count());
+  EXPECT_EQ(1, logger.call_count_error());
 }
 
 namespace test {
@@ -536,8 +533,8 @@ TEST_F(ServicesUtilInitialize, model_throws_in_write_array__radius_zero) {
       std::domain_error);
 
   EXPECT_EQ(3, logger.call_count());
-  EXPECT_EQ(3, logger.call_count_info());
-  EXPECT_EQ(1, logger.find_info("throwing within write_array"));
+  EXPECT_EQ(3, logger.call_count_warn());
+  EXPECT_EQ(1, logger.find_warn("throwing within write_array"));
 }
 
 TEST_F(ServicesUtilInitialize, model_throws_in_write_array__radius_two) {
@@ -550,8 +547,9 @@ TEST_F(ServicesUtilInitialize, model_throws_in_write_array__radius_two) {
                                        init_radius, print_timing, logger, init),
       std::domain_error);
   EXPECT_EQ(303, logger.call_count());
-  EXPECT_EQ(303, logger.call_count_info());
-  EXPECT_EQ(100, logger.find_info("throwing within write_array"));
+  EXPECT_EQ(300, logger.call_count_warn());
+  EXPECT_EQ(2, logger.call_count_error());
+  EXPECT_EQ(100, logger.find_warn("throwing within write_array"));
 }
 
 TEST_F(ServicesUtilInitialize, model_throws_in_write_array__full_init) {
@@ -575,6 +573,7 @@ TEST_F(ServicesUtilInitialize, model_throws_in_write_array__full_init) {
                                        init_radius, print_timing, logger, init),
       std::domain_error);
   EXPECT_EQ(303, logger.call_count());
-  EXPECT_EQ(303, logger.call_count_info());
-  EXPECT_EQ(100, logger.find_info("throwing within write_array"));
+  EXPECT_EQ(300, logger.call_count_warn());
+  EXPECT_EQ(2, logger.call_count_error());
+  EXPECT_EQ(100, logger.find_warn("throwing within write_array"));
 }

--- a/src/test/unit/services/util/initialize_test.cpp
+++ b/src/test/unit/services/util/initialize_test.cpp
@@ -398,7 +398,7 @@ TEST_F(ServicesUtilInitialize, model_errors__radius_zero) {
   EXPECT_EQ(1, logger.call_count());
   EXPECT_EQ(1, logger.call_count_error());
   EXPECT_EQ(1, logger.find_error("Unrecoverable error evaluating the log "
-                                "probability at the initial value."));
+                                 "probability at the initial value."));
 }
 
 TEST_F(ServicesUtilInitialize, model_errors__radius_two) {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Currently, the services functions are inconsistent on whether or not they will throw an exception. The versions which accept `num_chains` should never throw, but the older ones will throw if initialization fails.
This consistently puts `utils::initialize` in a `try` block. 

Additionally, we are currently using `logger.info` for messages which are errors, and in several places not logging an error where we could (e.g., the `catch` blocks accompanying the above `try`s).
#### Intended Effect

Improved error logging and exception safety in the services functions

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
