### PR TITLE
[mcmc/base_adapter][NFC] add const and noexcept where appropriate

### DIFF
--- a/src/stan/mcmc/base_adapter.hpp
+++ b/src/stan/mcmc/base_adapter.hpp
@@ -6,13 +6,13 @@ namespace mcmc {
 
 class base_adapter {
  public:
-  base_adapter() : adapt_flag_(false) {}
+  base_adapter() noexcept : adapt_flag_(false) {}
 
-  virtual void engage_adaptation() { adapt_flag_ = true; }
+  virtual void engage_adaptation() noexcept { adapt_flag_ = true; }
 
-  virtual void disengage_adaptation() { adapt_flag_ = false; }
+  virtual void disengage_adaptation() noexcept { adapt_flag_ = false; }
 
-  bool adapting() { return adapt_flag_; }
+  bool adapting() const noexcept { return adapt_flag_; }
 
  protected:
   bool adapt_flag_;

--- a/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp
@@ -42,7 +42,7 @@ class adapt_dense_e_nuts : public dense_e_nuts<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp
@@ -42,7 +42,7 @@ class adapt_diag_e_nuts : public diag_e_nuts<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/nuts/adapt_softabs_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_softabs_nuts.hpp
@@ -31,7 +31,7 @@ class adapt_softabs_nuts : public softabs_nuts<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/nuts/adapt_unit_e_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/adapt_unit_e_nuts.hpp
@@ -31,7 +31,7 @@ class adapt_unit_e_nuts : public unit_e_nuts<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_dense_e_nuts_classic.hpp
@@ -42,7 +42,7 @@ class adapt_dense_e_nuts_classic : public dense_e_nuts_classic<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_diag_e_nuts_classic.hpp
@@ -43,7 +43,7 @@ class adapt_diag_e_nuts_classic : public diag_e_nuts_classic<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/nuts_classic/adapt_unit_e_nuts_classic.hpp
+++ b/src/stan/mcmc/hmc/nuts_classic/adapt_unit_e_nuts_classic.hpp
@@ -32,7 +32,7 @@ class adapt_unit_e_nuts_classic : public unit_e_nuts_classic<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_dense_e_static_hmc.hpp
@@ -46,7 +46,7 @@ class adapt_dense_e_static_hmc : public dense_e_static_hmc<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_diag_e_static_hmc.hpp
@@ -46,7 +46,7 @@ class adapt_diag_e_static_hmc : public diag_e_static_hmc<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/static/adapt_softabs_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_softabs_static_hmc.hpp
@@ -35,7 +35,7 @@ class adapt_softabs_static_hmc : public softabs_static_hmc<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/static/adapt_unit_e_static_hmc.hpp
+++ b/src/stan/mcmc/hmc/static/adapt_unit_e_static_hmc.hpp
@@ -35,7 +35,7 @@ class adapt_unit_e_static_hmc : public unit_e_static_hmc<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_dense_e_static_uniform.hpp
@@ -43,7 +43,7 @@ class adapt_dense_e_static_uniform
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_diag_e_static_uniform.hpp
@@ -42,7 +42,7 @@ class adapt_diag_e_static_uniform
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_softabs_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_softabs_static_uniform.hpp
@@ -35,7 +35,7 @@ class adapt_softabs_static_uniform
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp
+++ b/src/stan/mcmc/hmc/static_uniform/adapt_unit_e_static_uniform.hpp
@@ -36,7 +36,7 @@ class adapt_unit_e_static_uniform
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/xhmc/adapt_dense_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_dense_e_xhmc.hpp
@@ -42,7 +42,7 @@ class adapt_dense_e_xhmc : public dense_e_xhmc<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/xhmc/adapt_diag_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_diag_e_xhmc.hpp
@@ -42,7 +42,7 @@ class adapt_diag_e_xhmc : public diag_e_xhmc<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/xhmc/adapt_softabs_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_softabs_xhmc.hpp
@@ -31,7 +31,7 @@ class adapt_softabs_xhmc : public softabs_xhmc<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/hmc/xhmc/adapt_unit_e_xhmc.hpp
+++ b/src/stan/mcmc/hmc/xhmc/adapt_unit_e_xhmc.hpp
@@ -31,7 +31,7 @@ class adapt_unit_e_xhmc : public unit_e_xhmc<Model, BaseRNG>,
     return s;
   }
 
-  void disengage_adaptation() {
+  void disengage_adaptation() noexcept {
     base_adapter::disengage_adaptation();
     this->stepsize_adaptation_.complete_adaptation(this->nom_epsilon_);
   }

--- a/src/stan/mcmc/stepsize_adaptation.hpp
+++ b/src/stan/mcmc/stepsize_adaptation.hpp
@@ -70,7 +70,7 @@ class stepsize_adaptation : public base_adaptation {
     epsilon = std::exp(x);
   }
 
-  void complete_adaptation(double& epsilon) {
+  void complete_adaptation(double& epsilon) noexcept {
     if (counter_ > 0)
       epsilon = std::exp(x_bar_);
   }


### PR DESCRIPTION
Allow querying the `adapting()` status of a const sampler, and mark loading/storing the bool member noexcept

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Tal Kedar, K2DQ LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)