### PR TITLE
Fix line search to avoid non-finite gradients

### DIFF
--- a/src/stan/optimization/bfgs_linesearch.hpp
+++ b/src/stan/optimization/bfgs_linesearch.hpp
@@ -253,7 +253,7 @@ int WolfeLineSearch(FunctorType &func, Scalar &alpha, XType &x1,
 
     x1.noalias() = x0 + alpha1 * p;
     ret = func(x1, func_val, gradx1);
-    if (ret != 0) {
+    if (ret != 0 || !std::isfinite(func_val) || !gradx1.allFinite()) {
       if (lsRestarts >= maxLSRestarts) {
         retCode = 1;
         break;

--- a/src/test/unit/optimization/bfgs_linesearch_test.cpp
+++ b/src/test/unit/optimization/bfgs_linesearch_test.cpp
@@ -235,3 +235,83 @@ TEST(OptimizationBfgsLinesearch, wolfeLineSearch_nonfinite_gradient) {
                         minAlpha, maxLSIts, maxLSRestarts);
   EXPECT_EQ(1, ret);
 }
+
+class linesearch_testfunc_nan {
+ public:
+  double operator()(const Eigen::Matrix<double, Eigen::Dynamic, 1> &x) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  int operator()(const Eigen::Matrix<double, Eigen::Dynamic, 1> &x, double &f,
+                 Eigen::Matrix<double, Eigen::Dynamic, 1> &g) {
+    f = std::numeric_limits<double>::quiet_NaN();
+    g = 2.0 * x;
+    return 1;
+  }
+};
+
+TEST(OptimizationBfgsLinesearch, wolfeLineSearch_nan) {
+  using stan::optimization::WolfeLineSearch;
+
+  static const double c1 = 1e-4;
+  static const double c2 = 0.9;
+  static const double minAlpha = 1e-16;
+  static const double maxLSIts = 20;
+  static const double maxLSRestarts = 10;
+
+  linesearch_testfunc_nan func1;
+  Eigen::Matrix<double, -1, 1> x0, x1;
+  double f0, f1;
+  Eigen::Matrix<double, -1, 1> p, gradx0, gradx1;
+  double alpha;
+  int ret;
+
+  x0.setOnes(5, 1);
+  func1(x0, f0, gradx0);
+
+  p = -gradx0;
+
+  alpha = 2.0;
+  ret = WolfeLineSearch(func1, alpha, x1, f1, gradx1, p, x0, f0, gradx0, c1, c2,
+                        minAlpha, maxLSIts, maxLSRestarts);
+  EXPECT_EQ(1, ret);
+}
+
+class linesearch_testfunc_inf {
+ public:
+  double operator()(const Eigen::Matrix<double, Eigen::Dynamic, 1> &x) {
+    return std::numeric_limits<double>::infinity();
+  }
+  int operator()(const Eigen::Matrix<double, Eigen::Dynamic, 1> &x, double &f,
+                 Eigen::Matrix<double, Eigen::Dynamic, 1> &g) {
+    f = std::numeric_limits<double>::infinity();
+    g = 2.0 * x;
+    return 1;
+  }
+};
+
+TEST(OptimizationBfgsLinesearch, wolfeLineSearch_inf) {
+  using stan::optimization::WolfeLineSearch;
+
+  static const double c1 = 1e-4;
+  static const double c2 = 0.9;
+  static const double minAlpha = 1e-16;
+  static const double maxLSIts = 20;
+  static const double maxLSRestarts = 10;
+
+  linesearch_testfunc_inf func1;
+  Eigen::Matrix<double, -1, 1> x0, x1;
+  double f0, f1;
+  Eigen::Matrix<double, -1, 1> p, gradx0, gradx1;
+  double alpha;
+  int ret;
+
+  x0.setOnes(5, 1);
+  func1(x0, f0, gradx0);
+
+  p = -gradx0;
+
+  alpha = 2.0;
+  ret = WolfeLineSearch(func1, alpha, x1, f1, gradx1, p, x0, f0, gradx0, c1, c2,
+                        minAlpha, maxLSIts, maxLSRestarts);
+  EXPECT_EQ(1, ret);
+}


### PR DESCRIPTION
Related to #3306

Modify the `WolfeLineSearch` function in `src/stan/optimization/bfgs_linesearch.hpp` to handle non-finite gradients.

* Check if the function value `func_val` is finite.
* Check if the gradient `gradx1` is finite.
* If either the function value or the gradient is non-finite, restart the line search with a smaller step size.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/stan-dev/stan/issues/3306?shareId=c908a68b-de72-4617-b7ba-89cb478a8ec7).