### PR TITLE
Replace usage of killOldBuilds with disableConcurrentBuilds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,6 +96,7 @@ pipeline {
         preserveStashes(buildCount: 7)
         parallelsAlwaysFailFast()
         buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '30'))
+        disableConcurrentBuilds(abortPrevious: true)
     }
     environment {
         GCC = 'g++'
@@ -114,19 +115,6 @@ pipeline {
         OPENCL_PLATFORM_ID_GPU = 0
     }
     stages {
-
-        stage('Kill previous builds') {
-            when {
-                not { branch 'develop' }
-                not { branch 'master' }
-                not { branch 'downstream_tests' }
-            }
-            steps {
-                script {
-                    utils.killOldBuilds()
-                }
-            }
-        }
         stage("Clang-format") {
             agent {
                 docker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
         preserveStashes(buildCount: 7)
         parallelsAlwaysFailFast()
         buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '30'))
-        disableConcurrentBuilds(abortPrevious: true)
+        disableConcurrentBuilds(abortPrevious: env.BRANCH_NAME != "downstream_tests" || env.BRANCH_NAME != "downstream_hotfix")
     }
     environment {
         GCC = 'g++'


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary

Due to some Jenkins changes, we have to migrate away from the old way of killing concurrent builds.

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
