### PR TITLE
PSR: Return early if no draws

### DIFF
--- a/src/stan/analyze/mcmc/compute_potential_scale_reduction.hpp
+++ b/src/stan/analyze/mcmc/compute_potential_scale_reduction.hpp
@@ -35,6 +35,9 @@ inline double compute_potential_scale_reduction(
     std::vector<const double*> draws, std::vector<size_t> sizes) {
   int num_chains = sizes.size();
   size_t num_draws = sizes[0];
+  if (num_draws == 0) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
   for (int chain = 1; chain < num_chains; ++chain) {
     num_draws = std::min(num_draws, sizes[chain]);
   }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

`stan::analyze::compute_potential_scale_reduction` still attempts to calculate the PSR if there are 0 draws passed, which is currently causing a segfault when calling `stansummary` on the output from `optimize`:

```
andrew@Andrews-MacBook-Air bernoulli % ./bernoulli optimize data file=bernoulli.data.json
...

andrew@Andrews-MacBook-Air bernoulli % ../../bin/stansummary output.csv
Warning: non-fatal error reading adaptation data
Assertion failed: (index >= 0 && index < size()), function operator(), file DenseCoeffsBase.h, line 181.
zsh: abort      ../../bin/stansummary output.csv
```

#### Intended Effect

No segfault

#### How to Verify

Call `stansummary` with this applied.

#### Side Effects

N/A

#### Documentation

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
