### PR TITLE
Ensure formatting of output is same for adapt=false samplers

### DIFF
--- a/src/stan/services/sample/hmc_nuts_dense_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e.hpp
@@ -237,7 +237,8 @@ int hmc_nuts_dense_e(Model& model, size_t num_chains,
             util::run_sampler(samplers[i], model, cont_vectors[i], num_warmup,
                               num_samples, num_thin, refresh, save_warmup,
                               rngs[i], interrupt, logger, sample_writer[i],
-                              diagnostic_writer[i], init_chain_id + i, num_chains);
+                              diagnostic_writer[i], init_chain_id + i,
+                              num_chains);
           }
         },
         tbb::simple_partitioner());

--- a/src/stan/services/sample/hmc_nuts_dense_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_dense_e.hpp
@@ -237,7 +237,7 @@ int hmc_nuts_dense_e(Model& model, size_t num_chains,
             util::run_sampler(samplers[i], model, cont_vectors[i], num_warmup,
                               num_samples, num_thin, refresh, save_warmup,
                               rngs[i], interrupt, logger, sample_writer[i],
-                              diagnostic_writer[i], init_chain_id + i);
+                              diagnostic_writer[i], init_chain_id + i, num_chains);
           }
         },
         tbb::simple_partitioner());

--- a/src/stan/services/sample/hmc_nuts_diag_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e.hpp
@@ -232,7 +232,8 @@ int hmc_nuts_diag_e(Model& model, size_t num_chains,
           util::run_sampler(samplers[i], model, cont_vectors[i], num_warmup,
                             num_samples, num_thin, refresh, save_warmup,
                             rngs[i], interrupt, logger, sample_writer[i],
-                            diagnostic_writer[i], init_chain_id + i, num_chains);
+                            diagnostic_writer[i], init_chain_id + i,
+                            num_chains);
         }
       },
       tbb::simple_partitioner());

--- a/src/stan/services/sample/hmc_nuts_diag_e.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e.hpp
@@ -232,7 +232,7 @@ int hmc_nuts_diag_e(Model& model, size_t num_chains,
           util::run_sampler(samplers[i], model, cont_vectors[i], num_warmup,
                             num_samples, num_thin, refresh, save_warmup,
                             rngs[i], interrupt, logger, sample_writer[i],
-                            diagnostic_writer[i], init_chain_id + i);
+                            diagnostic_writer[i], init_chain_id + i, num_chains);
         }
       },
       tbb::simple_partitioner());


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

These two overloads weren't passing `num_chains` to the run_sampler method, which meant they would never prefix their output with `Chain [#]` like their adaptive counterparts. 

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
