### PR TITLE
Adds size checking to uni index array assignment

### DIFF
--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -43,6 +43,11 @@ namespace model {
  *  - General overload for nested std vectors.
  */
 
+template <typename Tuple1, typename Tuple2,
+          require_all_t<internal::is_tuple<Tuple1>,
+                        internal::is_tuple<Tuple2>>* = nullptr>
+inline void assign(Tuple1&& x, Tuple2&& y, const char* name);
+
 /**
  * Assign one object to another.
  *

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -913,9 +913,9 @@ inline constexpr auto make_tuple_seq(std::integer_sequence<T, I...>) {
  * @param y A tuple with elements to be assigned from
  * @param name The name of the tuple to assign to
  */
-template <typename Tuple1, typename Tuple2,
-          require_all_t<internal::is_tuple<Tuple1>,
-                        internal::is_tuple<Tuple2>>*>
+template <
+    typename Tuple1, typename Tuple2,
+    require_all_t<internal::is_tuple<Tuple1>, internal::is_tuple<Tuple2>>*>
 inline void assign(Tuple1&& x, Tuple2&& y, const char* name) {
   constexpr auto t1_size = std::tuple_size<std::decay_t<Tuple1>>::value;
   stan::math::for_each(

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -837,7 +837,7 @@ template <typename StdVec, typename U, require_std_vector_t<StdVec>* = nullptr,
           require_t<std::is_assignable<value_type_t<StdVec>&, U>>* = nullptr>
 inline void assign(StdVec&& x, U&& y, const char* name, index_uni idx) {
   stan::math::check_range("array[uni,...] assign", name, x.size(), idx.n_);
-  x[idx.n_ - 1] = std::forward<U>(y);
+  assign(x[idx.n_ - 1], std::forward<U>(y), name);
 }
 
 /**

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -915,7 +915,7 @@ inline constexpr auto make_tuple_seq(std::integer_sequence<T, I...>) {
  */
 template <typename Tuple1, typename Tuple2,
           require_all_t<internal::is_tuple<Tuple1>,
-                        internal::is_tuple<Tuple2>>* = nullptr>
+                        internal::is_tuple<Tuple2>>*>
 inline void assign(Tuple1&& x, Tuple2&& y, const char* name) {
   constexpr auto t1_size = std::tuple_size<std::decay_t<Tuple1>>::value;
   stan::math::for_each(

--- a/src/test/unit/model/indexing/assign_test.cpp
+++ b/src/test/unit/model/indexing/assign_test.cpp
@@ -697,6 +697,22 @@ TEST(ModelIndexing, doubleToVar) {
   for (int j = 0; j < 3; ++j)
     EXPECT_FLOAT_EQ(c(1, j).val(), d(j));
 }
+
+TEST(ModelIndexing, std_vec_eigen_vec_size_throw) {
+  using stan::model::assign;
+
+  std::vector<Eigen::VectorXd> xs;
+  Eigen::VectorXd x1(3);
+  x1 << 1, 2, 3;
+  xs.push_back(x1);
+  xs.push_back(x1);
+  xs.push_back(x1);
+
+  Eigen::VectorXd x2(2);
+  x2 << 4, 5;
+  vector<Eigen::VectorXd> ys;
+  EXPECT_THROW(assign(xs, x2, "should throw", index_uni(1)), std::invalid_argument);
+}
 TEST(ModelIndexing, resultSizeNegIndexing) {
   using stan::model::assign;
   using stan::model::index_min_max;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes #3150 to do a size check when assigning to the inner elements of an array whose inner elements also have dimensions.

#### Intended Effect

Stop the use of accidental ragged arrays

#### How to Verify

New test added that can be run with 

```c++
python ./runTests.py -j18 ./src/test/unit/model/indexing/assign_test.cpp
```

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
