### PR TITLE
update psis to not add back the max and return the unnormalized resample ratios

### DIFF
--- a/src/stan/services/pathfinder/psis.hpp
+++ b/src/stan/services/pathfinder/psis.hpp
@@ -270,14 +270,7 @@ inline Eigen::Array<double, Eigen::Dynamic, 1> psis_weights(
   }
 
   // truncate at max of raw wts (i.e., 0 since max has been subtracted)
-  for (Eigen::Index i = 0; i < llr_weights.size(); ++i) {
-    if (llr_weights.coeff(i) > 0) {
-      llr_weights.coeffRef(i) = 0.0;
-    }
-  }
-  auto max_adj = (llr_weights + max_log_ratio).eval();
-  auto max_adj_exp = max_adj.exp();
-  return max_adj_exp / max_adj_exp.sum();
+  return (llr_weights.array() < 0.0).select(llr_weights, 0.0).exp().eval();
 }
 
 }  // namespace psis


### PR DESCRIPTION
Fixes #3241 by just removing the line that adds back the max log likelihood ratio

#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

#### Intended Effect

#### How to Verify

Should we have tests for this? This just seemed like a numeric bug inside of the function so I'm not sure if / how to test this

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Flatiron Institute



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
