### PR TITLE
Fix ambiguity with size_t on 32-bit platforms

### DIFF
--- a/src/stan/callbacks/structured_writer.hpp
+++ b/src/stan/callbacks/structured_writer.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_CALLBACKS_STRUCTURED_WRITER_HPP
 #define STAN_CALLBACKS_STRUCTURED_WRITER_HPP
 
+#include <cstdint>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <vector>
 #include <string>
@@ -65,11 +66,11 @@ class structured_writer {
   virtual void write(const std::string& key, int value) {}
 
   /**
-   * Write a key-value pair where the value is an `std::size_t`.
+   * Write a key-value pair where the value is an `uint64_t`.
    * @param key Name of the value pair
-   * @param value `std::size_t` to write.
+   * @param value `uint64_t` to write.
    */
-  virtual void write(const std::string& key, std::size_t value) {}
+  virtual void write(const std::string& key, uint64_t value) {}
 
   /**
    * Write a key-value pair where the value is an `long long int`.
@@ -85,7 +86,7 @@ class structured_writer {
    * @param key Name of the value pair
    * @param value `unsigned int` to write.
    */
-  virtual void write(const std::string& key, unsigned int value) {}
+  virtual void write(const std::string& key, uint32_t value) {}
 
   /**
    * Write a key-value pair where the value is a double.


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

I'm seeing a compilation failure with some downstream packaging on 32-bit systems:

```
../inst/include/stan/callbacks/structured_writer.hpp:88:16: error: class member cannot be redeclared
   88 |   virtual void write(const std::string& key, unsigned int value) {}
      |                ^
../inst/include/stan/callbacks/structured_writer.hpp:72:16: note: previous definition is here
   72 |   virtual void write(const std::string& key, std::size_t value) {}
```

Which is because `std::size_t` is an `unsigned int` on 32 bit. This PR just changes the overloads to explicit sized-types

#### Intended Effect

Fix compilation on 32-bit

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
