### PR TITLE
Replace Boost Regex with std::locale

### DIFF
--- a/src/stan/io/json/json_data_handler.hpp
+++ b/src/stan/io/json/json_data_handler.hpp
@@ -171,7 +171,7 @@ class json_data_handler : public stan::json::json_handler {
    *  and contain only letters, numbers, or an underscore.
    */
   bool valid_varname(const std::string& name) {
-    static const std::locale locale;
+    static const std::locale locale = std::locale::classic();
     if (name.empty() || !std::isalpha(name[0], locale)) {
       return false;
     }

--- a/src/stan/io/json/json_data_handler.hpp
+++ b/src/stan/io/json/json_data_handler.hpp
@@ -5,8 +5,8 @@
 #include <stan/io/json/json_handler.hpp>
 #include <stan/io/json/rapidjson_parser.hpp>
 #include <stan/io/var_context.hpp>
-#include <cctype>
 #include <iostream>
+#include <locale>
 #include <ostream>
 #include <limits>
 #include <map>
@@ -16,7 +16,6 @@
 #include <utility>
 #include <vector>
 #include <boost/algorithm/string.hpp>
-#include <boost/regex.hpp>
 
 namespace stan {
 
@@ -172,8 +171,13 @@ class json_data_handler : public stan::json::json_handler {
    *  and contain only letters, numbers, or an underscore.
    */
   bool valid_varname(const std::string& name) {
-    static const boost::regex re("[a-zA-Z][a-zA-Z0-9_]*");
-    return boost::regex_match(name, re);
+    static const std::locale locale;
+    if (name.empty() || !std::isalpha(name[0], locale)) {
+      return false;
+    }
+    return std::all_of(name.cbegin() + 1, name.cend(), [](const char c) {
+      return std::isalnum(c, locale) || c == '_';
+    });
   }
 
   bool is_array_tuples(const std::vector<std::string>& keys) {

--- a/src/stan/io/json/json_data_handler.hpp
+++ b/src/stan/io/json/json_data_handler.hpp
@@ -171,7 +171,7 @@ class json_data_handler : public stan::json::json_handler {
    *  and contain only letters, numbers, or an underscore.
    */
   bool valid_varname(const std::string& name) {
-    static const std::locale locale = std::locale::classic();
+    static const std::locale& locale = std::locale::classic();
     if (name.empty() || !std::isalpha(name[0], locale)) {
       return false;
     }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

The validation rules for Stan variable names are simple enough that we don't need the `boost/regex` dependency and can use basic string checking utilities from the standard library instead

#### Intended Effect

Reduce dependency footprint

#### How to Verify

Current tests and models all still run/pass

#### Side Effects

N/A

#### Documentation

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
