### PR TITLE
 Direct all std::vector assigns through size-aware version 

### DIFF
--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -791,6 +791,9 @@ inline void assign(T&& x, U&& y, const char* name) {
     }
   }
 
+  // If we've made it this far, we need x to have elements to assign to,
+  // and we know this is either a no-op or x has size 0
+  x.resize(y.size());
   if constexpr (std::is_rvalue_reference_v<U&&>) {
     for (size_t i = 0; i < y.size(); ++i) {
       assign(x[i], std::move(y[i]), name);

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -792,7 +792,8 @@ inline void assign(T&& x, U&& y, const char* name) {
   }
 
   // If we've made it this far, we need x to have elements to assign to,
-  // and we know this is either a no-op or x has size 0
+  // and we know this is either a no-op or x has size 0, which we treat as
+  // a wildcard that can take any size.
   x.resize(y.size());
   if constexpr (std::is_rvalue_reference_v<U&&>) {
     for (size_t i = 0; i < y.size(); ++i) {

--- a/src/test/unit/model/indexing/assign_test.cpp
+++ b/src/test/unit/model/indexing/assign_test.cpp
@@ -1197,3 +1197,18 @@ TEST(model_indexing, tuples_non_trivially_assignable) {
       },
       A, B);
 }
+
+
+TEST(model_indexing, stdvec_of_eigvec_errors) {
+  using stan::model::assign;
+  using stan::model::index_min_max;
+
+  std::vector<Eigen::VectorXd> x(1);
+  x[0] = Eigen::VectorXd(2);
+  x[0] << 1, 2;
+  std::vector<Eigen::VectorXd> y(1);
+  y[0] = Eigen::VectorXd(3);
+  y[0] << 3, 4, 5;
+
+  test_throw_ia(x, y);
+}

--- a/src/test/unit/model/indexing/assign_test.cpp
+++ b/src/test/unit/model/indexing/assign_test.cpp
@@ -1198,7 +1198,6 @@ TEST(model_indexing, tuples_non_trivially_assignable) {
       A, B);
 }
 
-
 TEST(model_indexing, stdvec_of_eigvec_errors) {
   using stan::model::assign;
   using stan::model::index_min_max;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #3351 

#### Intended Effect

More size mismatch errors are properly caught by Stan

#### How to Verify

New test added, which crashes on `develop` and passes on this branch.

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
