### PR TITLE
Adds option to turn off psis resampling and lp calculation for pathfinder

### DIFF
--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -136,7 +136,7 @@ class unique_stream_writer final : public writer {
    * @param[in] v Values in a block representing an Eigen column vector
    */
   virtual void operator()(
-      const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>) {
+      const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>& values) {
     if (output_ == nullptr)
       return;
     Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
@@ -153,7 +153,7 @@ class unique_stream_writer final : public writer {
    * @param[in] v Values in a block representing an Eigen row vector
    */
   virtual void operator()(
-      const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>) {
+      const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>& values) {
     if (output_ == nullptr)
       return;
     Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -118,8 +118,8 @@ class unique_stream_writer final : public writer {
   /**
    * Comma formatter for writing Eigen matrices
    */
-  Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                               ", ", "", "", "\n", "", "");
+  Eigen::IOFormat CommaInitFmt{Eigen::StreamPrecision, Eigen::DontAlignCols,
+                               ", ", "", "", "\n", "", ""};
 
   /**
    * Output stream

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -106,7 +106,7 @@ class unique_stream_writer final : public writer {
    * parameters in the rows and samples in the columns. The array is then
    * transposed for the output.
    */
-  void operator()(const Eigen::Array<double, -1, -1>& vals) {
+  void operator()(const Eigen::Array<double, -1, -1>& values) {
     if (output_ == nullptr)
       return;
     Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -91,16 +91,6 @@ class unique_stream_writer final : public writer {
   void operator()(const Eigen::Ref<Eigen::Matrix<double, -1, -1>>& values) {
     if (output_ == nullptr)
       return;
-    const bool is_row_vector = values.rows() == 1 && values.cols() > 1;
-    Eigen::IOFormat CommaInitFmt;
-    if (is_row_vector) {
-      CommaInitFmt = Eigen::IOFormat(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                                "\n", ", ", "", "", "", "\n");
-    } else {
-      CommaInitFmt = Eigen::IOFormat(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                                ", ", "", "", "\n", "", "");
-    }
-    
     *output_ << values.transpose().format(CommaInitFmt);
   }
 
@@ -126,6 +116,12 @@ class unique_stream_writer final : public writer {
   }
 
  private:
+  /**
+   * Comma formatter for writing Eigen matrices 
+   */
+  Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
+                            ", ", "", "", "\n", "", "");    
+
   /**
    * Output stream
    */

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -97,6 +97,24 @@ class unique_stream_writer final : public writer {
   }
 
   /**
+   * Writes multiple rows and columns of values in csv format.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] values An array of values. The input is expected to have
+   * parameters in the rows and samples in the columns. The array is then
+   * transposed for the output.
+   */
+  void operator()(const Eigen::Array<double, -1, -1>& vals) {
+    if (output_ == nullptr)
+      return;
+    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
+                                 ", ", "", "", "\n", "", "");
+    *output_ << values.transpose().format(CommaInitFmt);
+  }
+
+  /**
    * Writes the comment_prefix to the stream followed by a newline.
    */
   void operator()() {

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -77,6 +77,7 @@ class unique_stream_writer final : public writer {
       return;
     write_vector(values);
   }
+  
   /**
    * Writes a set of values in csv format followed by a newline.
    *
@@ -110,38 +111,6 @@ class unique_stream_writer final : public writer {
   }
 
   /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in an Eigen column array
-   */
-  void operator()(const Eigen::Array<double, -1, 1>& values) {
-    if (output_ == nullptr)
-      return;
-    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                                 ", ", "", "", "\n", "", "");
-    *output_ << values.transpose().format(CommaInitFmt);
-  }
-
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in an Eigen row array
-   */
-  void operator()(const Eigen::Array<double, 1, -1>& values) {
-    if (output_ == nullptr)
-      return;
-    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                                 ", ", "", "", "\n", "", "");
-    *output_ << values.format(CommaInitFmt);
-  }
-
-  /**
    * Writes multiple rows and columns of values in csv format.
    *
    * Note: the precision of the output is determined by the settings
@@ -152,24 +121,6 @@ class unique_stream_writer final : public writer {
    * transposed for the output.
    */
   void operator()(const Eigen::Matrix<double, -1, -1>& values) {
-    if (output_ == nullptr)
-      return;
-    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                                 ", ", "", "", "\n", "", "");
-    *output_ << values.transpose().format(CommaInitFmt);
-  }
-
-  /**
-   * Writes multiple rows and columns of values in csv format.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] values An array of values. The input is expected to have
-   * parameters in the rows and samples in the columns. The array is then
-   * transposed for the output.
-   */
-  void operator()(const Eigen::Array<double, -1, -1>& values) {
     if (output_ == nullptr)
       return;
     Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -77,7 +77,7 @@ class unique_stream_writer final : public writer {
       return;
     write_vector(values);
   }
-  
+
   /**
    * Writes a set of values in csv format followed by a newline.
    *

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -135,7 +135,8 @@ class unique_stream_writer final : public writer {
    *
    * @param[in] v Values in a block representing an Eigen column vector
    */
-  virtual void operator()(const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>) {
+  virtual void operator()(
+      const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>) {
     if (output_ == nullptr)
       return;
     Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
@@ -151,15 +152,14 @@ class unique_stream_writer final : public writer {
    *
    * @param[in] v Values in a block representing an Eigen row vector
    */
-  virtual void operator()(const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>) {
+  virtual void operator()(
+      const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>) {
     if (output_ == nullptr)
       return;
     Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
                                  ", ", "", "", "\n", "", "");
     *output_ << values.format(CommaInitFmt);
-
   }
-
 
   /**
    * Writes the comment_prefix to the stream followed by a newline.

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -77,6 +77,69 @@ class unique_stream_writer final : public writer {
       return;
     write_vector(values);
   }
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in an Eigen vector
+   */
+  void operator()(const Eigen::Matrix<double, -1, 1>& values) {
+    if (output_ == nullptr)
+      return;
+    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
+                                 ", ", "", "", "\n", "", "");
+    *output_ << values.transpose().format(CommaInitFmt);
+  }
+
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in an Eigen row vector
+   */
+  void operator()(const Eigen::Matrix<double, 1, -1>& values) {
+    if (output_ == nullptr)
+      return;
+    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
+                                 ", ", "", "", "\n", "", "");
+    *output_ << values.format(CommaInitFmt);
+  }
+
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in an Eigen column array
+   */
+  void operator()(const Eigen::Array<double, -1, 1>& values) {
+    if (output_ == nullptr)
+      return;
+    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
+                                 ", ", "", "", "\n", "", "");
+    *output_ << values.transpose().format(CommaInitFmt);
+  }
+
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in an Eigen row array
+   */
+  void operator()(const Eigen::Array<double, 1, -1>& values) {
+    if (output_ == nullptr)
+      return;
+    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
+                                 ", ", "", "", "\n", "", "");
+    *output_ << values.format(CommaInitFmt);
+  }
 
   /**
    * Writes multiple rows and columns of values in csv format.
@@ -88,7 +151,7 @@ class unique_stream_writer final : public writer {
    * parameters in the rows and samples in the columns. The matrix is then
    * transposed for the output.
    */
-  void operator()(const Eigen::MatrixXd& values) {
+  void operator()(const Eigen::Matrix<double, -1, -1>& values) {
     if (output_ == nullptr)
       return;
     Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -118,8 +118,8 @@ class unique_stream_writer final : public writer {
   /**
    * Comma formatter for writing Eigen matrices
    */
-  Eigen::IOFormat CommaInitFmt{Eigen::StreamPrecision, Eigen::DontAlignCols,
-                               ", ", "", "", "\n", "", ""};
+  Eigen::IOFormat CommaInitFmt{
+      Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", "", "", "\n", "", ""};
 
   /**
    * Output stream

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -127,6 +127,39 @@ class unique_stream_writer final : public writer {
                                  ", ", "", "", "\n", "", "");
     *output_ << values.transpose().format(CommaInitFmt);
   }
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in a block representing an Eigen column vector
+   */
+  virtual void operator()(const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>) {
+    if (output_ == nullptr)
+      return;
+    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
+                                 ", ", "", "", "\n", "", "");
+    *output_ << values.transpose().format(CommaInitFmt);
+  }
+
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in a block representing an Eigen row vector
+   */
+  virtual void operator()(const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>) {
+    if (output_ == nullptr)
+      return;
+    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
+                                 ", ", "", "", "\n", "", "");
+    *output_ << values.format(CommaInitFmt);
+
+  }
+
 
   /**
    * Writes the comment_prefix to the stream followed by a newline.

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -116,10 +116,10 @@ class unique_stream_writer final : public writer {
 
  private:
   /**
-   * Comma formatter for writing Eigen matrices 
+   * Comma formatter for writing Eigen matrices
    */
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                            ", ", "", "", "\n", "", "");    
+                               ", ", "", "", "\n", "", "");
 
   /**
    * Output stream

--- a/src/stan/callbacks/unique_stream_writer.hpp
+++ b/src/stan/callbacks/unique_stream_writer.hpp
@@ -79,38 +79,6 @@ class unique_stream_writer final : public writer {
   }
 
   /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in an Eigen vector
-   */
-  void operator()(const Eigen::Matrix<double, -1, 1>& values) {
-    if (output_ == nullptr)
-      return;
-    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                                 ", ", "", "", "\n", "", "");
-    *output_ << values.transpose().format(CommaInitFmt);
-  }
-
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in an Eigen row vector
-   */
-  void operator()(const Eigen::Matrix<double, 1, -1>& values) {
-    if (output_ == nullptr)
-      return;
-    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                                 ", ", "", "", "\n", "", "");
-    *output_ << values.format(CommaInitFmt);
-  }
-
-  /**
    * Writes multiple rows and columns of values in csv format.
    *
    * Note: the precision of the output is determined by the settings
@@ -120,46 +88,22 @@ class unique_stream_writer final : public writer {
    * parameters in the rows and samples in the columns. The matrix is then
    * transposed for the output.
    */
-  void operator()(const Eigen::Matrix<double, -1, -1>& values) {
+  void operator()(const Eigen::Ref<Eigen::Matrix<double, -1, -1>>& values) {
     if (output_ == nullptr)
       return;
-    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                                 ", ", "", "", "\n", "", "");
-    *output_ << values.transpose().format(CommaInitFmt);
-  }
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in a block representing an Eigen column vector
-   */
-  virtual void operator()(
-      const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>& values) {
-    if (output_ == nullptr)
-      return;
-    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                                 ", ", "", "", "\n", "", "");
+    const bool is_row_vector = values.rows() == 1 && values.cols() > 1;
+    Eigen::IOFormat CommaInitFmt;
+    if (is_row_vector) {
+      CommaInitFmt = Eigen::IOFormat(Eigen::StreamPrecision, Eigen::DontAlignCols,
+                                "\n", ", ", "", "", "", "\n");
+    } else {
+      CommaInitFmt = Eigen::IOFormat(Eigen::StreamPrecision, Eigen::DontAlignCols,
+                                ", ", "", "", "\n", "", "");
+    }
+    
     *output_ << values.transpose().format(CommaInitFmt);
   }
 
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in a block representing an Eigen row vector
-   */
-  virtual void operator()(
-      const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>& values) {
-    if (output_ == nullptr)
-      return;
-    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols,
-                                 ", ", "", "", "\n", "", "");
-    *output_ << values.format(CommaInitFmt);
-  }
 
   /**
    * Writes the comment_prefix to the stream followed by a newline.

--- a/src/stan/callbacks/writer.hpp
+++ b/src/stan/callbacks/writer.hpp
@@ -57,6 +57,18 @@ class writer {
    * transposed for the output.
    */
   virtual void operator()(const Eigen::MatrixXd& values) {}
