### PR TITLE
Properly allow multiple downstream jenkins runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
         preserveStashes(buildCount: 7)
         parallelsAlwaysFailFast()
         buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '30'))
-        disableConcurrentBuilds(abortPrevious: env.BRANCH_NAME != "downstream_tests" || env.BRANCH_NAME != "downstream_hotfix")
+        disableConcurrentBuilds(abortPrevious: env.BRANCH_NAME != "downstream_tests" && env.BRANCH_NAME != "downstream_hotfix")
     }
     environment {
         GCC = 'g++'


### PR DESCRIPTION
We had an || instead of an && so this was always `true`, which led to problems when multiple Math PRs were running at once. 

Cmdstan has the same issue currently, I'll open a separate PR