### PR TITLE
Remove unused deprecated boost header include

### DIFF
--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -16,7 +16,6 @@
 #include <tbb/parallel_for.h>
 #include <tbb/concurrent_vector.h>
 #include <boost/random/discrete_distribution.hpp>
-#include <boost/iterator.hpp>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Since  https://github.com/stan-dev/math/pull/2955, building cmdstan has been issuing the following warning:

```
stan/lib/stan_math/lib/boost_1.81.0/boost/config/pragma_message.hpp:24:34: note: ‘#pragma message: This header is deprecated. Use <iterator> instead.’
   24 | # define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
      |                                  ^~~~~~~
stan/lib/stan_math/lib/boost_1.81.0/boost/config/pragma_message.hpp:24:34: note: in definition of macro ‘BOOST_PRAGMA_MESSAGE’
   24 | # define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
      |                                  ^~~~~~~
stan/lib/stan_math/lib/boost_1.81.0/boost/iterator.hpp:10:1: note: in expansion of macro ‘BOOST_HEADER_DEPRECATED’
   10 | BOOST_HEADER_DEPRECATED("<iterator>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
```

We only include this header in the multipath pathfinder implementation, and it is not necessary.

#### Intended Effect

Remove the deprecation warning.

#### How to Verify

Build cmdstan with this branch

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
