### PR TITLE
Add convergence information to optimization outputs

### DIFF
--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -201,10 +201,12 @@ int bfgs(Model& model, const stan::io::var_context& init,
   if (ret >= 0) {
     logger.info("Optimization terminated normally: ");
     logger.info("  " + error_string);
+    parameter_writer("Optimization terminated normally: " + error_string);
     return_code = error_codes::OK;
   } else {
     logger.error("Optimization terminated with error: ");
     logger.error("  " + error_string);
+    parameter_writer("Optimization terminated with error: " + error_string);
     return_code = error_codes::SOFTWARE;
   }
 

--- a/src/stan/services/optimize/bfgs.hpp
+++ b/src/stan/services/optimize/bfgs.hpp
@@ -83,6 +83,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
   bfgs._conv_opts.maxIts = num_iterations;
 
   double lp = bfgs.logp();
+  int ret = 0;
 
   std::stringstream initial_msg;
   initial_msg << "Initial log joint probability = " << lp;
@@ -90,6 +91,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
 
   std::vector<std::string> names;
   names.push_back("lp__");
+  names.push_back("converged__");
   model.constrained_param_names(names, true, true);
   parameter_writer(names);
 
@@ -109,10 +111,9 @@ int bfgs(Model& model, const stan::io::var_context& init,
     if (msg.str().length() > 0)
       logger.info(msg);
 
-    values.insert(values.begin(), lp);
+    values.insert(values.begin(), {lp, static_cast<double>(ret)});
     parameter_writer(values);
   }
-  int ret = 0;
 
   try {
     while (ret == 0) {
@@ -168,7 +169,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
         if (msg.str().length() > 0)
           logger.info(msg);
 
-        values.insert(values.begin(), lp);
+        values.insert(values.begin(), {lp, static_cast<double>(ret)});
         parameter_writer(values);
       }
     }
@@ -192,7 +193,7 @@ int bfgs(Model& model, const stan::io::var_context& init,
     }
     if (msg.str().length() > 0)
       logger.info(msg);
-    values.insert(values.begin(), lp);
+    values.insert(values.begin(), {lp, static_cast<double>(ret)});
     parameter_writer(values);
   }
 

