### PR TITLE
Migration to new jenkins system

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,6 @@ properties([
 def image = 'stanorg/ci:v1'
 def commit
 def runRemainingStages = false
-def runOpenCL = false
 def LINUX_CXX = 'clang++-7 -Werror -Wno-inconsistent-missing-override -Wno-error=return-type -Wno-error=division-by-zero'
 def WIN_CXX = 'g++ -Werror -Wno-error=overloaded-virtual -Wno-error=template-id-cdtor -Wno-error=deprecated-declarations -Wno-error=cast-user-defined -Wno-error=unused-value -Wno-error=array-bounds'
 def MAC_CXX = 'clang++' // -Werror -Wno-inconsistent-missing-override -Wno-unused-but-set-variable
@@ -44,7 +43,6 @@ catchError {
           'lib/stan_math/stan', 'lib/stan_math/make', 'lib/stan_math/lib', 'lib/stan_math/test',
           'lib/stan_math/runTests.py', 'lib/stan_math/runChecks.py', 'lib/stan_math/makefile',
           'lib/stan_math/Jenkinsfile', 'lib/stan_math/.clang-format')
-        runOpenCL = params.downstream || params.run_all || filesChanged('src/stan/model/indexing')
       }
 
       stage("Clang-format") {
@@ -131,6 +129,7 @@ up the autoformatter locally.  (Check console output at ${env.BUILD_URL})
 STAN_OPENCL=true
 OPENCL_PLATFORM_ID=0
 OPENCL_DEVICE_ID=0
+LDFLAGS_OPENCL=-L/usr/local/cuda/targets/x86_64-linux/lib
 """)
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,11 +150,19 @@ LDFLAGS_OPENCL=-L/usr/local/cuda/targets/x86_64-linux/lib
         def integration_tests_flags = params.compile_all_models ? '--no-ignore-models' : ''
         def runIntegration = { args ->
           def pre = args.pre ?: ''
+          deleteDir()
+          checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/performance-tests-cmdstan']],
+            extensions: [cloneOption(shallow: true, depth: 2), submodule(recursiveSubmodules: true, shallow: true, depth: 32)])
+          dir('stanc3') {
+            checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/stanc3']],
+              extensions: [cloneOption(shallow: true, depth: 8)])
+          }
+          checkoutPR('cmdstan', params.cmdstan_pr)
           dir('cmdstan/stan') {
             checkout scm
-            writeFile(file: 'make/local', text: stanc3_bin_url) // only used on linux
+            writeFile(file: 'make/local', text: stanc3_bin_url)
           }
-          writeFile(file: 'cmdstan/make/local', text: args.local)
+          writeFile(file: 'cmdstan/make/local', text: args.local+"\n$stanc3_bin_url")
           batsh pre + """
             make -C cmdstan -j\$PARALLEL build
             python3 ./runPerformanceTests.py -j\$PARALLEL $integration_tests_flags --runs=0 stanc3/test/integration/good
@@ -172,32 +180,20 @@ LDFLAGS_OPENCL=-L/usr/local/cuda/targets/x86_64-linux/lib
         parallel linux: {
           runPod(image: image, checkout: false, cpus: 16, memory: '128Gi') {
             stage('Integration Linux') {
-              checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/performance-tests-cmdstan']],
-                extensions: [cloneOption(shallow: true, depth: 2), submodule(recursiveSubmodules: true, shallow: true, depth: 2)])
-              /* not sure why only linux does these: */
-              dir('stanc3') {
-                checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/stanc3']],
-                  extensions: [cloneOption(shallow: true, depth: 2)])
-              }
-              checkoutPR('cmdstan', params.cmdstan_pr)
-              runIntegration(local: "O=0\nCXX=${LINUX_CXX}\n$stanc3_bin_url")
+              runIntegration(local: "O=0\nCXX=${LINUX_CXX}")
             }
           }
         }, mac: {
           if (!params.downstream && (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME == 'master') || params.run_tests_all_os) {
             node('macos') {
               stage('Integration Mac') {
-                checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/performance-tests-cmdstan']],
-                  extensions: [cleanBeforeCheckout(), cloneOption(shallow: true, depth: 2), submodule(recursiveSubmodules: true, shallow: true, depth: 2)])
-                runIntegration(local: "O=0\nCXX=${MAC_CXX}\n")
+                runIntegration(local: "O=0\nCXX=${MAC_CXX}")
               }
             }
           }
         }, windows: {
           node('windows') {
             stage('Integration Windows') {
-              checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/performance-tests-cmdstan']],
-                extensions: [cleanBeforeCheckout(), cloneOption(shallow: true, depth: 2), submodule(recursiveSubmodules: true, shallow: true, depth: 2)])
               withEnv(["PATH+TBB=${WORKSPACE}\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb"]) {
                 runIntegration(local: "CXX=${WIN_CXX}\nPRECOMPILED_HEADERS=true\n", pre: WINSETENV)
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,7 +170,7 @@ LDFLAGS_OPENCL=-L/usr/local/cuda/targets/x86_64-linux/lib
         }
 
         parallel linux: {
-          runPod(image: image, checkout: false) {
+          runPod(image: image, checkout: false, cpus: 16, memory: '128Gi') {
             stage('Integration Linux') {
               checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/performance-tests-cmdstan']],
                 extensions: [cloneOption(shallow: true, depth: 2), submodule(recursiveSubmodules: true, shallow: true, depth: 2)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,526 +1,239 @@
-@Library('StanUtils')
-import org.stan.Utils
+properties([
+  disableConcurrentBuilds(abortPrevious: !params.downstream),
+  buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '30')),
+  parameters([
+    string(defaultValue: '', name: 'math_pr', description: "Leave blank "
+            + "unless testing against a specific math repo pull request, "
+            + "e.g. PR-640."),
+    string(defaultValue: 'develop', name: 'cmdstan_pr',
+      description: 'PR to test CmdStan upstream against e.g. PR-630'),
+    string(defaultValue: 'nightly', name: 'stanc3_bin_url',
+      description: 'Custom stanc3 binary url'),
+    booleanParam(defaultValue: false, name: 'downsteam', description: 'Run downstream tests from math (was previously downstream_hotfix/downstream_tests [develop])'),
+    booleanParam(defaultValue: false, name: 'run_tests_all_os', description: 'Run unit and integration tests on all OS.'),
+    booleanParam(defaultValue: false, name: 'compile_all_models', description: 'Run integration tests on the full test model suite.'),
+    booleanParam(defaultValue: false, name: 'run_all', description: 'Pretend all files changes'),
+  ])
+])
 
-def utils = new org.stan.Utils()
-def skipRemainingStages = false
-def skipOpenCL = false
+def commit
+def runRemainingStages = false
+def runOpenCL = false
+def LINUX_CXX = 'clang++-6.0 -Werror -Wno-inconsistent-missing-override -Wno-error=return-type -Wno-error=division-by-zero'
+def WIN_CXX = 'g++ -Werror -Wno-error=overloaded-virtual -Wno-error=template-id-cdtor -Wno-error=deprecated-declarations -Wno-error=cast-user-defined -Wno-error=unused-value -Wno-error=array-bounds'
+def MAC_CXX = 'clang++' // -Werror -Wno-inconsistent-missing-override -Wno-unused-but-set-variable
+def WINSETENV = '''
+  SET "PATH=%RTOOLS%\\x86_64-w64-mingw32.static.posix\\bin;%RTOOLS%;%RTOOLS%\\usr\\bin;%CONDA%;%PATH%"
+'''
+def stanc3_bin_url = params.stanc3_bin_url != "nightly" ? "STANC3_TEST_BIN_URL=${params.stanc3_bin_url}\n" : ''
 
-def setupCXX(failOnError = true, CXX = CXX, String stanc3_bin_url = "nightly") {
-    errorStr = failOnError ? "-Werror " : ""
-    stanc3_bin_url_str = stanc3_bin_url != "nightly" ? "\nSTANC3_TEST_BIN_URL=${stanc3_bin_url}\n" : ""
-    writeFile(file: "make/local", text: "CXX=${CXX} -Wno-inconsistent-missing-override ${errorStr}${stanc3_bin_url_str}")
-}
+catchError {
+  withEnv([
+    'GCC=g++',
+    'GIT_AUTHOR_NAME=Stan Jenkins',
+    'GIT_AUTHOR_EMAIL=mc.stanislaw@gmail.com',
+    'GIT_COMMITTER_NAME=Stan Jenkins',
+    'GIT_COMMITTER_EMAIL=mc.stanislaw@gmail.com'
+  ]) {
+    runPod(image: "stanorg/ci:gpu", cpus: 2) {
+      stage('Verify changes') {
+        commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+        runRemainingStages = params.downstream || params.run_all || filesChanged(
+          'make', 'src/stan', 'src/test', 'Jenkinsfile', 'makefile', 'runTests.py',
+          'lib/stan_math/stan', 'lib/stan_math/make', 'lib/stan_math/lib', 'lib/stan_math/test',
+          'lib/stan_math/runTests.py', 'lib/stan_math/runChecks.py', 'lib/stan_math/makefile',
+          'lib/stan_math/Jenkinsfile', 'lib/stan_math/.clang-format')
+        runOpenCL = params.downstream || params.run_all || filesChanged('src/stan/model/indexing')
+      }
 
-def runTests(String testPath, Boolean separateMakeStep=true) {
-    if (separateMakeStep) {
-        sh "python3 runTests.py -j${PARALLEL} ${testPath} --make-only"
+      stage("Clang-format") {
+        def dirty = sh returnStatus: true, script: """
+          clang-format --version
+          git ls-files 'src/*.hpp' 'src/*.cpp' | xargs -n20 -P\$PARALLEL clang-format -i
+          git diff --exit-code
+        """
+        if (dirty) {
+          def branch = env.CHANGE_BRANCH ?: env.BRANCH_NAME
+          def repo = env.CHANGE_FORK ?: "stan-dev"
+          if (!("/" in repo))
+            repo += "/stan.git"
+          echo "Exiting build because clang-format found changes."
+          emailext (
+              subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
+              body: """
+Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' has been autoformatted and the
+changes committed to your branch, if permissions allowed.  Please pull these
+changes before continuing.
+
+See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms for setting
+up the autoformatter locally.  (Check console output at ${env.BUILD_URL})
+""",
+              recipientProviders: [[$class: 'RequesterRecipientProvider']],
+              to: env.CHANGE_AUTHOR_EMAIL)
+          sh '''
+            git add -u src
+            git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
+          '''
+          gitPush(gitScm: scmGit(
+              userRemoteConfigs: [[credentialsId: "stan-github", name: 'dest', url: "https://github.com/$repo"]],
+              branches: [[name: "refs/heads/$branch"]]),
+              targetBranch: branch,
+              targetRepo: 'dest')
+          echo "Those changes are now found on stan-dev/stan under $repo branch $branch"
+          echo "Please 'git pull' before continuing to develop."
+          error "clang-format changes"
+        }
+      }
+
+      stage('Linting & Doc checks') {
+        checkoutPR("lib/stan_math", params.math_pr)
+        writeFile(file: "make/local", text: "CXX=$LINUX_CXX\n$stanc3_bin_url")
+        parallel(
+          CppLint: { sh "make cpplint" },
+          API_docs: { sh 'make doxygen' },
+        )
+      }
     }
-    try { sh "python3 runTests.py -j${PARALLEL} ${testPath}" }
-    finally { junit 'test/**/*.xml' }
-}
 
-def runTestsWin(String testPath, Boolean separateMakeStep=true) {
-    withEnv(['PATH+TBB=./lib/stan_math/lib/tbb']) {
-       if (separateMakeStep) {
-           bat """
-            SET \"PATH=C:\\Users\\jenkins\\Anaconda3;%PATH%\"
-            SET \"PATH=${env.RTOOLS40_HOME};%PATH%\"
-            SET \"PATH=${env.RTOOLS40_HOME}\\usr\\bin;${LLVM7}\\bin;%PATH%\" //
-            SET \"PATH=${env.RTOOLS40_HOME}\\mingw64\\bin;%PATH%\"
-            SET \"PATH=C:\\PROGRA~1\\R\\R-4.1.2\\bin;%PATH%\"
-            SET \"PATH=C:\\PROGRA~1\\Microsoft^ MPI\\Bin;%PATH%\"
-            SET \"MPI_HOME=C:\\PROGRA~1\\Microsoft^ MPI\\Bin\"
-            python runTests.py -j${PARALLEL} ${testPath} --make-only
-           """
-       }
-       try {
-            bat """
-                SET \"PATH=C:\\Users\\jenkins\\Anaconda3;%PATH%\"
-                SET \"PATH=${env.RTOOLS40_HOME};%PATH%\"
-                SET \"PATH=${env.RTOOLS40_HOME}\\usr\\bin;${LLVM7}\\bin;%PATH%\" //
-                SET \"PATH=${env.RTOOLS40_HOME}\\mingw64\\bin;%PATH%\"
-                SET \"PATH=C:\\PROGRA~1\\R\\R-4.1.2\\bin;%PATH%\"
-                SET \"PATH=C:\\PROGRA~1\\Microsoft^ MPI\\Bin;%PATH%\"
-                SET \"MPI_HOME=C:\\PROGRA~1\\Microsoft^ MPI\\Bin\"
-                python runTests.py -j${PARALLEL} ${testPath}
+    if (runRemainingStages) {
+      stage('Unit tests') {
+        def runUnit = { args ->
+          def local = "CXX=$args.cxx\n$stanc3_bin_url"
+          if (args.local)
+            local += args.local
+          writeFile(file: "make/local", text: local)
+          def pre = args.pre ?: ''
+          batsh(pre + 'make -j$PARALLEL test-headers')
+          batsh(pre + 'python3 runTests.py -j$PARALLEL src/test/unit --make-only')
+          catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
+            batsh(pre + 'python3 runTests.py -j$PARALLEL src/test/unit')
+          }
+          junit 'test/**/*.xml'
+        }
+
+        parallel windows: {
+          node('windows') {
+            stage('Windows Headers & Unit') {
+              checkout scm
+              bat """$WINSETENV
+                  make -f lib/stan_math/make/standalone math-libs
+              """
+              withEnv(["PATH+TBB=$WORKSPACE\\lib\\stan_math\\lib\\tbb"]) {
+                runUnit(cxx: WIN_CXX, pre: WINSETENV)
+              }
+            }
+          }
+        }, linux: {
+          runPod(image: "stanorg/ci:gpu", gpus: 1) {
+            stage('Linux Unit') {
+              runUnit(cxx: LINUX_CXX, local: """
+STAN_OPENCL=true
+OPENCL_PLATFORM_ID=0
+OPENCL_DEVICE_ID=0
+""")
+            }
+          }
+        }, mac: {
+          if (!params.downstream && (env.BRANCH_NAME == "develop" || env.BRANCH_NAME == "master") || params.run_tests_all_os) {
+            node('macos') {
+              stage('Mac Unit') {
+                checkout scm
+                runUnit(cxx: MAC_CXX)
+              }
+            }
+          }
+        }
+      }
+
+      stage('Integration') {
+        // TODO: this was disabled before
+        def integration_tests_flags = params.compile_all_models ? '--no-ignore-models' : ''
+        def runIntegration = { args ->
+          def pre = args.pre ?: ''
+          dir('cmdstan/stan') {
+            checkout scm
+            writeFile(file: 'make/local', text: stanc3_bin_url) // only used on linux
+          }
+          writeFile(file: 'cmdstan/make/local', text: args.local)
+          batsh pre + """
+            make -C cmdstan -j\$PARALLEL build
+            python3 ./runPerformanceTests.py -j\$PARALLEL $integration_tests_flags --runs=0 stanc3/test/integration/good
+            python3 ./runPerformanceTests.py -j\$PARALLEL $integration_tests_flags --runs=0 example-models
+          """
+          dir('cmdstan/stan') {
+            batsh pre + """
+                python3 ./runTests.py src/test/integration/compile_standalone_functions_test.cpp
+                python3 ./runTests.py src/test/integration/standalone_functions_test.cpp
+                python3 ./runTests.py src/test/integration/multiple_translation_units_test.cpp
             """
-       }
-       finally { junit 'test/**/*.xml' }
-    }
-}
-
-def deleteDirWin() {
-    bat "attrib -r -s /s /d"
-    deleteDir()
-}
-
-String stanc3_bin_url() { params.stanc3_bin_url ?: "nightly" }
-String cmdstan_pr() { params.cmdstan_pr ?: "downstream_tests" }
-String stan_pr() {
-    if (env.BRANCH_NAME == 'downstream_tests') {
-        ''
-    } else if (env.BRANCH_NAME == 'downstream_hotfix') {
-        'master'
-    } else {
-        env.BRANCH_NAME
-    }
-}
-String integration_tests_flags() {
-    if (params.compile_all_model) {
-        '--no-ignore-models '
-    } else {
-        ''
-    }
-}
-
-def isBranch(String b) { env.BRANCH_NAME == b }
-Boolean isPR() { env.CHANGE_URL != null }
-String fork() { env.CHANGE_FORK ?: "stan-dev" }
-String branchName() { isPR() ? env.CHANGE_BRANCH :env.BRANCH_NAME }
-
-pipeline {
-    agent none
-    parameters {
-        string(defaultValue: '', name: 'math_pr', description: "Leave blank "
-                + "unless testing against a specific math repo pull request, "
-                + "e.g. PR-640.")
-        string(defaultValue: 'downstream_tests', name: 'cmdstan_pr',
-          description: 'PR to test CmdStan upstream against e.g. PR-630')
-        string(defaultValue: 'nightly', name: 'stanc3_bin_url',
-          description: 'Custom stanc3 binary url')
-        booleanParam(defaultValue: false, name: 'run_tests_all_os', description: 'Run unit and integration tests on all OS.')
-        booleanParam(defaultValue: false, name: 'compile_all_models', description: 'Run integration tests on the full test model suite.')
-    }
-    options {
-        skipDefaultCheckout()
-        preserveStashes(buildCount: 7)
-        parallelsAlwaysFailFast()
-        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '30'))
-        disableConcurrentBuilds(abortPrevious: env.BRANCH_NAME != "downstream_tests" && env.BRANCH_NAME != "downstream_hotfix")
-    }
-    environment {
-        GCC = 'g++'
-        PARALLEL = 4
-        MAC_CXX = 'clang++'
-        LINUX_CXX = 'clang++-6.0'
-        WIN_CXX = 'g++'
-        GIT_AUTHOR_NAME = 'Stan Jenkins'
-        GIT_AUTHOR_EMAIL = 'mc.stanislaw@gmail.com'
-        GIT_COMMITTER_NAME = 'Stan Jenkins'
-        GIT_COMMITTER_EMAIL = 'mc.stanislaw@gmail.com'
-        OPENCL_DEVICE_ID_CPU = 0
-        OPENCL_DEVICE_ID_GPU = 0
-        OPENCL_PLATFORM_ID = 1
-        OPENCL_PLATFORM_ID_CPU = 0
-        OPENCL_PLATFORM_ID_GPU = 0
-    }
-    stages {
-        stage("Clang-format") {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
-            }
-            steps {
-                retry(3) { checkout scm }
-                withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                    usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                    sh """#!/bin/bash
-                        set -x
-                        git checkout -b ${branchName()}
-                        clang-format --version
-                        find src -name '*.hpp' -o -name '*.cpp' | xargs -n20 -P${PARALLEL} clang-format -i
-                        if [[ `git diff` != "" ]]; then
-                            git config user.email "mc.stanislaw@gmail.com"
-                            git config user.name "Stan Jenkins"
-                            git add src
-                            git commit -m "[Jenkins] auto-formatting by `clang-format --version`"
-                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/stan.git ${branchName()}
-                            echo "Exiting build because clang-format found changes."
-                            echo "Those changes are now found on stan-dev/stan under branch ${branchName()}"
-                            echo "Please 'git pull' before continuing to develop."
-                            exit 1
-                        fi
-                    """
-                }
-            }
-            post {
-                always { deleteDir() }
-                failure {
-                    script {
-                        emailext (
-                            subject: "[StanJenkins] Autoformattted: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
-                            body: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' " +
-                                "has been autoformatted and the changes committed " +
-                                "to your branch, if permissions allowed." +
-                                "Please pull these changes before continuing." +
-                                "\n\n" +
-                                "See https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms" +
-                                " for setting up the autoformatter locally.\n"+
-                            "(Check console output at ${env.BUILD_URL})",
-                            recipientProviders: [[$class: 'RequesterRecipientProvider']],
-                            to: "${env.CHANGE_AUTHOR_EMAIL}"
-                        )
-                    }
-                }
-            }
+          }
         }
-        stage('Linting & Doc checks') {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
+
+        parallel linux: {
+          runPod(image: 'stanorg/ci:gpu', checkout: false) {
+            stage('Integration Linux') {
+              checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/performance-tests-cmdstan']],
+                extensions: [cloneOption(shallow: true, depth: 2), submodule(recursiveSubmodules: true, shallow: true, depth: 2)])
+              /* not sure why only linux does these: */
+              dir('stanc3') {
+                checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/stanc3']],
+                  extensions: [cloneOption(shallow: true, depth: 2)])
+              }
+              checkoutPR('cmdstan', params.cmdstan_pr)
+              runIntegration(local: "O=0\nCXX=${LINUX_CXX}\n$stanc3_bin_url")
             }
-            steps {
-                script {
-                    retry(3) { checkout scm }
-                    sh """
-                       make math-revert
-                       make clean-all
-                       git clean -xffd
-                    """
-                    utils.checkout_pr("math", "lib/stan_math", params.math_pr)
-                    stash 'StanSetup'
-                    setupCXX(true, LINUX_CXX)
-                    parallel(
-                        CppLint: { sh "make cpplint" },
-                        API_docs: { sh 'make doxygen' },
-                    )
-                }
+          }
+        }, mac: {
+          if (!params.downstream && (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME == 'master') || params.run_tests_all_os) {
+            node('macos') {
+              stage('Integration Mac') {
+                checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/performance-tests-cmdstan']],
+                  extensions: [cleanBeforeCheckout(), cloneOption(shallow: true, depth: 2), submodule(recursiveSubmodules: true, shallow: true, depth: 2)])
+                runIntegration(local: "O=0\nCXX=${MAC_CXX}\n")
+              }
             }
-            post {
-                always {
-                    recordIssues(
-                        id: "lint_doc_checks",
-                        name: "Linting & Doc checks",
-                        enabledForFailure: true,
-                        aggregatingResults : true,
-                        tools: [
-                            cppLint(id: "cpplint", name: "Linting & Doc checks@CPPLINT")
-                        ],
-                        qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]],
-                        healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH'
-                    )
-                    deleteDir()
-                }
+          }
+        }, windows: {
+          node('windows') {
+            stage('Integration Windows') {
+              checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/performance-tests-cmdstan']],
+                extensions: [cleanBeforeCheckout(), cloneOption(shallow: true, depth: 2), submodule(recursiveSubmodules: true, shallow: true, depth: 2)])
+              withEnv(["PATH+TBB=${WORKSPACE}\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb"]) {
+                runIntegration(local: "CXX=${WIN_CXX}\nPRECOMPILED_HEADERS=true\n", pre: WINSETENV)
+              }
             }
+          }
         }
-        stage('Verify changes') {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
-            }
-            steps {
-                script {
+      }
 
-                    retry(3) { checkout scm }
-                    sh 'git clean -xffd'
-
-                    // These paths will be passed to git diff
-                    // If there are changes to them, CI/CD will continue else skip
-                    def paths = ['make', 'src/stan', 'src/test', 'Jenkinsfile', 'makefile', 'runTests.py',
-                        'lib/stan_math/stan', 'lib/stan_math/make', 'lib/stan_math/lib', 'lib/stan_math/test',
-                        'lib/stan_math/runTests.py', 'lib/stan_math/runChecks.py', 'lib/stan_math/makefile',
-                        'lib/stan_math/Jenkinsfile', 'lib/stan_math/.clang-format'
-                    ].join(" ")
-
-                    skipRemainingStages = utils.verifyChanges(paths)
-
-                    def openCLPaths = ['src/stan/model/indexing'].join(" ")
-                    skipOpenCL = utils.verifyChanges(openCLPaths)
-                }
-            }
-            post {
-                always {
-                    deleteDir()
-                }
-            }
-        }
-        stage('Unit tests') {
-            when {
-                expression {
-                    !skipRemainingStages
-                }
-            }
-            parallel {
-                stage('Windows Headers & Unit') {
-                    agent { label 'windows' }
-                    when {
-                        expression {
-                            !skipRemainingStages
-                        }
-                    }
-                    steps {
-                        deleteDirWin()
-                            unstash 'StanSetup'
-                            bat """
-                                SET \"PATH=${env.RTOOLS40_HOME};%PATH%\"
-                                SET \"PATH=${env.RTOOLS40_HOME}\\usr\\bin;${LLVM7}\\bin;%PATH%\" //
-                                SET \"PATH=${env.RTOOLS40_HOME}\\mingw64\\bin;%PATH%\"
-                                SET \"PATH=C:\\PROGRA~1\\R\\R-4.1.2\\bin;%PATH%\"
-                                SET \"PATH=C:\\PROGRA~1\\Microsoft^ MPI\\Bin;%PATH%\"
-                                SET \"MPI_HOME=C:\\PROGRA~1\\Microsoft^ MPI\\Bin\"
-                                make.exe -f lib/stan_math/make/standalone math-libs
-                                make.exe -j${PARALLEL} test-headers
-                            """
-                            setupCXX(false, WIN_CXX, stanc3_bin_url())
-                            runTestsWin("src/test/unit")
-                    }
-                    post { always { deleteDirWin() } }
-                }
-                stage('Linux Unit') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu'
-                            label 'linux && gpu'
-                            args '--pull always --gpus 1'
-                        }
-                    }
-                    steps {
-                        unstash 'StanSetup'
-                        setupCXX(true, LINUX_CXX, stanc3_bin_url())
-                        sh """
-                            echo STAN_OPENCL=true > make/local
-                            echo OPENCL_PLATFORM_ID=${OPENCL_PLATFORM_ID_GPU} >> make/local
-                            echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID_GPU} >> make/local
-                        """
-                        sh """
-                            make -j${PARALLEL} test-headers
-                        """
-                        runTests("src/test/unit")
-                    }
-                    post { always { deleteDir() } }
-                }
-                stage('Mac Unit') {
-                agent { label 'osx' }
-                    when {
-                        expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ||
-                            params.run_tests_all_os ) &&
-                            !skipRemainingStages
-                        }
-                    }
-                    steps {
-                        unstash 'StanSetup'
-                        setupCXX(false, MAC_CXX, stanc3_bin_url())
-                        runTests("src/test/unit")
-                    }
-                    post { always { deleteDir() } }
-                }
-            }
-        }
-        stage('Integration') {
-            when {
-                expression {
-                    !skipRemainingStages
-                }
-            }
-            parallel {
-                stage('Integration Linux') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:gpu'
-                            label 'linux'
-                        }
-                    }
-                    steps {
-                        sh """
-                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
-                            git clone https://github.com/stan-dev/stanc3/ performance-tests-cmdstan/stanc3
-                        """
-                        script {
-                            if (params.cmdstan_pr != 'downstream_tests') {
-                                if(params.cmdstan_pr.contains("PR-")){
-                                    pr_number = params.cmdstan_pr.split("-")[1]
-                                    sh """
-                                        cd performance-tests-cmdstan/cmdstan
-                                        git fetch origin pull/${pr_number}/head:pr/${pr_number}
-                                        git checkout pr/${pr_number}
-                                    """
-                                }else{
-                                    sh """
-                                        cd performance-tests-cmdstan/cmdstan
-                                        git checkout develop && git pull && git checkout ${params.cmdstan_pr}
-                                    """
-                                }
-                            }
-                            if (params.stanc3_bin_url != 'nightly') {
-                                sh """
-                                    cd performance-tests-cmdstan/cmdstan
-                                    echo 'STANC3_TEST_BIN_URL=${params.stanc3_bin_url}' >> make/local
-                                """
-                            }
-                        }
-                        dir('performance-tests-cmdstan/cmdstan/stan'){
-                            unstash 'StanSetup'
-                            script {
-                                if (params.stanc3_bin_url != 'nightly') {
-                                    sh """
-                                        echo 'STANC3_TEST_BIN_URL=${params.stanc3_bin_url}' >> make/local
-                                    """
-                                }
-                            }
-                        }
-                        sh """
-                            cd performance-tests-cmdstan/cmdstan
-                            echo 'O=0' >> make/local
-                            echo 'CXX=${LINUX_CXX}' >> make/local
-                            make clean-all
-                            make -j${PARALLEL} build
-                            cd ..
-                            python3 ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good
-                            python3 ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 example-models
-                        """
-                        sh """
-                            cd performance-tests-cmdstan/cmdstan/stan
-                            python3 ./runTests.py src/test/integration/compile_standalone_functions_test.cpp
-                            python3 ./runTests.py src/test/integration/standalone_functions_test.cpp
-                            python3 ./runTests.py src/test/integration/multiple_translation_units_test.cpp
-                        """
-                    }
-                    post { always { deleteDir() } }
-                }
-                stage('Integration Mac') {
-                    agent { label 'osx' }
-                    when {
-                        expression {
-                            ( env.BRANCH_NAME == "develop" ||
-                            env.BRANCH_NAME == "master" ||
-                            params.run_tests_all_os ) &&
-                            !skipRemainingStages
-                        }
-                    }
-                    steps {
-                        sh """
-                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
-                        """
-                        dir('performance-tests-cmdstan/cmdstan/stan'){
-                            unstash 'StanSetup'
-                        }
-                        sh """
-                            cd performance-tests-cmdstan/cmdstan
-                            echo 'O=0' >> make/local
-                            echo 'CXX=${MAC_CXX}' >> make/local
-                            make clean-all
-                            make -j${PARALLEL} build
-                            cd ..
-                            python3 ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good
-                            python3 ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 example-models
-                        """
-                        sh """
-                            cd performance-tests-cmdstan/cmdstan/stan
-                            python3 ./runTests.py src/test/integration/compile_standalone_functions_test.cpp
-                            python3 ./runTests.py src/test/integration/standalone_functions_test.cpp
-                            python3 ./runTests.py src/test/integration/multiple_translation_units_test.cpp
-                        """
-                    }
-                    post { always { deleteDir() } }
-                }
-                stage('Integration Windows') {
-                    agent { label 'windows' }
-                    when {
-                        expression {
-                            !skipRemainingStages
-                        }
-                    }
-                    steps {
-                        deleteDirWin()
-                        bat """
-                            git clone --recursive https://github.com/stan-dev/performance-tests-cmdstan
-                        """
-                        dir('performance-tests-cmdstan/cmdstan/stan'){
-                            unstash 'StanSetup'
-                        }
-                        writeFile(file: "performance-tests-cmdstan/cmdstan/make/local", text: "CXX=${WIN_CXX}\nPRECOMPILED_HEADERS=true")
-                        withEnv(["PATH+TBB=${WORKSPACE}\\performance-tests-cmdstan\\cmdstan\\stan\\lib\\stan_math\\lib\\tbb"]) {
-
-                            bat """
-                                SET \"PATH=C:\\Users\\jenkins\\Anaconda3;%PATH%\"
-                                SET \"PATH=${env.RTOOLS40_HOME};%PATH%\"
-                                SET \"PATH=${env.RTOOLS40_HOME}\\usr\\bin;${LLVM7}\\bin;%PATH%\" //
-                                SET \"PATH=${env.RTOOLS40_HOME}\\mingw64\\bin;%PATH%\"
-                                SET \"PATH=C:\\PROGRA~1\\R\\R-4.1.2\\bin;%PATH%\"
-                                SET \"PATH=C:\\PROGRA~1\\Microsoft^ MPI\\Bin;%PATH%\"
-                                SET \"MPI_HOME=C:\\PROGRA~1\\Microsoft^ MPI\\Bin\"
-                                cd performance-tests-cmdstan/cmdstan
-                                make.exe -j${PARALLEL} build
-                                cd ..
-                                python ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 stanc3/test/integration/good
-                                python ./runPerformanceTests.py -j${PARALLEL} ${integration_tests_flags()}--runs=0 example-models
-                            """
-                        }
-                        bat """
-                            SET \"PATH=C:\\Users\\jenkins\\Anaconda3;%PATH%\"
-                            SET \"PATH=${env.RTOOLS40_HOME};%PATH%\"
-                            SET \"PATH=${env.RTOOLS40_HOME}\\usr\\bin;${LLVM7}\\bin;%PATH%\" //
-                            SET \"PATH=${env.RTOOLS40_HOME}\\mingw64\\bin;%PATH%\"
-                            SET \"PATH=C:\\PROGRA~1\\R\\R-4.1.2\\bin;%PATH%\"
-                            SET \"PATH=C:\\PROGRA~1\\Microsoft^ MPI\\Bin;%PATH%\"
-                            SET \"MPI_HOME=C:\\PROGRA~1\\Microsoft^ MPI\\Bin\"
-                            cd performance-tests-cmdstan/cmdstan/stan
-                            python ./runTests.py src/test/integration/compile_standalone_functions_test.cpp
-                            python ./runTests.py src/test/integration/standalone_functions_test.cpp
-                            python ./runTests.py src/test/integration/multiple_translation_units_test.cpp
-                        """
-                    }
-                    post { always { deleteDirWin() } }
-                }
-            }
-        }
+      if (env.CHANGE_TARGET || params.downstream) {
         stage('Upstream CmdStan tests') {
-            when {
-                    expression {
-                        ( env.BRANCH_NAME ==~ /PR-\d+/ ||
-                        env.BRANCH_NAME == "downstream_tests" ||
-                        env.BRANCH_NAME == "downstream_hotfix" ) &&
-                        !skipRemainingStages
-                    }
-                }
-            steps {
-                build(job: "Stan/CmdStan/${cmdstan_pr()}",
-                      parameters: [
-                        string(name: 'stan_pr', value: stan_pr()),
-                        string(name: 'math_pr', value: params.math_pr),
-                        string(name: 'stanc3_bin_url', value: stanc3_bin_url())
-                      ])
-            }
+          build(job: "CCM/Stan/cmdstan/$params.cmdstan_pr",
+            parameters: [
+              booleanParam(name: 'downstream', value: true),
+              string(name: 'stan_pr', value: env.BRANCH_NAME),
+              string(name: 'math_pr', value: params.math_pr),
+              string(name: 'stanc3_bin_url', value: params.stanc3_bin_url)
+            ])
         }
+      }
+    }
+  }
 
-    }
-    // Below lines are commented to avoid spamming emails during migration/debug
-    post {
-        always {
-            node("linux") {
-                recordIssues(
-                    id: "pipeline",
-                    name: "Entire pipeline results",
-                    enabledForFailure: true,
-                    aggregatingResults : false,
-                    filters: [
-                        excludeFile('lib/.*')
-                    ],
-                    tools: [
-                        gcc4(id: "pipeline_gcc4", name: "GNU C Compiler"),
-                        clang(id: "pipeline_clang", name: "LLVM/Clang")
-                    ],
-                    qualityGates: [[threshold: 30, type: 'TOTAL', unstable: true]],
-                    healthy: 10, unhealthy: 100, minimumSeverity: 'HIGH'
-                )
-            }
+  if (env.BRANCH_NAME == 'develop') {
+    podTemplate(inheritFrom: 'jnlp') {
+      node(POD_LABEL) {
+        stage('Update upstream') {
+          dir('cmdstan') {
+            updateSubmodule('cmdstan', 'develop', 'stan', commit)
+          }
+          dir('rstan') {
+            updateSubmodule('rstan', 'develop', 'StanHeaders/inst/include/upstream', commit)
+          }
         }
-        success {
-            script {
-                utils.updateUpstream(env,'cmdstan')
-                utils.updateUpstream(env,'rstan')
-                utils.mailBuildResults("SUCCESSFUL")
-            }
-        }
-        unstable { script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com") } }
-        failure { script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com") } }
+      }
     }
+  }
 }
+
+emailFailure()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,10 +16,11 @@ properties([
   ])
 ])
 
+def image = 'stanorg/ci:v1'
 def commit
 def runRemainingStages = false
 def runOpenCL = false
-def LINUX_CXX = 'clang++-6.0 -Werror -Wno-inconsistent-missing-override -Wno-error=return-type -Wno-error=division-by-zero'
+def LINUX_CXX = 'clang++-7 -Werror -Wno-inconsistent-missing-override -Wno-error=return-type -Wno-error=division-by-zero'
 def WIN_CXX = 'g++ -Werror -Wno-error=overloaded-virtual -Wno-error=template-id-cdtor -Wno-error=deprecated-declarations -Wno-error=cast-user-defined -Wno-error=unused-value -Wno-error=array-bounds'
 def MAC_CXX = 'clang++' // -Werror -Wno-inconsistent-missing-override -Wno-unused-but-set-variable
 def WINSETENV = '''
@@ -35,7 +36,7 @@ catchError {
     'GIT_COMMITTER_NAME=Stan Jenkins',
     'GIT_COMMITTER_EMAIL=mc.stanislaw@gmail.com'
   ]) {
-    runPod(image: "stanorg/ci:gpu", cpus: 2) {
+    runPod(image: image, cpus: 2) {
       stage('Verify changes') {
         commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
         runRemainingStages = params.downstream || params.run_all || filesChanged(
@@ -124,7 +125,7 @@ up the autoformatter locally.  (Check console output at ${env.BUILD_URL})
             }
           }
         }, linux: {
-          runPod(image: "stanorg/ci:gpu", gpus: 1) {
+          runPod(image: image, gpus: 1) {
             stage('Linux Unit') {
               runUnit(cxx: LINUX_CXX, local: """
 STAN_OPENCL=true
@@ -170,7 +171,7 @@ OPENCL_DEVICE_ID=0
         }
 
         parallel linux: {
-          runPod(image: 'stanorg/ci:gpu', checkout: false) {
+          runPod(image: image, checkout: false) {
             stage('Integration Linux') {
               checkout scmGit(userRemoteConfigs: [[url: 'https://github.com/stan-dev/performance-tests-cmdstan']],
                 extensions: [cloneOption(shallow: true, depth: 2), submodule(recursiveSubmodules: true, shallow: true, depth: 2)])


### PR DESCRIPTION
Migration to jenkins-new, significant cleanup of Jenkinsfile, mostly maintains the same behaviors and tests.

- Fake downstream_ branches replaced with downstream parameter and clearer branch targets.
- Docker imaged replaced by local Dockerfile, which is just an optimized version of the old one, with some things removed (and downgraded back to clang++-6.0, since the image was based on an older Dockerfile)
- `recordIssues` is removed in favor of more `-Werror` arguments, though this could be reconsidered if there are other important features.

Remaining possible work:

- Add M1 mac builds
- Review and cleanup email result targets, including stan-buildbot list