### PR TITLE
Fix build with gcc13

### DIFF
--- a/src/stan/io/json/json_handler.hpp
+++ b/src/stan/io/json/json_handler.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_IO_JSON_JSON_HANDLER_HPP
 #define STAN_IO_JSON_JSON_HANDLER_HPP
 
+#include <cstdint>
 #include <string>
 
 namespace stan {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary

With GCC 13, some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library (see, e.g. [this](https://gcc.gnu.org/gcc-13/porting_to.html)). This has affected [many other projects](https://duckduckgo.com/?q=gcc13+cstdint+site%3Agithub.com&t=ffab). 

I noticed this when trying to run the tests with:
`python runTests.py -j$(nproc) src/test`

The fix is simple, `<cstdint>` has to be included manually.

#### Intended Effect
Fix build with g++13

#### How to Verify
Run the tests

#### Side Effects
None?

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
