### PR TITLE
Detect generated quantities timing in stan_csv_reader

### DIFF
--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -300,7 +300,9 @@ class stan_csv_reader {
           double warmup;
           std::stringstream(line.substr(left, right - left)) >> warmup;
           timing.warmup += warmup;
-        } else if (line.find("(Sampling)") != std::string::npos) {
+        } else if (line.find("(Sampling)") != std::string::npos
+                   || line.find("(Generated Quantities)")
+                          != std::string::npos) {
           int left = 17;
           int right = line.find(" seconds");
           double sampling;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Follow on to #3373. The primary benefit of this is it lets the `stansummary` tool up in CmdStan use these timings. Of course, ess/s is less meaningful when there was only forward sampling, but it at least removes a strange message about how 0 seconds were needed.

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
