### PR TITLE
Flush JSON writer at end of records

### DIFF
--- a/src/stan/callbacks/json_writer.hpp
+++ b/src/stan/callbacks/json_writer.hpp
@@ -228,6 +228,7 @@ class json_writer final : public structured_writer {
     } else {
       *output_ << "\n";
     }
+    output_->flush();
   }
 
   /**


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Should close stan-dev/cmdstan#1349 (@jgabry @bgoodri I'd appreciate you trying it out!)

#### Intended Effect

Write to file at the end of JSON records (in particular, also at the end of the file, which is a record)

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
