### PR TITLE
Fix nondeterminism in multi-Pathfinder

### DIFF
--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -14,7 +14,6 @@
 #include <stan/services/util/duration_diff.hpp>
 #include <stan/services/util/initialize.hpp>
 #include <tbb/parallel_for.h>
-#include <tbb/concurrent_vector.h>
 #include <boost/random/discrete_distribution.hpp>
 #include <string>
 #include <vector>
@@ -101,12 +100,11 @@ inline int pathfinder_lbfgs_multi(
   model.constrained_param_names(param_names, true, true);
 
   parameter_writer(param_names);
-  tbb::concurrent_vector<Eigen::Array<double, Eigen::Dynamic, 1>>
-      individual_lp_ratios;
-  individual_lp_ratios.reserve(num_paths);
-  tbb::concurrent_vector<Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>>
+  std::vector<Eigen::Array<double, Eigen::Dynamic, 1>> individual_lp_ratios;
+  individual_lp_ratios.resize(num_paths);
+  std::vector<Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>>
       individual_samples;
-  individual_samples.reserve(num_paths);
+  individual_samples.resize(num_paths);
   std::atomic<size_t> lp_calls{0};
   tbb::parallel_for(
       tbb::blocked_range<int>(0, num_paths), [&](tbb::blocked_range<int> r) {
@@ -125,13 +123,27 @@ inline int pathfinder_lbfgs_multi(
                          + std::to_string(iter) + " failed.");
             return;
           }
-          individual_lp_ratios.emplace_back(
-              std::move(std::get<1>(pathfinder_ret)));
-          individual_samples.emplace_back(
-              std::move(std::get<2>(pathfinder_ret)));
+          individual_lp_ratios[iter] = std::move(std::get<1>(pathfinder_ret));
+          individual_samples[iter] = std::move(std::get<2>(pathfinder_ret));
           lp_calls += std::get<3>(pathfinder_ret);
         }
       });
+
+  // if any pathfinders failed, we want to remove their empty results
+  individual_lp_ratios.erase(
+      std::remove_if(individual_lp_ratios.begin(), individual_lp_ratios.end(),
+                     [](const auto& v) {
+                       return v.size() == 0;
+                     }),
+      individual_lp_ratios.end());
+  individual_samples.erase(
+      std::remove_if(
+          individual_samples.begin(), individual_samples.end(),
+          [](const auto& v) {
+            return v.size() == 0;
+          }),
+      individual_samples.end());
+
   const auto end_pathfinders_time = std::chrono::steady_clock::now();
 
   const double pathfinders_delta_time = stan::services::util::duration_diff(

--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -132,16 +132,11 @@ inline int pathfinder_lbfgs_multi(
   // if any pathfinders failed, we want to remove their empty results
   individual_lp_ratios.erase(
       std::remove_if(individual_lp_ratios.begin(), individual_lp_ratios.end(),
-                     [](const auto& v) {
-                       return v.size() == 0;
-                     }),
+                     [](const auto& v) { return v.size() == 0; }),
       individual_lp_ratios.end());
   individual_samples.erase(
-      std::remove_if(
-          individual_samples.begin(), individual_samples.end(),
-          [](const auto& v) {
-            return v.size() == 0;
-          }),
+      std::remove_if(individual_samples.begin(), individual_samples.end(),
+                     [](const auto& v) { return v.size() == 0; }),
       individual_samples.end());
 
   const auto end_pathfinders_time = std::chrono::steady_clock::now();


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

The current design is such that the order of the single-pathfinder draws is determined by the order their thread completes, so a random seed does not always produce the same output of multi-pathfinder. 

More details are given in #3237

#### Intended Effect

Closes #3237 

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
