### PR TITLE
Replace boost/lexical_cast usage and delete miscellaneous dead includes 

### DIFF
--- a/src/test/unit/callbacks/stream_logger_test.cpp
+++ b/src/test/unit/callbacks/stream_logger_test.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#include <boost/lexical_cast.hpp>
 #include <sstream>
 #include <stan/callbacks/stream_logger.hpp>
 

--- a/src/test/unit/callbacks/stream_writer_test.cpp
+++ b/src/test/unit/callbacks/stream_writer_test.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#include <boost/lexical_cast.hpp>
 #include <stan/callbacks/stream_writer.hpp>
 
 class StanInterfaceCallbacksStreamWriter : public ::testing::Test {
@@ -32,7 +31,7 @@ TEST_F(StanInterfaceCallbacksStreamWriter, string_vector) {
   const int N = 5;
   std::vector<std::string> x;
   for (int n = 0; n < N; ++n)
-    x.push_back(boost::lexical_cast<std::string>(n));
+    x.push_back(std::to_string(n));
 
   EXPECT_NO_THROW(writer(x));
   EXPECT_EQ("0,1,2,3,4\n", ss.str());

--- a/src/test/unit/callbacks/unique_stream_writer_test.cpp
+++ b/src/test/unit/callbacks/unique_stream_writer_test.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#include <boost/lexical_cast.hpp>
 #include <stan/callbacks/unique_stream_writer.hpp>
 
 struct deleter_noop {
@@ -51,7 +50,7 @@ TEST_F(StanInterfaceCallbacksStreamWriter, string_vector) {
   const int N = 5;
   std::vector<std::string> x;
   for (int n = 0; n < N; ++n)
-    x.push_back(boost::lexical_cast<std::string>(n));
+    x.push_back(std::to_string(n));
 
   EXPECT_NO_THROW(writer(x));
   EXPECT_EQ("0,1,2,3,4\n", ss.str());

--- a/src/test/unit/callbacks/writer_test.cpp
+++ b/src/test/unit/callbacks/writer_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
-#include <boost/lexical_cast.hpp>
 #include <stan/callbacks/writer.hpp>
+#include <string>
 
 class StanInterfaceCallbacksWriter : public ::testing::Test {
  public:
@@ -22,7 +22,7 @@ TEST_F(StanInterfaceCallbacksWriter, string_vector) {
   const int N = 5;
   std::vector<std::string> x;
   for (int n = 0; n < N; ++n)
-    x.push_back(boost::lexical_cast<std::string>(n));
+    x.push_back(std::to_string(n));
 
   EXPECT_NO_THROW(writer(x));
 }

--- a/src/test/unit/io/json/json_data_test.cpp
+++ b/src/test/unit/io/json/json_data_test.cpp
@@ -7,7 +7,6 @@
 #include <test/unit/util.hpp>
 #include <test/unit/io/json/util.hpp>
 
-#include <boost/limits.hpp>
 #include <boost/math/concepts/real_concept.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <gtest/gtest.h>

--- a/src/test/unit/model/indexing/index_test.cpp
+++ b/src/test/unit/model/indexing/index_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/model/indexing.hpp>
 #include <gtest/gtest.h>
-#include <boost/type_traits/is_same.hpp>
 #include <vector>
 
 using stan::model::index_max;

--- a/src/test/unit/variational/eta_adapt_small_test.cpp
+++ b/src/test/unit/variational/eta_adapt_small_test.cpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <iostream>
 #include <stan/services/util/create_rng.hpp>
-#include <boost/version.hpp>
 
 class eta_adapt_small_test : public ::testing::Test {
  public:


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Pretty trivial one, the `lexical_cast` usages were only converting an `int` to an `std::string` so these can be replaced with `std::to_string`. There were also a few `boost` includes which were unused and could just be deleted

#### Intended Effect

Reduce dependency footprint

#### How to Verify

Tests & models still run and pass

#### Side Effects

N/A

#### Documentation

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