--- a/src/stan/services/optimize/lbfgs.hpp
+++ b/src/stan/services/optimize/lbfgs.hpp
@@ -87,6 +87,7 @@ int lbfgs(Model& model, const stan::io::var_context& init,
   lbfgs._conv_opts.maxIts = num_iterations;
 
   double lp = lbfgs.logp();
+  int ret = 0;
 
   std::stringstream initial_msg;
   initial_msg << "Initial log joint probability = " << lp;
@@ -94,6 +95,7 @@ int lbfgs(Model& model, const stan::io::var_context& init,
 
   std::vector<std::string> names;
   names.push_back("lp__");
+  names.push_back("converged__");
   model.constrained_param_names(names, true, true);
   parameter_writer(names);
 
@@ -104,10 +106,9 @@ int lbfgs(Model& model, const stan::io::var_context& init,
     if (msg.str().length() > 0)
       logger.info(msg);
 
-    values.insert(values.begin(), lp);
+    values.insert(values.begin(), {lp, static_cast<double>(ret)});
     parameter_writer(values);
   }
-  int ret = 0;
 
   try {
     while (ret == 0) {
@@ -161,7 +162,7 @@ int lbfgs(Model& model, const stan::io::var_context& init,
         if (msg.str().length() > 0)
           logger.info(msg);
 
-        values.insert(values.begin(), lp);
+        values.insert(values.begin(), {lp, static_cast<double>(ret)});
         parameter_writer(values);
       }
     }
@@ -186,7 +187,7 @@ int lbfgs(Model& model, const stan::io::var_context& init,
     if (msg.str().length() > 0)
       logger.info(msg);
 
-    values.insert(values.begin(), lp);
+    values.insert(values.begin(), {lp, static_cast<double>(ret)});
     parameter_writer(values);
   }
 

--- a/src/stan/services/optimize/lbfgs.hpp
+++ b/src/stan/services/optimize/lbfgs.hpp
@@ -196,10 +196,12 @@ int lbfgs(Model& model, const stan::io::var_context& init,
   if (ret >= 0) {
     logger.info("Optimization terminated normally: ");
     logger.info("  " + error_string);
+    parameter_writer("Optimization terminated normally: " + error_string);
     return_code = error_codes::OK;
   } else {
     logger.error("Optimization terminated with error: ");
     logger.error("  " + error_string);
+    parameter_writer("Optimization terminated with error: " + error_string);
     return_code = error_codes::SOFTWARE;
   }
 

--- a/src/stan/services/optimize/newton.hpp
+++ b/src/stan/services/optimize/newton.hpp
@@ -5,6 +5,7 @@
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/writer.hpp>
 #include <stan/io/var_context.hpp>
+#include <stan/optimization/bfgs.hpp>
 #include <stan/optimization/newton.hpp>
 #include <stan/services/error_codes.hpp>
 #include <stan/services/util/initialize.hpp>
@@ -92,6 +93,8 @@ int newton(Model& model, const stan::io::var_context& init,
   parameter_writer(names);
 
   double lastlp = lp;
+  int ret = 0;
+
   for (int m = 0; m < num_iterations; m++) {
     if (save_iterations) {
       std::vector<double> values;
@@ -99,7 +102,7 @@ int newton(Model& model, const stan::io::var_context& init,
       model.write_array(rng, cont_vector, disc_vector, values, true, true, &ss);
       if (ss.str().length() > 0)
         logger.info(ss);
-      values.insert(values.begin(), {lp, 0});
+      values.insert(values.begin(), {lp, static_cast<double>(ret)});
       parameter_writer(values);
     }
     interrupt();
@@ -117,13 +120,19 @@ int newton(Model& model, const stan::io::var_context& init,
       break;
   }
 
+  if (std::fabs(lp - lastlp) <= 1e-8) {
+    ret = optimization::TERM_ABSF;
+  } else {
+    ret = optimization::TERM_MAXIT;
+  }
+
   {
     std::vector<double> values;
     std::stringstream ss;
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &ss);
     if (ss.str().length() > 0)
       logger.info(ss);
-    values.insert(values.begin(), {lp, 0});
+    values.insert(values.begin(), {lp, static_cast<double>(ret)});
     parameter_writer(values);
   }
   return error_codes::OK;

--- a/src/stan/services/optimize/newton.hpp
+++ b/src/stan/services/optimize/newton.hpp
@@ -85,7 +85,9 @@ int newton(Model& model, const stan::io::var_context& init,
   logger.info(msg);
 
   std::vector<std::string> names;
+
   names.push_back("lp__");
+  names.push_back("converged__");
   model.constrained_param_names(names, true, true);
   parameter_writer(names);
 
@@ -97,7 +99,7 @@ int newton(Model& model, const stan::io::var_context& init,
       model.write_array(rng, cont_vector, disc_vector, values, true, true, &ss);
       if (ss.str().length() > 0)
         logger.info(ss);
-      values.insert(values.begin(), lp);
+      values.insert(values.begin(), {lp, 0});
       parameter_writer(values);
     }
     interrupt();
@@ -121,7 +123,7 @@ int newton(Model& model, const stan::io::var_context& init,
     model.write_array(rng, cont_vector, disc_vector, values, true, true, &ss);
     if (ss.str().length() > 0)
       logger.info(ss);
-    values.insert(values.begin(), lp);
+    values.insert(values.begin(), {lp, 0});
     parameter_writer(values);
   }
   return error_codes::OK;

--- a/src/test/unit/services/optimize/bfgs_jacobian_test.cpp
+++ b/src/test/unit/services/optimize/bfgs_jacobian_test.cpp
@@ -34,10 +34,11 @@ TEST_F(ServicesOptimize, withJacobian) {
   EXPECT_TRUE(logger.find("Optimization terminated normally: "));
   EXPECT_FLOAT_EQ(return_code, 0);
 
-  ASSERT_EQ(2, parameter.names_.size());
+  ASSERT_EQ(3, parameter.names_.size());
   EXPECT_EQ("lp__", parameter.names_[0]);
-  EXPECT_EQ("sigma", parameter.names_[1]);
-  EXPECT_NEAR((3 + std::sqrt(13)) / 2, parameter.states_.back()[1], 0.0001);
+  EXPECT_EQ("converged__", parameter.names_[1]);
+  EXPECT_EQ("sigma", parameter.names_[2]);
+  EXPECT_NEAR((3 + std::sqrt(13)) / 2, parameter.states_.back()[2], 0.0001);
   EXPECT_GT(interrupt.call_count(), 0);
 }
 
@@ -58,9 +59,10 @@ TEST_F(ServicesOptimize, withoutJacobian) {
   EXPECT_TRUE(logger.find("Optimization terminated normally: "));
   EXPECT_FLOAT_EQ(return_code, 0);
 
-  ASSERT_EQ(2, parameter.names_.size());
+  ASSERT_EQ(3, parameter.names_.size());
   EXPECT_EQ("lp__", parameter.names_[0]);
-  EXPECT_EQ("sigma", parameter.names_[1]);
-  EXPECT_NEAR(3, parameter.states_.back()[1], 0.0001);
+  EXPECT_EQ("converged__", parameter.names_[1]);
+  EXPECT_EQ("sigma", parameter.names_[2]);
+  EXPECT_NEAR(3, parameter.states_.back()[2], 0.0001);
   EXPECT_GT(interrupt.call_count(), 1);
 }

--- a/src/test/unit/services/optimize/bfgs_test.cpp
+++ b/src/test/unit/services/optimize/bfgs_test.cpp
@@ -40,19 +40,20 @@ TEST_F(ServicesOptimize, rosenbrock) {
 
   EXPECT_EQ("0,0\n", init_ss.str());
 
-  ASSERT_EQ(3, parameter.names_.size());
+  ASSERT_EQ(4, parameter.names_.size());
   EXPECT_EQ("lp__", parameter.names_[0]);
-  EXPECT_EQ("x", parameter.names_[1]);
-  EXPECT_EQ("y", parameter.names_[2]);
+  EXPECT_EQ("converged__", parameter.names_[1]);
+  EXPECT_EQ("x", parameter.names_[2]);
+  EXPECT_EQ("y", parameter.names_[3]);
 
   EXPECT_EQ(20, parameter.states_.size());
-  EXPECT_FLOAT_EQ(0, parameter.states_.front()[1])
-      << "initial value should be (0, 0)";
   EXPECT_FLOAT_EQ(0, parameter.states_.front()[2])
       << "initial value should be (0, 0)";
-  EXPECT_FLOAT_EQ(1, parameter.states_.back()[1])
-      << "optimal value should be (1, 1)";
+  EXPECT_FLOAT_EQ(0, parameter.states_.front()[3])
+      << "initial value should be (0, 0)";
   EXPECT_FLOAT_EQ(1, parameter.states_.back()[2])
+      << "optimal value should be (1, 1)";
+  EXPECT_FLOAT_EQ(1, parameter.states_.back()[3])
       << "optimal value should be (1, 1)";
   EXPECT_FLOAT_EQ(return_code, 0);
   EXPECT_EQ(19, interrupt.call_count());

--- a/src/test/unit/services/optimize/lbfgs_jacobian_test.cpp
+++ b/src/test/unit/services/optimize/lbfgs_jacobian_test.cpp
@@ -35,10 +35,11 @@ TEST_F(ServicesOptimize, with_jacobian) {
   EXPECT_TRUE(logger.find("Optimization terminated normally: "));
   EXPECT_FLOAT_EQ(return_code, 0);
 
-  ASSERT_EQ(2, parameter.names_.size());
+  ASSERT_EQ(3, parameter.names_.size());
   EXPECT_EQ("lp__", parameter.names_[0]);
-  EXPECT_EQ("sigma", parameter.names_[1]);
-  EXPECT_NEAR((3 + std::sqrt(13)) / 2, parameter.states_.back()[1], 0.0001);
+  EXPECT_EQ("converged__", parameter.names_[1]);
+  EXPECT_EQ("sigma", parameter.names_[2]);
+  EXPECT_NEAR((3 + std::sqrt(13)) / 2, parameter.states_.back()[2], 0.0001);
 }
 
 TEST_F(ServicesOptimize, without_jacobian) {
@@ -58,8 +59,9 @@ TEST_F(ServicesOptimize, without_jacobian) {
   EXPECT_TRUE(logger.find("Optimization terminated normally: "));
   EXPECT_FLOAT_EQ(return_code, 0);
 
-  ASSERT_EQ(2, parameter.names_.size());
+  ASSERT_EQ(3, parameter.names_.size());
   EXPECT_EQ("lp__", parameter.names_[0]);
-  EXPECT_EQ("sigma", parameter.names_[1]);
-  EXPECT_NEAR(3, parameter.states_.back()[1], 0.0001);
+  EXPECT_EQ("converged__", parameter.names_[1]);
+  EXPECT_EQ("sigma", parameter.names_[2]);
+  EXPECT_NEAR(3, parameter.states_.back()[2], 0.0001);
 }

--- a/src/test/unit/services/optimize/lbfgs_test.cpp
+++ b/src/test/unit/services/optimize/lbfgs_test.cpp
@@ -40,19 +40,20 @@ TEST_F(ServicesOptimize, rosenbrock) {
 
   EXPECT_EQ("0,0\n", init_ss.str());
 
-  ASSERT_EQ(3, parameter.names_.size());
+  ASSERT_EQ(4, parameter.names_.size());
   EXPECT_EQ("lp__", parameter.names_[0]);
-  EXPECT_EQ("x", parameter.names_[1]);
-  EXPECT_EQ("y", parameter.names_[2]);
+  EXPECT_EQ("converged__", parameter.names_[1]);
+  EXPECT_EQ("x", parameter.names_[2]);
+  EXPECT_EQ("y", parameter.names_[3]);
 
   EXPECT_EQ(23, parameter.states_.size());
-  EXPECT_FLOAT_EQ(0, parameter.states_.front()[1])
-      << "initial value should be (0, 0)";
   EXPECT_FLOAT_EQ(0, parameter.states_.front()[2])
       << "initial value should be (0, 0)";
-  EXPECT_FLOAT_EQ(0.99998301, parameter.states_.back()[1])
+  EXPECT_FLOAT_EQ(0, parameter.states_.front()[3])
+      << "initial value should be (0, 0)";
+  EXPECT_FLOAT_EQ(0.99998301, parameter.states_.back()[2])
       << "optimal value should be (1, 1)";
-  EXPECT_FLOAT_EQ(0.99996597, parameter.states_.back()[2])
+  EXPECT_FLOAT_EQ(0.99996597, parameter.states_.back()[3])
       << "optimal value should be (1, 1)";
   EXPECT_FLOAT_EQ(return_code, 0);
   EXPECT_EQ(22, interrupt.call_count());

--- a/src/test/unit/services/optimize/newton_jacobian_test.cpp
+++ b/src/test/unit/services/optimize/newton_jacobian_test.cpp
@@ -32,10 +32,11 @@ TEST_F(ServicesOptimize, withJacobian) {
 
   EXPECT_FLOAT_EQ(return_code, 0);
 
-  ASSERT_EQ(2, parameter.names_.size());
+  ASSERT_EQ(3, parameter.names_.size());
   EXPECT_EQ("lp__", parameter.names_[0]);
-  EXPECT_EQ("sigma", parameter.names_[1]);
-  EXPECT_NEAR((3 + std::sqrt(13)) / 2, parameter.states_.back()[1], 0.001);
+  EXPECT_EQ("converged__", parameter.names_[1]);
+  EXPECT_EQ("sigma", parameter.names_[2]);
+  EXPECT_NEAR((3 + std::sqrt(13)) / 2, parameter.states_.back()[2], 0.001);
   EXPECT_GT(interrupt.call_count(), 0);
 }
 
@@ -54,9 +55,10 @@ TEST_F(ServicesOptimize, withoutJacobian) {
 
   EXPECT_FLOAT_EQ(return_code, 0);
 
-  ASSERT_EQ(2, parameter.names_.size());
+  ASSERT_EQ(3, parameter.names_.size());
   EXPECT_EQ("lp__", parameter.names_[0]);
-  EXPECT_EQ("sigma", parameter.names_[1]);
-  EXPECT_NEAR(3, parameter.states_.back()[1], 0.001);
+  EXPECT_EQ("converged__", parameter.names_[1]);
+  EXPECT_EQ("sigma", parameter.names_[2]);
+  EXPECT_NEAR(3, parameter.states_.back()[2], 0.001);
   EXPECT_GT(interrupt.call_count(), 0);
 }

--- a/src/test/unit/services/optimize/newton_test.cpp
+++ b/src/test/unit/services/optimize/newton_test.cpp
@@ -36,19 +36,20 @@ TEST_F(ServicesOptimize, rosenbrock) {
   EXPECT_EQ(1, logger.find("Initial log joint probability = -1"));
   EXPECT_EQ(1, logger.find("Iteration  1. Log joint probability ="));
 
-  ASSERT_EQ(3, parameter.names_.size());
+  ASSERT_EQ(4, parameter.names_.size());
   EXPECT_EQ("lp__", parameter.names_[0]);
-  EXPECT_EQ("x", parameter.names_[1]);
-  EXPECT_EQ("y", parameter.names_[2]);
+  EXPECT_EQ("converged__", parameter.names_[1]);
+  EXPECT_EQ("x", parameter.names_[2]);
+  EXPECT_EQ("y", parameter.names_[3]);
 
   EXPECT_GT(parameter.states_.size(), 0);
-  EXPECT_FLOAT_EQ(0, parameter.states_.front()[1])
-      << "initial value should be (0, 0)";
   EXPECT_FLOAT_EQ(0, parameter.states_.front()[2])
       << "initial value should be (0, 0)";
-  EXPECT_NEAR(1, parameter.states_.back()[1], 1e-3)
-      << "optimal value should be (1, 1)";
+  EXPECT_FLOAT_EQ(0, parameter.states_.front()[3])
+      << "initial value should be (0, 0)";
   EXPECT_NEAR(1, parameter.states_.back()[2], 1e-3)
+      << "optimal value should be (1, 1)";
+  EXPECT_NEAR(1, parameter.states_.back()[3], 1e-3)
       << "optimal value should be (1, 1)";
   EXPECT_FLOAT_EQ(return_code, 0);
   EXPECT_LT(0, interrupt.call_count());
@@ -75,15 +76,16 @@ TEST_F(ServicesOptimize, rosenbrock_no_save_iterations) {
 
   EXPECT_EQ("0,0\n", init_ss.str());
 
-  ASSERT_EQ(3, parameter.names_.size());
+  ASSERT_EQ(4, parameter.names_.size());
   EXPECT_EQ("lp__", parameter.names_[0]);
-  EXPECT_EQ("x", parameter.names_[1]);
-  EXPECT_EQ("y", parameter.names_[2]);
+  EXPECT_EQ("converged__", parameter.names_[1]);
+  EXPECT_EQ("x", parameter.names_[2]);
+  EXPECT_EQ("y", parameter.names_[3]);
 
   EXPECT_EQ(1, parameter.states_.size());
-  EXPECT_NEAR(1, parameter.states_.back()[1], 1e-3)
-      << "optimal value should be (1, 1)";
   EXPECT_NEAR(1, parameter.states_.back()[2], 1e-3)
+      << "optimal value should be (1, 1)";
+  EXPECT_NEAR(1, parameter.states_.back()[3], 1e-3)
       << "optimal value should be (1, 1)";
   EXPECT_FLOAT_EQ(return_code, 0);
   EXPECT_LT(0, interrupt.call_count());


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

This adds a second column of diagnostic parameters to the optimize algorithms, `converged__`, which corresponds to the
per-iteration return of the algorithm (e.g., `0` is a sucessful step but not done, `-1` is a failure, positive numbers indicate different convergence criteria hit). These values are defined in `stan::optimize::TerminationCondition`

It also adds the message associated with the final value, which is currently printed to stdout, as a trailing comment in the CSV file

#### Intended Effect

Allow consumers of the output files to understand if optimization converged, c.f. https://github.com/stan-dev/cmdstanpy/pull/851#issuecomment-4256988417

#### How to Verify

#### Side Effects

#### Documentation

I will update the documentation for cmdstan after this is merged.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