+
+  /**
+   * Writes multiple rows and columns of values in csv format.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] values An array of values. The input is expected to have
+   * parameters in the rows and samples in the columns. The array is then
+   * transposed for the output.
+   */
+  void operator()(const Eigen::Array<double, -1, -1>& vals) {}
 };
 
 }  // namespace callbacks

--- a/src/stan/callbacks/writer.hpp
+++ b/src/stan/callbacks/writer.hpp
@@ -87,7 +87,7 @@ class writer {
    * @param[in] v Values in a block representing an Eigen column vector
    */
   virtual void operator()(
-      const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>) {}
+      const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>& values) {}
 
   /**
    * Writes a set of values in csv format followed by a newline.
@@ -98,7 +98,7 @@ class writer {
    * @param[in] v Values in a block representing an Eigen row vector
    */
   virtual void operator()(
-      const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>) {}
+      const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>& values) {}
 };
 
 }  // namespace callbacks

--- a/src/stan/callbacks/writer.hpp
+++ b/src/stan/callbacks/writer.hpp
@@ -68,7 +68,47 @@ class writer {
    * parameters in the rows and samples in the columns. The array is then
    * transposed for the output.
    */
-  void operator()(const Eigen::Array<double, -1, -1>& vals) {}
+  virtual void operator()(const Eigen::Array<double, -1, -1>& vals) {}
+
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in an Eigen vector
+   */
+  virtual void operator()(const Eigen::Matrix<double, -1, 1>& values) {}
+
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in an Eigen row vector
+   */
+  virtual void operator()(const Eigen::Matrix<double, 1, -1>& values) {}
+
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in an Eigen column array
+   */
+  virtual void operator()(const Eigen::Array<double, -1, 1>& values) {}
+
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in an Eigen row array
+   */
+  virtual void operator()(const Eigen::Array<double, 1, -1>& values) {}
 };
 
 }  // namespace callbacks

--- a/src/stan/callbacks/writer.hpp
+++ b/src/stan/callbacks/writer.hpp
@@ -86,7 +86,8 @@ class writer {
    *
    * @param[in] v Values in a block representing an Eigen column vector
    */
-  virtual void operator()(const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>) {}
+  virtual void operator()(
+      const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>) {}
 
   /**
    * Writes a set of values in csv format followed by a newline.
@@ -96,8 +97,8 @@ class writer {
    *
    * @param[in] v Values in a block representing an Eigen row vector
    */
-  virtual void operator()(const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>) {}
-
+  virtual void operator()(
+      const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>) {}
 };
 
 }  // namespace callbacks

--- a/src/stan/callbacks/writer.hpp
+++ b/src/stan/callbacks/writer.hpp
@@ -56,19 +56,7 @@ class writer {
    * parameters in the rows and samples in the columns. The matrix is then
    * transposed for the output.
    */
-  virtual void operator()(const Eigen::MatrixXd& values) {}
-
-  /**
-   * Writes multiple rows and columns of values in csv format.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] values An array of values. The input is expected to have
-   * parameters in the rows and samples in the columns. The array is then
-   * transposed for the output.
-   */
-  virtual void operator()(const Eigen::Array<double, -1, -1>& vals) {}
+  virtual void operator()(const Eigen::Matrix<double, -1, -1>& values) {}
 
   /**
    * Writes a set of values in csv format followed by a newline.
@@ -90,25 +78,6 @@ class writer {
    */
   virtual void operator()(const Eigen::Matrix<double, 1, -1>& values) {}
 
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in an Eigen column array
-   */
-  virtual void operator()(const Eigen::Array<double, -1, 1>& values) {}
-
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in an Eigen row array
-   */
-  virtual void operator()(const Eigen::Array<double, 1, -1>& values) {}
 };
 
 }  // namespace callbacks

--- a/src/stan/callbacks/writer.hpp
+++ b/src/stan/callbacks/writer.hpp
@@ -77,7 +77,6 @@ class writer {
    * @param[in] v Values in an Eigen row vector
    */
   virtual void operator()(const Eigen::Matrix<double, 1, -1>& values) {}
-
 };
 
 }  // namespace callbacks

