### PR TITLE
improve Pareto k warning message

### DIFF
--- a/src/stan/services/pathfinder/psis.hpp
+++ b/src/stan/services/pathfinder/psis.hpp
@@ -262,9 +262,9 @@ inline Eigen::Array<double, Eigen::Dynamic, 1> psis_weights(
       }
       if (smoothed.second > 0.7) {
         logger.warn(std::string("Pareto k value (") +
-         std::to_string(smoothed.second) + ") is greater than 0.7 which may"
-         " indicate a poor approximation of the target distribution"
-         " or model misspecification.");
+         std::to_string(smoothed.second) + ") is greater than 0.7."
+         " Importance resampling was not able to improve the approximation,"
+         " which may indicate that the approximation itself is poor.");
       }
     }
   }

--- a/src/stan/services/pathfinder/psis.hpp
+++ b/src/stan/services/pathfinder/psis.hpp
@@ -262,8 +262,9 @@ inline Eigen::Array<double, Eigen::Dynamic, 1> psis_weights(
       }
       if (smoothed.second > 0.7) {
         logger.warn(std::string("Pareto k value (") +
-         std::to_string(smoothed.second) + ") is greater than 0.7 which often"
-         " indicates model" " misspecification.");
+         std::to_string(smoothed.second) + ") is greater than 0.7 which may"
+         " indicate a poor approximation of the target distribution"
+         " or model misspecification.");
       }
     }
   }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes #3223. Improves misleading Pareto k warning message. I didn't see any tests that check the text of this message so I didn't edit any tests.

The old message said "...which often indicates model misspecification", but this is somewhat misleading. More accurate is 
"... which may indicate a poor approximation of the target distribution or model misspecification". 

@avehtari What do you think of this message? 

#### Intended Effect

Change text of warning message. 

#### How to Verify

I suppose run a model that results in the warning message (are there any we know to definitely trigger the warning? Aki will probably know), but I think it’s sufficient to just look at the edited text. 

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University 



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
