### PR TITLE
Ensure linux unit tests run on a gpu node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -276,7 +276,7 @@ pipeline {
                     agent {
                         docker {
                             image 'stanorg/ci:gpu'
-                            label 'linux'
+                            label 'linux && gpu'
                             args '--pull always --gpus 1'
                         }
                     }


### PR DESCRIPTION
`develop` has been failing since a new Jenkins executor that _doesn't_ have a GPU was added. This fixes it.