### PR TITLE
update to restrict a write in serializer to only scalars

### DIFF
--- a/src/stan/io/serializer.hpp
+++ b/src/stan/io/serializer.hpp
@@ -45,7 +45,7 @@ class serializer {
 
   template <typename S>
   using is_arithmetic_or_ad
-      = bool_constant<std::is_arithmetic<S>::value || is_autodiff<S>::value>;
+      = bool_constant<(std::is_arithmetic<S>::value || is_autodiff<S>::value) && is_stan_scalar<S>::value>;
 
  public:
   using matrix_t = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;

--- a/src/stan/io/serializer.hpp
+++ b/src/stan/io/serializer.hpp
@@ -45,7 +45,8 @@ class serializer {
 
   template <typename S>
   using is_arithmetic_or_ad
-      = bool_constant<(std::is_arithmetic<S>::value || is_autodiff<S>::value) && is_stan_scalar<S>::value>;
+      = bool_constant<(std::is_arithmetic<S>::value || is_autodiff<S>::value)
+                      && is_stan_scalar<S>::value>;
 
  public:
   using matrix_t = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fix for https://github.com/stan-dev/math/pull/3240. The `require` for writing a scalar to the serializer needed to be made more specific given the changes to `is_autodiff` in https://github.com/stan-dev/math/pull/3240 that made it work for more than scalars.

#### How to Verify

All tests pass 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simon's Foundation



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
