### PR TITLE
Avoid indexing past vector length in Pathfinder writer

### DIFF
--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -346,7 +346,7 @@ inline int pathfinder_lbfgs_multi(
             // write again if there are remaining draws
             if (j < (psis_draw_idxs.size() - 1)) {
               while (j < (single_path_psis_idxs[i].second)
-                      && draw_idx == psis_draw_idxs.coeff(j + 1)) {
+                     && draw_idx == psis_draw_idxs.coeff(j + 1)) {
                 safe_write(sample_row);
                 ++j;
               }

--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -343,11 +343,13 @@ inline int pathfinder_lbfgs_multi(
             sample_row.tail(uc_param_size) = approx_samples_constrained_col;
             safe_write(sample_row);
             // If we see the same draw idx more than once, just increment j and
-            // write again
-            while (j < (single_path_psis_idxs[i].second)
-                   && draw_idx == psis_draw_idxs.coeff(j + 1)) {
-              safe_write(sample_row);
-              ++j;
+            // write again if there are remaining draws
+            if (j < (psis_draw_idxs.size() - 1)) {
+              while (j < (single_path_psis_idxs[i].second)
+                      && draw_idx == psis_draw_idxs.coeff(j + 1)) {
+                safe_write(sample_row);
+                ++j;
+              }
             }
           }
         }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Resolves the address sanitizer error from #3361 

In the pathfinder writer logic for checking whether a draw id is present multiple times:

```cpp
    while (j < (single_path_psis_idxs[i].second)
            && draw_idx == psis_draw_idxs.coeff(j + 1)) {
      safe_write(sample_row);
      ++j;
    }
```

The `while` statement checks a value at index `j + 1`, but this reads past the end of the vector when `j` is the last iteration. This PR just wraps the logic in a conditional on `j` not being the last element

#### Intended Effect

Resolve address sanitizer error

#### How to Verify

Run bernoulli example model with sanitizers

#### Side Effects

N/A

#### Documentation

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
