### PR TITLE
Update json_writer's vector handling for consistency

### DIFF
--- a/src/stan/callbacks/json_writer.hpp
+++ b/src/stan/callbacks/json_writer.hpp
@@ -372,8 +372,9 @@ class json_writer final : public structured_writer {
       for (auto it = values.begin(); it != last; ++it) {
         *output_ << process_string(*it) << ", ";
       }
+      *output_ << process_string(values.back());
     }
-    *output_ << values.back() << " ]";
+    *output_ << " ]";
   }
 
   /**
@@ -420,8 +421,9 @@ class json_writer final : public structured_writer {
       for (auto it = values.begin(); it != last; ++it) {
         *output_ << *it << ", ";
       }
+      *output_ << values.back();
     }
-    *output_ << values.back() << " ]";
+    *output_ << " ]";
   }
 
   /**
@@ -439,12 +441,13 @@ class json_writer final : public structured_writer {
 
     *output_ << "[ ";
     if (values.size() > 0) {
-      size_t last = values.size() - 1;
-      for (size_t i = 0; i < last; ++i) {
-        write_complex_value(values[i]);
+      auto last = values.end();
+      --last;
+      for (auto it = values.begin(); it != last; ++it) {
+        write_complex_value(*it);
         *output_ << ", ";
       }
-      write_complex_value(values[last]);
+      write_complex_value(values.back());
     }
     *output_ << " ]";
   }

--- a/src/test/unit/callbacks/json_writer_test.cpp
+++ b/src/test/unit/callbacks/json_writer_test.cpp
@@ -196,6 +196,17 @@ TEST_F(StanInterfaceCallbacksJsonWriter, write_string_vector) {
   EXPECT_EQ("\"key\":[0,1,2,3,4]", out);
 }
 
+TEST_F(StanInterfaceCallbacksJsonWriter, write_weird_string_vector) {
+  const int N = 5;
+  std::vector<std::string> x;
+  for (int n = 0; n < N; ++n)
+    x.push_back(std::to_string(n) + "\"");
+
+  writer.write("key", x);
+  auto out = output_sans_whitespace(ss);
+  EXPECT_EQ("\"key\":[0\\\",1\\\",2\\\",3\\\",4\\\"]", out);
+}
+
 TEST_F(StanInterfaceCallbacksJsonWriter, write_null) {
   writer.write("message");
   auto out = output_sans_whitespace(ss);
@@ -223,6 +234,16 @@ TEST_F(StanInterfaceCallbacksJsonWriter, write_int_vector) {
 TEST_F(StanInterfaceCallbacksJsonWriter, write_empty_vector) {
   std::string key("key");
   std::vector<double> x;
+  writer.write(key, x);
+  auto out = output_sans_whitespace(ss);
+  EXPECT_EQ("\"key\":[]", out);
+}
+
+TEST_F(StanInterfaceCallbacksJsonWriter, write_empty_int_vector) {
+  std::string key("key");
+  std::vector<int> x;
+  ss.clear();
+  x.clear();
   writer.write(key, x);
   auto out = output_sans_whitespace(ss);
   EXPECT_EQ("\"key\":[]", out);


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #3424. These overloads had an inconsistent style which could have led to a couple out of bounds reads and some string mangling. 

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
