### PR TITLE
Update Jenkinsfile to bump rstan's submodule on merges to develop

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -516,6 +516,7 @@ pipeline {
         success {
             script {
                 utils.updateUpstream(env,'cmdstan')
+                utils.updateUpstream(env,'rstan')
                 utils.mailBuildResults("SUCCESSFUL")
             }
         }


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py src/test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary

With the merge of [this PR](https://github.com/stan-dev/ci-scripts/pull/37) we can now update the Jenkins upstream update steps to include `rstan`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