--- a/src/stan/callbacks/writer.hpp
+++ b/src/stan/callbacks/writer.hpp
@@ -77,6 +77,27 @@ class writer {
    * @param[in] v Values in an Eigen row vector
    */
   virtual void operator()(const Eigen::Matrix<double, 1, -1>& values) {}
+
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in a block representing an Eigen column vector
+   */
+  virtual void operator()(const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>) {}
+
+  /**
+   * Writes a set of values in csv format followed by a newline.
+   *
+   * Note: the precision of the output is determined by the settings
+   *  of the stream on construction.
+   *
+   * @param[in] v Values in a block representing an Eigen row vector
+   */
+  virtual void operator()(const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>) {}
+
 };
 
 }  // namespace callbacks

--- a/src/stan/callbacks/writer.hpp
+++ b/src/stan/callbacks/writer.hpp
@@ -56,49 +56,8 @@ class writer {
    * parameters in the rows and samples in the columns. The matrix is then
    * transposed for the output.
    */
-  virtual void operator()(const Eigen::Matrix<double, -1, -1>& values) {}
+  virtual void operator()(const Eigen::Ref<Eigen::Matrix<double, -1, -1>>& values) {}
 
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in an Eigen vector
-   */
-  virtual void operator()(const Eigen::Matrix<double, -1, 1>& values) {}
-
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in an Eigen row vector
-   */
-  virtual void operator()(const Eigen::Matrix<double, 1, -1>& values) {}
-
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in a block representing an Eigen column vector
-   */
-  virtual void operator()(
-      const Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>& values) {}
-
-  /**
-   * Writes a set of values in csv format followed by a newline.
-   *
-   * Note: the precision of the output is determined by the settings
-   *  of the stream on construction.
-   *
-   * @param[in] v Values in a block representing an Eigen row vector
-   */
-  virtual void operator()(
-      const Eigen::Block<Eigen::Matrix<double, -1, -1>, 1, -1, true>& values) {}
 };
 
 }  // namespace callbacks

