### PR TITLE
Allow min:max indexing to always succeed if it is an empty selection 

### DIFF
--- a/src/stan/model/indexing/rvalue.hpp
+++ b/src/stan/model/indexing/rvalue.hpp
@@ -786,8 +786,8 @@ template <typename StdVec, typename Idx1, typename... Idxs,
           require_not_same_t<Idx1, index_uni>* = nullptr>
 inline auto rvalue(StdVec&& v, const char* name, const Idx1& idx1,
                    Idxs&&... idxs) {
-  using inner_type = plain_type_t<decltype(rvalue(v[rvalue_at(0, idx1) - 1],
-                                                  name, idxs...))>;
+  using inner_type = plain_type_t<decltype(
+      rvalue(v[rvalue_at(0, idx1) - 1], name, idxs...))>;
   const auto index_size = rvalue_index_size(idx1, v.size());
   stan::math::check_greater_or_equal("array[..., ...] indexing", "size",
                                      index_size, 0);

--- a/src/test/unit/model/indexing/rvalue_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_test.cpp
@@ -185,7 +185,7 @@ TEST(ModelIndexing, rvalue_eigenvec_min_max_nil) {
   x(1) = 2.2;
   x(2) = 3.3;
   x(3) = 4.4;
-  // min > max
+  // min < max
   for (int mn = 0; mn < 4; ++mn) {
     for (int mx = mn; mx < 4; ++mx) {
       Eigen::Matrix<double, -1, 1> rx
@@ -196,21 +196,31 @@ TEST(ModelIndexing, rvalue_eigenvec_min_max_nil) {
     }
   }
 
-  // max > min
-  for (int mn = 3; mn > -1; --mn) {
-    for (int mx = mn; mx > -1; --mx) {
+  // min > max, including min > size
+  for (int mn = 5; mn > -1; --mn) {
+    for (int mx = mn - 1; mx > -1; --mx) {
       Eigen::Matrix<double, -1, 1> rx
           = rvalue(x, "", index_min_max(mn + 1, mx + 1));
-      if (mn == mx) {
-        EXPECT_FLOAT_EQ(1, rx.size());
-      } else {
-        EXPECT_FLOAT_EQ(0, rx.size());
-      }
+      EXPECT_FLOAT_EQ(0, rx.size());
     }
+  }
+
+  // min == max
+  for (int mn = 3; mn > -1; --mn) {
+    Eigen::Matrix<double, -1, 1> rx
+        = rvalue(x, "", index_min_max(mn + 1, mn + 1));
+    EXPECT_FLOAT_EQ(1, rx.size());
   }
 
   test_out_of_range(x, index_min_max(0, 2));
   test_out_of_range(x, index_min_max(2, 5));
+
+  // empty min-max on empty vectors
+  Eigen::Matrix<double, -1, 1> z(0);
+  EXPECT_EQ(0, rvalue(z, "", index_min_max(1, 0)).size());
+  EXPECT_EQ(0,
+            rvalue(rvalue(x, "", index_min_max(2, 1)), "", index_min_max(1, 0))
+                .size());
 }
 
 TEST(ModelIndexing, rvalue_doubless_uni_uni) {

--- a/src/test/unit/model/indexing/rvalue_varmat_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_varmat_test.cpp
@@ -264,7 +264,7 @@ TEST_F(RvalueRev, negative_min_max_vec) {
   }
   var_value<Eigen::VectorXd> x(x_val);
   EXPECT_NO_THROW(rvalue(x, "", index_min_max(2, 0)));
-  test_throw_out_of_range(x, index_min_max(5, 2));
+  EXPECT_NO_THROW(rvalue(x, "", index_min_max(5, 2)));
 }
 
 auto make_std_varvec() {
@@ -374,7 +374,7 @@ TEST_F(RvalueRev, uni_stdvec_negative_minmax_vec) {
       = rvalue(x, "", index_uni(2), index_min_max(2, 1));
   EXPECT_EQ(0U, y.size());
   EXPECT_NO_THROW(rvalue(x, "", index_uni(1), index_min_max(3, 0)));
-  test_throw_out_of_range(x, index_uni(1), index_min_max(15, 2));
+  EXPECT_NO_THROW(rvalue(x, "" , index_uni(1), index_min_max(15, 2)));
 }
 TEST_F(RvalueRev, uni_stdvec_omni_vec) {
   using Eigen::VectorXd;
@@ -561,7 +561,7 @@ TEST_F(RvalueRev, negative_minmax_uni_matrix) {
   EXPECT_EQ(1U, y.cols());
   test_throw_out_of_range(x, index_min_max(3, 2), index_uni(0));
   test_throw_out_of_range(x, index_min_max(3, 2), index_uni(5));
-  test_throw_out_of_range(x, index_min_max(6, 1), index_uni(4));
+  EXPECT_NO_THROW(rvalue(x, "", index_min_max(6, 1), index_uni(4)));
   EXPECT_NO_THROW(rvalue(x, "", index_min_max(1, 0), index_uni(4)));
 }
 
@@ -938,7 +938,7 @@ TEST_F(RvalueRev, negative_min_max_mat) {
   EXPECT_EQ(0, y.rows());
   EXPECT_EQ(4, y.cols());
   EXPECT_NO_THROW(rvalue(x, "", index_min_max(3, 0)));
-  test_throw_out_of_range(x, index_min_max(15, 2));
+  EXPECT_NO_THROW(rvalue(x, "", index_min_max(15, 2)));
 }
 
 TEST_F(RvalueRev, positive_minmax_positive_minmax_matrix) {
@@ -1071,7 +1071,7 @@ TEST_F(RvalueRev, uni_negative_minmax_matrix) {
   EXPECT_EQ(0U, y.cols());
   test_throw_out_of_range(x, index_uni(0), index_min_max(4, 2));
   test_throw_out_of_range(x, index_uni(7), index_min_max(4, 2));
-  test_throw_out_of_range(x, index_uni(2), index_min_max(15, 0));
+  EXPECT_NO_THROW(rvalue(x, "", index_uni(2), index_min_max(15, 0)));
   EXPECT_NO_THROW(rvalue(x, "", index_uni(2), index_min_max(2, 0)));
 }
 

--- a/src/test/unit/model/indexing/rvalue_varmat_test.cpp
+++ b/src/test/unit/model/indexing/rvalue_varmat_test.cpp
@@ -374,7 +374,7 @@ TEST_F(RvalueRev, uni_stdvec_negative_minmax_vec) {
       = rvalue(x, "", index_uni(2), index_min_max(2, 1));
   EXPECT_EQ(0U, y.size());
   EXPECT_NO_THROW(rvalue(x, "", index_uni(1), index_min_max(3, 0)));
-  EXPECT_NO_THROW(rvalue(x, "" , index_uni(1), index_min_max(15, 2)));
+  EXPECT_NO_THROW(rvalue(x, "", index_uni(1), index_min_max(15, 2)));
 }
 TEST_F(RvalueRev, uni_stdvec_omni_vec) {
   using Eigen::VectorXd;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes #3359 

#### Intended Effect

A `x:y` selection where x is bigger than y results in an empty slice, even when `x` is greater than the size of the container.

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
