### PR TITLE
update opencl assign test to reassign zero sized vector after recover_memory() 

### DIFF
--- a/src/test/unit/model/indexing/assign_cl_test.cpp
+++ b/src/test/unit/model/indexing/assign_cl_test.cpp
@@ -105,7 +105,7 @@ TEST(ModelIndexing, assign_opencl_vector_1d) {
                          stan::math::from_matrix_cl(m1_v_cl.adj()));
         EXPECT_MATRIX_EQ(m1_v1.val(),
                          stan::math::from_matrix_cl(m1_v_cl.val()));
-        
+
         EXPECT_THROW(assign(m1_v_cl, m_err, "double err1", index_cl),
                      std::invalid_argument);
         EXPECT_ANY_THROW(assign(m_empty_v_cl,
@@ -147,7 +147,7 @@ TEST(ModelIndexing, assign_opencl_vector_1d) {
         stan::math::var_value<stan::math::matrix_cl<double>> m_v_err = m_err;
         EXPECT_THROW(assign(m1_v_cl, m_v_err, "double err2", index_cl),
                      std::invalid_argument);
-        m_empty_v_cl = stan::math::matrix_cl<double>(0, 1);        
+        m_empty_v_cl = stan::math::matrix_cl<double>(0, 1);
         EXPECT_ANY_THROW(assign(m_empty_v_cl,
                                 rvalue(m2_v_cl, "rvalue var cl", index_cl),
                                 "var cl index err", index_cl));

--- a/src/test/unit/model/indexing/assign_cl_test.cpp
+++ b/src/test/unit/model/indexing/assign_cl_test.cpp
@@ -101,18 +101,16 @@ TEST(ModelIndexing, assign_opencl_vector_1d) {
         set_adjoints1(m1_v_cl);
 
         stan::math::grad();
-
         EXPECT_MATRIX_EQ(m1_v1.adj(),
                          stan::math::from_matrix_cl(m1_v_cl.adj()));
         EXPECT_MATRIX_EQ(m1_v1.val(),
                          stan::math::from_matrix_cl(m1_v_cl.val()));
-
+        
         EXPECT_THROW(assign(m1_v_cl, m_err, "double err1", index_cl),
                      std::invalid_argument);
         EXPECT_ANY_THROW(assign(m_empty_v_cl,
                                 rvalue(m2_cl, "rvalue double cl", index_cl),
                                 "double cl index err", index_cl));
-
         stan::math::recover_memory();
 
         // rev = rev
@@ -136,9 +134,7 @@ TEST(ModelIndexing, assign_opencl_vector_1d) {
         set_adjoints2(m2_v1);
         set_adjoints1(m1_v_cl);
         set_adjoints2(m2_v_cl);
-
         stan::math::grad();
-
         EXPECT_MATRIX_EQ(m1_v1.adj(),
                          stan::math::from_matrix_cl(m1_v_cl.adj()));
         EXPECT_MATRIX_EQ(m2_v1.adj(),
@@ -151,10 +147,10 @@ TEST(ModelIndexing, assign_opencl_vector_1d) {
         stan::math::var_value<stan::math::matrix_cl<double>> m_v_err = m_err;
         EXPECT_THROW(assign(m1_v_cl, m_v_err, "double err2", index_cl),
                      std::invalid_argument);
+        m_empty_v_cl = stan::math::matrix_cl<double>(0, 1);        
         EXPECT_ANY_THROW(assign(m_empty_v_cl,
-                                rvalue(m2_v_cl, "rvalue double cl", index_cl),
-                                "double cl index err", index_cl));
-
+                                rvalue(m2_v_cl, "rvalue var cl", index_cl),
+                                "var cl index err", index_cl));
         stan::math::recover_memory();
       },
       indices);


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes a bug in the stan opencl assign tests that reuses a `var_value<matrix_cl<double>>` after `stan::math::recover_memory()` is called. This popped up in https://github.com/stan-dev/math/pull/2905 in the math. My guess is that this could be the cause of why sometimes these tests would fail randomly.

@t4c1 if you have any time could you take a look at this? I wasn't sure if this was intended as some part of the test or not and I'm missing something. You can replicate the error this fixes with the following

```bash
git clone --recursive git@github.com:stan-dev/stan.git
cd lib/stan_math
git checkout feature/threadsafe-matrixcl
cd ../../
python ./runTests.py ./src/test/unit/model/indexing/assign_cl_test.cpp
```

It's odd because after `recover_memory()` is called `m_empty_v_cl` will have a size of (4, 1). Which is the same size as the m2_cl vector we try to assign to it, but that test successfully throws so I'm not sure why that would happen.

#### Intended Effect

Fix bug in `var_value<matrix_cl<double>>` assignment

#### How to Verify

```bash
python ./runTests.py ./src/test/unit/model/indexing/assign_cl_test.cpp
```

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
