### PR TITLE
Remove Boost iterator_range dependency

### DIFF
--- a/src/stan/services/pathfinder/multi.hpp
+++ b/src/stan/services/pathfinder/multi.hpp
@@ -233,8 +233,7 @@ inline int pathfinder_lbfgs_multi(
   using discrete_dist_t
       = boost::random::discrete_distribution<Eigen::Index, double>;
   boost::variate_generator<stan::rng_t&, discrete_dist_t> rand_psis_idx(
-      rng, discrete_dist_t(boost::iterator_range<double*>(
-               weight_vals.data(), weight_vals.data() + weight_vals.size())));
+      rng, discrete_dist_t(weight_vals.cbegin(), weight_vals.cend()));
   Eigen::Matrix<Eigen::Index, -1, 1> psis_draw_idxs(num_multi_draws);
   for (size_t i = 0; i <= num_multi_draws - 1; ++i) {
     psis_draw_idxs.coeffRef(i) = rand_psis_idx();


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

The [Math PR removing Boost `odeint`](https://github.com/stan-dev/math/pull/3357) identified that `boost::iterator_range` was being used here without a matching `#include`. The code doesn't actually need the `iterator_range`, since the `discrete_distribution` can take `start`/`end` iterators directly 

#### Intended Effect

Remove Boost `iterative_range` dependency

#### How to Verify

All tests compile and pass

#### Side Effects

N/A

#### Documentation

N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
