### PR TITLE
Fix model_header include order when STAN_MODEL_FVAR_VAR is defined

### DIFF
--- a/src/stan/model/model_base.hpp
+++ b/src/stan/model/model_base.hpp
@@ -78,8 +78,7 @@ class model_base : public prob_grad {
    */
   virtual void get_param_names(std::vector<std::string>& names,
                                bool include_tparams = true,
-                               bool include_gqs = true) const
-      = 0;
+                               bool include_gqs = true) const = 0;
   /**
    * WARNING: This function bakes in the assumption that the
    * parameter values are rectangular. This is already not true
@@ -108,8 +107,7 @@ class model_base : public prob_grad {
    */
   virtual void get_dims(std::vector<std::vector<size_t> >& dimss,
                         bool include_tparams = true,
-                        bool include_gqs = true) const
-      = 0;
+                        bool include_gqs = true) const = 0;
   /**
    *  Set the specified sequence to the indexed, scalar, constrained
    *  parameter names.  Each variable is output with a
@@ -150,8 +148,7 @@ class model_base : public prob_grad {
    */
   virtual void constrained_param_names(std::vector<std::string>& param_names,
                                        bool include_tparams = true,
-                                       bool include_gqs = true) const
-      = 0;
+                                       bool include_gqs = true) const = 0;
 
   /**
    * Set the specified sequence of parameter names to the
@@ -180,8 +177,7 @@ class model_base : public prob_grad {
    */
   virtual void unconstrained_param_names(std::vector<std::string>& param_names,
                                          bool include_tparams = true,
-                                         bool include_gqs = true) const
-      = 0;
+                                         bool include_gqs = true) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -192,8 +188,8 @@ class model_base : public prob_grad {
    * @param[in,out] msgs message stream
    * @return log density for specified parameters
    */
-  virtual double log_prob(Eigen::VectorXd& params_r, std::ostream* msgs) const
-      = 0;
+  virtual double log_prob(Eigen::VectorXd& params_r,
+                          std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -205,8 +201,7 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual math::var log_prob(Eigen::Matrix<math::var, -1, 1>& params_r,
-                             std::ostream* msgs) const
-      = 0;
+                             std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -222,8 +217,7 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual double log_prob_jacobian(Eigen::VectorXd& params_r,
-                                   std::ostream* msgs) const
-      = 0;
+                                   std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -239,8 +233,7 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual math::var log_prob_jacobian(Eigen::Matrix<math::var, -1, 1>& params_r,
-                                      std::ostream* msgs) const
-      = 0;
+                                      std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -257,8 +250,7 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual double log_prob_propto(Eigen::VectorXd& params_r,
-                                 std::ostream* msgs) const
-      = 0;
+                                 std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -270,8 +262,7 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual math::var log_prob_propto(Eigen::Matrix<math::var, -1, 1>& params_r,
-                                    std::ostream* msgs) const
-      = 0;
+                                    std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -292,8 +283,7 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual double log_prob_propto_jacobian(Eigen::VectorXd& params_r,
-                                          std::ostream* msgs) const
-      = 0;
+                                          std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -309,8 +299,7 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual math::var log_prob_propto_jacobian(
-      Eigen::Matrix<math::var, -1, 1>& params_r, std::ostream* msgs) const
-      = 0;
+      Eigen::Matrix<math::var, -1, 1>& params_r, std::ostream* msgs) const = 0;
 
   /**
    * Convenience template function returning the log density for the
@@ -358,8 +347,7 @@ class model_base : public prob_grad {
    */
   virtual void transform_inits(const io::var_context& context,
                                Eigen::VectorXd& params_r,
-                               std::ostream* msgs) const
-      = 0;
+                               std::ostream* msgs) const = 0;
 
   /**
    * Convert the specified sequence of unconstrained parameters to a
@@ -382,8 +370,7 @@ class model_base : public prob_grad {
   virtual void write_array(stan::rng_t& base_rng, Eigen::VectorXd& params_r,
                            Eigen::VectorXd& params_constrained_r,
                            bool include_tparams = true, bool include_gqs = true,
-                           std::ostream* msgs = 0) const
-      = 0;
+                           std::ostream* msgs = 0) const = 0;
 
   /**
    * Convert the specified sequence of constrained parameters to a
@@ -398,8 +385,7 @@ class model_base : public prob_grad {
    */
   virtual void unconstrain_array(const Eigen::VectorXd& params_r_constrained,
                                  Eigen::VectorXd& params_r,
-                                 std::ostream* msgs = nullptr) const
-      = 0;
+                                 std::ostream* msgs = nullptr) const = 0;
 
   // TODO(carpenter): cut redundant std::vector versions from here ===
 
