### PR TITLE
Update tests to use rtools-provided make

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,7 +192,7 @@ pipeline {
             }
             post {
                 always {
-                    recordIssues( 
+                    recordIssues(
                         id: "lint_doc_checks",
                         name: "Linting & Doc checks",
                         enabledForFailure: true,
@@ -264,8 +264,8 @@ pipeline {
                                 SET \"PATH=C:\\PROGRA~1\\R\\R-4.1.2\\bin;%PATH%\"
                                 SET \"PATH=C:\\PROGRA~1\\Microsoft^ MPI\\Bin;%PATH%\"
                                 SET \"MPI_HOME=C:\\PROGRA~1\\Microsoft^ MPI\\Bin\"
-                                mingw32-make.exe -f lib/stan_math/make/standalone math-libs
-                                mingw32-make.exe -j${PARALLEL} test-headers
+                                make.exe -f lib/stan_math/make/standalone math-libs
+                                make.exe -j${PARALLEL} test-headers
                             """
                             setupCXX(false, WIN_CXX, stanc3_bin_url())
                             runTestsWin("src/test/unit")
@@ -448,7 +448,7 @@ pipeline {
                                 SET \"PATH=C:\\PROGRA~1\\Microsoft^ MPI\\Bin;%PATH%\"
                                 SET \"MPI_HOME=C:\\PROGRA~1\\Microsoft^ MPI\\Bin\"
                                 cd performance-tests-cmdstan/cmdstan
-                                mingw32-make.exe -j${PARALLEL} build
+                                make.exe -j${PARALLEL} build
                                 cd ..
                                 python ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good
                                 python ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 example-models
@@ -496,7 +496,7 @@ pipeline {
     post {
         always {
             node("linux") {
-                recordIssues( 
+                recordIssues(
                     id: "pipeline",
                     name: "Entire pipeline results",
                     enabledForFailure: true,

--- a/make/tests
+++ b/make/tests
@@ -85,12 +85,15 @@ HEADER_TESTS := $(addsuffix -test,$(call findfiles,src/stan,*.hpp))
 
 ifeq ($(OS),Windows_NT)
   DEV_NULL = nul
+  ifeq ($(IS_UCRT),true)
+    UCRT_NULL_FLAG = -S
+  endif
 else
   DEV_NULL = /dev/null
 endif
 
 %.hpp-test : %.hpp test/dummy.cpp
-	$(COMPILE.cpp) -O0 -include $^ -o $(DEV_NULL)
+	$(COMPILE.cpp) -O0 -include $^ $(UCRT_NULL_FLAG) -o $(DEV_NULL)
 
 test/dummy.cpp:
 	@mkdir -p test

--- a/runTests.py
+++ b/runTests.py
@@ -80,8 +80,6 @@ def doCommand(command, exit_on_failure=True):
     """Run command as a shell command and report/exit on errors."""
     print("------------------------------------------------------------")
     print("%s" % command)
-    if isWin() and command.startswith("make "):
-        command = command.replace("make ", "mingw32-make ")
     p1 = subprocess.Popen(command, shell=True)
     p1.wait()
     if exit_on_failure and (not (p1.returncode is None) and not (p1.returncode == 0)):


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Continuing updates to our build/testing process to remove dependency on `mingw32-make`

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
