### PR TITLE
Use stan::test::is_valid_JSON consistently

### DIFF
--- a/src/test/unit/callbacks/json_writer_test.cpp
+++ b/src/test/unit/callbacks/json_writer_test.cpp
@@ -1,5 +1,5 @@
 #include <stan/callbacks/json_writer.hpp>
-#include<test/unit/util.hpp>
+#include <test/unit/util.hpp>
 #include <gtest/gtest.h>
 #include <string>
 

--- a/src/test/unit/callbacks/json_writer_test.cpp
+++ b/src/test/unit/callbacks/json_writer_test.cpp
@@ -1,5 +1,5 @@
 #include <stan/callbacks/json_writer.hpp>
-#include <rapidjson/document.h>
+#include<test/unit/util.hpp>
 #include <gtest/gtest.h>
 #include <string>
 
@@ -86,9 +86,10 @@ TEST_F(StanInterfaceCallbacksJsonWriter, begin_end_record_nested) {
   }
 }
 )json";
-  EXPECT_EQ(expected, ss.str());
-  rapidjson::Document document;
-  ASSERT_FALSE(document.Parse<0>(ss.str().c_str()).HasParseError());
+
+  auto json = ss.str();
+  EXPECT_EQ(expected, json);
+  ASSERT_TRUE(stan::test::is_valid_JSON(json));
 }
 
 TEST_F(StanInterfaceCallbacksJsonWriter, write_double_vector) {
@@ -147,7 +148,6 @@ TEST_F(StanInterfaceCallbacksJsonWriter, more_members) {
 TEST_F(StanInterfaceCallbacksJsonWriter, write_double_vector_precision2) {
   ss << std::setprecision(2);
   std::string key("key");
-  const int N = 5;
   std::vector<double> x{1.23456789, 2.3456789, 3.45678910, 4.567890123};
   writer.write(key, x);
   auto out = output_sans_whitespace(ss);
@@ -178,7 +178,6 @@ TEST_F(StanInterfaceCallbacksJsonWriter, write_string_special_characters) {
       ss.str());
 }
 TEST_F(StanInterfaceCallbacksJsonWriter, write_double_vector_precision3) {
-  const int N = 5;
   std::vector<double> x{1.23456789, 2.3456789, 3.45678910, 4.567890123};
   ss.precision(3);
   writer.write("key", x);

--- a/src/test/unit/services/pathfinder/normal_glm_test.cpp
+++ b/src/test/unit/services/pathfinder/normal_glm_test.cpp
@@ -10,7 +10,7 @@
 #include <test/unit/services/instrumented_callbacks.hpp>
 #include <test/unit/services/pathfinder/util.hpp>
 #include <test/unit/services/util.hpp>
-#include <rapidjson/document.h>
+#include <test/unit/util.hpp>
 #include <gtest/gtest.h>
 
 // Locally tests can use threads but for jenkins we should just use 1 thread
@@ -90,7 +90,7 @@ TEST_F(ServicesPathfinderGLM, single) {
 
   std::vector<std::tuple<Eigen::VectorXd, Eigen::VectorXd>> input_iters;
 
-  int return_code = stan::services::pathfinder::pathfinder_lbfgs_single(
+  stan::services::pathfinder::pathfinder_lbfgs_single(
       model, empty_context, seed, chain, init_radius, history_size, init_alpha,
       tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param, num_iterations,
       num_elbo_draws, num_draws, save_iterations, refresh, callback, logger,
@@ -132,8 +132,8 @@ TEST_F(ServicesPathfinderGLM, single) {
   for (int i = 2; i < all_mean_vals.cols(); ++i) {
     EXPECT_NEAR(0, all_sd_vals(2, i), .1);
   }
-  rapidjson::Document document;
-  ASSERT_FALSE(document.Parse<0>(diagnostic_ss.str().c_str()).HasParseError());
+  auto json = diagnostic_ss.str();
+  ASSERT_TRUE(stan::test::is_valid_JSON(json));
 }
 
 TEST_F(ServicesPathfinderGLM, multi) {
@@ -166,7 +166,7 @@ TEST_F(ServicesPathfinderGLM, multi) {
         std::make_unique<decltype(init_init_context())>(init_init_context()));
   }
   stan::test::mock_callback callback;
-  int return_code = stan::services::pathfinder::pathfinder_lbfgs_multi(
+  stan::services::pathfinder::pathfinder_lbfgs_multi(
       model, single_path_inits, seed, chain, init_radius, history_size,
       init_alpha, tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param,
       num_iterations, num_elbo_draws, num_draws, num_multi_draws, num_paths,


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Follow up on #3230, uses the new utility function in a couple places we were directly using RapidJSON for testing

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
