### PR TITLE
[BUGFIX] Replace STL regex with Boost for MinGW bug

### DIFF
--- a/src/stan/io/json/json_data_handler.hpp
+++ b/src/stan/io/json/json_data_handler.hpp
@@ -16,7 +16,7 @@
 #include <utility>
 #include <vector>
 #include <boost/algorithm/string.hpp>
-#include <regex>
+#include <boost/regex>
 
 namespace stan {
 
@@ -172,8 +172,8 @@ class json_data_handler : public stan::json::json_handler {
    *  and contain only letters, numbers, or an underscore.
    */
   bool valid_varname(const std::string& name) {
-    static const std::regex re("[a-zA-Z][a-zA-Z0-9_]*");
-    return std::regex_match(name, re);
+    static const boost::regex re("[a-zA-Z][a-zA-Z0-9_]*");
+    return boost::regex_match(name, re);
   }
 
   bool is_array_tuples(const std::vector<std::string>& keys) {

--- a/src/stan/io/json/json_data_handler.hpp
+++ b/src/stan/io/json/json_data_handler.hpp
@@ -16,7 +16,7 @@
 #include <utility>
 #include <vector>
 #include <boost/algorithm/string.hpp>
-#include <boost/regex>
+#include <boost/regex.hpp>
 
 namespace stan {
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Depending on the user's locale, using `std::regex` with the MinGW GCC in RTools will result in a memory leak and the program hangs.

This has previously been reported as bug to MinGW [here](https://sourceforge.net/p/mingw-w64/mailman/mingw-w64-public/thread/CABFfbXvurKZjO8tjrFrirwy_Spego-nRvOksjkmnDtYsESu%3DYQ%40mail.gmail.com/#msg37203838), but it is still an issue.

For Stan, this can cause a hang when parsing JSON data (seen recently as the cause of this [downstream issue](https://github.com/andrjohns/StanEstimators/issues/1)). We can instead use the Boost Regex headers as a drop-in replacement, which I've verified resolve the issue.

#### Intended Effect

Avoid hanging under certain locales

#### How to Verify

#### Side Effects

N/A

#### Documentation

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
