### PR TITLE
Change default RNG to boost::mixmax 

### DIFF
--- a/src/stan/services/util/create_rng.hpp
+++ b/src/stan/services/util/create_rng.hpp
@@ -1,11 +1,11 @@
 #ifndef STAN_SERVICES_UTIL_CREATE_RNG_HPP
 #define STAN_SERVICES_UTIL_CREATE_RNG_HPP
 
-#include <boost/random/additive_combine.hpp>
+#include <boost/random/mixmax.hpp>
 
 namespace stan {
 
-using rng_t = boost::ecuyer1988;
+using rng_t = boost::random::mixmax;
 
 namespace services {
 namespace util {
@@ -26,12 +26,7 @@ namespace util {
  * @return an stan::rng_t instance
  */
 inline rng_t create_rng(unsigned int seed, unsigned int chain) {
-  using boost::uintmax_t;
-  static constexpr uintmax_t DISCARD_STRIDE = static_cast<uintmax_t>(1) << 50;
-  rng_t rng(seed);
-  // always discard at least 1 to avoid issue with small seeds for certain RNG
-  // distributions. See stan#3167 and boostorg/random#92
-  rng.discard(std::max(static_cast<uintmax_t>(1), DISCARD_STRIDE * chain));
+  rng_t rng(seed + chain);
   return rng;
 }
 

--- a/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp
@@ -333,7 +333,7 @@ TEST(McmcNutsBaseNuts, divergence_test) {
 }
 
 TEST(McmcNutsBaseNuts, transition) {
-  stan::rng_t base_rng(0);
+  stan::rng_t base_rng = stan::services::util::create_rng(0, 0);
 
   int model_size = 1;
   double init_momentum = 1.5;
@@ -362,7 +362,7 @@ TEST(McmcNutsBaseNuts, transition) {
   EXPECT_EQ((2 << (sampler.get_max_depth() - 1)) - 1, sampler.n_leapfrog_);
   EXPECT_FALSE(sampler.divergent_);
 
-  EXPECT_EQ(21 * init_momentum, s.cont_params()(0));
+  EXPECT_EQ(-31 * init_momentum, s.cont_params()(0));
   EXPECT_EQ(0, s.log_prob());
   EXPECT_EQ(1, s.accept_stat());
   EXPECT_EQ("", debug.str());
@@ -373,7 +373,7 @@ TEST(McmcNutsBaseNuts, transition) {
 }
 
 TEST(McmcNutsBaseNuts, transition_egde_momenta) {
-  stan::rng_t base_rng(0);
+  stan::rng_t base_rng = stan::services::util::create_rng(424243, 0);
 
   int model_size = 1;
   double init_momentum = 1.5;

--- a/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/softabs_nuts_test.cpp
@@ -309,7 +309,7 @@ TEST(McmcSoftAbsNuts, tree_boundary_test) {
 }
 
 TEST(McmcSoftAbsNuts, transition_test) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::softabs_point z_init(3);
   z_init.q(0) = 1;
@@ -338,15 +338,15 @@ TEST(McmcSoftAbsNuts, transition_test) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_EQ(4, sampler.depth_);
-  EXPECT_EQ((2 << 3) - 1, sampler.n_leapfrog_);
+  EXPECT_EQ(5, sampler.depth_);
+  EXPECT_EQ((2 << 4) - 1, sampler.n_leapfrog_);
   EXPECT_FALSE(sampler.divergent_);
 
-  EXPECT_FLOAT_EQ(1.9313564, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.86902142, s.cont_params()(1));
-  EXPECT_FLOAT_EQ(1.6008, s.cont_params()(2));
-  EXPECT_FLOAT_EQ(-3.5239484, s.log_prob());
-  EXPECT_FLOAT_EQ(0.99690288, s.accept_stat());
+  EXPECT_FLOAT_EQ(-1.7373296, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(1.0898665, s.cont_params()(1));
+  EXPECT_FLOAT_EQ(-0.38303182, s.cont_params()(2));
+  EXPECT_FLOAT_EQ(-2.1764181, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9993856, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());

--- a/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
+++ b/src/test/unit/mcmc/hmc/nuts/unit_e_nuts_test.cpp
@@ -309,7 +309,7 @@ TEST(McmcUnitENuts, tree_boundary_test) {
 }
 
 TEST(McmcUnitENuts, transition_test) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::unit_e_point z_init(3);
   z_init.q(0) = 1;
@@ -338,15 +338,15 @@ TEST(McmcUnitENuts, transition_test) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_EQ(4, sampler.depth_);
-  EXPECT_EQ((2 << 3) - 1, sampler.n_leapfrog_);
+  EXPECT_EQ(5, sampler.depth_);
+  EXPECT_EQ((2 << 4) - 1, sampler.n_leapfrog_);
   EXPECT_FALSE(sampler.divergent_);
 
-  EXPECT_FLOAT_EQ(1.8718261, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.74208695, s.cont_params()(1));
-  EXPECT_FLOAT_EQ(1.5202962, s.cont_params()(2));
-  EXPECT_FLOAT_EQ(-3.1828632, s.log_prob());
-  EXPECT_FLOAT_EQ(0.99604273, s.accept_stat());
+  EXPECT_FLOAT_EQ(-1.7890506, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(1.2320533, s.cont_params()(1));
+  EXPECT_FLOAT_EQ(-0.62397981, s.cont_params()(2));
+  EXPECT_FLOAT_EQ(-2.554004, s.log_prob());
+  EXPECT_FLOAT_EQ(0.99910343, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());

--- a/src/test/unit/mcmc/hmc/static_uniform/derived_static_uniform_test.cpp
+++ b/src/test/unit/mcmc/hmc/static_uniform/derived_static_uniform_test.cpp
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 
 TEST(McmcStaticUniform, unit_e_transition) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::unit_e_point z_init(1);
   z_init.q(0) = 1;
@@ -41,9 +41,9 @@ TEST(McmcStaticUniform, unit_e_transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
-  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_FLOAT_EQ(1.5896972, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-1.2635686, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9994188, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());
@@ -52,7 +52,7 @@ TEST(McmcStaticUniform, unit_e_transition) {
 }
 
 TEST(McmcStaticUniform, diag_e_transition) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::diag_e_point z_init(1);
   z_init.q(0) = 1;
@@ -78,9 +78,9 @@ TEST(McmcStaticUniform, diag_e_transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
-  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_FLOAT_EQ(1.5896972, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-1.2635686, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9994188, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());
@@ -89,7 +89,7 @@ TEST(McmcStaticUniform, diag_e_transition) {
 }
 
 TEST(McmcStaticUniform, dense_e_transition) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::dense_e_point z_init(1);
   z_init.q(0) = 1;
@@ -115,9 +115,9 @@ TEST(McmcStaticUniform, dense_e_transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
-  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_FLOAT_EQ(1.5896972, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-1.2635686, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9994188, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());
@@ -126,7 +126,7 @@ TEST(McmcStaticUniform, dense_e_transition) {
 }
 
 TEST(McmcStaticUniform, softabs_transition) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::softabs_point z_init(1);
   z_init.q(0) = 1;
@@ -152,9 +152,9 @@ TEST(McmcStaticUniform, softabs_transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_FLOAT_EQ(0.37006485, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.068473995, s.log_prob());
-  EXPECT_FLOAT_EQ(0.9999119, s.accept_stat());
+  EXPECT_FLOAT_EQ(1.5338461, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-1.176342, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9996115, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());
@@ -163,7 +163,7 @@ TEST(McmcStaticUniform, softabs_transition) {
 }
 
 TEST(McmcStaticUniform, adapt_unit_e_transition) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::unit_e_point z_init(1);
   z_init.q(0) = 1;
@@ -189,9 +189,9 @@ TEST(McmcStaticUniform, adapt_unit_e_transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
-  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_FLOAT_EQ(1.5896972, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-1.2635686, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9994188, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());
@@ -200,7 +200,7 @@ TEST(McmcStaticUniform, adapt_unit_e_transition) {
 }
 
 TEST(McmcStaticUniform, adapt_diag_e_transition) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::diag_e_point z_init(1);
   z_init.q(0) = 1;
@@ -226,9 +226,9 @@ TEST(McmcStaticUniform, adapt_diag_e_transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
-  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_FLOAT_EQ(1.5896972, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-1.2635686, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9994188, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());
@@ -237,7 +237,7 @@ TEST(McmcStaticUniform, adapt_diag_e_transition) {
 }
 
 TEST(McmcStaticUniform, adapt_dense_e_transition) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::dense_e_point z_init(1);
   z_init.q(0) = 1;
@@ -263,9 +263,9 @@ TEST(McmcStaticUniform, adapt_dense_e_transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_FLOAT_EQ(0.27224374, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.037058324, s.log_prob());
-  EXPECT_FLOAT_EQ(0.9998666, s.accept_stat());
+  EXPECT_FLOAT_EQ(1.5896972, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-1.2635686, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9994188, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());
@@ -274,7 +274,7 @@ TEST(McmcStaticUniform, adapt_dense_e_transition) {
 }
 
 TEST(McmcStaticUniform, adapt_softabs_e_transition) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::softabs_point z_init(1);
   z_init.q(0) = 1;
@@ -300,9 +300,9 @@ TEST(McmcStaticUniform, adapt_softabs_e_transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_FLOAT_EQ(0.37006485, s.cont_params()(0));
-  EXPECT_FLOAT_EQ(-0.068473995, s.log_prob());
-  EXPECT_FLOAT_EQ(0.9999119, s.accept_stat());
+  EXPECT_FLOAT_EQ(1.5338461, s.cont_params()(0));
+  EXPECT_FLOAT_EQ(-1.176342, s.log_prob());
+  EXPECT_FLOAT_EQ(0.9996115, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());

--- a/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/base_xhmc_test.cpp
@@ -221,7 +221,7 @@ TEST(McmcXHMCBaseXHMC, divergence_test) {
 }
 
 TEST(McmcXHMCBaseXHMC, transition) {
-  stan::rng_t base_rng(0);
+  stan::rng_t base_rng = stan::services::util::create_rng(0, 0);
 
   int model_size = 1;
   double init_momentum = 1.5;
@@ -245,7 +245,7 @@ TEST(McmcXHMCBaseXHMC, transition) {
 
   stan::mcmc::sample s = sampler.transition(init_sample, logger);
 
-  EXPECT_EQ(31.5, s.cont_params()(0));
+  EXPECT_EQ(-31 * init_momentum, s.cont_params()(0));
   EXPECT_EQ(0, s.log_prob());
   EXPECT_EQ(1, s.accept_stat());
   EXPECT_EQ("", debug.str());

--- a/src/test/unit/mcmc/hmc/xhmc/softabs_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/softabs_xhmc_test.cpp
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 
 TEST(McmcUnitEXHMC, build_tree) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(4839294, 0);
 
   stan::mcmc::softabs_point z_init(3);
   z_init.q(0) = 1;
@@ -58,13 +58,13 @@ TEST(McmcUnitEXHMC, build_tree) {
   EXPECT_FLOAT_EQ(1.5019561, sampler.z().p(1));
   EXPECT_FLOAT_EQ(-1.5019561, sampler.z().p(2));
 
-  EXPECT_FLOAT_EQ(0.8330583, z_propose.q(0));
-  EXPECT_FLOAT_EQ(-0.8330583, z_propose.q(1));
-  EXPECT_FLOAT_EQ(0.8330583, z_propose.q(2));
+  EXPECT_FLOAT_EQ(0.42903179, z_propose.q(0));
+  EXPECT_FLOAT_EQ(-0.42903179, z_propose.q(1));
+  EXPECT_FLOAT_EQ(0.42903179, z_propose.q(2));
 
-  EXPECT_FLOAT_EQ(-1.1836562, z_propose.p(0));
-  EXPECT_FLOAT_EQ(1.1836562, z_propose.p(1));
-  EXPECT_FLOAT_EQ(-1.1836562, z_propose.p(2));
+  EXPECT_FLOAT_EQ(-1.4385087, z_propose.p(0));
+  EXPECT_FLOAT_EQ(1.4385087, z_propose.p(1));
+  EXPECT_FLOAT_EQ(-1.4385087, z_propose.p(2));
 
   EXPECT_EQ(8, n_leapfrog);
   EXPECT_FLOAT_EQ(3.7645235, ave);
@@ -79,7 +79,7 @@ TEST(McmcUnitEXHMC, build_tree) {
 }
 
 TEST(McmcUnitEXHMC, transition) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(483294, 0);
 
   stan::mcmc::softabs_point z_init(3);
   z_init.q(0) = 1;
@@ -112,7 +112,7 @@ TEST(McmcUnitEXHMC, transition) {
   EXPECT_FLOAT_EQ(-1, s.cont_params()(1));
   EXPECT_FLOAT_EQ(1, s.cont_params()(2));
   EXPECT_FLOAT_EQ(-1.5, s.log_prob());
-  EXPECT_FLOAT_EQ(0.99829924, s.accept_stat());
+  EXPECT_FLOAT_EQ(0.99993229, s.accept_stat());
 
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());

--- a/src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp
+++ b/src/test/unit/mcmc/hmc/xhmc/unit_e_xhmc_test.cpp
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 
 TEST(McmcUnitEXHMC, build_tree) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(483294, 0);
 
   stan::mcmc::unit_e_point z_init(3);
   z_init.q(0) = 1;
@@ -58,13 +58,13 @@ TEST(McmcUnitEXHMC, build_tree) {
   EXPECT_FLOAT_EQ(1.4131583, sampler.z().p(1));
   EXPECT_FLOAT_EQ(-1.4131583, sampler.z().p(2));
 
-  EXPECT_FLOAT_EQ(0.78105003, z_propose.q(0));
-  EXPECT_FLOAT_EQ(-0.78105003, z_propose.q(1));
-  EXPECT_FLOAT_EQ(0.78105003, z_propose.q(2));
+  EXPECT_FLOAT_EQ(0.65928948, z_propose.q(0));
+  EXPECT_FLOAT_EQ(-0.65928948, z_propose.q(1));
+  EXPECT_FLOAT_EQ(0.65928948, z_propose.q(2));
 
-  EXPECT_FLOAT_EQ(-1.1785525, z_propose.p(0));
-  EXPECT_FLOAT_EQ(1.1785525, z_propose.p(1));
-  EXPECT_FLOAT_EQ(-1.1785525, z_propose.p(2));
+  EXPECT_FLOAT_EQ(-1.2505695, z_propose.p(0));
+  EXPECT_FLOAT_EQ(1.2505695, z_propose.p(1));
+  EXPECT_FLOAT_EQ(-1.2505695, z_propose.p(2));
 
   EXPECT_EQ(8, n_leapfrog);
   EXPECT_FLOAT_EQ(4.2207355, ave);
@@ -79,7 +79,7 @@ TEST(McmcUnitEXHMC, build_tree) {
 }
 
 TEST(McmcUnitEXHMC, transition) {
-  stan::rng_t base_rng(4839294);
+  stan::rng_t base_rng = stan::services::util::create_rng(483294, 0);
 
   stan::mcmc::unit_e_point z_init(3);
   z_init.q(0) = 1;
@@ -112,7 +112,7 @@ TEST(McmcUnitEXHMC, transition) {
   EXPECT_FLOAT_EQ(-1, s.cont_params()(1));
   EXPECT_FLOAT_EQ(1, s.cont_params()(2));
   EXPECT_FLOAT_EQ(-1.5, s.log_prob());
-  EXPECT_FLOAT_EQ(0.99805242, s.accept_stat());
+  EXPECT_FLOAT_EQ(0.99994934, s.accept_stat());
   EXPECT_EQ("", debug.str());
   EXPECT_EQ("", info.str());
   EXPECT_EQ("", warn.str());

--- a/src/test/unit/services/pathfinder/normal_glm_test.cpp
+++ b/src/test/unit/services/pathfinder/normal_glm_test.cpp
@@ -83,17 +83,19 @@ TEST_F(ServicesPathfinderGLM, single) {
   constexpr int refresh = 1;
 
   stan::test::mock_callback callback;
-  stan::io::empty_var_context empty_context;  // = init_init_context();
+  stan::io::array_var_context init_context = init_init_context();
   std::unique_ptr<std::ostream> empty_ostream(nullptr);
   stan::test::test_logger logger(std::move(empty_ostream));
 
   std::vector<std::tuple<Eigen::VectorXd, Eigen::VectorXd>> input_iters;
 
-  stan::services::pathfinder::pathfinder_lbfgs_single(
-      model, empty_context, seed, chain, init_radius, history_size, init_alpha,
+  int rc = stan::services::pathfinder::pathfinder_lbfgs_single(
+      model, init_context, seed, chain, init_radius, history_size, init_alpha,
       tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param, num_iterations,
       num_elbo_draws, num_draws, save_iterations, refresh, callback, logger,
       init, parameter, diagnostics);
+  ASSERT_EQ(rc, 0);
+
   Eigen::MatrixXd param_vals = std::move(parameter.values_);
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
                                "", "");
@@ -154,17 +156,18 @@ TEST_F(ServicesPathfinderGLM, single_noreturnlp) {
   constexpr bool calculate_lp = false;
 
   stan::test::mock_callback callback;
-  stan::io::empty_var_context empty_context;  // = init_init_context();
+  stan::io::array_var_context init_context = init_init_context();
   std::unique_ptr<std::ostream> empty_ostream(nullptr);
   stan::test::test_logger logger(std::move(empty_ostream));
 
   std::vector<std::tuple<Eigen::VectorXd, Eigen::VectorXd>> input_iters;
 
-  stan::services::pathfinder::pathfinder_lbfgs_single(
-      model, empty_context, seed, chain, init_radius, history_size, init_alpha,
+  int rc = stan::services::pathfinder::pathfinder_lbfgs_single(
+      model, init_context, seed, chain, init_radius, history_size, init_alpha,
       tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param, num_iterations,
       num_elbo_draws, num_draws, save_iterations, refresh, callback, logger,
       init, parameter, diagnostics, calculate_lp);
+  ASSERT_EQ(rc, 0);
   Eigen::MatrixXd param_vals = std::move(parameter.values_);
   for (Eigen::Index i = 0; i < num_elbo_draws; ++i) {
     EXPECT_FALSE(std::isnan(param_vals.coeff(1, num_draws + i)))
@@ -206,7 +209,7 @@ TEST_F(ServicesPathfinderGLM, multi) {
         std::make_unique<decltype(init_init_context())>(init_init_context()));
   }
   stan::test::mock_callback callback;
-  stan::services::pathfinder::pathfinder_lbfgs_multi(
+  int rc = stan::services::pathfinder::pathfinder_lbfgs_multi(
       model, single_path_inits, seed, chain, init_radius, history_size,
       init_alpha, tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param,
       num_iterations, num_elbo_draws, num_draws, num_multi_draws, num_paths,
@@ -214,6 +217,7 @@ TEST_F(ServicesPathfinderGLM, multi) {
       std::vector<stan::callbacks::stream_writer>(num_paths, init),
       single_path_parameter_writer, single_path_diagnostic_writer, parameter,
       diagnostics);
+  ASSERT_EQ(rc, 0);
 
   Eigen::MatrixXd param_vals(parameter.eigen_states_.size(),
                              parameter.eigen_states_[0].size());
@@ -291,7 +295,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample) {
         std::make_unique<decltype(init_init_context())>(init_init_context()));
   }
   stan::test::mock_callback callback;
-  stan::services::pathfinder::pathfinder_lbfgs_multi(
+  int rc = stan::services::pathfinder::pathfinder_lbfgs_multi(
       model, single_path_inits, seed, chain, init_radius, history_size,
       init_alpha, tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param,
       num_iterations, num_elbo_draws, num_draws, num_multi_draws, num_paths,
@@ -299,6 +303,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample) {
       std::vector<stan::callbacks::stream_writer>(num_paths, init),
       single_path_parameter_writer, single_path_diagnostic_writer, parameter,
       diagnostics, calculate_lp, resample);
+  ASSERT_EQ(rc, 0);
 
   Eigen::MatrixXd param_vals = parameter.values_;
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
@@ -340,7 +345,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample_noreturnlp) {
         std::make_unique<decltype(init_init_context())>(init_init_context()));
   }
   stan::test::mock_callback callback;
-  stan::services::pathfinder::pathfinder_lbfgs_multi(
+  int rc = stan::services::pathfinder::pathfinder_lbfgs_multi(
       model, single_path_inits, seed, chain, init_radius, history_size,
       init_alpha, tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param,
       num_iterations, num_elbo_draws, num_draws, num_multi_draws, num_paths,
@@ -348,6 +353,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample_noreturnlp) {
       std::vector<stan::callbacks::stream_writer>(num_paths, init),
       single_path_parameter_writer, single_path_diagnostic_writer, parameter,
       diagnostics, calculate_lp, resample);
+  ASSERT_EQ(rc, 0);
 
   Eigen::MatrixXd param_vals = parameter.values_;
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
@@ -399,7 +405,7 @@ TEST_F(ServicesPathfinderGLM, multi_resample_noreturnlp) {
         std::make_unique<decltype(init_init_context())>(init_init_context()));
   }
   stan::test::mock_callback callback;
-  stan::services::pathfinder::pathfinder_lbfgs_multi(
+  int rc = stan::services::pathfinder::pathfinder_lbfgs_multi(
       model, single_path_inits, seed, chain, init_radius, history_size,
       init_alpha, tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param,
       num_iterations, num_elbo_draws, num_draws, num_multi_draws, num_paths,
@@ -407,6 +413,7 @@ TEST_F(ServicesPathfinderGLM, multi_resample_noreturnlp) {
       std::vector<stan::callbacks::stream_writer>(num_paths, init),
       single_path_parameter_writer, single_path_diagnostic_writer, parameter,
       diagnostics, calculate_lp, resample);
+  ASSERT_EQ(rc, 0);
 
   Eigen::MatrixXd param_vals = parameter.values_;
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",
@@ -458,7 +465,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample_returnlp) {
         std::make_unique<decltype(init_init_context())>(init_init_context()));
   }
   stan::test::mock_callback callback;
-  stan::services::pathfinder::pathfinder_lbfgs_multi(
+  int rc = stan::services::pathfinder::pathfinder_lbfgs_multi(
       model, single_path_inits, seed, chain, init_radius, history_size,
       init_alpha, tol_obj, tol_rel_obj, tol_grad, tol_rel_grad, tol_param,
       num_iterations, num_elbo_draws, num_draws, num_multi_draws, num_paths,
@@ -466,6 +473,7 @@ TEST_F(ServicesPathfinderGLM, multi_noresample_returnlp) {
       std::vector<stan::callbacks::stream_writer>(num_paths, init),
       single_path_parameter_writer, single_path_diagnostic_writer, parameter,
       diagnostics, calculate_lp, resample);
+  ASSERT_EQ(rc, 0);
 
   Eigen::MatrixXd param_vals = parameter.values_;
   Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, 0, ", ", ", ", "\n", "",

--- a/src/test/unit/services/pathfinder/util.hpp
+++ b/src/test/unit/services/pathfinder/util.hpp
@@ -93,7 +93,11 @@ class test_logger : public stan::callbacks::logger {
    *
    * @param[in] message message
    */
-  virtual void error(const std::string& message) { *log_ << message << "\n"; }
+  virtual void error(const std::string& message) {
+    if (log_ != nullptr) {
+      *log_ << message << "\n";
+    }
+  }
 
   /**
    * Logs an error with error log level.

--- a/src/test/unit/variational/advi_messages_test.cpp
+++ b/src/test/unit/variational/advi_messages_test.cpp
@@ -27,7 +27,7 @@ class advi_test : public ::testing::Test {
 
     model_ = new stan_model(data_var_context, 0, &model_stream_);
     cont_params_ = Eigen::VectorXd::Zero(model_->num_params_r());
-    base_rng_.seed(3021828106u);
+    base_rng_.seed(3021828109u);
     model_stream_.str("");
     log_stream_.str("");
     parameter_stream_.str("");

--- a/src/test/unit/variational/eta_adapt_small_test.cpp
+++ b/src/test/unit/variational/eta_adapt_small_test.cpp
@@ -21,7 +21,7 @@ class eta_adapt_small_test : public ::testing::Test {
 
     model_ = new stan_model(data_var_context, 0, &model_stream_);
     cont_params_ = Eigen::VectorXd::Zero(model_->num_params_r());
-    base_rng_.seed(727802408);
+    base_rng_.seed(727802409);
     model_stream_.str("");
     log_stream_.str("");
 
@@ -59,11 +59,6 @@ TEST_F(eta_adapt_small_test, eta_should_be_small) {
   stan::variational::normal_fullrank fullrank_init
       = stan::variational::normal_fullrank(cont_params_);
 
-#if BOOST_VERSION >= 106400
   EXPECT_EQ(0.1, advi_meanfield_->adapt_eta(meanfield_init, 1000, logger));
   EXPECT_EQ(0.1, advi_fullrank_->adapt_eta(fullrank_init, 1000, logger));
-#else
-  EXPECT_EQ(0.1, advi_meanfield_->adapt_eta(meanfield_init, 50, logger));
-  EXPECT_EQ(0.1, advi_fullrank_->adapt_eta(fullrank_init, 50, logger));
-#endif
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #3256. This switches the pRNG used by default in the services and tests to be `boost::mixmax`, as recommended by the boost maintainers: https://github.com/boostorg/random/issues/92 

#### Intended Effect

Resolve both https://github.com/stan-dev/stan/issues/3167 and https://github.com/stan-dev/cmdstan/issues/1241, avoid other issues with RNG quality.

#### How to Verify

#### Side Effects

Seeds used in previous versions will have different meanings from this version on. **We should note this in the release notes**.

Additionally, by changing the type alias of `rng_t` introduced in #3263, this PR changes the ABI of the model base, so code which calls it directly will need to be aware. This is most obviously relevant for things which use the standalone-functions feature of stanc like cmdstanr and rstan, I believe. @andrjohns 
#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
