### PR TITLE
ci: bump github actions versions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules:  true
       - name: Install clang++
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules:  true
       - name: Install clang++


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Hi, this is my first PR to the project.

This PR bumps the versions of the used GitHub Actions, which will get rid of the warnings (e.g. Node.js 16 actions are deprecated. [...] in the [Annotations section under Actions](https://github.com/stan-dev/stan/actions/runs/8983897655).

#### Intended Effect

No warning should be issued in the GitHub Actions annotations.

#### How to Verify

No warning should be issued in the GitHub Actions annotations.

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Heinz-Alexander Fütterer

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
