### PR TITLE
Fix typo in quality gate filter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -514,7 +514,7 @@ pipeline {
                 enabledForFailure: true,
                 aggregatingResults : false,
                 filters: [
-                    excludeFile('/lib/.*')
+                    excludeFile('lib/.*')
                 ],
                 tools: [
                     gcc4(id: "pipeline_gcc4", name: "GNU C Compiler"),


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary

Fix a typo in the quality gate filter, this fails downstream tests in Math by being unstable, see [pipeline](https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FMath/detail/PR-2822/85/pipeline/).

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Toptal



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