@@ -416,8 +402,8 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual double log_prob(std::vector<double>& params_r,
-                          std::vector<int>& params_i, std::ostream* msgs) const
-      = 0;
+                          std::vector<int>& params_i,
+                          std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -433,8 +419,7 @@ class model_base : public prob_grad {
    */
   virtual math::var log_prob(std::vector<math::var>& params_r,
                              std::vector<int>& params_i,
-                             std::ostream* msgs) const
-      = 0;
+                             std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -454,8 +439,7 @@ class model_base : public prob_grad {
    */
   virtual double log_prob_jacobian(std::vector<double>& params_r,
                                    std::vector<int>& params_i,
-                                   std::ostream* msgs) const
-      = 0;
+                                   std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -475,8 +459,7 @@ class model_base : public prob_grad {
    */
   virtual math::var log_prob_jacobian(std::vector<math::var>& params_r,
                                       std::vector<int>& params_i,
-                                      std::ostream* msgs) const
-      = 0;
+                                      std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -497,8 +480,7 @@ class model_base : public prob_grad {
    */
   virtual double log_prob_propto(std::vector<double>& params_r,
                                  std::vector<int>& params_i,
-                                 std::ostream* msgs) const
-      = 0;
+                                 std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -514,8 +496,7 @@ class model_base : public prob_grad {
    */
   virtual math::var log_prob_propto(std::vector<math::var>& params_r,
                                     std::vector<int>& params_i,
-                                    std::ostream* msgs) const
-      = 0;
+                                    std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -540,8 +521,7 @@ class model_base : public prob_grad {
    */
   virtual double log_prob_propto_jacobian(std::vector<double>& params_r,
                                           std::vector<int>& params_i,
-                                          std::ostream* msgs) const
-      = 0;
+                                          std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -561,8 +541,7 @@ class model_base : public prob_grad {
    */
   virtual math::var log_prob_propto_jacobian(std::vector<math::var>& params_r,
                                              std::vector<int>& params_i,
-                                             std::ostream* msgs) const
-      = 0;
+                                             std::ostream* msgs) const = 0;
 
   /**
    * Convenience template function returning the log density for the
@@ -617,8 +596,7 @@ class model_base : public prob_grad {
   virtual void transform_inits(const io::var_context& context,
                                std::vector<int>& params_i,
                                std::vector<double>& params_r,
-                               std::ostream* msgs) const
-      = 0;
+                               std::ostream* msgs) const = 0;
 
   /**
    * Convert the specified sequence of unconstrained parameters to a
@@ -643,8 +621,7 @@ class model_base : public prob_grad {
                            std::vector<int>& params_i,
                            std::vector<double>& params_r_constrained,
                            bool include_tparams = true, bool include_gqs = true,
-                           std::ostream* msgs = 0) const
-      = 0;
+                           std::ostream* msgs = 0) const = 0;
 
   /**
    * Convert the specified sequence of constrained parameters to a
@@ -659,8 +636,7 @@ class model_base : public prob_grad {
    */
   virtual void unconstrain_array(
       const std::vector<double>& params_r_constrained,
-      std::vector<double>& params_r, std::ostream* msgs = nullptr) const
-      = 0;
+      std::vector<double>& params_r, std::ostream* msgs = nullptr) const = 0;
 
 #ifdef STAN_MODEL_FVAR_VAR
 
@@ -675,8 +651,7 @@ class model_base : public prob_grad {
    */
   virtual math::fvar<math::var> log_prob(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const
-      = 0;
+      std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -693,8 +668,7 @@ class model_base : public prob_grad {
    */
   virtual math::fvar<math::var> log_prob_jacobian(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const
-      = 0;
+      std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -707,8 +681,7 @@ class model_base : public prob_grad {
    */
   virtual math::fvar<math::var> log_prob_propto(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const
-      = 0;
+      std::ostream* msgs) const = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -725,8 +698,7 @@ class model_base : public prob_grad {
    */
   virtual math::fvar<math::var> log_prob_propto_jacobian(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const
-      = 0;
+      std::ostream* msgs) const = 0;
 #endif
 };
 

--- a/src/stan/model/model_base.hpp
+++ b/src/stan/model/model_base.hpp
@@ -1,11 +1,11 @@
 #ifndef STAN_MODEL_MODEL_BASE_HPP
 #define STAN_MODEL_MODEL_BASE_HPP
 
-#include <stan/io/var_context.hpp>
-#include <stan/math/rev/core.hpp>
 #ifdef STAN_MODEL_FVAR_VAR
 #include <stan/math/mix.hpp>
 #endif
+#include <stan/io/var_context.hpp>
+#include <stan/math/rev/core.hpp>
 #include <stan/model/prob_grad.hpp>
 #include <stan/services/util/create_rng.hpp>
 #include <ostream>
@@ -78,7 +78,8 @@ class model_base : public prob_grad {
    */
   virtual void get_param_names(std::vector<std::string>& names,
                                bool include_tparams = true,
-                               bool include_gqs = true) const = 0;
+                               bool include_gqs = true) const
+      = 0;
   /**
    * WARNING: This function bakes in the assumption that the
    * parameter values are rectangular. This is already not true
@@ -107,7 +108,8 @@ class model_base : public prob_grad {
    */
   virtual void get_dims(std::vector<std::vector<size_t> >& dimss,
                         bool include_tparams = true,
-                        bool include_gqs = true) const = 0;
+                        bool include_gqs = true) const
+      = 0;
   /**
    *  Set the specified sequence to the indexed, scalar, constrained
    *  parameter names.  Each variable is output with a
@@ -148,7 +150,8 @@ class model_base : public prob_grad {
    */
   virtual void constrained_param_names(std::vector<std::string>& param_names,
                                        bool include_tparams = true,
-                                       bool include_gqs = true) const = 0;
+                                       bool include_gqs = true) const
+      = 0;
 
   /**
    * Set the specified sequence of parameter names to the
@@ -177,7 +180,8 @@ class model_base : public prob_grad {
    */
   virtual void unconstrained_param_names(std::vector<std::string>& param_names,
                                          bool include_tparams = true,
-                                         bool include_gqs = true) const = 0;
+                                         bool include_gqs = true) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -188,8 +192,8 @@ class model_base : public prob_grad {
    * @param[in,out] msgs message stream
    * @return log density for specified parameters
    */
-  virtual double log_prob(Eigen::VectorXd& params_r,
-                          std::ostream* msgs) const = 0;
+  virtual double log_prob(Eigen::VectorXd& params_r, std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -201,7 +205,8 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual math::var log_prob(Eigen::Matrix<math::var, -1, 1>& params_r,
-                             std::ostream* msgs) const = 0;
+                             std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -217,7 +222,8 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual double log_prob_jacobian(Eigen::VectorXd& params_r,
-                                   std::ostream* msgs) const = 0;
+                                   std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -233,7 +239,8 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual math::var log_prob_jacobian(Eigen::Matrix<math::var, -1, 1>& params_r,
-                                      std::ostream* msgs) const = 0;
+                                      std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -250,7 +257,8 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual double log_prob_propto(Eigen::VectorXd& params_r,
-                                 std::ostream* msgs) const = 0;
+                                 std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -262,7 +270,8 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual math::var log_prob_propto(Eigen::Matrix<math::var, -1, 1>& params_r,
-                                    std::ostream* msgs) const = 0;
+                                    std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -283,7 +292,8 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual double log_prob_propto_jacobian(Eigen::VectorXd& params_r,
-                                          std::ostream* msgs) const = 0;
+                                          std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -299,7 +309,8 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual math::var log_prob_propto_jacobian(
-      Eigen::Matrix<math::var, -1, 1>& params_r, std::ostream* msgs) const = 0;
+      Eigen::Matrix<math::var, -1, 1>& params_r, std::ostream* msgs) const
+      = 0;
 
   /**
    * Convenience template function returning the log density for the
@@ -347,7 +358,8 @@ class model_base : public prob_grad {
    */
   virtual void transform_inits(const io::var_context& context,
                                Eigen::VectorXd& params_r,
-                               std::ostream* msgs) const = 0;
+                               std::ostream* msgs) const
+      = 0;
 
   /**
    * Convert the specified sequence of unconstrained parameters to a
@@ -370,7 +382,8 @@ class model_base : public prob_grad {
   virtual void write_array(stan::rng_t& base_rng, Eigen::VectorXd& params_r,
                            Eigen::VectorXd& params_constrained_r,
                            bool include_tparams = true, bool include_gqs = true,
-                           std::ostream* msgs = 0) const = 0;
+                           std::ostream* msgs = 0) const
+      = 0;
 
   /**
    * Convert the specified sequence of constrained parameters to a
@@ -385,7 +398,8 @@ class model_base : public prob_grad {
    */
   virtual void unconstrain_array(const Eigen::VectorXd& params_r_constrained,
                                  Eigen::VectorXd& params_r,
-                                 std::ostream* msgs = nullptr) const = 0;
+                                 std::ostream* msgs = nullptr) const
+      = 0;
 
   // TODO(carpenter): cut redundant std::vector versions from here ===
 
@@ -402,8 +416,8 @@ class model_base : public prob_grad {
    * @return log density for specified parameters
    */
   virtual double log_prob(std::vector<double>& params_r,
-                          std::vector<int>& params_i,
-                          std::ostream* msgs) const = 0;
+                          std::vector<int>& params_i, std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -419,7 +433,8 @@ class model_base : public prob_grad {
    */
   virtual math::var log_prob(std::vector<math::var>& params_r,
                              std::vector<int>& params_i,
-                             std::ostream* msgs) const = 0;
+                             std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -439,7 +454,8 @@ class model_base : public prob_grad {
    */
   virtual double log_prob_jacobian(std::vector<double>& params_r,
                                    std::vector<int>& params_i,
-                                   std::ostream* msgs) const = 0;
+                                   std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -459,7 +475,8 @@ class model_base : public prob_grad {
    */
   virtual math::var log_prob_jacobian(std::vector<math::var>& params_r,
                                       std::vector<int>& params_i,
-                                      std::ostream* msgs) const = 0;
+                                      std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -480,7 +497,8 @@ class model_base : public prob_grad {
    */
   virtual double log_prob_propto(std::vector<double>& params_r,
                                  std::vector<int>& params_i,
-                                 std::ostream* msgs) const = 0;
+                                 std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -496,7 +514,8 @@ class model_base : public prob_grad {
    */
   virtual math::var log_prob_propto(std::vector<math::var>& params_r,
                                     std::vector<int>& params_i,
-                                    std::ostream* msgs) const = 0;
+                                    std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -521,7 +540,8 @@ class model_base : public prob_grad {
    */
   virtual double log_prob_propto_jacobian(std::vector<double>& params_r,
                                           std::vector<int>& params_i,
-                                          std::ostream* msgs) const = 0;
+                                          std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -541,7 +561,8 @@ class model_base : public prob_grad {
    */
   virtual math::var log_prob_propto_jacobian(std::vector<math::var>& params_r,
                                              std::vector<int>& params_i,
-                                             std::ostream* msgs) const = 0;
+                                             std::ostream* msgs) const
+      = 0;
 
   /**
    * Convenience template function returning the log density for the
@@ -596,7 +617,8 @@ class model_base : public prob_grad {
   virtual void transform_inits(const io::var_context& context,
                                std::vector<int>& params_i,
                                std::vector<double>& params_r,
-                               std::ostream* msgs) const = 0;
+                               std::ostream* msgs) const
+      = 0;
 
   /**
    * Convert the specified sequence of unconstrained parameters to a
@@ -621,7 +643,8 @@ class model_base : public prob_grad {
                            std::vector<int>& params_i,
                            std::vector<double>& params_r_constrained,
                            bool include_tparams = true, bool include_gqs = true,
-                           std::ostream* msgs = 0) const = 0;
+                           std::ostream* msgs = 0) const
+      = 0;
 
   /**
    * Convert the specified sequence of constrained parameters to a
@@ -636,7 +659,8 @@ class model_base : public prob_grad {
    */
   virtual void unconstrain_array(
       const std::vector<double>& params_r_constrained,
-      std::vector<double>& params_r, std::ostream* msgs = nullptr) const = 0;
+      std::vector<double>& params_r, std::ostream* msgs = nullptr) const
+      = 0;
 
 #ifdef STAN_MODEL_FVAR_VAR
 
@@ -651,7 +675,8 @@ class model_base : public prob_grad {
    */
   virtual math::fvar<math::var> log_prob(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const = 0;
+      std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -668,7 +693,8 @@ class model_base : public prob_grad {
    */
   virtual math::fvar<math::var> log_prob_jacobian(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const = 0;
+      std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -681,7 +707,8 @@ class model_base : public prob_grad {
    */
   virtual math::fvar<math::var> log_prob_propto(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const = 0;
+      std::ostream* msgs) const
+      = 0;
 
   /**
    * Return the log density for the specified unconstrained
@@ -698,7 +725,8 @@ class model_base : public prob_grad {
    */
   virtual math::fvar<math::var> log_prob_propto_jacobian(
       Eigen::Matrix<math::fvar<math::var>, -1, 1>& params_r,
-      std::ostream* msgs) const = 0;
+      std::ostream* msgs) const
+      = 0;
 #endif
 };
 

--- a/src/stan/model/model_base_crtp.hpp
+++ b/src/stan/model/model_base_crtp.hpp
@@ -1,10 +1,10 @@
 #ifndef STAN_MODEL_MODEL_BASE_CRTP_HPP
 #define STAN_MODEL_MODEL_BASE_CRTP_HPP
 
-#include <stan/model/model_base.hpp>
 #ifdef STAN_MODEL_FVAR_VAR
 #include <stan/math/mix.hpp>
 #endif
+#include <stan/model/model_base.hpp>
 #include <iostream>
 #include <utility>
 #include <vector>

--- a/src/stan/model/model_header.hpp
+++ b/src/stan/model/model_header.hpp
@@ -1,14 +1,14 @@
 #ifndef STAN_MODEL_MODEL_HEADER_HPP
 #define STAN_MODEL_MODEL_HEADER_HPP
 
+#include <stan/model/model_base.hpp>
+#include <stan/model/model_base_crtp.hpp>
 #include <stan/math.hpp>
 
 #include <stan/io/deserializer.hpp>
 #include <stan/io/serializer.hpp>
 
 #include <stan/model/rethrow_located.hpp>
-#include <stan/model/model_base.hpp>
-#include <stan/model/model_base_crtp.hpp>
 #include <stan/model/prob_grad.hpp>
 #include <stan/model/indexing.hpp>
 #include <stan/services/util/create_rng.hpp>

--- a/src/test/test-models/good/model/accumulate.stan
+++ b/src/test/test-models/good/model/accumulate.stan
@@ -1,0 +1,9 @@
+data {
+  int<lower=1> N;
+}
+parameters {
+  vector[N] y;
+}
+model {
+  target += y;
+}

--- a/src/test/unit/model/compile_test.cpp
+++ b/src/test/unit/model/compile_test.cpp
@@ -1,0 +1,2 @@
+// test model which previously failed with -DSTAN_MODEL_FVAR_VAR
+#include <test/test-models/good/model/accumulate.hpp>


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes an issue ([initially reported in BridgeStan](https://github.com/roualdes/bridgestan/issues/237)) where C++ compilation would fail for this model if the forward-mode overloads for the model class were enabled:

```
data {
  int<lower=1> N;
}
parameters {
  vector[N] y;
}
model {
  target += y;
}
```

This was because `accumulate` was not picking up on the forward mode overload for `stan::math::sum`. Moving this includes such that the `fwd.hpp` header is included earlier resolves the issue.

#### Intended Effect

Allow compilation to succeed in this case.

#### How to Verify

Compilation test added which will be picked up by the Github Action that runs with `-DSTAN_MODEL_FVAR_VAR`

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