--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -77,14 +77,16 @@ namespace pathfinder {
  * @param[in,out] parameter_writer output for parameter values
  * @param[in,out] diagnostic_writer output for diagnostics values,
  * `error_codes::SOFTWARE` for failures
- * @param[in] calculate_lp Whether single pathfinder should return lp calculations.
- *  If `true`, calculates the joint log probability for each sample.
- *  If `false`, (`num_draws` - `num_elbo_draws`) of the joint log probability
- *  calculations will be `NA` and psis resampling will not be performed.
+ * @param[in] calculate_lp Whether single pathfinder should return lp
+ * calculations. If `true`, calculates the joint log probability for each
+ * sample. If `false`, (`num_draws` - `num_elbo_draws`) of the joint log
+ * probability calculations will be `NA` and psis resampling will not be
+ * performed.
  * @param[in] psis_resampling If `true`, psis resampling is performed over the
  *  samples returned by all of the individual pathfinders and `num_multi_draws`
- *  samples are written to `parameter_writer`. If `false`, no psis resampling is performed
- *  and (`num_paths` * `num_draws`) samples are written to `parameter_writer`.
+ *  samples are written to `parameter_writer`. If `false`, no psis resampling is
+ * performed and (`num_paths` * `num_draws`) samples are written to
+ * `parameter_writer`.
  * @return error_codes::OK if successful
  */
 template <class Model, typename InitContext, typename InitWriter,
@@ -214,10 +216,10 @@ inline int pathfinder_lbfgs_multi(
   }
   parameter_writer();
   const auto time_header = std::string("Elapsed Time: ");
-  std::string optim_time_str = time_header
-                               + std::to_string(pathfinders_delta_time)
-                               + std::string(" seconds") +
-                               ((psis_resample && calculate_lp) ? " (Pathfinders)" : " (Total)");
+  std::string optim_time_str
+      = time_header + std::to_string(pathfinders_delta_time)
+        + std::string(" seconds")
+        + ((psis_resample && calculate_lp) ? " (Pathfinders)" : " (Total)");
   parameter_writer(optim_time_str);
   if (psis_resample && calculate_lp) {
     std::string psis_time_str = std::string(time_header.size(), ' ')

--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -77,6 +77,13 @@ namespace pathfinder {
  * @param[in,out] parameter_writer output for parameter values
  * @param[in,out] diagnostic_writer output for diagnostics values,
  * `error_codes::SOFTWARE` for failures
+ * @param[in] return_lp Whether single pathfinder should return lp calculations.
+ *  If `true`, calculates the joint log probability for each sample.
+ *  If `false`, (`num_draws` - `num_elbo_draws`) of the joint log probability calculations will be `NA` and psis resampling will not be performed.
+ * @param[in] psis_resampling If `true`, psis resampling is performed over the 
+ *  samples returned by all of the individual pathfinders and `num_multi_draws` 
+ *  samples are returned. If `false`, no psis resampling is performed 
+ *  and (`num_paths` * `num_draws`) samples are returned.
  * @return error_codes::OK if successful
  */
 template <class Model, typename InitContext, typename InitWriter,
@@ -92,7 +99,8 @@ inline int pathfinder_lbfgs_multi(
     callbacks::logger& logger, InitWriter&& init_writers,
     std::vector<SingleParamWriter>& single_path_parameter_writer,
     std::vector<SingleDiagnosticWriter>& single_path_diagnostic_writer,
-    ParamWriter& parameter_writer, DiagnosticWriter& diagnostic_writer) {
+    ParamWriter& parameter_writer, DiagnosticWriter& diagnostic_writer,
+    bool return_lp = true, bool psis_resample = true) {
   const auto start_pathfinders_time = std::chrono::steady_clock::now();
   std::vector<std::string> param_names;
   param_names.push_back("lp_approx__");
@@ -117,7 +125,7 @@ inline int pathfinder_lbfgs_multi(
                   num_elbo_draws, num_draws, save_iterations, refresh,
                   interrupt, logger, init_writers[iter],
                   single_path_parameter_writer[iter],
-                  single_path_diagnostic_writer[iter]);
+                  single_path_diagnostic_writer[iter], return_lp);
           if (unlikely(std::get<0>(pathfinder_ret) != error_codes::OK)) {
             logger.error(std::string("Pathfinder iteration: ")
                          + std::to_string(iter) + " failed.");
@@ -158,53 +166,68 @@ inline int pathfinder_lbfgs_multi(
   for (auto&& ilpr : individual_lp_ratios) {
     num_returned_samples += ilpr.size();
   }
-  Eigen::Array<double, Eigen::Dynamic, 1> lp_ratios(num_returned_samples);
+  // Rows are individual parameters and columns are samples per iteration  
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic> samples(
       individual_samples[0].rows(), num_returned_samples);
   Eigen::Index filling_start_row = 0;
   for (size_t i = 0; i < successful_pathfinders; ++i) {
-    const Eigen::Index individ_num_samples = individual_lp_ratios[i].size();
-    lp_ratios.segment(filling_start_row, individ_num_samples)
-        = individual_lp_ratios[i];
+    const Eigen::Index individ_num_samples = individual_samples[i].cols();
     samples.middleCols(filling_start_row, individ_num_samples)
         = individual_samples[i];
     filling_start_row += individ_num_samples;
   }
-  const auto tail_len = std::min(0.2 * num_returned_samples,
-                                 3 * std::sqrt(num_returned_samples));
-  Eigen::Array<double, Eigen::Dynamic, 1> weight_vals
-      = stan::services::psis::psis_weights(lp_ratios, tail_len, logger);
-  boost::ecuyer1988 rng
-      = util::create_rng<boost::ecuyer1988>(random_seed, stride_id);
-  boost::variate_generator<
-      boost::ecuyer1988&,
-      boost::random::discrete_distribution<Eigen::Index, double>>
-      rand_psis_idx(rng,
-                    boost::random::discrete_distribution<Eigen::Index, double>(
-                        boost::iterator_range<double*>(
-                            weight_vals.data(),
-                            weight_vals.data() + weight_vals.size())));
-  for (size_t i = 0; i <= num_multi_draws - 1; ++i) {
-    parameter_writer(samples.col(rand_psis_idx()));
+  double psis_delta_time = 0;
+  if (psis_resample && return_lp) {
+    Eigen::Array<double, Eigen::Dynamic, 1> lp_ratios(num_returned_samples);
+    filling_start_row = 0;
+    for (size_t i = 0; i < successful_pathfinders; ++i) {
+      const Eigen::Index individ_num_samples = individual_lp_ratios[i].size();
+      lp_ratios.segment(filling_start_row, individ_num_samples)
+          = individual_lp_ratios[i];
+      filling_start_row += individ_num_samples;
+    }
+
+    const auto tail_len = std::min(0.2 * num_returned_samples,
+                                  3 * std::sqrt(num_returned_samples));
+    Eigen::Array<double, Eigen::Dynamic, 1> weight_vals
+        = stan::services::psis::psis_weights(lp_ratios, tail_len, logger);
+    boost::ecuyer1988 rng
+        = util::create_rng<boost::ecuyer1988>(random_seed, stride_id);
+    boost::variate_generator<
+        boost::ecuyer1988&,
+        boost::random::discrete_distribution<Eigen::Index, double>>
+        rand_psis_idx(rng,
+                      boost::random::discrete_distribution<Eigen::Index, double>(
+                          boost::iterator_range<double*>(
+                              weight_vals.data(),
+                              weight_vals.data() + weight_vals.size())));
+    for (size_t i = 0; i <= num_multi_draws - 1; ++i) {
+      parameter_writer(samples.col(rand_psis_idx()));
+    }
+    const auto end_psis_time = std::chrono::steady_clock::now();
+    psis_delta_time
+        = stan::services::util::duration_diff(start_psis_time, end_psis_time);
+
+  } else {
+    parameter_writer(samples);
   }
-  const auto end_psis_time = std::chrono::steady_clock::now();
-  double psis_delta_time
-      = stan::services::util::duration_diff(start_psis_time, end_psis_time);
   parameter_writer();
   const auto time_header = std::string("Elapsed Time: ");
   std::string optim_time_str = time_header
                                + std::to_string(pathfinders_delta_time)
                                + " seconds (Pathfinders)";
   parameter_writer(optim_time_str);
-  std::string psis_time_str = std::string(time_header.size(), ' ')
-                              + std::to_string(psis_delta_time)
-                              + " seconds (PSIS)";
-  parameter_writer(psis_time_str);
-  std::string total_time_str
-      = std::string(time_header.size(), ' ')
-        + std::to_string(pathfinders_delta_time + psis_delta_time)
-        + " seconds (Total)";
-  parameter_writer(total_time_str);
+  if (psis_resample && return_lp) {
+    std::string psis_time_str = std::string(time_header.size(), ' ')
+                                + std::to_string(psis_delta_time)
+                                + " seconds (PSIS)";
+    parameter_writer(psis_time_str);
+    std::string total_time_str
+        = std::string(time_header.size(), ' ')
+          + std::to_string(pathfinders_delta_time + psis_delta_time)
+          + " seconds (Total)";
+    parameter_writer(total_time_str);
+  }
   parameter_writer();
   return 0;
 }

--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -170,13 +170,13 @@ inline int pathfinder_lbfgs_multi(
     num_returned_samples += ilpr.size();
   }
   // Rows are individual parameters and columns are samples per iteration
-  Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic> samples(
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> samples(
       individual_samples[0].rows(), num_returned_samples);
   Eigen::Index filling_start_row = 0;
   for (size_t i = 0; i < successful_pathfinders; ++i) {
     const Eigen::Index individ_num_samples = individual_samples[i].cols();
     samples.middleCols(filling_start_row, individ_num_samples)
-        = individual_samples[i];
+        = individual_samples[i].matrix();
     filling_start_row += individ_num_samples;
   }
   double psis_delta_time = 0;

--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -79,10 +79,11 @@ namespace pathfinder {
  * `error_codes::SOFTWARE` for failures
  * @param[in] return_lp Whether single pathfinder should return lp calculations.
  *  If `true`, calculates the joint log probability for each sample.
- *  If `false`, (`num_draws` - `num_elbo_draws`) of the joint log probability calculations will be `NA` and psis resampling will not be performed.
- * @param[in] psis_resampling If `true`, psis resampling is performed over the 
- *  samples returned by all of the individual pathfinders and `num_multi_draws` 
- *  samples are returned. If `false`, no psis resampling is performed 
+ *  If `false`, (`num_draws` - `num_elbo_draws`) of the joint log probability
+ *  calculations will be `NA` and psis resampling will not be performed.
+ * @param[in] psis_resampling If `true`, psis resampling is performed over the
+ *  samples returned by all of the individual pathfinders and `num_multi_draws`
+ *  samples are returned. If `false`, no psis resampling is performed
  *  and (`num_paths` * `num_draws`) samples are returned.
  * @return error_codes::OK if successful
  */
@@ -166,7 +167,7 @@ inline int pathfinder_lbfgs_multi(
   for (auto&& ilpr : individual_lp_ratios) {
     num_returned_samples += ilpr.size();
   }
-  // Rows are individual parameters and columns are samples per iteration  
+  // Rows are individual parameters and columns are samples per iteration
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic> samples(
       individual_samples[0].rows(), num_returned_samples);
   Eigen::Index filling_start_row = 0;
@@ -188,7 +189,7 @@ inline int pathfinder_lbfgs_multi(
     }
 
     const auto tail_len = std::min(0.2 * num_returned_samples,
-                                  3 * std::sqrt(num_returned_samples));
+                                   3 * std::sqrt(num_returned_samples));
     Eigen::Array<double, Eigen::Dynamic, 1> weight_vals
         = stan::services::psis::psis_weights(lp_ratios, tail_len, logger);
     boost::ecuyer1988 rng
@@ -196,11 +197,11 @@ inline int pathfinder_lbfgs_multi(
     boost::variate_generator<
         boost::ecuyer1988&,
         boost::random::discrete_distribution<Eigen::Index, double>>
-        rand_psis_idx(rng,
-                      boost::random::discrete_distribution<Eigen::Index, double>(
-                          boost::iterator_range<double*>(
-                              weight_vals.data(),
-                              weight_vals.data() + weight_vals.size())));
+        rand_psis_idx(
+            rng, boost::random::discrete_distribution<Eigen::Index, double>(
+                     boost::iterator_range<double*>(
+                         weight_vals.data(),
+                         weight_vals.data() + weight_vals.size())));
     for (size_t i = 0; i <= num_multi_draws - 1; ++i) {
       parameter_writer(samples.col(rand_psis_idx()));
     }

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -881,7 +881,7 @@ inline auto pathfinder_lbfgs_single(
       const auto total_size = elbo_draws.cols() + new_draws.cols();
       constrained_draws_mat
           = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>(names.size(),
-                                                                 total_size);
+                                                                  total_size);
       Eigen::VectorXd unconstrained_col;
       Eigen::VectorXd approx_samples_constrained_col;
       for (Eigen::Index i = 0; i < elbo_draws.cols(); ++i) {
@@ -889,7 +889,8 @@ inline auto pathfinder_lbfgs_single(
         unconstrained_col = elbo_draws.col(i);
         constrained_draws_mat.col(i).tail(num_unconstrained_params)
             = constrain_fun(rng, unconstrained_col,
-                            approx_samples_constrained_col).matrix();
+                            approx_samples_constrained_col)
+                  .matrix();
       }
       for (Eigen::Index i = elbo_draws.cols(), j = 0; i < total_size;
            ++i, ++j) {
@@ -897,7 +898,8 @@ inline auto pathfinder_lbfgs_single(
         unconstrained_col = new_draws.col(j);
         constrained_draws_mat.col(i).tail(num_unconstrained_params)
             = constrain_fun(rng, unconstrained_col,
-                            approx_samples_constrained_col).matrix();
+                            approx_samples_constrained_col)
+                  .matrix();
       }
     } catch (const std::exception& e) {
       std::string err_msg = e.what();
@@ -917,7 +919,8 @@ inline auto pathfinder_lbfgs_single(
         unconstrained_col = elbo_draws.col(i);
         constrained_draws_mat.col(i).tail(num_unconstrained_params)
             = constrain_fun(rng, unconstrained_col,
-                            approx_samples_constrained_col).matrix();
+                            approx_samples_constrained_col)
+                  .matrix();
       }
       lp_ratio = std::move(elbo_best.lp_ratio);
     }
@@ -932,7 +935,8 @@ inline auto pathfinder_lbfgs_single(
       unconstrained_col = elbo_draws.col(i);
       constrained_draws_mat.col(i).tail(num_unconstrained_params)
           = constrain_fun(rng, unconstrained_col,
-                          approx_samples_constrained_col).matrix();
+                          approx_samples_constrained_col)
+                .matrix();
     }
     lp_ratio = std::move(elbo_best.lp_ratio);
   }

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -217,8 +217,8 @@ inline elbo_est_t est_approx_draws(LPF&& lp_fun, ConstrainF&& constrain_fun,
                                    RNG&& rng,
                                    const taylor_approx_t& taylor_approx,
                                    size_t num_samples, const EigVec& alpha,
-                                   const std::string& iter_msg,
-                                   Logger&& logger, bool return_lp = true) {
+                                   const std::string& iter_msg, Logger&& logger,
+                                   bool return_lp = true) {
   boost::variate_generator<boost::ecuyer1988&, boost::normal_distribution<>>
       rand_unit_gaus(rng, boost::normal_distribution<>());
   const auto num_params = taylor_approx.x_center.size();
@@ -253,10 +253,12 @@ inline elbo_est_t est_approx_draws(LPF&& lp_fun, ConstrainF&& constrain_fun,
       }
       log_stream(logger, pathfinder_ss, iter_msg);
     }
-    lp_ratio = lp_mat.col(1) - lp_mat.col(0);    
+    lp_ratio = lp_mat.col(1) - lp_mat.col(0);
   } else {
-    lp_ratio = Eigen::Array<double, Eigen::Dynamic, 1>::Constant(lp_mat.rows(), std::numeric_limits<double>::quiet_NaN());
-    lp_mat.col(1) = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(lp_mat.rows(), std::numeric_limits<double>::quiet_NaN());
+    lp_ratio = Eigen::Array<double, Eigen::Dynamic, 1>::Constant(
+        lp_mat.rows(), std::numeric_limits<double>::quiet_NaN());
+    lp_mat.col(1) = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(
+        lp_mat.rows(), std::numeric_limits<double>::quiet_NaN());
   }
   if (ReturnElbo) {
     double elbo = lp_ratio.mean();
@@ -582,8 +584,9 @@ auto pathfinder_impl(RNG&& rng, LPFun&& lp_fun, ConstrainFun&& constrain_fun,
  * @param[in,out] diagnostic_writer output for diagnostics values
  * @param[in] return_lp Whether single pathfinder should return lp calculations.
  *  If `true`, calculates the joint log probability for each sample.
- *  If `false`, (`num_draws` - `num_elbo_draws`) of the joint log probability calculations will be `NA` and psis resampling will not be performed.
- *  Setting this parameter to `false` will also set all of the lp ratios to `NaN`.
+ *  If `false`, (`num_draws` - `num_elbo_draws`) of the joint log probability
+ * calculations will be `NA` and psis resampling will not be performed. Setting
+ * this parameter to `false` will also set all of the lp ratios to `NaN`.
  * @return If `ReturnLpSamples` is `true`, returns a tuple of the error code,
  * approximate draws, and a vector of the lp ratio. If `false`, only returns an
  * error code `error_codes::OK` if successful, `error_codes::SOFTWARE`
@@ -596,7 +599,7 @@ inline auto pathfinder_lbfgs_single(
     unsigned int stride_id, double init_radius, int max_history_size,
     double init_alpha, double tol_obj, double tol_rel_obj, double tol_grad,
     double tol_rel_grad, double tol_param, int num_iterations,
-    int num_elbo_draws, int num_draws, bool save_iterations, int refresh, 
+    int num_elbo_draws, int num_draws, bool save_iterations, int refresh,
     callbacks::interrupt& interrupt, callbacks::logger& logger,
     callbacks::writer& init_writer, ParamWriter& parameter_writer,
     DiagnosticWriter& diagnostic_writer, bool return_lp = true) {
@@ -868,8 +871,8 @@ inline auto pathfinder_lbfgs_single(
       auto&& new_lp_ratio = est_draws.lp_ratio;
       auto&& lp_draws = est_draws.lp_mat;
       auto&& new_draws = est_draws.repeat_draws;
-      lp_ratio = Eigen::Array<double, Eigen::Dynamic, 1>(
-          elbo_lp_ratio.size() + new_lp_ratio.size());
+      lp_ratio = Eigen::Array<double, Eigen::Dynamic, 1>(elbo_lp_ratio.size()
+                                                         + new_lp_ratio.size());
       lp_ratio.head(elbo_lp_ratio.size()) = elbo_lp_ratio.array();
       lp_ratio.tail(new_lp_ratio.size()) = new_lp_ratio.array();
       const auto total_size = elbo_draws.cols() + new_draws.cols();

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -208,7 +208,8 @@ generate_matrix(Generator&& variate_generator, const Eigen::Index num_params,
  * @param alpha The approximation of the diagonal hessian
  * @param iter_msg The beginning of messages that includes the iteration number
  * @param logger A callback writer for messages
- * @param calculate_lp If true, calculate the log probability of the samples. Else set to `NaN` for each sample.
+ * @param calculate_lp If true, calculate the log probability of the samples.
+ * Else set to `NaN` for each sample.
  * @return A struct with the ELBO estimate along with the samples and log
  * probability ratios.
  */
@@ -583,11 +584,12 @@ auto pathfinder_impl(RNG&& rng, LPFun&& lp_fun, ConstrainFun&& constrain_fun,
  * @param[in,out] init_writer Writer callback for unconstrained inits
  * @param[in,out] parameter_writer Writer callback for parameter values
  * @param[in,out] diagnostic_writer output for diagnostics values
- * @param[in] calculate_lp Whether single pathfinder should return lp calculations.
- *  If `true`, calculates the joint log probability for each sample.
- *  If `false`, (`num_draws` - `num_elbo_draws`) of the joint log probability
- * calculations will be `NA` and psis resampling will not be performed. Setting
- * this parameter to `false` will also set all of the lp ratios to `NaN`.
+ * @param[in] calculate_lp Whether single pathfinder should return lp
+ * calculations. If `true`, calculates the joint log probability for each
+ * sample. If `false`, (`num_draws` - `num_elbo_draws`) of the joint log
+ * probability calculations will be `NA` and psis resampling will not be
+ * performed. Setting this parameter to `false` will also set all of the lp
+ * ratios to `NaN`.
  * @return If `ReturnLpSamples` is `true`, returns a tuple of the error code,
  * approximate draws, and a vector of the lp ratio. If `false`, only returns an
  * error code `error_codes::OK` if successful, `error_codes::SOFTWARE`

--- a/src/test/unit/services/pathfinder/normal_glm_test.cpp
+++ b/src/test/unit/services/pathfinder/normal_glm_test.cpp
@@ -136,6 +136,46 @@ TEST_F(ServicesPathfinderGLM, single) {
   ASSERT_TRUE(stan::test::is_valid_JSON(json));
 }
 
+TEST_F(ServicesPathfinderGLM, single_noreturnlp) {
+  constexpr unsigned int seed = 3;
+  constexpr unsigned int chain = 1;
+  constexpr double init_radius = 2;
+  constexpr double num_elbo_draws = 80;
+  constexpr double num_draws = 500;
+  constexpr int history_size = 35;
+  constexpr double init_alpha = 1;
+  constexpr double tol_obj = 0;
+  constexpr double tol_rel_obj = 0;
+  constexpr double tol_grad = 0;
+  constexpr double tol_rel_grad = 0;
+  constexpr double tol_param = 0;
+  constexpr int num_iterations = 400;
+  constexpr bool save_iterations = true;
+  constexpr int refresh = 1;
+  constexpr bool return_lp = false;
+
+  stan::test::mock_callback callback;
+  stan::io::empty_var_context empty_context;  // = init_init_context();
+  std::unique_ptr<std::ostream> empty_ostream(nullptr);
+  stan::test::test_logger logger(std::move(empty_ostream));
+
+  std::vector<std::tuple<Eigen::VectorXd, Eigen::VectorXd>> input_iters;
+
+  stan::services::pathfinder::pathfinder_lbfgs_single(
+      model, empty_context, seed, chain, init_radius, history_size, init_alpha,
+      tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param, num_iterations,
+      num_elbo_draws, num_draws, save_iterations, refresh, callback, logger,
+      init, parameter, diagnostics, return_lp);
+  Eigen::MatrixXd param_vals = std::move(parameter.values_);
+  for (Eigen::Index i = 0; i < num_elbo_draws; ++i) {
+    EXPECT_FALSE(std::isnan(param_vals.coeff(1,  num_draws + i))) << "row: " << (num_draws + i);
+  }
+  for (Eigen::Index i = 0; i < (num_draws - num_elbo_draws); ++i) {
+    EXPECT_TRUE(std::isnan(param_vals.coeff(1, num_elbo_draws + i)))  << "row: " << (num_draws + num_elbo_draws + i);
+  }
+
+}
+
 TEST_F(ServicesPathfinderGLM, multi) {
   constexpr unsigned int seed = 0;
   constexpr unsigned int chain = 1;
@@ -215,5 +255,228 @@ TEST_F(ServicesPathfinderGLM, multi) {
   }
   for (int i = 2; i < all_mean_vals.cols(); ++i) {
     EXPECT_NEAR(0, all_sd_vals(2, i), .1);
+  }
+}
+
+
+
+TEST_F(ServicesPathfinderGLM, multi_noresample) {
+  constexpr unsigned int seed = 0;
+  constexpr unsigned int chain = 1;
+  constexpr double init_radius = 1;
+  constexpr double num_multi_draws = 100;
+  constexpr int num_paths = 4;
+  constexpr double num_elbo_draws = 1000;
+  // Should return num_paths * num_draws = 8000
+  constexpr double num_draws = 2000;
+  constexpr int history_size = 15;
+  constexpr double init_alpha = 1;
+  constexpr double tol_obj = 0;
+  constexpr double tol_rel_obj = 0;
+  constexpr double tol_grad = 0;
+  constexpr double tol_rel_grad = 0;
+  constexpr double tol_param = 0;
+  constexpr int num_iterations = 220;
+  constexpr bool save_iterations = false;
+  constexpr int refresh = 0;
+  constexpr bool return_lp = true;
+  constexpr bool resample = false;
+
+  std::unique_ptr<std::ostream> empty_ostream(nullptr);
+  stan::test::test_logger logger(std::move(empty_ostream));
+  std::vector<stan::callbacks::writer> single_path_parameter_writer(num_paths);
+  std::vector<stan::callbacks::json_writer<std::stringstream>>
+      single_path_diagnostic_writer(num_paths);
+  std::vector<std::unique_ptr<decltype(init_init_context())>> single_path_inits;
+  for (int i = 0; i < num_paths; ++i) {
+    single_path_inits.emplace_back(
+        std::make_unique<decltype(init_init_context())>(init_init_context()));
+  }
+  stan::test::mock_callback callback;
+  stan::services::pathfinder::pathfinder_lbfgs_multi(
+      model, single_path_inits, seed, chain, init_radius, history_size,
+      init_alpha, tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param,
+      num_iterations, num_elbo_draws, num_draws, num_multi_draws, num_paths,
+      save_iterations, refresh, callback, logger,
+      std::vector<stan::callbacks::stream_writer>(num_paths, init),
+      single_path_parameter_writer, single_path_diagnostic_writer, parameter,
+      diagnostics, return_lp, resample);
+
+  Eigen::MatrixXd param_vals = parameter.values_;
+  Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
+                               "", "");
+  EXPECT_EQ(param_vals.rows(), 10);
+  EXPECT_EQ(param_vals.cols(), 8000);  
+}
+
+TEST_F(ServicesPathfinderGLM, multi_noresample_noreturnlp) {
+  constexpr unsigned int seed = 0;
+  constexpr unsigned int chain = 1;
+  constexpr double init_radius = 1;
+  constexpr double num_multi_draws = 100;
+  constexpr int num_paths = 4;
+  constexpr double num_elbo_draws = 1000;
+  // Should return num_paths * num_draws = 8000
+  constexpr double num_draws = 2000;
+  constexpr int history_size = 15;
+  constexpr double init_alpha = 1;
+  constexpr double tol_obj = 0;
+  constexpr double tol_rel_obj = 0;
+  constexpr double tol_grad = 0;
+  constexpr double tol_rel_grad = 0;
+  constexpr double tol_param = 0;
+  constexpr int num_iterations = 220;
+  constexpr bool save_iterations = false;
+  constexpr int refresh = 0;
+  constexpr bool return_lp = false;
+  constexpr bool resample = false;
+
+  std::unique_ptr<std::ostream> empty_ostream(nullptr);
+  stan::test::test_logger logger(std::move(empty_ostream));
+  std::vector<stan::callbacks::writer> single_path_parameter_writer(num_paths);
+  std::vector<stan::callbacks::json_writer<std::stringstream>>
+      single_path_diagnostic_writer(num_paths);
+  std::vector<std::unique_ptr<decltype(init_init_context())>> single_path_inits;
+  for (int i = 0; i < num_paths; ++i) {
+    single_path_inits.emplace_back(
+        std::make_unique<decltype(init_init_context())>(init_init_context()));
+  }
+  stan::test::mock_callback callback;
+  stan::services::pathfinder::pathfinder_lbfgs_multi(
+      model, single_path_inits, seed, chain, init_radius, history_size,
+      init_alpha, tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param,
+      num_iterations, num_elbo_draws, num_draws, num_multi_draws, num_paths,
+      save_iterations, refresh, callback, logger,
+      std::vector<stan::callbacks::stream_writer>(num_paths, init),
+      single_path_parameter_writer, single_path_diagnostic_writer, parameter,
+      diagnostics, return_lp, resample);
+
+  Eigen::MatrixXd param_vals = parameter.values_;
+  Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
+                               "", "");
+  EXPECT_EQ(param_vals.rows(), 10);
+  EXPECT_EQ(param_vals.cols(), 8000);
+  for (Eigen::Index paths_i = 0; paths_i < num_paths; ++paths_i) {
+    // Iterate over each set of results from the single pathfinders
+    for (Eigen::Index i = 0; i < num_elbo_draws; ++i) {
+      EXPECT_FALSE(std::isnan(param_vals.coeff(1,  num_draws * paths_i + i)));
+    }
+    for (Eigen::Index i = 0; i < (num_draws - num_elbo_draws); ++i) {
+      EXPECT_TRUE(std::isnan(param_vals.coeff(1, num_draws * paths_i + num_elbo_draws + i)));
+    }
+  }
+}
+
+TEST_F(ServicesPathfinderGLM, multi_resample_noreturnlp) {
+  constexpr unsigned int seed = 0;
+  constexpr unsigned int chain = 1;
+  constexpr double init_radius = 1;
+  constexpr double num_multi_draws = 100;
+  constexpr int num_paths = 4;
+  constexpr double num_elbo_draws = 1000;
+  // Should return num_paths * num_draws = 8000
+  constexpr double num_draws = 2000;
+  constexpr int history_size = 15;
+  constexpr double init_alpha = 1;
+  constexpr double tol_obj = 0;
+  constexpr double tol_rel_obj = 0;
+  constexpr double tol_grad = 0;
+  constexpr double tol_rel_grad = 0;
+  constexpr double tol_param = 0;
+  constexpr int num_iterations = 220;
+  constexpr bool save_iterations = false;
+  constexpr int refresh = 0;
+  constexpr bool return_lp = false;
+  constexpr bool resample = true;
+
+  std::unique_ptr<std::ostream> empty_ostream(nullptr);
+  stan::test::test_logger logger(std::move(empty_ostream));
+  std::vector<stan::callbacks::writer> single_path_parameter_writer(num_paths);
+  std::vector<stan::callbacks::json_writer<std::stringstream>>
+      single_path_diagnostic_writer(num_paths);
+  std::vector<std::unique_ptr<decltype(init_init_context())>> single_path_inits;
+  for (int i = 0; i < num_paths; ++i) {
+    single_path_inits.emplace_back(
+        std::make_unique<decltype(init_init_context())>(init_init_context()));
+  }
+  stan::test::mock_callback callback;
+  stan::services::pathfinder::pathfinder_lbfgs_multi(
+      model, single_path_inits, seed, chain, init_radius, history_size,
+      init_alpha, tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param,
+      num_iterations, num_elbo_draws, num_draws, num_multi_draws, num_paths,
+      save_iterations, refresh, callback, logger,
+      std::vector<stan::callbacks::stream_writer>(num_paths, init),
+      single_path_parameter_writer, single_path_diagnostic_writer, parameter,
+      diagnostics, return_lp, resample);
+
+  Eigen::MatrixXd param_vals = parameter.values_;
+  Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
+                               "", "");
+  EXPECT_EQ(param_vals.rows(), 10);
+  EXPECT_EQ(param_vals.cols(), 8000);
+  for (Eigen::Index paths_i = 0; paths_i < num_paths; ++paths_i) {
+    // Iterate over each set of results from the single pathfinders
+    for (Eigen::Index i = 0; i < num_elbo_draws; ++i) {
+      EXPECT_FALSE(std::isnan(param_vals.coeff(1,  num_draws * paths_i + i)));
+    }
+    for (Eigen::Index i = 0; i < (num_draws - num_elbo_draws); ++i) {
+      EXPECT_TRUE(std::isnan(param_vals.coeff(1, num_draws * paths_i + num_elbo_draws + i)));
+    }
+  }
+}
+
+
+TEST_F(ServicesPathfinderGLM, multi_noresample_returnlp) {
+  constexpr unsigned int seed = 0;
+  constexpr unsigned int chain = 1;
+  constexpr double init_radius = 1;
+  constexpr double num_multi_draws = 100;
+  constexpr int num_paths = 4;
+  constexpr double num_elbo_draws = 1000;
+  // Should return num_paths * num_draws = 8000
+  constexpr double num_draws = 2000;
+  constexpr int history_size = 15;
+  constexpr double init_alpha = 1;
+  constexpr double tol_obj = 0;
+  constexpr double tol_rel_obj = 0;
+  constexpr double tol_grad = 0;
+  constexpr double tol_rel_grad = 0;
+  constexpr double tol_param = 0;
+  constexpr int num_iterations = 220;
+  constexpr bool save_iterations = false;
+  constexpr int refresh = 0;
+  constexpr bool return_lp = true;
+  constexpr bool resample = false;
+
+  std::unique_ptr<std::ostream> empty_ostream(nullptr);
+  stan::test::test_logger logger(std::move(empty_ostream));
+  std::vector<stan::callbacks::writer> single_path_parameter_writer(num_paths);
+  std::vector<stan::callbacks::json_writer<std::stringstream>>
+      single_path_diagnostic_writer(num_paths);
+  std::vector<std::unique_ptr<decltype(init_init_context())>> single_path_inits;
+  for (int i = 0; i < num_paths; ++i) {
+    single_path_inits.emplace_back(
+        std::make_unique<decltype(init_init_context())>(init_init_context()));
+  }
+  stan::test::mock_callback callback;
+  stan::services::pathfinder::pathfinder_lbfgs_multi(
+      model, single_path_inits, seed, chain, init_radius, history_size,
+      init_alpha, tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param,
+      num_iterations, num_elbo_draws, num_draws, num_multi_draws, num_paths,
+      save_iterations, refresh, callback, logger,
+      std::vector<stan::callbacks::stream_writer>(num_paths, init),
+      single_path_parameter_writer, single_path_diagnostic_writer, parameter,
+      diagnostics, return_lp, resample);
+
+  Eigen::MatrixXd param_vals = parameter.values_;
+  Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
+                               "", "");
+  EXPECT_EQ(param_vals.rows(), 10);
+  EXPECT_EQ(param_vals.cols(), 8000);
+  for (Eigen::Index paths_i = 0; paths_i < num_paths; ++paths_i) {
+    // Iterate over each set of results from the single pathfinders
+    for (Eigen::Index i = 0; i < num_draws; ++i) {
+      EXPECT_FALSE(std::isnan(param_vals.coeff(1,  num_draws * paths_i + i)));
+    }
   }
 }

--- a/src/test/unit/services/pathfinder/normal_glm_test.cpp
+++ b/src/test/unit/services/pathfinder/normal_glm_test.cpp
@@ -152,7 +152,7 @@ TEST_F(ServicesPathfinderGLM, single_noreturnlp) {
   constexpr int num_iterations = 400;
   constexpr bool save_iterations = true;
   constexpr int refresh = 1;
-  constexpr bool return_lp = false;
+  constexpr bool calculate_lp = false;
 
   stan::test::mock_callback callback;
   stan::io::empty_var_context empty_context;  // = init_init_context();
@@ -165,7 +165,7 @@ TEST_F(ServicesPathfinderGLM, single_noreturnlp) {
       model, empty_context, seed, chain, init_radius, history_size, init_alpha,
       tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param, num_iterations,
       num_elbo_draws, num_draws, save_iterations, refresh, callback, logger,
-      init, parameter, diagnostics, return_lp);
+      init, parameter, diagnostics, calculate_lp);
   Eigen::MatrixXd param_vals = std::move(parameter.values_);
   for (Eigen::Index i = 0; i < num_elbo_draws; ++i) {
     EXPECT_FALSE(std::isnan(param_vals.coeff(1, num_draws + i)))
@@ -278,7 +278,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample) {
   constexpr int num_iterations = 220;
   constexpr bool save_iterations = false;
   constexpr int refresh = 0;
-  constexpr bool return_lp = true;
+  constexpr bool calculate_lp = true;
   constexpr bool resample = false;
 
   std::unique_ptr<std::ostream> empty_ostream(nullptr);
@@ -299,7 +299,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample) {
       save_iterations, refresh, callback, logger,
       std::vector<stan::callbacks::stream_writer>(num_paths, init),
       single_path_parameter_writer, single_path_diagnostic_writer, parameter,
-      diagnostics, return_lp, resample);
+      diagnostics, calculate_lp, resample);
 
   Eigen::MatrixXd param_vals = parameter.values_;
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
@@ -327,7 +327,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample_noreturnlp) {
   constexpr int num_iterations = 220;
   constexpr bool save_iterations = false;
   constexpr int refresh = 0;
-  constexpr bool return_lp = false;
+  constexpr bool calculate_lp = false;
   constexpr bool resample = false;
 
   std::unique_ptr<std::ostream> empty_ostream(nullptr);
@@ -348,7 +348,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample_noreturnlp) {
       save_iterations, refresh, callback, logger,
       std::vector<stan::callbacks::stream_writer>(num_paths, init),
       single_path_parameter_writer, single_path_diagnostic_writer, parameter,
-      diagnostics, return_lp, resample);
+      diagnostics, calculate_lp, resample);
 
   Eigen::MatrixXd param_vals = parameter.values_;
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
@@ -386,7 +386,7 @@ TEST_F(ServicesPathfinderGLM, multi_resample_noreturnlp) {
   constexpr int num_iterations = 220;
   constexpr bool save_iterations = false;
   constexpr int refresh = 0;
-  constexpr bool return_lp = false;
+  constexpr bool calculate_lp = false;
   constexpr bool resample = true;
 
   std::unique_ptr<std::ostream> empty_ostream(nullptr);
@@ -407,7 +407,7 @@ TEST_F(ServicesPathfinderGLM, multi_resample_noreturnlp) {
       save_iterations, refresh, callback, logger,
       std::vector<stan::callbacks::stream_writer>(num_paths, init),
       single_path_parameter_writer, single_path_diagnostic_writer, parameter,
-      diagnostics, return_lp, resample);
+      diagnostics, calculate_lp, resample);
 
   Eigen::MatrixXd param_vals = parameter.values_;
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
@@ -445,7 +445,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample_returnlp) {
   constexpr int num_iterations = 220;
   constexpr bool save_iterations = false;
   constexpr int refresh = 0;
-  constexpr bool return_lp = true;
+  constexpr bool calculate_lp = true;
   constexpr bool resample = false;
 
   std::unique_ptr<std::ostream> empty_ostream(nullptr);
@@ -466,7 +466,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample_returnlp) {
       save_iterations, refresh, callback, logger,
       std::vector<stan::callbacks::stream_writer>(num_paths, init),
       single_path_parameter_writer, single_path_diagnostic_writer, parameter,
-      diagnostics, return_lp, resample);
+      diagnostics, calculate_lp, resample);
 
   Eigen::MatrixXd param_vals = parameter.values_;
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",

