### PR TITLE
Clean up var memory in laplace_sample

### DIFF
--- a/src/stan/services/optimize/laplace_sample.hpp
+++ b/src/stan/services/optimize/laplace_sample.hpp
@@ -121,6 +121,8 @@ void laplace_sample(const Model& model, const Eigen::VectorXd& theta_hat,
 
     double log_p;
     if (calculate_lp) {
+      // clean up created vars after scope exit
+      stan::math::nested_rev_autodiff stack;
       log_p = log_density_fun(unc_draw).val();
     } else {
       log_p = std::numeric_limits<double>::quiet_NaN();


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

First reported here: https://discourse.mc-stan.org/t/memory-errors-with-laplace-approximation-in-cmdstanr/37585

The call to log_prob needs to create vars so that the `propto=true` template argument works as intended. However, the vars created here are never cleaned up, so memory grows over iterations.

#### Intended Effect

This uses the `stan::math::nested_rev_autodiff` RAII class to ensure the memory is always cleaned up each iteration.

#### How to Verify

Running the model in the forum post and keeping an eye on `htop`

#### Side Effects
None
#### Documentation
None
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
