### PR TITLE
Log optimization errors on error channel

### DIFF
--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -172,14 +172,16 @@ int bfgs(Model& model, const stan::io::var_context& init,
   }
 
   int return_code;
+  auto error_string = bfgs.get_code_string(ret);
   if (ret >= 0) {
     logger.info("Optimization terminated normally: ");
+    logger.info("  " + error_string);
     return_code = error_codes::OK;
   } else {
     logger.error("Optimization terminated with error: ");
+    logger.error("  " + error_string);
     return_code = error_codes::SOFTWARE;
   }
-  logger.info("  " + bfgs.get_code_string(ret));
 
   return return_code;
 }

--- a/src/stan/services/optimize/lbfgs.hpp
+++ b/src/stan/services/optimize/lbfgs.hpp
@@ -176,14 +176,17 @@ int lbfgs(Model& model, const stan::io::var_context& init,
   }
 
   int return_code;
+  auto error_string = lbfgs.get_code_string(ret);
+
   if (ret >= 0) {
     logger.info("Optimization terminated normally: ");
+    logger.info("  " + error_string);
     return_code = error_codes::OK;
   } else {
     logger.error("Optimization terminated with error: ");
+    logger.error("  " + error_string);
     return_code = error_codes::SOFTWARE;
   }
-  logger.info("  " + lbfgs.get_code_string(ret));
 
   return return_code;
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Similar to #3214, this makes it so an error message emitted by bfgs or lbfgs is not split between stderr and stdout but is entirely sent to stderr.

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