--- a/src/test/unit/services/pathfinder/normal_glm_test.cpp
+++ b/src/test/unit/services/pathfinder/normal_glm_test.cpp
@@ -168,12 +168,13 @@ TEST_F(ServicesPathfinderGLM, single_noreturnlp) {
       init, parameter, diagnostics, return_lp);
   Eigen::MatrixXd param_vals = std::move(parameter.values_);
   for (Eigen::Index i = 0; i < num_elbo_draws; ++i) {
-    EXPECT_FALSE(std::isnan(param_vals.coeff(1,  num_draws + i))) << "row: " << (num_draws + i);
+    EXPECT_FALSE(std::isnan(param_vals.coeff(1, num_draws + i)))
+        << "row: " << (num_draws + i);
   }
   for (Eigen::Index i = 0; i < (num_draws - num_elbo_draws); ++i) {
-    EXPECT_TRUE(std::isnan(param_vals.coeff(1, num_elbo_draws + i)))  << "row: " << (num_draws + num_elbo_draws + i);
+    EXPECT_TRUE(std::isnan(param_vals.coeff(1, num_elbo_draws + i)))
+        << "row: " << (num_draws + num_elbo_draws + i);
   }
-
 }
 
 TEST_F(ServicesPathfinderGLM, multi) {
@@ -258,8 +259,6 @@ TEST_F(ServicesPathfinderGLM, multi) {
   }
 }
 
