### PR TITLE
jenkins: cleanup old build logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,7 @@ pipeline {
         skipDefaultCheckout()
         preserveStashes(buildCount: 7)
         parallelsAlwaysFailFast()
+        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '30'))
     }
     environment {
         GCC = 'g++'


### PR DESCRIPTION
Add jenkins configuration to remove old build logs and artifacts after some time to avoid running out of disk space. Feel free to tweak the specific numbers, as long as we don't keep them forever.