### PR TITLE
Pathfinder: stop returning more draws than requested

### DIFF
--- a/src/stan/services/pathfinder/psis.hpp
+++ b/src/stan/services/pathfinder/psis.hpp
@@ -5,6 +5,8 @@
 #include <stan/callbacks/logger.hpp>
 #include <stan/services/error_codes.hpp>
 #include <tbb/parallel_invoke.h>
+#include <iomanip>
+#include <sstream>
 
 namespace stan {
 namespace services {
@@ -261,10 +263,13 @@ inline Eigen::Array<double, Eigen::Dynamic, 1> psis_weights(
         llr_weights.coeffRef(idx.coeff(i)) = smoothed.first.coeff(i);
       }
       if (smoothed.second > 0.7) {
-        logger.warn(std::string("Pareto k value (") +
-         std::to_string(smoothed.second) + ") is greater than 0.7."
-         " Importance resampling was not able to improve the approximation,"
-         " which may indicate that the approximation itself is poor.");
+        std::stringstream s;
+        s << "Pareto k value (" << std::setprecision(2) << smoothed.second
+          << ") is greater than 0.7. Importance resampling was not able to "
+          << "improve the approximation, which may indicate that the "
+          << "approximation itself is poor.";
+
+        logger.warn(s.str());
       }
     }
   }

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -935,8 +935,8 @@ inline auto pathfinder_lbfgs_single(
   } else {
     // output only first num_draws from what we computed for ELBO
     constrained_draws_mat
-        = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>(
-            names.size(), num_draws);
+        = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>(names.size(),
+                                                                num_draws);
     Eigen::VectorXd approx_samples_constrained_col;
     Eigen::VectorXd unconstrained_col;
     for (Eigen::Index i = 0; i < num_draws; ++i) {

--- a/src/stan/services/pathfinder/single.hpp
+++ b/src/stan/services/pathfinder/single.hpp
@@ -933,12 +933,13 @@ inline auto pathfinder_lbfgs_single(
       lp_ratio = std::move(elbo_best.lp_ratio);
     }
   } else {
+    // output only first num_draws from what we computed for ELBO
     constrained_draws_mat
         = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>(
-            names.size(), elbo_draws.cols());
+            names.size(), num_draws);
     Eigen::VectorXd approx_samples_constrained_col;
     Eigen::VectorXd unconstrained_col;
-    for (Eigen::Index i = 0; i < elbo_draws.cols(); ++i) {
+    for (Eigen::Index i = 0; i < num_draws; ++i) {
       constrained_draws_mat.col(i).head(2) = elbo_lp_mat.row(i).matrix();
       unconstrained_col = elbo_draws.col(i);
       constrained_draws_mat.col(i).tail(num_unconstrained_params)
@@ -946,7 +947,7 @@ inline auto pathfinder_lbfgs_single(
                           approx_samples_constrained_col)
                 .matrix();
     }
-    lp_ratio = std::move(elbo_best.lp_ratio);
+    lp_ratio = std::move(elbo_best.lp_ratio.head(num_draws));
   }
   parameter_writer(constrained_draws_mat);
   parameter_writer();


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #3268. Now when the number of draws requested is smaller than the number of draws the ELBO calculations do internally, they are truncated to the expected size rather than all returned. 

I also fixed up #3278 

#### Intended Effect

#### How to Verify

I have a test [in another project](https://github.com/WardBrian/tinystan/blob/4a758bd221d81a0e9627f0624070eb9597c3dec3/clients/python/tests/test_pathfinder.py#L81-L91), I wasn't sure if we wanted to adapt one for here or not. 

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