-
-
 TEST_F(ServicesPathfinderGLM, multi_noresample) {
   constexpr unsigned int seed = 0;
   constexpr unsigned int chain = 1;
@@ -306,7 +305,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample) {
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
                                "", "");
   EXPECT_EQ(param_vals.rows(), 10);
-  EXPECT_EQ(param_vals.cols(), 8000);  
+  EXPECT_EQ(param_vals.cols(), 8000);
 }
 
 TEST_F(ServicesPathfinderGLM, multi_noresample_noreturnlp) {
@@ -359,10 +358,11 @@ TEST_F(ServicesPathfinderGLM, multi_noresample_noreturnlp) {
   for (Eigen::Index paths_i = 0; paths_i < num_paths; ++paths_i) {
     // Iterate over each set of results from the single pathfinders
     for (Eigen::Index i = 0; i < num_elbo_draws; ++i) {
-      EXPECT_FALSE(std::isnan(param_vals.coeff(1,  num_draws * paths_i + i)));
+      EXPECT_FALSE(std::isnan(param_vals.coeff(1, num_draws * paths_i + i)));
     }
     for (Eigen::Index i = 0; i < (num_draws - num_elbo_draws); ++i) {
-      EXPECT_TRUE(std::isnan(param_vals.coeff(1, num_draws * paths_i + num_elbo_draws + i)));
+      EXPECT_TRUE(std::isnan(
+          param_vals.coeff(1, num_draws * paths_i + num_elbo_draws + i)));
     }
   }
 }
@@ -417,14 +417,14 @@ TEST_F(ServicesPathfinderGLM, multi_resample_noreturnlp) {
   for (Eigen::Index paths_i = 0; paths_i < num_paths; ++paths_i) {
     // Iterate over each set of results from the single pathfinders
     for (Eigen::Index i = 0; i < num_elbo_draws; ++i) {
-      EXPECT_FALSE(std::isnan(param_vals.coeff(1,  num_draws * paths_i + i)));
+      EXPECT_FALSE(std::isnan(param_vals.coeff(1, num_draws * paths_i + i)));
     }
     for (Eigen::Index i = 0; i < (num_draws - num_elbo_draws); ++i) {
-      EXPECT_TRUE(std::isnan(param_vals.coeff(1, num_draws * paths_i + num_elbo_draws + i)));
+      EXPECT_TRUE(std::isnan(
+          param_vals.coeff(1, num_draws * paths_i + num_elbo_draws + i)));
     }
   }
 }
-
 
 TEST_F(ServicesPathfinderGLM, multi_noresample_returnlp) {
   constexpr unsigned int seed = 0;
@@ -476,7 +476,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample_returnlp) {
   for (Eigen::Index paths_i = 0; paths_i < num_paths; ++paths_i) {
     // Iterate over each set of results from the single pathfinders
     for (Eigen::Index i = 0; i < num_draws; ++i) {
-      EXPECT_FALSE(std::isnan(param_vals.coeff(1,  num_draws * paths_i + i)));
+      EXPECT_FALSE(std::isnan(param_vals.coeff(1, num_draws * paths_i + i)));
     }
   }
 }

--- a/src/test/unit/services/pathfinder/util.hpp
+++ b/src/test/unit/services/pathfinder/util.hpp
@@ -176,6 +176,10 @@ class in_memory_writer : public stan::callbacks::stream_writer {
   void operator()(const EigMat& vals) {
     values_ = vals;
   }
+  template <int R, int C>
+  void operator()(const Eigen::Array<double, R, C>& vals) {
+    values_ = vals.matrix();
+  }
 };
 
 Eigen::Matrix<double, 10, 100> eight_schools_r_answer() {

--- a/src/test/unit/services/pathfinder/util.hpp
+++ b/src/test/unit/services/pathfinder/util.hpp
@@ -176,10 +176,6 @@ class in_memory_writer : public stan::callbacks::stream_writer {
   void operator()(const EigMat& vals) {
     values_ = vals;
   }
-  template <int R, int C>
-  void operator()(const Eigen::Array<double, R, C>& vals) {
-    values_ = vals.matrix();
-  }
 };
 
 Eigen::Matrix<double, 10, 100> eight_schools_r_answer() {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds the request from @avehtari in #3242 to add an option for turning off resampling and calculating the lp.

 If `psis_resample` is false then psis resampling is not performed and the full set of samples is returned from all the individual pathfinders. 

If `return_lp` is false then the lp values are not calculated for each sample. I think a lot of upstream packages assume that a `lp__` column at least exists so here I just set the column of lp values to `NaN`. This also means psis resampling is turned off since we cannot calculate the lp ratio and the full set of samples is returned from all the individual pathfinders. 

Something questionable here is that since we have to calculate the lp values for the set of samples we compute the elbo metric on we just get those lp calculations for free. So here I still include those lp values even if `return_lp` is false. But that could be weird for users. I documented it, but another approach here would be to just explicitly set all lp values in that column to `NaN`.

#### Intended Effect

#### How to Verify

Tests were added for the new options and can be run with 

```bash
python3 ./runTests.py ./src/test/unit/services/pathfinder/normal_glm_test.cpp
```

#### Side Effects

#### Documentation

Once we open the cmdstan PR we should add documentation for these new options

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
