### PR TITLE
adds wrapper to hard copy write events for opencl copies

### DIFF
--- a/src/stan/model/indexing/rvalue_cl.hpp
+++ b/src/stan/model/indexing/rvalue_cl.hpp
@@ -255,7 +255,7 @@ inline math::var rvalue(Expr&& expr, const char* name,
   math::check_range("uni indexing", name, expr.cols(), col_index.n_);
   Val res;
   try {
-    std::vector<cl::Event> copy_write_events(expr_.write_events().begin(),
+    std::vector<cl::Event> copy_write_events(expr.write_events().begin(),
                                              expr.write_events().end());
     cl::Event copy_event;
     cl::CommandQueue& queue = stan::math::opencl_context.queue();

--- a/src/stan/model/indexing/rvalue_cl.hpp
+++ b/src/stan/model/indexing/rvalue_cl.hpp
@@ -255,8 +255,8 @@ inline math::var rvalue(Expr&& expr, const char* name,
   math::check_range("uni indexing", name, expr.cols(), col_index.n_);
   Val res;
   try {
-    std::vector<cl::Event> copy_write_events(expr.write_events().begin(),
-                                             expr.write_events().end());
+    std::vector<cl::Event> copy_write_events(expr.val().write_events().begin(),
+                                             expr.val().write_events().end());
     cl::Event copy_event;
     cl::CommandQueue& queue = stan::math::opencl_context.queue();
     queue.enqueueReadBuffer(

--- a/src/stan/model/indexing/rvalue_cl.hpp
+++ b/src/stan/model/indexing/rvalue_cl.hpp
@@ -163,15 +163,17 @@ inline auto rvalue(Expr&& expr, const char* name, const index_uni row_index,
   decltype(auto) expr_eval = expr.eval();
   math::check_range("uni indexing", name, expr_eval.rows(), row_index.n_);
   math::check_range("uni indexing", name, expr_eval.cols(), col_index.n_);
-  cl::CommandQueue queue = stan::math::opencl_context.queue();
   Val res;
   try {
     cl::Event copy_event;
+    std::vector<cl::Event> copy_write_events(expr_eval.write_events().begin(),
+                                             expr_eval.write_events().end());
+    cl::CommandQueue& queue = stan::math::opencl_context.queue();
     queue.enqueueReadBuffer(
         expr_eval.buffer(), true,
         sizeof(Val)
             * (row_index.n_ - 1 + (col_index.n_ - 1) * expr_eval.rows()),
-        sizeof(Val), &res, &expr_eval.write_events(), &copy_event);
+        sizeof(Val), &res, &copy_write_events, &copy_event);
     copy_event.wait();
   } catch (const cl::Error& e) {
     std::ostringstream m;
@@ -251,14 +253,16 @@ inline math::var rvalue(Expr&& expr, const char* name,
   using Val = stan::value_type_t<stan::value_type_t<Expr>>;
   math::check_range("uni indexing", name, expr.rows(), row_index.n_);
   math::check_range("uni indexing", name, expr.cols(), col_index.n_);
-  cl::CommandQueue queue = stan::math::opencl_context.queue();
   Val res;
   try {
+    std::vector<cl::Event> copy_write_events(expr_.write_events().begin(),
+                                             expr.write_events().end());
     cl::Event copy_event;
+    cl::CommandQueue& queue = stan::math::opencl_context.queue();
     queue.enqueueReadBuffer(
         expr.val().buffer(), true,
         sizeof(Val) * (row_index.n_ - 1 + (col_index.n_ - 1) * expr.rows()),
-        sizeof(Val), &res, &expr.val().write_events(), &copy_event);
+        sizeof(Val), &res, &copy_write_events, &copy_event);
     copy_event.wait();
   } catch (const cl::Error& e) {
     std::ostringstream m;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

For https://github.com/stan-dev/math/pull/2905 I need to make a hard copy of the event vector for OpenCL before making a copy to go from a tbb concurrent vector to a standard vector.

#### Intended Effect

In the downstream PR above the stan tests should now pass

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
