### PR TITLE
stan_csv_reader: avoid infinite loops on poorly placed EOF

### DIFF
--- a/src/stan/io/stan_csv_reader.hpp
+++ b/src/stan/io/stan_csv_reader.hpp
@@ -104,9 +104,9 @@ class stan_csv_reader {
     std::stringstream ss;
     std::string line;
 
-    if (in.peek() != '#')
+    if (in.peek() != '#' || !in.good())
       return;
-    while (in.peek() == '#') {
+    while (in.peek() == '#' && in.good()) {
       std::getline(in, line);
       ss << line << '\n';
     }
@@ -225,7 +225,7 @@ class stan_csv_reader {
     int lines = 0;
     if (in.peek() != '#' || in.good() == false)
       return;
-    while (in.peek() == '#') {
+    while (in.peek() == '#' && in.good()) {
       std::getline(in, line);
       ss << line << std::endl;
       lines++;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #3426. While this can only be triggered by an invalid file, it is still better to not loop forever. 

#### Intended Effect

#### How to Verify

#### Side Effects

#### Documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
