### PR TITLE
release/v2.38.0: updating version numbers

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -24,4 +24,4 @@ Describe what you expect the output to be. Knowing the correct behavior is also 
 Provide any additional information here.
 
 #### Current Version:
-v2.37.0
+v2.38.0

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,14 @@ Note: these are the release notes for the stan-dev/stan repository.
 Further changes may arise at the interface level (stan-dev/{rstan,
 pystan, cmdstan}) and math library level (stan-dev/math).
 
+v2.38.0 (6 January 2026)
+======================================================================
+
+ - Allow `min:max` indexing to always succeed if it is an empty selection. (#3362)
+ - Updated scalar templating in the serializer. (#3355)
+ - Removed the uses of `forward_as` from the stan repo and adds `if constexpr` where possible. (#3357)
+ - Updated Pathfinder writer to avoid indexing past vector length. (#3364)
+
 v2.37.0 (2 September 2025)
 ======================================================================
 

--- a/src/doxygen/doxygen.cfg
+++ b/src/doxygen/doxygen.cfg
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Stan"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.37.0
+PROJECT_NUMBER         = 2.38.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/stan/version.hpp
+++ b/src/stan/version.hpp
@@ -12,7 +12,7 @@
 #endif
 
 #define STAN_MAJOR 2
-#define STAN_MINOR 37
+#define STAN_MINOR 38
 #define STAN_PATCH 0
 
 namespace stan {

--- a/src/test/unit/version_test.cpp
+++ b/src/test/unit/version_test.cpp
@@ -3,12 +3,12 @@
 
 TEST(Stan, macro) {
   EXPECT_EQ(2, STAN_MAJOR);
-  EXPECT_EQ(37, STAN_MINOR);
+  EXPECT_EQ(38, STAN_MINOR);
   EXPECT_EQ(0, STAN_PATCH);
 }
 
 TEST(Stan, version) {
   EXPECT_EQ("2", stan::MAJOR_VERSION);
-  EXPECT_EQ("37", stan::MINOR_VERSION);
+  EXPECT_EQ("38", stan::MINOR_VERSION);
   EXPECT_EQ("0", stan::PATCH_VERSION);
 }


### PR DESCRIPTION
#### Summary

Update versions to 2.38.0 and add release notes.
