### PR TITLE
Removes code that uses `forward_as`

### DIFF
--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -882,10 +882,11 @@ inline void assign(T&& x, U&& y, const char* name, const Idx1& idx1,
                    const Idxs&... idxs) {
   int x_idx_size = rvalue_index_size(idx1, x.size());
   // If there is a reverse min_max index or negative max index
-  if (std::is_same<std::decay_t<Idx1>, index_min_max>::value
-      || std::is_same<std::decay_t<Idx1>, index_max>::value) {
+  constexpr bool is_idx1_minmax_or_max = std::is_same<std::decay_t<Idx1>, index_min_max>::value
+      || std::is_same<std::decay_t<Idx1>, index_max>::value;
+  if constexpr (is_idx1_minmax_or_max) {
     if (x_idx_size == 0) {
-      if (std::is_same<std::decay_t<Idx1>, index_min_max>::value) {
+      if constexpr (std::is_same<std::decay_t<Idx1>, index_min_max>::value) {
         stan::math::check_size_match("array[negative_min_max, ...] assign",
                                      name, 0, "right hand side", y.size());
       } else {
@@ -900,7 +901,7 @@ inline void assign(T&& x, U&& y, const char* name, const Idx1& idx1,
   for (size_t n = 0; n < y.size(); ++n) {
     size_t i = rvalue_at(n, idx1);
     stan::math::check_range("array[multi, ...] assign", name, x.size(), i);
-    if (std::is_rvalue_reference<U&&>::value) {
+    if constexpr (std::is_rvalue_reference<U&&>::value) {
       assign(x[i - 1], std::move(y[n]), name, idxs...);
     } else {
       assign(x[i - 1], y[n], name, idxs...);

--- a/src/stan/model/indexing/assign.hpp
+++ b/src/stan/model/indexing/assign.hpp
@@ -882,8 +882,9 @@ inline void assign(T&& x, U&& y, const char* name, const Idx1& idx1,
                    const Idxs&... idxs) {
   int x_idx_size = rvalue_index_size(idx1, x.size());
   // If there is a reverse min_max index or negative max index
-  constexpr bool is_idx1_minmax_or_max = std::is_same<std::decay_t<Idx1>, index_min_max>::value
-      || std::is_same<std::decay_t<Idx1>, index_max>::value;
+  constexpr bool is_idx1_minmax_or_max
+      = std::is_same<std::decay_t<Idx1>, index_min_max>::value
+        || std::is_same<std::decay_t<Idx1>, index_max>::value;
   if constexpr (is_idx1_minmax_or_max) {
     if (x_idx_size == 0) {
       if constexpr (std::is_same<std::decay_t<Idx1>, index_min_max>::value) {

--- a/src/stan/model/indexing/assign_cl.hpp
+++ b/src/stan/model/indexing/assign_cl.hpp
@@ -291,7 +291,7 @@ inline void assign(ExprLhs&& expr_lhs, const ScalRhs& scal_rhs,
             expr_lhs.val_op(), row_index.n_ - 1, col_index.n_ - 1, 1, 1);
         decltype(auto) lhs_adj = math::block_zero_based(
             expr_lhs.adj(), row_index.n_ - 1, col_index.n_ - 1, 1, 1);
-        if (!is_constant<ScalRhs>::value) {
+        if constexpr (!is_constant<ScalRhs>::value) {
           math::adjoint_of(scal_rhs) += math::from_matrix_cl<double>(lhs_adj);
         }
         math::results(lhs_adj, lhs_val)

--- a/src/stan/model/indexing/assign_varmat.hpp
+++ b/src/stan/model/indexing/assign_varmat.hpp
@@ -83,7 +83,7 @@ inline void assign(VarVec&& x, const U& y, const char* name, index_uni idx) {
   x.vi_->val_.coeffRef(coeff_idx) = stan::math::value_of(y);
   stan::math::reverse_pass_callback([x, y, coeff_idx, prev_val]() mutable {
     x.vi_->val_.coeffRef(coeff_idx) = prev_val;
-    if (!is_constant<U>::value) {
+    if constexpr (!is_constant<U>::value) {
       math::adjoint_of(y) += x.adj().coeffRef(coeff_idx);
     }
     x.adj().coeffRef(coeff_idx) = 0.0;
@@ -138,7 +138,7 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name,
     }
   }
 
-  if (!is_constant<Vec2>::value) {
+  if constexpr (!is_constant<Vec2>::value) {
     stan::math::reverse_pass_callback([x, y, x_idx, prev_vals]() mutable {
       for (Eigen::Index i = 0; i < x_idx.size(); ++i) {
         if (likely(x_idx[i] != -1)) {
@@ -149,10 +149,7 @@ inline void assign(Vec1&& x, const Vec2& y, const char* name,
       }
       for (Eigen::Index i = 0; i < x_idx.size(); ++i) {
         if (likely(x_idx[i] != -1)) {
-          math::forward_as<math::promote_scalar_t<math::var, Vec2>>(y)
-              .adj()
-              .coeffRef(i)
-              += prev_vals.coeff(i);
+          y.adj().coeffRef(i) += prev_vals.coeff(i);
         }
       }
     });
@@ -196,7 +193,7 @@ inline void assign(Mat&& x, const U& y, const char* name, index_uni row_idx,
   stan::math::reverse_pass_callback(
       [x, y, row_idx_val, col_idx_val, prev_val]() mutable {
         x.vi_->val_.coeffRef(row_idx_val, col_idx_val) = prev_val;
-        if (!is_constant<U>::value) {
+        if constexpr (!is_constant<U>::value) {
           math::adjoint_of(y) += x.adj().coeff(row_idx_val, col_idx_val);
         }
         x.adj().coeffRef(row_idx_val, col_idx_val) = 0.0;
@@ -255,7 +252,7 @@ inline void assign(Mat1&& x, const Vec& y, const char* name, index_uni row_idx,
       x.vi_->val_.coeffRef(row_idx_val, x_idx[i]) = y_val_idx.coeff(i);
     }
   }
-  if (!is_constant<Vec>::value) {
+  if constexpr (!is_constant<Vec>::value) {
     stan::math::reverse_pass_callback(
         [x, y, row_idx_val, x_idx, prev_val]() mutable {
           for (size_t i = 0; i < x_idx.size(); ++i) {
@@ -267,10 +264,7 @@ inline void assign(Mat1&& x, const Vec& y, const char* name, index_uni row_idx,
           }
           for (size_t i = 0; i < x_idx.size(); ++i) {
             if (likely(x_idx[i] != -1)) {
-              math::forward_as<math::promote_scalar_t<math::var, Vec>>(y)
-                  .adj()
-                  .coeffRef(i)
-                  += prev_val.coeff(i);
+              y.adj().coeffRef(i) += prev_val.coeff(i);
             }
           }
         });
@@ -338,7 +332,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
     }
   }
 
-  if (!is_constant<Mat2>::value) {
+  if constexpr (!is_constant<Mat2>::value) {
     stan::math::reverse_pass_callback([x, y, prev_vals, x_idx]() mutable {
       for (size_t i = 0; i < x_idx.size(); ++i) {
         if (likely(x_idx[i] != -1)) {
@@ -349,10 +343,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
       }
       for (size_t i = 0; i < x_idx.size(); ++i) {
         if (likely(x_idx[i] != -1)) {
-          math::forward_as<math::promote_scalar_t<math::var, Mat2>>(y)
-              .adj()
-              .row(i)
-              += prev_vals.row(i);
+          y.adj().row(i) += prev_vals.row(i);
         }
       }
     });
@@ -442,7 +433,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
       }
     }
   }
-  if (!is_constant<Mat2>::value) {
+  if constexpr (!is_constant<Mat2>::value) {
     stan::math::reverse_pass_callback(
         [x, y, prev_vals, x_col_idx, x_row_idx]() mutable {
           for (int j = 0; j < x_col_idx.size(); ++j) {
@@ -462,10 +453,7 @@ inline void assign(Mat1&& x, const Mat2& y, const char* name,
             if (likely(x_col_idx[j] != -1)) {
               for (int i = 0; i < x_row_idx.size(); ++i) {
                 if (likely(x_row_idx[i] != -1)) {
-                  math::forward_as<math::promote_scalar_t<math::var, Mat2>>(y)
-                      .adj()
-                      .coeffRef(i, j)
-                      += prev_vals.coeff(i, j);
+                  y.adj().coeffRef(i, j) += prev_vals.coeff(i, j);
                 }
               }
             }

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -788,16 +788,20 @@ inline auto rvalue(StdVec&& v, const char* name, const Idx1& idx1,
   stan::math::check_greater_or_equal("array[..., ...] indexing", "size",
                                      index_size, 0);
   std::vector<inner_type> result(index_size);
-  if ((std::is_same<std::decay_t<Idx1>, index_min_max>::value
-       || std::is_same<std::decay_t<Idx1>, index_max>::value)
-      && index_size == 0) {
-    return result;
+  constexpr bool is_idx1_minmax_or_max =
+    std::is_same<std::decay_t<Idx1>, index_min_max>::value
+       || std::is_same<std::decay_t<Idx1>, index_max>::value;
+  if constexpr (is_idx1_minmax_or_max) {
+    if (index_size == 0) {
+      return result;
+    }
   }
   for (int i = 0; i < index_size; ++i) {
     const int n = rvalue_at(i, idx1);
     math::check_range("array[..., ...] index", name, v.size(), n);
-    if ((!std::is_same<std::decay_t<Idx1>, index_multi>::value)
-        && std::is_rvalue_reference<StdVec>::value) {
+    constexpr bool is_rvalue_multi_idx = (!std::is_same<std::decay_t<Idx1>, index_multi>::value)
+        && std::is_rvalue_reference<StdVec>::value;
+    if constexpr (is_rvalue_multi_idx) {
       result[i] = rvalue(std::move(v[n - 1]), name, idxs...);
     } else {
       result[i] = rvalue(v[n - 1], name, idxs...);

--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -788,9 +788,9 @@ inline auto rvalue(StdVec&& v, const char* name, const Idx1& idx1,
   stan::math::check_greater_or_equal("array[..., ...] indexing", "size",
                                      index_size, 0);
   std::vector<inner_type> result(index_size);
-  constexpr bool is_idx1_minmax_or_max =
-    std::is_same<std::decay_t<Idx1>, index_min_max>::value
-       || std::is_same<std::decay_t<Idx1>, index_max>::value;
+  constexpr bool is_idx1_minmax_or_max
+      = std::is_same<std::decay_t<Idx1>, index_min_max>::value
+        || std::is_same<std::decay_t<Idx1>, index_max>::value;
   if constexpr (is_idx1_minmax_or_max) {
     if (index_size == 0) {
       return result;
@@ -799,8 +799,9 @@ inline auto rvalue(StdVec&& v, const char* name, const Idx1& idx1,
   for (int i = 0; i < index_size; ++i) {
     const int n = rvalue_at(i, idx1);
     math::check_range("array[..., ...] index", name, v.size(), n);
-    constexpr bool is_rvalue_multi_idx = (!std::is_same<std::decay_t<Idx1>, index_multi>::value)
-        && std::is_rvalue_reference<StdVec>::value;
+    constexpr bool is_rvalue_multi_idx
+        = (!std::is_same<std::decay_t<Idx1>, index_multi>::value)
+          && std::is_rvalue_reference<StdVec>::value;
     if constexpr (is_rvalue_multi_idx) {
       result[i] = rvalue(std::move(v[n - 1]), name, idxs...);
     } else {

--- a/src/stan/model/model_base.hpp
+++ b/src/stan/model/model_base.hpp
@@ -325,14 +325,16 @@ class model_base : public prob_grad {
   template <bool propto, bool jacobian, typename T>
   inline T log_prob(Eigen::Matrix<T, -1, 1>& params_r,
                     std::ostream* msgs) const {
-    if (propto && jacobian)
+    if constexpr (propto && jacobian) {
       return log_prob_propto_jacobian(params_r, msgs);
-    else if (propto && !jacobian)
+    } else if constexpr (propto && !jacobian) {
       return log_prob_propto(params_r, msgs);
-    else if (!propto && jacobian)
+    } else if constexpr (!propto && jacobian) {
       return log_prob_jacobian(params_r, msgs);
-    else  // if (!propto && !jacobian)
+    } else {
+      // if (!propto && !jacobian)
       return log_prob(params_r, msgs);
+    }
   }
 
   /**
@@ -570,14 +572,15 @@ class model_base : public prob_grad {
   template <bool propto, bool jacobian, typename T>
   inline T log_prob(std::vector<T>& params_r, std::vector<int>& params_i,
                     std::ostream* msgs) const {
-    if (propto && jacobian)
+    if constexpr (propto && jacobian) {
       return log_prob_propto_jacobian(params_r, params_i, msgs);
-    else if (propto && !jacobian)
+    } else if constexpr (propto && !jacobian) {
       return log_prob_propto(params_r, params_i, msgs);
-    else if (!propto && jacobian)
+    } else if constexpr (!propto && jacobian) {
       return log_prob_jacobian(params_r, params_i, msgs);
-    else  // if (!propto && !jacobian)
+    } else { // if (!propto && !jacobian)
       return log_prob(params_r, params_i, msgs);
+    }
   }
 
   /**

--- a/src/stan/model/model_base.hpp
+++ b/src/stan/model/model_base.hpp
@@ -578,7 +578,7 @@ class model_base : public prob_grad {
       return log_prob_propto(params_r, params_i, msgs);
     } else if constexpr (!propto && jacobian) {
       return log_prob_jacobian(params_r, params_i, msgs);
-    } else { // if (!propto && !jacobian)
+    } else {  // if (!propto && !jacobian)
       return log_prob(params_r, params_i, msgs);
     }
   }

--- a/src/test/unit/model/indexing/assign_varmat_test.cpp
+++ b/src/test/unit/model/indexing/assign_varmat_test.cpp
@@ -1551,7 +1551,7 @@ inline void assign_tester(T1&& x, const I1& idx1, const I2& idx2) {
   // Since this just moves the pointer x1 omni is diff than
   // multi
   if constexpr (!std::is_same<I1, index_omni>::value
-      && !std::is_same<I2, index_omni>::value) {
+                && !std::is_same<I2, index_omni>::value) {
     EXPECT_MATRIX_EQ(x1.val(), x2.val());
     EXPECT_MATRIX_EQ(x1.adj(), x2.adj());
     EXPECT_MATRIX_EQ(y.adj(),

--- a/src/test/unit/model/indexing/assign_varmat_test.cpp
+++ b/src/test/unit/model/indexing/assign_varmat_test.cpp
@@ -77,7 +77,7 @@ void test_nil_vec() {
   EXPECT_MATRIX_EQ(x.val(), stan::math::value_of(y));
   stan::math::sum(x).grad();
   auto check_all = [](int i) { return true; };
-  if (stan::is_var<RhsScalar>::value) {
+  if constexpr (stan::is_var<RhsScalar>::value) {
     EXPECT_MATRIX_EQ(x.val(), stan::math::value_of(y));
     check_adjs(check_all, x, "lhs", 1);
     check_adjs(check_all, y, "rhs", 1);
@@ -205,14 +205,14 @@ void test_omni_vec() {
   EXPECT_FLOAT_EQ(y_val[3], x.val()[3]);
   EXPECT_FLOAT_EQ(y_val[4], x.val()[4]);
   sum(x).grad();
-  if (stan::is_var<RhsScalar>::value) {
+  if constexpr (stan::is_var<RhsScalar>::value) {
     EXPECT_MATRIX_EQ(x.val(), y_val);
     EXPECT_MATRIX_EQ(x_copy.val(), x_val);
   } else {
     EXPECT_MATRIX_EQ(x.val(), x_val);
   }
   auto check_i = [](int i) { return true; };
-  if (stan::is_var<RhsScalar>::value) {
+  if constexpr (stan::is_var<RhsScalar>::value) {
     check_adjs(check_i, x, "lhs", 1.0);
   } else {
     check_adjs(check_i, x, "lhs", 0.0);
@@ -963,7 +963,7 @@ void omni_matrix_test() {
   Eigen::MatrixXd x_val = x.val();
   auto y = conditionally_generate_linear_var_matrix<RhsScalar>(5, 5, 10);
   assign(x, y, "", index_omni());
-  if (stan::is_var<RhsScalar>::value) {
+  if constexpr (stan::is_var<RhsScalar>::value) {
     EXPECT_MATRIX_EQ(value_of(y), x.val());
   } else {
     EXPECT_MATRIX_EQ(value_of(y), x.val());
@@ -971,7 +971,7 @@ void omni_matrix_test() {
   }
   sum(x).grad();
   auto check_all = [](int /* i */) { return true; };
-  if (stan::is_var<RhsScalar>::value) {
+  if constexpr (stan::is_var<RhsScalar>::value) {
     EXPECT_MATRIX_EQ(x.val(), value_of(y));
     check_adjs(check_all, check_all, x, "lhs");
     check_adjs(check_all, check_all, y, "rhs");
@@ -1009,7 +1009,7 @@ void omni_omni_matrix_test() {
   stan::math::var lp = sum(x_copy);
   lp.adj() = 1;
   assign(x, y, "", index_omni(), index_omni());
-  if (stan::is_var<RhsScalar>::value) {
+  if constexpr (stan::is_var<RhsScalar>::value) {
     EXPECT_MATRIX_EQ(value_of(y), x.val());
   } else {
     EXPECT_MATRIX_EQ(value_of(y), x.val());
@@ -1017,7 +1017,7 @@ void omni_omni_matrix_test() {
   }
   sum(x).grad();
   auto check_all = [](int /* i */) { return true; };
-  if (stan::is_var<RhsScalar>::value) {
+  if constexpr (stan::is_var<RhsScalar>::value) {
     EXPECT_MATRIX_EQ(x.val(), value_of(y));
     check_adjs(check_all, check_all, x, "lhs");
     check_adjs(check_all, check_all, y, "rhs");
@@ -1494,7 +1494,7 @@ void nil_matrix() {
   EXPECT_MATRIX_EQ(stan::math::value_of(y), x.val());
   sum(x).grad();
   auto check_all = [](int /* i */) { return true; };
-  if (stan::is_var<RhsScalar>::value) {
+  if constexpr (stan::is_var<RhsScalar>::value) {
     EXPECT_MATRIX_EQ(x.val(), stan::math::value_of(y));
     check_adjs(check_all, check_all, x, "lhs");
     check_adjs(check_all, check_all, y, "rhs");
@@ -1550,7 +1550,7 @@ inline void assign_tester(T1&& x, const I1& idx1, const I2& idx2) {
   stan::math::sum(stan::math::add(x1, x2)).grad();
   // Since this just moves the pointer x1 omni is diff than
   // multi
-  if (!std::is_same<I1, index_omni>::value
+  if constexpr (!std::is_same<I1, index_omni>::value
       && !std::is_same<I2, index_omni>::value) {
     EXPECT_MATRIX_EQ(x1.val(), x2.val());
     EXPECT_MATRIX_EQ(x1.adj(), x2.adj());

--- a/src/test/unit/model/model_base_crtp_test.cpp
+++ b/src/test/unit/model/model_base_crtp_test.cpp
@@ -36,21 +36,21 @@ struct mock_model : public stan::model::model_base_crtp<mock_model> {
 
   template <bool propto, bool jacobian, typename T>
   T log_prob(Eigen::Matrix<T, -1, 1>& params_r, std::ostream* msgs) const {
-    if (std::is_same<T, double>::value) {
-      if (!propto && !jacobian)
+    if constexpr (std::is_same<T, double>::value) {
+      if constexpr (!propto && !jacobian)
         return 1;
-      else if (!propto && jacobian)
+      else if constexpr (!propto && jacobian)
         return 3;
-      else if (propto && !jacobian)
+      else if constexpr (propto && !jacobian)
         return 5;
       else
         return 7;
     } else {
-      if (!propto && !jacobian)
+      if constexpr (!propto && !jacobian)
         return 2;
-      else if (!propto && jacobian)
+      else if constexpr (!propto && jacobian)
         return 4;
-      else if (propto && !jacobian)
+      else if constexpr (propto && !jacobian)
         return 6;
       else
         return 8;
@@ -69,21 +69,21 @@ struct mock_model : public stan::model::model_base_crtp<mock_model> {
   template <bool propto, bool jacobian, typename T>
   T log_prob(std::vector<T>& params_r, std::vector<int>& params_i,
              std::ostream* msgs) const {
-    if (std::is_same<T, double>::value) {
-      if (!propto && !jacobian)
+    if constexpr (std::is_same<T, double>::value) {
+      if constexpr (!propto && !jacobian)
         return 1;
-      else if (!propto && jacobian)
+      else if constexpr (!propto && jacobian)
         return 3;
-      else if (propto && !jacobian)
+      else if constexpr (propto && !jacobian)
         return 5;
       else
         return 7;
     } else {
-      if (!propto && !jacobian)
+      if constexpr (!propto && !jacobian)
         return 2;
-      else if (!propto && jacobian)
+      else if constexpr (!propto && jacobian)
         return 4;
-      else if (propto && !jacobian)
+      else if constexpr (propto && !jacobian)
         return 6;
       else
         return 8;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

For https://github.com/stan-dev/math/pull/3242 this removes the uses of `forward_as` from the stan repo and adds `if constexpr` where possible

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
