### PR TITLE
Make json_writer a structured_writer, improve output formatting

### DIFF
--- a/src/stan/callbacks/json_writer.hpp
+++ b/src/stan/callbacks/json_writer.hpp
@@ -103,8 +103,9 @@ class json_writer final : public structured_writer {
 
   template <typename T>
   void write_int_like(const std::string& key, T value) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
     *output_ << value;
@@ -190,8 +191,9 @@ class json_writer final : public structured_writer {
    * Writes "{", initial token of a JSON record.
    */
   void begin_record() {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     *output_ << "{";
     record_depth_++;
@@ -203,8 +205,9 @@ class json_writer final : public structured_writer {
    * @param[in] key The name of the record.
    */
   void begin_record(const std::string& key) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
     *output_ << "{";
@@ -215,8 +218,9 @@ class json_writer final : public structured_writer {
    * Writes "}", final token of a JSON record.
    */
   void end_record() {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     record_depth_--;
     *output_ << "\n" << std::string(record_depth_ * 2, ' ') << "}";
     if (record_depth_ > 0) {
@@ -232,8 +236,9 @@ class json_writer final : public structured_writer {
    * @param key Name of the value pair
    */
   void write(const std::string& key) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
     *output_ << "null";
@@ -245,8 +250,9 @@ class json_writer final : public structured_writer {
    * @param value string to write.
    */
   void write(const std::string& key, const std::string& value) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     std::string processsed_string = process_string(value);
     write_sep();
     write_key(key);
@@ -259,8 +265,9 @@ class json_writer final : public structured_writer {
    * @param value pointer to chars to write.
    */
   void write(const std::string& key, const char* value) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     std::string processsed_string = process_string(value);
     write_sep();
     write_key(key);
@@ -273,8 +280,9 @@ class json_writer final : public structured_writer {
    * @param value bool to write.
    */
   void write(const std::string& key, bool value) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
     *output_ << (value ? "true" : "false");
@@ -322,8 +330,9 @@ class json_writer final : public structured_writer {
    * @param value double to write.
    */
   void write(const std::string& key, double value) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
     write_value(value);
@@ -335,8 +344,9 @@ class json_writer final : public structured_writer {
    * @param value complex value to write.
    */
   void write(const std::string& key, const std::complex<double>& value) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
     write_complex_value(value);
@@ -348,8 +358,9 @@ class json_writer final : public structured_writer {
    * @param values vector to write.
    */
   void write(const std::string& key, const std::vector<std::string>& v) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
 
@@ -370,8 +381,9 @@ class json_writer final : public structured_writer {
    * @param values vector to write.
    */
   void write(const std::string& key, const std::vector<double>& v) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
 
@@ -394,8 +406,9 @@ class json_writer final : public structured_writer {
    * @param values vector to write.
    */
   void write(const std::string& key, const std::vector<int>& v) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
 
@@ -417,8 +430,9 @@ class json_writer final : public structured_writer {
    */
   void write(const std::string& key,
              const std::vector<std::complex<double>>& v) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
 
@@ -440,8 +454,9 @@ class json_writer final : public structured_writer {
    * @param vec Eigen Vector to write.
    */
   void write(const std::string& key, const Eigen::VectorXd& vec) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
     write_eigen_vector(vec);
@@ -453,8 +468,9 @@ class json_writer final : public structured_writer {
    * @param vec Eigen Vector to write.
    */
   void write(const std::string& key, const Eigen::RowVectorXd& vec) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
     write_eigen_vector(vec);
@@ -466,8 +482,9 @@ class json_writer final : public structured_writer {
    * @param mat Eigen Matrix to write.
    */
   void write(const std::string& key, const Eigen::MatrixXd& mat) {
-    if (output_ == nullptr)
+    if (output_ == nullptr) {
       return;
+    }
     write_sep();
     write_key(key);
     *output_ << "[ ";

--- a/src/stan/callbacks/json_writer.hpp
+++ b/src/stan/callbacks/json_writer.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
+#include <stan/callbacks/structured_writer.hpp>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -28,7 +29,7 @@ namespace callbacks {
  * output stream
  */
 template <typename Stream, typename Deleter = std::default_delete<Stream>>
-class json_writer {
+class json_writer final : public structured_writer {
  private:
   // Output stream
   std::unique_ptr<Stream, Deleter> output_{nullptr};
@@ -37,30 +38,17 @@ class json_writer {
   // Depth of records (used to determine whether or not to print comma
   // separator)
   int record_depth_ = 0;
-  // Whether or not the record's parent object needs a comma separator
-  bool record_needs_comma_ = false;
-
-  /**
-   * Writes a comma separator for the record's parent object if needed.
-   */
-  void write_record_comma_if_needed() {
-    if (record_depth_ > 0 && record_needs_comma_) {
-      *output_ << ",\n";
-      record_needs_comma_ = false;
-    } else {
-      write_sep();
-    }
-  }
 
   /**
    * Determines whether a record's internal object requires a comma separator
    */
   void write_sep() {
     if (record_element_needs_comma_) {
-      *output_ << ", ";
+      *output_ << ",";
     } else {
       record_element_needs_comma_ = true;
     }
+    *output_ << "\n";
   }
 
   /**
@@ -109,7 +97,17 @@ class json_writer {
    * @param[in] key member name.
    */
   void write_key(const std::string& key) {
-    *output_ << "\"" << process_string(key) << "\" : ";
+    *output_ << std::string(record_depth_ * 2, ' ') << "\""
+             << process_string(key) << "\" : ";
+  }
+
+  template <typename T>
+  void write_int_like(const std::string& key, T value) {
+    if (output_ == nullptr)
+      return;
+    write_sep();
+    write_key(key);
+    *output_ << value;
   }
 
   /**
@@ -142,78 +140,6 @@ class json_writer {
     *output_ << ", ";
     write_value(v.imag());
     *output_ << "]";
-  }
-
-  /**
-   * Writes a set of comma separated strings.
-   * Strings are cleaned to escape special characters.
-   *
-   * @param[in] v Values in a std::vector
-   */
-  void write_vector(const std::vector<std::string>& v) {
-    *output_ << "[ ";
-    if (v.size() > 0) {
-      auto last = v.end();
-      --last;
-      for (auto it = v.begin(); it != last; ++it) {
-        *output_ << process_string(*it) << ", ";
-      }
-    }
-    *output_ << v.back() << " ]";
-  }
-
-  /**
-   * Writes a set of comma separated double values.
-   *
-   * @param[in] v Values in a std::vector
-   */
-  void write_vector(const std::vector<double>& v) {
-    *output_ << "[ ";
-    if (v.size() > 0) {
-      auto last = v.end();
-      --last;
-      for (auto it = v.begin(); it != last; ++it) {
-        write_value(*it);
-        *output_ << ", ";
-      }
-      write_value(v.back());
-    }
-    *output_ << " ]";
-  }
-
-  /**
-   * Writes a set of comma separated integer values.
-   *
-   * @param[in] v Values in a std::vector
-   */
-  void write_vector(const std::vector<int>& v) {
-    *output_ << "[ ";
-    if (v.size() > 0) {
-      auto last = v.end();
-      --last;
-      for (auto it = v.begin(); it != last; ++it) {
-        *output_ << *it << ", ";
-      }
-    }
-    *output_ << v.back() << " ]";
-  }
-
-  /**
-   * Writes a set of comma separated complex values.
-   *
-   * @param[in] v Values in a std::vector
-   */
-  void write_vector(const std::vector<std::complex<double>>& v) {
-    *output_ << "[ ";
-    if (v.size() > 0) {
-      size_t last = v.size() - 1;
-      for (size_t i = 0; i < last; ++i) {
-        write_complex_value(v[i]);
-        *output_ << ", ";
-      }
-      write_complex_value(v[last]);
-    }
-    *output_ << " ]";
   }
 
   /**
@@ -266,7 +192,7 @@ class json_writer {
   void begin_record() {
     if (output_ == nullptr)
       return;
-    write_record_comma_if_needed();
+    write_sep();
     *output_ << "{";
     record_depth_++;
     record_element_needs_comma_ = false;
@@ -279,8 +205,9 @@ class json_writer {
   void begin_record(const std::string& key) {
     if (output_ == nullptr)
       return;
-    write_record_comma_if_needed();
-    *output_ << "\"" << key << "\" : {";
+    write_sep();
+    write_key(key);
+    *output_ << "{";
     record_depth_++;
     record_element_needs_comma_ = false;
   }
@@ -290,10 +217,10 @@ class json_writer {
   void end_record() {
     if (output_ == nullptr)
       return;
-    *output_ << "}";
     record_depth_--;
+    *output_ << "\n" << std::string(record_depth_ * 2, ' ') << "}";
     if (record_depth_ > 0) {
-      record_needs_comma_ = true;
+      record_element_needs_comma_ = true;
     } else {
       *output_ << "\n";
     }
@@ -358,13 +285,7 @@ class json_writer {
    * @param key Name of the value pair
    * @param value int to write.
    */
-  void write(const std::string& key, int value) {
-    if (output_ == nullptr)
-      return;
-    write_sep();
-    write_key(key);
-    *output_ << value;
-  }
+  void write(const std::string& key, int value) { write_int_like(key, value); }
 
   /**
    * Write a key-value pair where the value is an `std::size_t`.
@@ -372,11 +293,25 @@ class json_writer {
    * @param value `std::size_t` to write.
    */
   void write(const std::string& key, std::size_t value) {
-    if (output_ == nullptr)
-      return;
-    write_sep();
-    write_key(key);
-    *output_ << value;
+    write_int_like(key, value);
+  }
+
+  /**
+   * Write a key-value pair where the value is an `long long int`.
+   * @param key Name of the value pair
+   * @param value `long long int` to write.
+   */
+  void write(const std::string& key, long long int value) {
+    write_int_like(key, value);
+  }
+
+  /**
+   * Write a key-value pair where the value is an `unsigned int`.
+   * @param key Name of the value pair
+   * @param value `unsigned int` to write.
+   */
+  void write(const std::string& key, unsigned int value) {
+    write_int_like(key, value);
   }
 
   /**
@@ -410,13 +345,91 @@ class json_writer {
    * @param key Name of the value pair
    * @param values vector to write.
    */
-  template <typename T>
-  void write(const std::string& key, const std::vector<T>& values) {
+  void write(const std::string& key, const std::vector<std::string>& v) {
     if (output_ == nullptr)
       return;
     write_sep();
     write_key(key);
-    write_vector(values);
+
+    *output_ << "[ ";
+    if (v.size() > 0) {
+      auto last = v.end();
+      --last;
+      for (auto it = v.begin(); it != last; ++it) {
+        *output_ << process_string(*it) << ", ";
+      }
+    }
+    *output_ << v.back() << " ]";
+  }
+
+  /**
+   * Write a key-value pair where the value is a vector to be made a list.
+   * @param key Name of the value pair
+   * @param values vector to write.
+   */
+  void write(const std::string& key, const std::vector<double>& v) {
+    if (output_ == nullptr)
+      return;
+    write_sep();
+    write_key(key);
+
+    *output_ << "[ ";
+    if (v.size() > 0) {
+      auto last = v.end();
+      --last;
+      for (auto it = v.begin(); it != last; ++it) {
+        write_value(*it);
+        *output_ << ", ";
+      }
+      write_value(v.back());
+    }
+    *output_ << " ]";
+  }
+
+  /**
+   * Write a key-value pair where the value is a vector to be made a list.
+   * @param key Name of the value pair
+   * @param values vector to write.
+   */
+  void write(const std::string& key, const std::vector<int>& v) {
+    if (output_ == nullptr)
+      return;
+    write_sep();
+    write_key(key);
+
+    *output_ << "[ ";
+    if (v.size() > 0) {
+      auto last = v.end();
+      --last;
+      for (auto it = v.begin(); it != last; ++it) {
+        *output_ << *it << ", ";
+      }
+    }
+    *output_ << v.back() << " ]";
+  }
+
+  /**
+   * Write a key-value pair where the value is a vector to be made a list.
+   * @param key Name of the value pair
+   * @param values vector to write.
+   */
+  void write(const std::string& key,
+             const std::vector<std::complex<double>>& v) {
+    if (output_ == nullptr)
+      return;
+    write_sep();
+    write_key(key);
+
+    *output_ << "[ ";
+    if (v.size() > 0) {
+      size_t last = v.size() - 1;
+      for (size_t i = 0; i < last; ++i) {
+        write_complex_value(v[i]);
+        *output_ << ", ";
+      }
+      write_complex_value(v[last]);
+    }
+    *output_ << " ]";
   }
 
   /**

--- a/src/stan/callbacks/json_writer.hpp
+++ b/src/stan/callbacks/json_writer.hpp
@@ -301,7 +301,9 @@ class json_writer final : public structured_writer {
    * @param key Name of the value pair
    * @param value `long long int` to write.
    */
-  void write(const std::string& key, long long int value) {
+  void write(const std::string& key,
+             long long int value  // NOLINT(runtime/int)
+  ) {
     write_int_like(key, value);
   }
 

--- a/src/stan/callbacks/json_writer.hpp
+++ b/src/stan/callbacks/json_writer.hpp
@@ -184,7 +184,7 @@ class json_writer final : public structured_writer {
   json_writer(json_writer&& other) noexcept
       : output_(std::move(other.output_)) {}
 
-  ~json_writer() {}
+  virtual ~json_writer() {}
 
   /**
    * Writes "{", initial token of a JSON record.

--- a/src/stan/callbacks/structured_writer.hpp
+++ b/src/stan/callbacks/structured_writer.hpp
@@ -76,7 +76,9 @@ class structured_writer {
    * @param key Name of the value pair
    * @param value `long long int` to write.
    */
-  virtual void write(const std::string& key, long long int value) {}
+  virtual void write(const std::string& key,
+                     long long int value  // NOLINT(runtime/int)
+  ) {}
 
   /**
    * Write a key-value pair where the value is an `unsigned int`.

--- a/src/stan/callbacks/structured_writer.hpp
+++ b/src/stan/callbacks/structured_writer.hpp
@@ -115,35 +115,51 @@ class structured_writer {
    * @param key Name of the value pair
    * @param values vector of strings to write.
    */
-  void write(const std::string& key, const std::vector<std::string>& values) {}
+  virtual void write(const std::string& key,
+                     const std::vector<std::string>& values) {}
+
+  /**
+   * Write a key-value pair where the value is a vector to be made a list.
+   * @param key Name of the value pair
+   * @param values vector to write.
+   */
+  virtual void write(const std::string& key,
+                     const std::vector<std::complex<double>>& v) {}
+
+  /**
+   * Write a key-value pair where the value is a vector to be made a list.
+   * @param key Name of the value pair
+   * @param values vector to write.
+   */
+  virtual void write(const std::string& key, const std::vector<int>& v) {}
 
   /**
    * Write a key-value pair where the value is an Eigen Matrix.
    * @param key Name of the value pair
    * @param mat Eigen Matrix to write.
    */
-  void write(const std::string& key, const Eigen::MatrixXd& mat) {}
+  virtual void write(const std::string& key, const Eigen::MatrixXd& mat) {}
 
   /**
    * Write a key-value pair where the value is an Eigen Vector.
    * @param key Name of the value pair
    * @param vec Eigen Vector to write.
    */
-  void write(const std::string& key, const Eigen::VectorXd& vec) {}
+  virtual void write(const std::string& key, const Eigen::VectorXd& vec) {}
 
   /**
    * Write a key-value pair where the value is a Eigen RowVector.
    * @param key Name of the value pair
    * @param vec Eigen RowVector to write.
    */
-  void write(const std::string& key, const Eigen::RowVectorXd& vec) {}
+  virtual void write(const std::string& key, const Eigen::RowVectorXd& vec) {}
 
   /**
    * Write a key-value pair where the value is a const char*.
    * @param key Name of the value pair
    * @param value pointer to chars to write.
    */
-  void write(const std::string& key, const char* value) {}
+  virtual void write(const std::string& key, const char* value) {}
 };
 
 }  // namespace callbacks

--- a/src/stan/callbacks/structured_writer.hpp
+++ b/src/stan/callbacks/structured_writer.hpp
@@ -29,22 +29,12 @@ class structured_writer {
    * Writes key followed by start token of a structured record.
    * @param[in] key The name of the record.
    */
-  virtual void begin_record(const std::string& key, bool newline = false) {}
+  virtual void begin_record(const std::string& key) {}
 
   /**
    * Writes end token of a structured record.
    */
   virtual void end_record() {}
-
-  /**
-   * Writes start token of a list.
-   */
-  virtual void begin_list() {}
-
-  /**
-   * Writes end token of a list.
-   */
-  virtual void end_list() {}
 
   /**
    * Write a key-value pair to the output stream with a value of null as the
@@ -59,11 +49,6 @@ class structured_writer {
    * @param value string to write.
    */
   virtual void write(const std::string& key, const std::string& value) {}
-
-  /**
-   * No-op
-   */
-  virtual void write() {}
 
   /**
    * Write a key-value pair where the value is a bool.
@@ -85,6 +70,20 @@ class structured_writer {
    * @param value `std::size_t` to write.
    */
   virtual void write(const std::string& key, std::size_t value) {}
+
+  /**
+   * Write a key-value pair where the value is an `long long int`.
+   * @param key Name of the value pair
+   * @param value `long long int` to write.
+   */
+  virtual void write(const std::string& key, long long int value) {}
+
+  /**
+   * Write a key-value pair where the value is an `unsigned int`.
+   * @param key Name of the value pair
+   * @param value `unsigned int` to write.
+   */
+  virtual void write(const std::string& key, unsigned int value) {}
 
   /**
    * Write a key-value pair where the value is a double.
@@ -143,11 +142,6 @@ class structured_writer {
    * @param value pointer to chars to write.
    */
   void write(const std::string& key, const char* value) {}
-
-  /**
-   * Reset state
-   */
-  virtual void reset() {}
 };
 
 }  // namespace callbacks


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Follow up on #3191.

This PR:
- Improves the output of the JSON writer to be a bit more human readable (mainly by more consistently outputting newlines between key:value pairs)
- Updates both `structured_writer` and `json_writer` such that the latter can be a subclass of the former. 
- Fixed a bug where `j.begin_record("foo"); j.end_record(); j.write("anything here");` would generate invalid JSON

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
