### PR TITLE
Only swallow domain_errors in various algorithms 

### DIFF
--- a/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/base_hamiltonian.hpp
@@ -52,7 +52,7 @@ class base_hamiltonian {
   void update_potential(Point& z, callbacks::logger& logger) {
     try {
       z.V = -stan::model::log_prob_propto<true>(model_, z.q);
-    } catch (const std::exception& e) {
+    } catch (const std::domain_error& e) {
       this->write_error_msg_(e, logger);
       z.V = std::numeric_limits<double>::infinity();
     }
@@ -62,7 +62,7 @@ class base_hamiltonian {
     try {
       stan::model::gradient(model_, z.q, z.V, z.g, logger);
       z.V = -z.V;
-    } catch (const std::exception& e) {
+    } catch (const std::domain_error& e) {
       this->write_error_msg_(e, logger);
       z.V = std::numeric_limits<double>::infinity();
     }

--- a/src/stan/optimization/bfgs.hpp
+++ b/src/stan/optimization/bfgs.hpp
@@ -309,7 +309,7 @@ class ModelAdaptor {
 
     try {
       f = -log_prob_propto<jacobian>(_model, _x, _params_i, _msgs);
-    } catch (const std::exception &e) {
+    } catch (const std::domain_error &e) {
       if (_msgs)
         (*_msgs) << e.what() << std::endl;
       return 1;
@@ -341,7 +341,7 @@ class ModelAdaptor {
 
     try {
       f = -log_prob_grad<true, jacobian>(_model, _x, _params_i, _g, _msgs);
-    } catch (const std::exception &e) {
+    } catch (const std::domain_error &e) {
       if (_msgs)
         (*_msgs) << e.what() << std::endl;
       return 1;

--- a/src/stan/optimization/newton.hpp
+++ b/src/stan/optimization/newton.hpp
@@ -60,7 +60,7 @@ double newton_step(M& model, std::vector<double>& params_r,
     try {
       f1 = stan::model::log_prob_grad<true, jacobian>(model, new_params_r,
                                                       params_i, gradient);
-    } catch (std::exception& e) {
+    } catch (std::domain_error& e) {
       // FIXME:  this is not a good way to handle a general exception
       f1 = -1e100;
     }

--- a/src/stan/services/experimental/advi/fullrank.hpp
+++ b/src/stan/services/experimental/advi/fullrank.hpp
@@ -86,8 +86,13 @@ int fullrank(Model& model, const stan::io::var_context& init,
                           stan::rng_t>
       cmd_advi(model, cont_params, rng, grad_samples, elbo_samples, eval_elbo,
                output_samples);
-  cmd_advi.run(eta, adapt_engaged, adapt_iterations, tol_rel_obj,
-               max_iterations, logger, parameter_writer, diagnostic_writer);
+  try {
+    cmd_advi.run(eta, adapt_engaged, adapt_iterations, tol_rel_obj,
+                 max_iterations, logger, parameter_writer, diagnostic_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
 
   return stan::services::error_codes::OK;
 }

--- a/src/stan/services/experimental/advi/meanfield.hpp
+++ b/src/stan/services/experimental/advi/meanfield.hpp
@@ -85,8 +85,13 @@ int meanfield(Model& model, const stan::io::var_context& init,
                           stan::rng_t>
       cmd_advi(model, cont_params, rng, grad_samples, elbo_samples, eval_elbo,
                output_samples);
-  cmd_advi.run(eta, adapt_engaged, adapt_iterations, tol_rel_obj,
-               max_iterations, logger, parameter_writer, diagnostic_writer);
+  try {
+    cmd_advi.run(eta, adapt_engaged, adapt_iterations, tol_rel_obj,
+                 max_iterations, logger, parameter_writer, diagnostic_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
 
   return stan::services::error_codes::OK;
 }

--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -96,7 +96,16 @@ int bfgs(Model& model, const stan::io::var_context& init,
   if (save_iterations) {
     std::vector<double> values;
     std::stringstream msg;
-    model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
+    try {
+      model.write_array(rng, cont_vector, disc_vector, values, true, true,
+                        &msg);
+    } catch (const std::exception& e) {
+      if (msg.str().length() > 0) {
+        logger.info(msg);
+      }
+      logger.error(e.what());
+      return error_codes::SOFTWARE;
+    }
     if (msg.str().length() > 0)
       logger.info(msg);
 
@@ -119,7 +128,13 @@ int bfgs(Model& model, const stan::io::var_context& init,
           "  # evals"
           "  Notes ");
 
-    ret = bfgs.step();
+    try {
+      ret = bfgs.step();
+    } catch (const std::exception& e) {
+      logger.error(e.what());
+      return error_codes::SOFTWARE;
+    }
+
     lp = bfgs.logp();
     bfgs.params_r(cont_vector);
 
@@ -150,8 +165,16 @@ int bfgs(Model& model, const stan::io::var_context& init,
     if (save_iterations) {
       std::vector<double> values;
       std::stringstream msg;
-      model.write_array(rng, cont_vector, disc_vector, values, true, true,
-                        &msg);
+      try {
+        model.write_array(rng, cont_vector, disc_vector, values, true, true,
+                          &msg);
+      } catch (const std::exception& e) {
+        if (msg.str().length() > 0) {
+          logger.info(msg);
+        }
+        logger.error(e.what());
+        return error_codes::SOFTWARE;
+      }
       // This if is here to match the pre-refactor behavior
       if (msg.str().length() > 0)
         logger.info(msg);
@@ -164,7 +187,16 @@ int bfgs(Model& model, const stan::io::var_context& init,
   if (!save_iterations) {
     std::vector<double> values;
     std::stringstream msg;
-    model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
+    try {
+      model.write_array(rng, cont_vector, disc_vector, values, true, true,
+                        &msg);
+    } catch (const std::exception& e) {
+      if (msg.str().length() > 0) {
+        logger.info(msg);
+      }
+      logger.error(e.what());
+      return error_codes::SOFTWARE;
+    }
     if (msg.str().length() > 0)
       logger.info(msg);
     values.insert(values.begin(), lp);

--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -172,7 +172,6 @@ int bfgs(Model& model, const stan::io::var_context& init,
         parameter_writer(values);
       }
     }
-
   } catch (const std::exception& e) {
     logger.error(e.what());
     return error_codes::SOFTWARE;

--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -114,74 +114,68 @@ int bfgs(Model& model, const stan::io::var_context& init,
   }
   int ret = 0;
 
-  while (ret == 0) {
-    interrupt();
-    if (refresh > 0
-        && (bfgs.iter_num() == 0 || ((bfgs.iter_num() + 1) % refresh == 0)))
-      logger.info(
-          "    Iter"
-          "      log prob"
-          "        ||dx||"
-          "      ||grad||"
-          "       alpha"
-          "      alpha0"
-          "  # evals"
-          "  Notes ");
+  try {
+    while (ret == 0) {
+      interrupt();
+      if (refresh > 0
+          && (bfgs.iter_num() == 0 || ((bfgs.iter_num() + 1) % refresh == 0)))
+        logger.info(
+            "    Iter"
+            "      log prob"
+            "        ||dx||"
+            "      ||grad||"
+            "       alpha"
+            "      alpha0"
+            "  # evals"
+            "  Notes ");
 
-    try {
       ret = bfgs.step();
-    } catch (const std::exception& e) {
-      logger.error(e.what());
-      return error_codes::SOFTWARE;
-    }
 
-    lp = bfgs.logp();
-    bfgs.params_r(cont_vector);
+      lp = bfgs.logp();
+      bfgs.params_r(cont_vector);
 
-    if (refresh > 0
-        && (ret != 0 || !bfgs.note().empty() || bfgs.iter_num() == 0
-            || ((bfgs.iter_num() + 1) % refresh == 0))) {
-      std::stringstream msg;
-      msg << " " << std::setw(7) << bfgs.iter_num() << " ";
-      msg << " " << std::setw(12) << std::setprecision(6) << lp << " ";
-      msg << " " << std::setw(12) << std::setprecision(6)
-          << bfgs.prev_step_size() << " ";
-      msg << " " << std::setw(12) << std::setprecision(6)
-          << bfgs.curr_g().norm() << " ";
-      msg << " " << std::setw(10) << std::setprecision(4) << bfgs.alpha()
-          << " ";
-      msg << " " << std::setw(10) << std::setprecision(4) << bfgs.alpha0()
-          << " ";
-      msg << " " << std::setw(7) << bfgs.grad_evals() << " ";
-      msg << " " << bfgs.note() << " ";
-      logger.info(msg);
-    }
+      if (refresh > 0
+          && (ret != 0 || !bfgs.note().empty() || bfgs.iter_num() == 0
+              || ((bfgs.iter_num() + 1) % refresh == 0))) {
+        std::stringstream msg;
+        msg << " " << std::setw(7) << bfgs.iter_num() << " ";
+        msg << " " << std::setw(12) << std::setprecision(6) << lp << " ";
+        msg << " " << std::setw(12) << std::setprecision(6)
+            << bfgs.prev_step_size() << " ";
+        msg << " " << std::setw(12) << std::setprecision(6)
+            << bfgs.curr_g().norm() << " ";
+        msg << " " << std::setw(10) << std::setprecision(4) << bfgs.alpha()
+            << " ";
+        msg << " " << std::setw(10) << std::setprecision(4) << bfgs.alpha0()
+            << " ";
+        msg << " " << std::setw(7) << bfgs.grad_evals() << " ";
+        msg << " " << bfgs.note() << " ";
+        logger.info(msg);
+      }
 
-    if (bfgs_ss.str().length() > 0) {
-      logger.info(bfgs_ss);
-      bfgs_ss.str("");
-    }
+      if (bfgs_ss.str().length() > 0) {
+        logger.info(bfgs_ss);
+        bfgs_ss.str("");
+      }
 
-    if (save_iterations) {
-      std::vector<double> values;
-      std::stringstream msg;
-      try {
+      if (save_iterations) {
+        std::vector<double> values;
+        std::stringstream msg;
         model.write_array(rng, cont_vector, disc_vector, values, true, true,
                           &msg);
-      } catch (const std::exception& e) {
-        if (msg.str().length() > 0) {
-          logger.info(msg);
-        }
-        logger.error(e.what());
-        return error_codes::SOFTWARE;
-      }
-      // This if is here to match the pre-refactor behavior
-      if (msg.str().length() > 0)
-        logger.info(msg);
 
-      values.insert(values.begin(), lp);
-      parameter_writer(values);
+        // This if is here to match the pre-refactor behavior
+        if (msg.str().length() > 0)
+          logger.info(msg);
+
+        values.insert(values.begin(), lp);
+        parameter_writer(values);
+      }
     }
+
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
   }
 
   if (!save_iterations) {

--- a/src/stan/services/optimize/lbfgs.hpp
+++ b/src/stan/services/optimize/lbfgs.hpp
@@ -123,7 +123,12 @@ int lbfgs(Model& model, const stan::io::var_context& init,
           "  # evals"
           "  Notes ");
 
-    ret = lbfgs.step();
+    try {
+      ret = lbfgs.step();
+    } catch (const std::exception& e) {
+      logger.error(e.what());
+      return error_codes::SOFTWARE;
+    }
     lp = lbfgs.logp();
     lbfgs.params_r(cont_vector);
 
@@ -154,8 +159,16 @@ int lbfgs(Model& model, const stan::io::var_context& init,
     if (save_iterations) {
       std::vector<double> values;
       std::stringstream msg;
-      model.write_array(rng, cont_vector, disc_vector, values, true, true,
-                        &msg);
+      try {
+        model.write_array(rng, cont_vector, disc_vector, values, true, true,
+                          &msg);
+      } catch (const std::exception& e) {
+        if (msg.str().length() > 0) {
+          logger.info(msg);
+        }
+        logger.error(e.what());
+        return error_codes::SOFTWARE;
+      }
       if (msg.str().length() > 0)
         logger.info(msg);
 
@@ -167,7 +180,16 @@ int lbfgs(Model& model, const stan::io::var_context& init,
   if (!save_iterations) {
     std::vector<double> values;
     std::stringstream msg;
-    model.write_array(rng, cont_vector, disc_vector, values, true, true, &msg);
+    try {
+      model.write_array(rng, cont_vector, disc_vector, values, true, true,
+                        &msg);
+    } catch (const std::exception& e) {
+      if (msg.str().length() > 0) {
+        logger.info(msg);
+      }
+      logger.error(e.what());
+      return error_codes::SOFTWARE;
+    }
     if (msg.str().length() > 0)
       logger.info(msg);
 

--- a/src/stan/services/optimize/lbfgs.hpp
+++ b/src/stan/services/optimize/lbfgs.hpp
@@ -109,72 +109,65 @@ int lbfgs(Model& model, const stan::io::var_context& init,
   }
   int ret = 0;
 
-  while (ret == 0) {
-    interrupt();
-    if (refresh > 0
-        && (lbfgs.iter_num() == 0 || ((lbfgs.iter_num() + 1) % refresh == 0)))
-      logger.info(
-          "    Iter"
-          "      log prob"
-          "        ||dx||"
-          "      ||grad||"
-          "       alpha"
-          "      alpha0"
-          "  # evals"
-          "  Notes ");
+  try {
+    while (ret == 0) {
+      interrupt();
+      if (refresh > 0
+          && (lbfgs.iter_num() == 0 || ((lbfgs.iter_num() + 1) % refresh == 0)))
+        logger.info(
+            "    Iter"
+            "      log prob"
+            "        ||dx||"
+            "      ||grad||"
+            "       alpha"
+            "      alpha0"
+            "  # evals"
+            "  Notes ");
 
-    try {
       ret = lbfgs.step();
-    } catch (const std::exception& e) {
-      logger.error(e.what());
-      return error_codes::SOFTWARE;
-    }
-    lp = lbfgs.logp();
-    lbfgs.params_r(cont_vector);
 
-    if (refresh > 0
-        && (ret != 0 || !lbfgs.note().empty() || lbfgs.iter_num() == 0
-            || ((lbfgs.iter_num() + 1) % refresh == 0))) {
-      std::stringstream msg;
-      msg << " " << std::setw(7) << lbfgs.iter_num() << " ";
-      msg << " " << std::setw(12) << std::setprecision(6) << lp << " ";
-      msg << " " << std::setw(12) << std::setprecision(6)
-          << lbfgs.prev_step_size() << " ";
-      msg << " " << std::setw(12) << std::setprecision(6)
-          << lbfgs.curr_g().norm() << " ";
-      msg << " " << std::setw(10) << std::setprecision(4) << lbfgs.alpha()
-          << " ";
-      msg << " " << std::setw(10) << std::setprecision(4) << lbfgs.alpha0()
-          << " ";
-      msg << " " << std::setw(7) << lbfgs.grad_evals() << " ";
-      msg << " " << lbfgs.note() << " ";
-      logger.info(msg);
-    }
+      lp = lbfgs.logp();
+      lbfgs.params_r(cont_vector);
 
-    if (lbfgs_ss.str().length() > 0) {
-      logger.info(lbfgs_ss);
-      lbfgs_ss.str("");
-    }
+      if (refresh > 0
+          && (ret != 0 || !lbfgs.note().empty() || lbfgs.iter_num() == 0
+              || ((lbfgs.iter_num() + 1) % refresh == 0))) {
+        std::stringstream msg;
+        msg << " " << std::setw(7) << lbfgs.iter_num() << " ";
+        msg << " " << std::setw(12) << std::setprecision(6) << lp << " ";
+        msg << " " << std::setw(12) << std::setprecision(6)
+            << lbfgs.prev_step_size() << " ";
+        msg << " " << std::setw(12) << std::setprecision(6)
+            << lbfgs.curr_g().norm() << " ";
+        msg << " " << std::setw(10) << std::setprecision(4) << lbfgs.alpha()
+            << " ";
+        msg << " " << std::setw(10) << std::setprecision(4) << lbfgs.alpha0()
+            << " ";
+        msg << " " << std::setw(7) << lbfgs.grad_evals() << " ";
+        msg << " " << lbfgs.note() << " ";
+        logger.info(msg);
+      }
 
-    if (save_iterations) {
-      std::vector<double> values;
-      std::stringstream msg;
-      try {
+      if (lbfgs_ss.str().length() > 0) {
+        logger.info(lbfgs_ss);
+        lbfgs_ss.str("");
+      }
+
+      if (save_iterations) {
+        std::vector<double> values;
+        std::stringstream msg;
         model.write_array(rng, cont_vector, disc_vector, values, true, true,
                           &msg);
-      } catch (const std::exception& e) {
-        if (msg.str().length() > 0) {
+        if (msg.str().length() > 0)
           logger.info(msg);
-        }
-        logger.error(e.what());
-        return error_codes::SOFTWARE;
-      }
-      if (msg.str().length() > 0)
-        logger.info(msg);
 
-      values.insert(values.begin(), lp);
-      parameter_writer(values);
+        values.insert(values.begin(), lp);
+        parameter_writer(values);
+      }
     }
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
   }
 
   if (!save_iterations) {

--- a/src/stan/services/optimize/newton.hpp
+++ b/src/stan/services/optimize/newton.hpp
@@ -62,7 +62,7 @@ int newton(Model& model, const stan::io::var_context& init,
     lp = model.template log_prob<false, jacobian>(cont_vector, disc_vector,
                                                   &message);
     logger.info(message);
-  } catch (const std::exception& e) {
+  } catch (const std::domain_error& e) {
     logger.info("");
     logger.info(
         "Informational Message: The current"

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -820,7 +820,7 @@ inline auto pathfinder_lbfgs_single(
         logger.info(lbfgs_ss);
         lbfgs_ss.str("");
       }
-      throw e;
+      throw;
     }
   }
   if (unlikely(save_iterations)) {

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -820,7 +820,12 @@ inline auto pathfinder_lbfgs_single(
         logger.info(lbfgs_ss);
         lbfgs_ss.str("");
       }
-      throw;
+      if (ReturnLpSamples) {
+        throw;
+      } else {
+        logger.error(e.what());
+        return error_codes::SOFTWARE;
+      }
     }
   }
   if (unlikely(save_iterations)) {

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -821,10 +821,14 @@ inline auto pathfinder_lbfgs_single(
         lbfgs_ss.str("");
       }
       if (ReturnLpSamples) {
+        // we want to terminate multi-path pathfinder during these unrecoverable
+        // exceptions
         throw;
       } else {
         logger.error(e.what());
-        return error_codes::SOFTWARE;
+        return internal::ret_pathfinder<ReturnLpSamples>(
+            error_codes::SOFTWARE, Eigen::Array<double, Eigen::Dynamic, 1>(0),
+            Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>(0, 0), 0);
       }
     }
   }

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -250,7 +250,7 @@ inline elbo_est_t est_approx_draws(LPF&& lp_fun, ConstrainF&& constrain_fun,
         approx_samples_col = approx_samples.col(i);
         ++lp_fun_calls;
         lp_mat.coeffRef(i, 1) = lp_fun(approx_samples_col, pathfinder_ss);
-      } catch (const std::exception& e) {
+      } catch (const std::domain_error& e) {
         lp_mat.coeffRef(i, 1) = -std::numeric_limits<double>::infinity();
       }
       log_stream(logger, pathfinder_ss, iter_msg);
@@ -530,7 +530,7 @@ auto pathfinder_impl(RNG&& rng, LPFun&& lp_fun, ConstrainFun&& constrain_fun,
                               lp_fun, constrain_fun, rng, taylor_appx,
                               num_elbo_draws, alpha, iter_msg, logger),
                           taylor_appx);
-  } catch (const std::exception& e) {
+  } catch (const std::domain_error& e) {
     logger.warn(iter_msg + "ELBO estimation failed "
                 + " with error: " + e.what());
     return std::make_pair(internal::elbo_est_t{}, internal::taylor_approx_t{});
@@ -900,7 +900,7 @@ inline auto pathfinder_lbfgs_single(
                             approx_samples_constrained_col)
                   .matrix();
       }
-    } catch (const std::exception& e) {
+    } catch (const std::domain_error& e) {
       std::string err_msg = e.what();
       logger.warn(path_num + "Final sampling approximation failed with error: "
                   + err_msg);

--- a/src/stan/services/sample/hmc_nuts_dense_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e.hpp
@@ -81,9 +81,14 @@ int hmc_nuts_dense_e(Model& model, const stan::io::var_context& init,
   sampler.set_stepsize_jitter(stepsize_jitter);
   sampler.set_max_depth(max_depth);
 
-  util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
-                    num_thin, refresh, save_warmup, rng, interrupt, logger,
-                    sample_writer, diagnostic_writer);
+  try {
+    util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
+                      num_thin, refresh, save_warmup, rng, interrupt, logger,
+                      sample_writer, diagnostic_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
   return error_codes::OK;
 }
 
@@ -221,20 +226,25 @@ int hmc_nuts_dense_e(Model& model, size_t num_chains,
     logger.error(e.what());
     return error_codes::CONFIG;
   }
-  tbb::parallel_for(
-      tbb::blocked_range<size_t>(0, num_chains, 1),
-      [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
-       init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
-       &sample_writer, &cont_vectors,
-       &diagnostic_writer](const tbb::blocked_range<size_t>& r) {
-        for (size_t i = r.begin(); i != r.end(); ++i) {
-          util::run_sampler(samplers[i], model, cont_vectors[i], num_warmup,
-                            num_samples, num_thin, refresh, save_warmup,
-                            rngs[i], interrupt, logger, sample_writer[i],
-                            diagnostic_writer[i], init_chain_id + i);
-        }
-      },
-      tbb::simple_partitioner());
+  try {
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, num_chains, 1),
+        [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
+         init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
+         &sample_writer, &cont_vectors,
+         &diagnostic_writer](const tbb::blocked_range<size_t>& r) {
+          for (size_t i = r.begin(); i != r.end(); ++i) {
+            util::run_sampler(samplers[i], model, cont_vectors[i], num_warmup,
+                              num_samples, num_thin, refresh, save_warmup,
+                              rngs[i], interrupt, logger, sample_writer[i],
+                              diagnostic_writer[i], init_chain_id + i);
+          }
+        },
+        tbb::simple_partitioner());
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
   return error_codes::OK;
 }
 

--- a/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e_adapt.hpp
@@ -98,11 +98,15 @@ int hmc_nuts_dense_e_adapt(
 
   sampler.set_window_params(num_warmup, init_buffer, term_buffer, window,
                             logger);
-
-  util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
-                             num_samples, num_thin, refresh, save_warmup, rng,
-                             interrupt, logger, sample_writer,
-                             diagnostic_writer, metric_writer);
+  try {
+    util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
+                               num_samples, num_thin, refresh, save_warmup, rng,
+                               interrupt, logger, sample_writer,
+                               diagnostic_writer, metric_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
 
   return error_codes::OK;
 }
@@ -379,21 +383,26 @@ int hmc_nuts_dense_e_adapt(
     logger.error(e.what());
     return error_codes::CONFIG;
   }
-  tbb::parallel_for(
-      tbb::blocked_range<size_t>(0, num_chains, 1),
-      [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
-       init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
-       &sample_writer, &cont_vectors, &diagnostic_writer,
-       &metric_writer](const tbb::blocked_range<size_t>& r) {
-        for (size_t i = r.begin(); i != r.end(); ++i) {
-          util::run_adaptive_sampler(
-              samplers[i], model, cont_vectors[i], num_warmup, num_samples,
-              num_thin, refresh, save_warmup, rngs[i], interrupt, logger,
-              sample_writer[i], diagnostic_writer[i], metric_writer[i],
-              init_chain_id + i, num_chains);
-        }
-      },
-      tbb::simple_partitioner());
+  try {
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, num_chains, 1),
+        [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
+         init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
+         &sample_writer, &cont_vectors, &diagnostic_writer,
+         &metric_writer](const tbb::blocked_range<size_t>& r) {
+          for (size_t i = r.begin(); i != r.end(); ++i) {
+            util::run_adaptive_sampler(
+                samplers[i], model, cont_vectors[i], num_warmup, num_samples,
+                num_thin, refresh, save_warmup, rngs[i], interrupt, logger,
+                sample_writer[i], diagnostic_writer[i], metric_writer[i],
+                init_chain_id + i, num_chains);
+          }
+        },
+        tbb::simple_partitioner());
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
   return error_codes::OK;
 }
 

--- a/src/stan/services/sample/hmc_nuts_diag_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e.hpp
@@ -79,10 +79,14 @@ int hmc_nuts_diag_e(Model& model, const stan::io::var_context& init,
   sampler.set_stepsize_jitter(stepsize_jitter);
   sampler.set_max_depth(max_depth);
 
-  util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
-                    num_thin, refresh, save_warmup, rng, interrupt, logger,
-                    sample_writer, diagnostic_writer);
-
+  try {
+    util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
+                      num_thin, refresh, save_warmup, rng, interrupt, logger,
+                      sample_writer, diagnostic_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
   return error_codes::OK;
 }
 

--- a/src/stan/services/sample/hmc_nuts_unit_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_unit_e.hpp
@@ -69,10 +69,14 @@ int hmc_nuts_unit_e(Model& model, const stan::io::var_context& init,
   sampler.set_stepsize_jitter(stepsize_jitter);
   sampler.set_max_depth(max_depth);
 
-  util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
-                    num_thin, refresh, save_warmup, rng, interrupt, logger,
-                    sample_writer, diagnostic_writer);
-
+  try {
+    util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
+                      num_thin, refresh, save_warmup, rng, interrupt, logger,
+                      sample_writer, diagnostic_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
   return error_codes::OK;
 }
 
@@ -155,21 +159,26 @@ int hmc_nuts_unit_e(Model& model, size_t num_chains,
     logger.error(e.what());
     return error_codes::CONFIG;
   }
-  tbb::parallel_for(
-      tbb::blocked_range<size_t>(0, num_chains, 1),
-      [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
-       init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
-       &sample_writer, &cont_vectors,
-       &diagnostic_writer](const tbb::blocked_range<size_t>& r) {
-        for (size_t i = r.begin(); i != r.end(); ++i) {
-          util::run_sampler(samplers[i], model, cont_vectors[i], num_warmup,
-                            num_samples, num_thin, refresh, save_warmup,
-                            rngs[i], interrupt, logger, sample_writer[i],
-                            diagnostic_writer[i], init_chain_id + i,
-                            num_chains);
-        }
-      },
-      tbb::simple_partitioner());
+  try {
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, num_chains, 1),
+        [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
+         init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
+         &sample_writer, &cont_vectors,
+         &diagnostic_writer](const tbb::blocked_range<size_t>& r) {
+          for (size_t i = r.begin(); i != r.end(); ++i) {
+            util::run_sampler(samplers[i], model, cont_vectors[i], num_warmup,
+                              num_samples, num_thin, refresh, save_warmup,
+                              rngs[i], interrupt, logger, sample_writer[i],
+                              diagnostic_writer[i], init_chain_id + i,
+                              num_chains);
+          }
+        },
+        tbb::simple_partitioner());
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
   return error_codes::OK;
 }
 

--- a/src/stan/services/sample/hmc_nuts_unit_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_unit_e_adapt.hpp
@@ -83,11 +83,15 @@ int hmc_nuts_unit_e_adapt(
   sampler.get_stepsize_adaptation().set_kappa(kappa);
   sampler.get_stepsize_adaptation().set_t0(t0);
 
-  util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
-                             num_samples, num_thin, refresh, save_warmup, rng,
-                             interrupt, logger, sample_writer,
-                             diagnostic_writer, metric_writer);
-
+  try {
+    util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
+                               num_samples, num_thin, refresh, save_warmup, rng,
+                               interrupt, logger, sample_writer,
+                               diagnostic_writer, metric_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
   return error_codes::OK;
 }
 
@@ -228,21 +232,26 @@ int hmc_nuts_unit_e_adapt(
     logger.error(e.what());
     return error_codes::CONFIG;
   }
-  tbb::parallel_for(
-      tbb::blocked_range<size_t>(0, num_chains, 1),
-      [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
-       init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
-       &sample_writer, &cont_vectors, &diagnostic_writer,
-       &metric_writer](const tbb::blocked_range<size_t>& r) {
-        for (size_t i = r.begin(); i != r.end(); ++i) {
-          util::run_adaptive_sampler(
-              samplers[i], model, cont_vectors[i], num_warmup, num_samples,
-              num_thin, refresh, save_warmup, rngs[i], interrupt, logger,
-              sample_writer[i], diagnostic_writer[i], metric_writer[i],
-              init_chain_id + i, num_chains);
-        }
-      },
-      tbb::simple_partitioner());
+  try {
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, num_chains, 1),
+        [num_warmup, num_samples, num_thin, refresh, save_warmup, num_chains,
+         init_chain_id, &samplers, &model, &rngs, &interrupt, &logger,
+         &sample_writer, &cont_vectors, &diagnostic_writer,
+         &metric_writer](const tbb::blocked_range<size_t>& r) {
+          for (size_t i = r.begin(); i != r.end(); ++i) {
+            util::run_adaptive_sampler(
+                samplers[i], model, cont_vectors[i], num_warmup, num_samples,
+                num_thin, refresh, save_warmup, rngs[i], interrupt, logger,
+                sample_writer[i], diagnostic_writer[i], metric_writer[i],
+                init_chain_id + i, num_chains);
+          }
+        },
+        tbb::simple_partitioner());
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
   return error_codes::OK;
 }
 

--- a/src/stan/services/sample/hmc_static_dense_e.hpp
+++ b/src/stan/services/sample/hmc_static_dense_e.hpp
@@ -76,9 +76,14 @@ int hmc_static_dense_e(
   sampler.set_nominal_stepsize_and_T(stepsize, int_time);
   sampler.set_stepsize_jitter(stepsize_jitter);
 
-  util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
-                    num_thin, refresh, save_warmup, rng, interrupt, logger,
-                    sample_writer, diagnostic_writer);
+  try {
+    util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
+                      num_thin, refresh, save_warmup, rng, interrupt, logger,
+                      sample_writer, diagnostic_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
 
   return error_codes::OK;
 }

--- a/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_dense_e_adapt.hpp
@@ -98,10 +98,15 @@ int hmc_static_dense_e_adapt(
                             logger);
 
   callbacks::structured_writer dummy_metric_writer;
-  util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
-                             num_samples, num_thin, refresh, save_warmup, rng,
-                             interrupt, logger, sample_writer,
-                             diagnostic_writer, dummy_metric_writer);
+  try {
+    util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
+                               num_samples, num_thin, refresh, save_warmup, rng,
+                               interrupt, logger, sample_writer,
+                               diagnostic_writer, dummy_metric_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
 
   return error_codes::OK;
 }

--- a/src/stan/services/sample/hmc_static_diag_e.hpp
+++ b/src/stan/services/sample/hmc_static_diag_e.hpp
@@ -78,10 +78,14 @@ int hmc_static_diag_e(Model& model, const stan::io::var_context& init,
   sampler.set_metric(inv_metric);
   sampler.set_nominal_stepsize_and_T(stepsize, int_time);
   sampler.set_stepsize_jitter(stepsize_jitter);
-
-  util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
-                    num_thin, refresh, save_warmup, rng, interrupt, logger,
-                    sample_writer, diagnostic_writer);
+  try {
+    util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
+                      num_thin, refresh, save_warmup, rng, interrupt, logger,
+                      sample_writer, diagnostic_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
 
   return error_codes::OK;
 }

--- a/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_diag_e_adapt.hpp
@@ -96,10 +96,16 @@ int hmc_static_diag_e_adapt(
                             logger);
 
   callbacks::structured_writer dummy_metric_writer;
-  util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
-                             num_samples, num_thin, refresh, save_warmup, rng,
-                             interrupt, logger, sample_writer,
-                             diagnostic_writer, dummy_metric_writer);
+
+  try {
+    util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
+                               num_samples, num_thin, refresh, save_warmup, rng,
+                               interrupt, logger, sample_writer,
+                               diagnostic_writer, dummy_metric_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
 
   return error_codes::OK;
 }

--- a/src/stan/services/sample/hmc_static_unit_e.hpp
+++ b/src/stan/services/sample/hmc_static_unit_e.hpp
@@ -68,9 +68,14 @@ int hmc_static_unit_e(Model& model, const stan::io::var_context& init,
   sampler.set_nominal_stepsize_and_T(stepsize, int_time);
   sampler.set_stepsize_jitter(stepsize_jitter);
 
-  util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
-                    num_thin, refresh, save_warmup, rng, interrupt, logger,
-                    sample_writer, diagnostic_writer);
+  try {
+    util::run_sampler(sampler, model, cont_vector, num_warmup, num_samples,
+                      num_thin, refresh, save_warmup, rng, interrupt, logger,
+                      sample_writer, diagnostic_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
 
   return error_codes::OK;
 }

--- a/src/stan/services/sample/hmc_static_unit_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_static_unit_e_adapt.hpp
@@ -80,10 +80,15 @@ int hmc_static_unit_e_adapt(
   sampler.get_stepsize_adaptation().set_t0(t0);
 
   callbacks::structured_writer dummy_metric_writer;
-  util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
-                             num_samples, num_thin, refresh, save_warmup, rng,
-                             interrupt, logger, sample_writer,
-                             diagnostic_writer, dummy_metric_writer);
+  try {
+    util::run_adaptive_sampler(sampler, model, cont_vector, num_warmup,
+                               num_samples, num_thin, refresh, save_warmup, rng,
+                               interrupt, logger, sample_writer,
+                               diagnostic_writer, dummy_metric_writer);
+  } catch (const std::exception& e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
 
   return error_codes::OK;
 }

--- a/src/stan/services/sample/standalone_gqs.hpp
+++ b/src/stan/services/sample/standalone_gqs.hpp
@@ -67,19 +67,23 @@ int standalone_generate(const Model &model, const Eigen::MatrixXd &draws,
 
   std::vector<double> unconstrained_params_r;
   std::vector<double> row(draws.cols());
-
-  for (size_t i = 0; i < draws.rows(); ++i) {
-    Eigen::Map<Eigen::VectorXd>(&row[0], draws.cols()) = draws.row(i);
-    try {
-      model.unconstrain_array(row, unconstrained_params_r, &msg);
-    } catch (const std::exception &e) {
-      if (msg.str().length() > 0)
-        logger.error(msg);
-      logger.error(e.what());
-      return error_codes::DATAERR;
+  try {
+    for (size_t i = 0; i < draws.rows(); ++i) {
+      Eigen::Map<Eigen::VectorXd>(&row[0], draws.cols()) = draws.row(i);
+      try {
+        model.unconstrain_array(row, unconstrained_params_r, &msg);
+      } catch (const std::exception &e) {
+        if (msg.str().length() > 0)
+          logger.error(msg);
+        logger.error(e.what());
+        return error_codes::DATAERR;
+      }
+      interrupt();  // call out to interrupt and fail
+      writer.write_gq_values(model, rng, unconstrained_params_r);
     }
-    interrupt();  // call out to interrupt and fail
-    writer.write_gq_values(model, rng, unconstrained_params_r);
+  } catch (const std::exception &e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
   }
   return error_codes::OK;
 }
@@ -147,34 +151,40 @@ int standalone_generate(const Model &model, const int num_chains,
     rngs.emplace_back(util::create_rng(seed, i + 1));
   }
   bool error_any = false;
-  tbb::parallel_for(
-      tbb::blocked_range<size_t>(0, num_chains, 1),
-      [&draws, &model, &logger, &interrupt, &writers, &rngs,
-       &error_any](const tbb::blocked_range<size_t> &r) {
-        Eigen::VectorXd unconstrained_params_r(draws[0].cols());
-        Eigen::VectorXd row(draws[0].cols());
-        std::stringstream msg;
-        for (size_t slice_idx = r.begin(); slice_idx != r.end(); ++slice_idx) {
-          for (size_t i = 0; i < draws[slice_idx].rows(); ++i) {
-            if (error_any)
-              return;
-            try {
-              row = draws[slice_idx].row(i);
-              model.unconstrain_array(row, unconstrained_params_r, &msg);
-            } catch (const std::exception &e) {
-              if (msg.str().length() > 0)
-                logger.error(msg);
-              logger.error(e.what());
-              error_any = true;
-              return;
+  try {
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, num_chains, 1),
+        [&draws, &model, &logger, &interrupt, &writers, &rngs,
+         &error_any](const tbb::blocked_range<size_t> &r) {
+          Eigen::VectorXd unconstrained_params_r(draws[0].cols());
+          Eigen::VectorXd row(draws[0].cols());
+          std::stringstream msg;
+          for (size_t slice_idx = r.begin(); slice_idx != r.end();
+               ++slice_idx) {
+            for (size_t i = 0; i < draws[slice_idx].rows(); ++i) {
+              if (error_any)
+                return;
+              try {
+                row = draws[slice_idx].row(i);
+                model.unconstrain_array(row, unconstrained_params_r, &msg);
+              } catch (const std::domain_error &e) {
+                if (msg.str().length() > 0)
+                  logger.error(msg);
+                logger.error(e.what());
+                error_any = true;
+                return;
+              }
+              interrupt();  // call out to interrupt and fail
+              writers[slice_idx].write_gq_values(model, rngs[slice_idx],
+                                                 unconstrained_params_r);
             }
-            interrupt();  // call out to interrupt and fail
-            writers[slice_idx].write_gq_values(model, rngs[slice_idx],
-                                               unconstrained_params_r);
           }
-        }
-      },
-      tbb::simple_partitioner());
+        },
+        tbb::simple_partitioner());
+  } catch (const std::exception &e) {
+    logger.error(e.what());
+    return error_codes::SOFTWARE;
+  }
   return error_any ? error_codes::DATAERR : error_codes::OK;
 }
 

--- a/src/stan/services/util/gq_writer.hpp
+++ b/src/stan/services/util/gq_writer.hpp
@@ -79,10 +79,15 @@ class gq_writer {
       model.write_array(rng, draw, params_i, values, false, true, &ss);
       if (ss.str().length() > 0)
         logger_.info(ss);
+    } catch (const std::domain_error& e) {
+      if (ss.str().length() > 0)
+        logger_.info(ss);
+      logger_.info(e.what());
     } catch (const std::exception& e) {
       if (ss.str().length() > 0)
         logger_.info(ss);
       logger_.info(e.what());
+      throw;
     }
 
     std::vector<double> gq_values(values.begin() + num_constrained_params_,
@@ -110,11 +115,16 @@ class gq_writer {
       if (ss.str().length() > 0) {
         logger_.info(ss);
       }
-    } catch (const std::exception& e) {
+    } catch (const std::domain_error& e) {
       if (ss.str().length() > 0) {
         logger_.info(ss);
       }
       logger_.info(e.what());
+    } catch (const std::exception& e) {
+      if (ss.str().length() > 0)
+        logger_.info(ss);
+      logger_.info(e.what());
+      throw;
     }
     sample_writer_(values);
   }

--- a/src/stan/services/util/mcmc_writer.hpp
+++ b/src/stan/services/util/mcmc_writer.hpp
@@ -111,11 +111,16 @@ class mcmc_writer {
           sample.cont_params().data() + sample.cont_params().size());
       model.write_array(rng, cont_params, params_i, model_values, true, true,
                         &ss);
-    } catch (const std::exception& e) {
+    } catch (const std::domain_error& e) {
       if (ss.str().length() > 0)
         logger_.info(ss);
       ss.str("");
       logger_.info(e.what());
+    } catch (const std::exception& e) {
+      if (ss.str().length() > 0)
+        logger_.info(ss);
+      logger_.info(e.what());
+      throw;
     }
     if (ss.str().length() > 0)
       logger_.info(ss);


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #3258. This changes any place which caught `std::exception` from the model to only catch `std::domain_error`, matching what is done during initialization. 

This prevents odd behavior like an indexing exception that only occurs randomly being swallowed if initialization happens to pass, and allows things like an `exit()` function in the language.

#### Intended Effect

Cause certain exceptions to terminate the inference algorithms.

#### How to Verify

This model will usually initialize but quickly fail now: 

```stan
parameters {
  real mu;
}
model {
  mu ~ normal(0, 1);

  if (mu > 1) {
    array[1] int sigma;
    print(sigma[2]);
  }
}
```

#### Side Effects

I've installed handlers in the service functions, but code that calls the internals of these algorithms (e.g `run_adaptive_sampler`) _not_ through the services will need to be ready to catch exceptions

Additionally, if any Math functions raise an exception which is intended to be recoverable but is not a domain_error, they will need updating. Because this is the current behavior in initialization, I suspect we have probably already smoked any of these out.

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
