### PR TITLE
Flush JSON after top level finishes 

### DIFF
--- a/src/stan/callbacks/json_writer.hpp
+++ b/src/stan/callbacks/json_writer.hpp
@@ -24,7 +24,7 @@ namespace callbacks {
  * The writer doesn't try to validate the object's internal structure
  * or object completeness, only syntactic correctness.
  *
- * @tparam Stream A type with with a valid `operator<<(std::string)`
+ * @tparam Stream A type with a valid `operator<<(std::string)` and `flush()`
  * @tparam Deleter A class with a valid `operator()` method for deleting the
  * output stream
  */
@@ -227,6 +227,7 @@ class json_writer final : public structured_writer {
       record_element_needs_comma_ = true;
     } else {
       *output_ << "\n";
+      output_->flush();
     }
   }
 

--- a/src/test/unit/callbacks/json_writer_test.cpp
+++ b/src/test/unit/callbacks/json_writer_test.cpp
@@ -1,24 +1,12 @@
 #include <stan/callbacks/json_writer.hpp>
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
-#include <sstream>
 #include <string>
 
 struct deleter_noop {
   template <typename T>
   constexpr void operator()(T* arg) const {}
 };
-
-class counting_streambuf : public std::stringbuf {
- public:
-  int sync() override {
-    ++sync_count;
-    return std::stringbuf::sync();
-  }
-
-  int sync_count = 0;
-};
-
 class StanInterfaceCallbacksJsonWriter : public ::testing::Test {
  public:
   StanInterfaceCallbacksJsonWriter()
@@ -102,35 +90,6 @@ TEST_F(StanInterfaceCallbacksJsonWriter, begin_end_record_nested) {
   auto json = ss.str();
   EXPECT_EQ(expected, json);
   ASSERT_TRUE(stan::test::is_valid_JSON(json));
-}
-
-TEST_F(StanInterfaceCallbacksJsonWriter, flushes_completed_top_level_record) {
-  counting_streambuf buffer;
-  std::ostream output(&buffer);
-  stan::callbacks::json_writer<std::ostream, deleter_noop> writer{
-      std::unique_ptr<std::ostream, deleter_noop>(&output)};
-
-  writer.begin_record();
-  writer.begin_record("nested");
-  writer.write("value", 1);
-  writer.end_record();
-  EXPECT_EQ(0, buffer.sync_count);
-
-  writer.end_record();
-  EXPECT_EQ(1, buffer.sync_count);
-  const char* expected = R"json(
-{
-  "nested" : {
-    "value" : 1
-  }
-}
-)json";
-  auto json = buffer.str();
-  EXPECT_EQ(expected, json);
-  EXPECT_TRUE(stan::test::is_valid_JSON(json));
-
-  stan::callbacks::json_writer<std::ostream, deleter_noop> no_op_writer;
-  EXPECT_NO_THROW(no_op_writer.end_record());
 }
 
 TEST_F(StanInterfaceCallbacksJsonWriter, write_double_vector) {

--- a/src/test/unit/callbacks/json_writer_test.cpp
+++ b/src/test/unit/callbacks/json_writer_test.cpp
@@ -1,12 +1,24 @@
 #include <stan/callbacks/json_writer.hpp>
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
+#include <sstream>
 #include <string>
 
 struct deleter_noop {
   template <typename T>
   constexpr void operator()(T* arg) const {}
 };
+
+class counting_streambuf : public std::stringbuf {
+ public:
+  int sync() override {
+    ++sync_count;
+    return std::stringbuf::sync();
+  }
+
+  int sync_count = 0;
+};
+
 class StanInterfaceCallbacksJsonWriter : public ::testing::Test {
  public:
   StanInterfaceCallbacksJsonWriter()
@@ -90,6 +102,35 @@ TEST_F(StanInterfaceCallbacksJsonWriter, begin_end_record_nested) {
   auto json = ss.str();
   EXPECT_EQ(expected, json);
   ASSERT_TRUE(stan::test::is_valid_JSON(json));
+}
+
+TEST_F(StanInterfaceCallbacksJsonWriter, flushes_completed_top_level_record) {
+  counting_streambuf buffer;
+  std::ostream output(&buffer);
+  stan::callbacks::json_writer<std::ostream, deleter_noop> writer{
+      std::unique_ptr<std::ostream, deleter_noop>(&output)};
+
+  writer.begin_record();
+  writer.begin_record("nested");
+  writer.write("value", 1);
+  writer.end_record();
+  EXPECT_EQ(0, buffer.sync_count);
+
+  writer.end_record();
+  EXPECT_EQ(1, buffer.sync_count);
+  const char* expected = R"json(
+{
+  "nested" : {
+    "value" : 1
+  }
+}
+)json";
+  auto json = buffer.str();
+  EXPECT_EQ(expected, json);
+  EXPECT_TRUE(stan::test::is_valid_JSON(json));
+
+  stan::callbacks::json_writer<std::ostream, deleter_noop> no_op_writer;
+  EXPECT_NO_THROW(no_op_writer.end_record());
 }
 
 TEST_F(StanInterfaceCallbacksJsonWriter, write_double_vector) {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

https://github.com/stan-dev/cmdstan/issues/1349 has the context. 

Flush when the top level JSON object is finished. @WardBrian I guess this is slightly different than your suggestion, but I think equivalent for the metric JSON files. I wasn't sure if there are ever nested JSON objects in other contexts. 


#### Intended Effect

Make it so that metric JSON files are readable after warmup but before sampling finishes

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
