### PR TITLE
Fix ps_point reserve capacity

### DIFF
--- a/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/ps_point.hpp
@@ -24,7 +24,7 @@ class ps_point {
 
   virtual inline void get_param_names(std::vector<std::string>& model_names,
                                       std::vector<std::string>& names) {
-    names.reserve(q.size() + p.size() + g.size());
+    names.reserve(names.size() + q.size() + p.size() + g.size());
     for (int i = 0; i < q.size(); ++i)
       names.emplace_back(model_names[i]);
     for (int i = 0; i < p.size(); ++i)
@@ -34,7 +34,7 @@ class ps_point {
   }
 
   virtual inline void get_params(std::vector<double>& values) {
-    values.reserve(q.size() + p.size() + g.size());
+    values.reserve(values.size() + q.size() + p.size() + g.size());
     for (int i = 0; i < q.size(); ++i)
       values.push_back(q[i]);
     for (int i = 0; i < p.size(); ++i)

--- a/src/test/unit/mcmc/hmc/hamiltonians/ps_point_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/ps_point_test.cpp
@@ -21,5 +21,30 @@ TEST(psPoint, write_metric_streams) {
   EXPECT_EQ("", stan::test::cerr_ss.str());
 }
 
+TEST(psPoint, get_param_names_appends_to_existing_names) {
+  ps_point point(2);
+  std::vector<std::string> model_names{"alpha", "beta"};
+  std::vector<std::string> names{"lp__"};
+
+  point.get_param_names(model_names, names);
+
+  std::vector<std::string> expected{"lp__",   "alpha",   "beta",  "p_alpha",
+                                    "p_beta", "g_alpha", "g_beta"};
+  EXPECT_EQ(expected, names);
+}
+
+TEST(psPoint, get_params_appends_to_existing_values) {
+  ps_point point(2);
+  point.q << 1.0, 2.0;
+  point.p << 3.0, 4.0;
+  point.g << 5.0, 6.0;
+  std::vector<double> values{-1.0};
+
+  point.get_params(values);
+
+  std::vector<double> expected{-1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+  EXPECT_EQ(expected, values);
+}
+
 }  // namespace mcmc
 }  // namespace stan


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes https://github.com/stan-dev/stan/issues/3384 and adds `names.size()` to string reserve

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simons Foundation



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
